### PR TITLE
Custom cluster feature creation function

### DIFF
--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -38,6 +38,8 @@ import {getUid} from '../util.js';
  *   return feature.getGeometry();
  * }
  * ```
+ * @property {function(Feature, Array<Feature>):any} [hydrate] Function called after creating
+ * cluster feature
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
  * @property {VectorSource} [source] Source.
@@ -107,6 +109,12 @@ class Cluster extends VectorSource {
         assert(geometry.getType() == GeometryType.POINT, 10); // The default `geometryFunction` can only handle `Point` geometries
         return geometry;
       };
+
+    /**
+     * @type {function(Feature, Array<Feature>):any}
+     * @protected
+     */
+    this.hydrate = options.hydrate;
 
     /**
      * @type {VectorSource}
@@ -295,6 +303,9 @@ class Cluster extends VectorSource {
       centroid[1] * (1 - ratio) + searchCenter[1] * ratio,
     ]);
     const cluster = new Feature(geometry);
+    if (this.hydrate) {
+      this.hydrate(cluster, features);
+    }
     cluster.set('features', features, true);
     return cluster;
   }

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -41,8 +41,8 @@ import {getUid} from '../util.js';
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
  * @property {function(Point, Array<Feature>):Feature} [createClusterFeature]
- * Function that takes cluster's ceter {@link module:ol/geom/Point} and array
- * of {@link module:ol/Feature} included in this cluster, must return
+ * Function that takes the cluster's center {@link module:ol/geom/Point} and an array
+ * of {@link module:ol/Feature} included in this cluster. Must return a
  * {@link module:ol/Feature} that will be used to render. Default implementation is:
  * ```js
  * function(point, features) {
@@ -196,28 +196,6 @@ class Cluster extends VectorSource {
    */
   setMinDistance(minDistance) {
     this.updateDistance(this.distance, minDistance);
-  }
-
-  /**
-   * Current function used to create cluster features
-   * @return {function(Point, Array<Feature>):Feature | undefined} cluster creation function
-   * @api
-   */
-  getCreateClusterFeature() {
-    return this.createClusterFeature;
-  }
-
-  /**
-   * Set function used to create cluster features
-   * @param {function(Point, Array<Feature>):Feature | undefined} createClusterFeature creation function
-   * @api
-   */
-  setCreateClusterFeature(createClusterFeature) {
-    const changed = this.createClusterFeature != createClusterFeature;
-    this.createClusterFeature = createClusterFeature;
-    if (changed) {
-      this.refresh();
-    }
   }
 
   /**

--- a/test/browser/spec/ol/source/cluster.test.js
+++ b/test/browser/spec/ol/source/cluster.test.js
@@ -99,26 +99,6 @@ describe('ol.source.Cluster', function () {
       expect(source.getFeatures().length).to.be(1);
       expect(source.getFeatures()[0].get('sum')).to.be(3);
     });
-    it('reacts setCreateClusterFeature', function () {
-      const feature1 = new Feature(new Point([0, 0]));
-      const feature2 = new Feature(new Point([0, 0]));
-      const source = new Cluster({
-        source: new VectorSource({
-          features: [feature1, feature2],
-        }),
-      });
-      source.loadFeatures(extent, 1, projection);
-      expect(source.getFeatures().length).to.be(1);
-      expect(source.getFeatures()[0].get('sum')).to.be(undefined);
-      source.setCreateClusterFeature(function (clusterPoint, features) {
-        return new Feature({
-          geometry: clusterPoint,
-          sum: features.length,
-        });
-      });
-      expect(source.getFeatures().length).to.be(1);
-      expect(source.getFeatures()[0].get('sum')).to.be(2);
-    });
   });
 
   describe('#setDistance', function () {

--- a/test/browser/spec/ol/source/cluster.test.js
+++ b/test/browser/spec/ol/source/cluster.test.js
@@ -75,7 +75,7 @@ describe('ol.source.Cluster', function () {
       expect(source.getFeatures().length).to.be(1);
       expect(source.getFeatures()[0].get('features').length).to.be(2);
     });
-    it('hydrates cluster feature with additional fields', function () {
+    it('custom cluster feature with additional fields', function () {
       const feature1 = new Feature(new Point([0, 0]));
       const feature2 = new Feature(new Point([0, 0]));
       feature1.set('value', 1);
@@ -84,13 +84,40 @@ describe('ol.source.Cluster', function () {
         source: new VectorSource({
           features: [feature1, feature2],
         }),
-        hydrate: function (clusterFeature, features) {
-          clusterFeature.set('sum', 3);
+        createClusterFeature: function (clusterPoint, features) {
+          let sum = 0;
+          for (const ft of features) {
+            sum += ft.get('value');
+          }
+          return new Feature({
+            geometry: clusterPoint,
+            sum: sum,
+          });
         },
       });
       source.loadFeatures(extent, 1, projection);
       expect(source.getFeatures().length).to.be(1);
       expect(source.getFeatures()[0].get('sum')).to.be(3);
+    });
+    it('reacts setCreateClusterFeature', function () {
+      const feature1 = new Feature(new Point([0, 0]));
+      const feature2 = new Feature(new Point([0, 0]));
+      const source = new Cluster({
+        source: new VectorSource({
+          features: [feature1, feature2],
+        }),
+      });
+      source.loadFeatures(extent, 1, projection);
+      expect(source.getFeatures().length).to.be(1);
+      expect(source.getFeatures()[0].get('sum')).to.be(undefined);
+      source.setCreateClusterFeature(function (clusterPoint, features) {
+        return new Feature({
+          geometry: clusterPoint,
+          sum: features.length,
+        });
+      });
+      expect(source.getFeatures().length).to.be(1);
+      expect(source.getFeatures()[0].get('sum')).to.be(2);
     });
   });
 

--- a/test/browser/spec/ol/source/cluster.test.js
+++ b/test/browser/spec/ol/source/cluster.test.js
@@ -75,6 +75,23 @@ describe('ol.source.Cluster', function () {
       expect(source.getFeatures().length).to.be(1);
       expect(source.getFeatures()[0].get('features').length).to.be(2);
     });
+    it('hydrates cluster feature with additional fields', function () {
+      const feature1 = new Feature(new Point([0, 0]));
+      const feature2 = new Feature(new Point([0, 0]));
+      feature1.set('value', 1);
+      feature2.set('value', 2);
+      const source = new Cluster({
+        source: new VectorSource({
+          features: [feature1, feature2],
+        }),
+        hydrate: function (clusterFeature, features) {
+          clusterFeature.set('sum', 3);
+        },
+      });
+      source.loadFeatures(extent, 1, projection);
+      expect(source.getFeatures().length).to.be(1);
+      expect(source.getFeatures()[0].get('sum')).to.be(3);
+    });
   });
 
   describe('#setDistance', function () {


### PR DESCRIPTION
Adds `hydrate` function option into Cluster constructor. It allows to for example fill cluster's feature with attributes, set custom style etc.

I'm not sure if `hydrate` is right name here. It's called after Feature is created, before `features` attribute is set.

I'm not able to run tests locally (due to https://github.com/openlayers/openlayers/issues/12486)

example usage:
```ts
      const source = new Cluster({
        source: new VectorSource({
          features: [feature1, feature2],
        }),
        hydrate: (clusterFeature, features) => {
          clusterFeature.set('sum', features.reduce((acc, ft) => acc + ft.get('value'), 0);
          clusterFeature.set('hasAllValidItems', features.every((ft) => acc + ft.get('isValid'));
        },
      });
```

It might be useful when you receive events elsewhere and you want to have for example the same attribute in every feature on map, whether it's clustered or not

// EDIT
Changed to  `createClusterFeature: (clusterPoint: Point, featuresInCluster: Feature[]): Feature`, it will be more elastic. Now inserting features is optional and can be done under different attribute name. Also we can use different Feature implementation (if anyone needs it), reuse etc.