### PR TITLE
MousePosition: allow rendering of empty string

### DIFF
--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -35,8 +35,8 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * @property {string} [undefinedHTML='&#160;'] Markup to show when coordinates are not
  * available (e.g. when the pointer leaves the map viewport).  By default, the last position
  * will be replaced with `'&#160;'` (`&nbsp;`) when the pointer leaves the viewport.  To
- * retain the last rendered position, set this option to something falsey (like an empty
- * string `''`).
+ * retain the last rendered position, set this option to something falsey. An exception is an
+ * empty string `''`. It does not count as falsey in this case.
  */
 
 /**
@@ -89,7 +89,8 @@ class MousePosition extends Control {
      * @private
      * @type {boolean}
      */
-    this.renderOnMouseOut_ = !!this.undefinedHTML_;
+    this.renderOnMouseOut_ =
+      this.undefinedHTML_ === '' || !!this.undefinedHTML_;
 
     /**
      * @private

--- a/test/browser/spec/ol/control/mouseposition.test.js
+++ b/test/browser/spec/ol/control/mouseposition.test.js
@@ -105,7 +105,30 @@ describe('ol/control/MousePosition', function () {
         expect(element.innerHTML).to.be('&nbsp;');
       });
 
-      it('retains the mouse position when undefinedHTML is falsey and mouse moves outside the viewport', function () {
+      it('retains the mouse position when undefinedHTML is false and mouse moves outside the viewport', function () {
+        const ctrl = new MousePosition({
+          undefinedHTML: false,
+        });
+        ctrl.setMap(map);
+        map.renderSync();
+
+        const element = document.querySelector(
+          '.ol-mouse-position',
+          map.getTarget()
+        );
+
+        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
+        expect(element.innerHTML).to.be('');
+
+        target.dispatchEvent(new PointerEvent('pointermove'));
+        simulateEvent(EventType.POINTERMOVE, 20, 30);
+        expect(element.innerHTML).to.be('20,-30');
+
+        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
+        expect(element.innerHTML).to.be('20,-30');
+      });
+
+      it('renders an empty string if undefinedHTML is an empty string and mouse moves outside the viewport', function () {
         const ctrl = new MousePosition({
           undefinedHTML: '',
         });
@@ -125,7 +148,7 @@ describe('ol/control/MousePosition', function () {
         expect(element.innerHTML).to.be('20,-30');
 
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('20,-30');
+        expect(element.innerHTML).to.be('');
       });
     });
   });


### PR DESCRIPTION
fixes #12482

 **ol.control.MousePosition** 
This PR makes it possible to enter an empty string `''` as `undefinedHTML` value. This will finally add an empty string into the target HTML element. The behavior before was that an empty string was recognized as falsey and therefore the default value - a whitespace - was used in the target HTML element.
