### PR TITLE
CanvasLayerRenderer: Forward LayerType type parameter to LayerRenderer

### DIFF
--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -21,6 +21,7 @@ import {createCanvasContext2D} from '../../dom.js';
 /**
  * @abstract
  * @template {import("../../layer/Layer.js").default} LayerType
+ * @extends {LayerRenderer<LayerType>}
  */
 class CanvasLayerRenderer extends LayerRenderer {
   /**


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
This change fixes a minor issue with the generated TypeScript definitions, where `CanvasLayerRenderer` does not currently forward its `LayerType` type parameter to the `LayerRenderer` superclass. This results in the following declaration:

```typescript
class CanvasLayerRenderer<LayerType extends Layer = Layer> extends LayerRenderer<any> { ... }
```
which results in type errors when `CanvasLayerRenderer<T>` is extended in application code. By forwarding the type parameter correctly, the declaration becomes

```typescript
class CanvasLayerRenderer<LayerType extends Layer = Layer> extends LayerRenderer<LayerType> { ... }
```
which fixes the type errors.