### PR TITLE
Fix adding controls with map config

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -383,16 +383,6 @@ class PluggableMap extends BaseObject {
     // is "defined" already.
     this.setProperties(optionsInternal.values);
 
-    this.controls.forEach(
-      /**
-       * @param {import("./control/Control.js").default} control Control.
-       * @this {PluggableMap}
-       */
-      function (control) {
-        control.setMap(this);
-      }.bind(this)
-    );
-
     this.controls.addEventListener(
       CollectionEventType.ADD,
       /**
@@ -410,16 +400,6 @@ class PluggableMap extends BaseObject {
        */
       function (event) {
         event.element.setMap(null);
-      }.bind(this)
-    );
-
-    this.interactions.forEach(
-      /**
-       * @param {import("./interaction/Interaction.js").default} interaction Interaction.
-       * @this {PluggableMap}
-       */
-      function (interaction) {
-        interaction.setMap(this);
       }.bind(this)
     );
 
@@ -442,8 +422,6 @@ class PluggableMap extends BaseObject {
         event.element.setMap(null);
       }.bind(this)
     );
-
-    this.overlays_.forEach(this.addOverlayInternal_.bind(this));
 
     this.overlays_.addEventListener(
       CollectionEventType.ADD,
@@ -473,6 +451,28 @@ class PluggableMap extends BaseObject {
         event.element.setMap(null);
       }.bind(this)
     );
+
+    this.controls.forEach(
+      /**
+       * @param {import("./control/Control.js").default} control Control.
+       * @this {PluggableMap}
+       */
+      function (control) {
+        control.setMap(this);
+      }.bind(this)
+    );
+
+    this.interactions.forEach(
+      /**
+       * @param {import("./interaction/Interaction.js").default} interaction Interaction.
+       * @this {PluggableMap}
+       */
+      function (interaction) {
+        interaction.setMap(this);
+      }.bind(this)
+    );
+
+    this.overlays_.forEach(this.addOverlayInternal_.bind(this));
   }
 
   /**

--- a/test/browser/spec/ol/map.test.js
+++ b/test/browser/spec/ol/map.test.js
@@ -1,3 +1,4 @@
+import Control from '../../../../src/ol/control/Control.js';
 import DoubleClickZoom from '../../../../src/ol/interaction/DoubleClickZoom.js';
 import DragPan from '../../../../src/ol/interaction/DragPan.js';
 import Feature from '../../../../src/ol/Feature.js';
@@ -65,6 +66,35 @@ describe('ol.Map', function () {
 
       const containerStop = map.getOverlayContainerStopEvent();
       expect(containerStop.className).to.be('ol-overlaycontainer-stopevent');
+    });
+
+    it('calls setMap for controls added by other controls', function () {
+      let subSetMapCalled = false;
+      class SubControl extends Control {
+        setMap(map) {
+          super.setMap(map);
+          subSetMapCalled = true;
+        }
+      }
+      class MainControl extends Control {
+        setMap(map) {
+          super.setMap(map);
+          map.addControl(
+            new SubControl({
+              element: document.createElement('div'),
+            })
+          );
+        }
+      }
+      new Map({
+        target: document.createElement('div'),
+        controls: [
+          new MainControl({
+            element: document.createElement('div'),
+          }),
+        ],
+      });
+      expect(subSetMapCalled).to.be(true);
     });
   });
 


### PR DESCRIPTION
If a control like [ol.control.Bar](https://viglino.github.io/ol-ext/doc/doc-pages/ol.control.Bar.html) by @Viglino adds sub controls when added to a map it fails during map creation because the listeners are added after the control was added to the map.

Adding listeners before adding controls / interactions / overlays fixes this

See https://codesandbox.io/s/ol-ext-bar-map-config-vl1o0?file=/src/index.js for an example

