### PR TITLE
Shorter name for the option to create a custom cluster

### DIFF
--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -40,7 +40,7 @@ import {getUid} from '../util.js';
  * ```
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
- * @property {function(Point, Array<Feature>):Feature} [createClusterFeature]
+ * @property {function(Point, Array<Feature>):Feature} [createCluster]
  * Function that takes the cluster's center {@link module:ol/geom/Point} and an array
  * of {@link module:ol/Feature} included in this cluster. Must return a
  * {@link module:ol/Feature} that will be used to render. Default implementation is:
@@ -122,9 +122,9 @@ class Cluster extends VectorSource {
 
     /**
      * @type {function(Point, Array<Feature>):Feature}
-     * @protected
+     * @private
      */
-    this.createClusterFeature = options.createClusterFeature;
+    this.createCustomCluster_ = options.createCluster;
 
     /**
      * @type {VectorSource}
@@ -312,8 +312,8 @@ class Cluster extends VectorSource {
       centroid[0] * (1 - ratio) + searchCenter[0] * ratio,
       centroid[1] * (1 - ratio) + searchCenter[1] * ratio,
     ]);
-    if (this.createClusterFeature) {
-      return this.createClusterFeature(geometry, features);
+    if (this.createCustomCluster_) {
+      return this.createCustomCluster_(geometry, features);
     } else {
       return new Feature({
         geometry,

--- a/test/browser/spec/ol/source/cluster.test.js
+++ b/test/browser/spec/ol/source/cluster.test.js
@@ -84,7 +84,7 @@ describe('ol.source.Cluster', function () {
         source: new VectorSource({
           features: [feature1, feature2],
         }),
-        createClusterFeature: function (clusterPoint, features) {
+        createCluster: function (clusterPoint, features) {
           let sum = 0;
           for (const ft of features) {
             sum += ft.get('value');


### PR DESCRIPTION
This is a minor modification to the change in #12487.

Since the type and docs make it clear that this function returns a feature, I don't think "Feature" needs to be repeated in the name.