### PR TITLE
Treat custom loaders without success/fail handling as if they were a void loader

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -983,7 +983,7 @@ class VectorSource extends Source {
       }
     }
     this.loading =
-      this.loader_ === VOID ? false : this.loadingExtentsCount_ > 0;
+      this.loader_.length < 4 ? false : this.loadingExtentsCount_ > 0;
   }
 
   refresh() {

--- a/test/browser/spec/ol/map.test.js
+++ b/test/browser/spec/ol/map.test.js
@@ -270,6 +270,13 @@ describe('ol.Map', function () {
               features: [new Feature(new Point([0, 0]))],
             }),
           }),
+          new VectorLayer({
+            source: new VectorSource({
+              loader: function (extent, resolution, projection) {
+                this.addFeature(new Feature(new Point([0, 0])));
+              },
+            }),
+          }),
         ],
       });
     });


### PR DESCRIPTION
Fixes #12515

#11941 broke subsequent events when custom loaders such as `ol/layer/Graticule` do not handle success/fail.  Treating such loaders in the same way as a void loader fixes it.
