### PR TITLE
Add setDisplacement method to ol/style/Image and subclasses

### DIFF
--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -32,7 +32,7 @@ import {getUid} from '../util.js';
  * to provide the size of the image, with the `imgSize` option.
  * @property {Array<number>} [offset=[0, 0]] Offset, which, together with the size and the offset origin, define the
  * sub-rectangle to use from the original icon image.
- * @property {Array<number>} [displacement=[0,0]] Displacement the icon
+ * @property {Array<number>} [displacement=[0,0]] Displacement of the icon.
  * @property {import("./IconOrigin.js").default} [offsetOrigin='top-left'] Origin of the offset: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`.
  * @property {number} [opacity=1] Opacity of the icon.

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -244,53 +244,50 @@ class Icon extends ImageStyle {
    * @api
    */
   getAnchor() {
-    if (this.normalizedAnchor_) {
-      return this.normalizedAnchor_;
-    }
-    let anchor = this.anchor_;
-    const size = this.getSize();
-    if (
-      this.anchorXUnits_ == IconAnchorUnits.FRACTION ||
-      this.anchorYUnits_ == IconAnchorUnits.FRACTION
-    ) {
-      if (!size) {
-        return null;
-      }
-      anchor = this.anchor_.slice();
-      if (this.anchorXUnits_ == IconAnchorUnits.FRACTION) {
-        anchor[0] *= size[0];
-      }
-      if (this.anchorYUnits_ == IconAnchorUnits.FRACTION) {
-        anchor[1] *= size[1];
-      }
-    }
-
-    if (this.anchorOrigin_ != IconOrigin.TOP_LEFT) {
-      if (!size) {
-        return null;
-      }
-      if (anchor === this.anchor_) {
+    let anchor = this.normalizedAnchor_;
+    if (!anchor) {
+      anchor = this.anchor_;
+      const size = this.getSize();
+      if (
+        this.anchorXUnits_ == IconAnchorUnits.FRACTION ||
+        this.anchorYUnits_ == IconAnchorUnits.FRACTION
+      ) {
+        if (!size) {
+          return null;
+        }
         anchor = this.anchor_.slice();
+        if (this.anchorXUnits_ == IconAnchorUnits.FRACTION) {
+          anchor[0] *= size[0];
+        }
+        if (this.anchorYUnits_ == IconAnchorUnits.FRACTION) {
+          anchor[1] *= size[1];
+        }
       }
-      if (
-        this.anchorOrigin_ == IconOrigin.TOP_RIGHT ||
-        this.anchorOrigin_ == IconOrigin.BOTTOM_RIGHT
-      ) {
-        anchor[0] = -anchor[0] + size[0];
+
+      if (this.anchorOrigin_ != IconOrigin.TOP_LEFT) {
+        if (!size) {
+          return null;
+        }
+        if (anchor === this.anchor_) {
+          anchor = this.anchor_.slice();
+        }
+        if (
+          this.anchorOrigin_ == IconOrigin.TOP_RIGHT ||
+          this.anchorOrigin_ == IconOrigin.BOTTOM_RIGHT
+        ) {
+          anchor[0] = -anchor[0] + size[0];
+        }
+        if (
+          this.anchorOrigin_ == IconOrigin.BOTTOM_LEFT ||
+          this.anchorOrigin_ == IconOrigin.BOTTOM_RIGHT
+        ) {
+          anchor[1] = -anchor[1] + size[1];
+        }
       }
-      if (
-        this.anchorOrigin_ == IconOrigin.BOTTOM_LEFT ||
-        this.anchorOrigin_ == IconOrigin.BOTTOM_RIGHT
-      ) {
-        anchor[1] = -anchor[1] + size[1];
-      }
+      this.normalizedAnchor_ = anchor;
     }
     const displacement = this.getDisplacement();
-    anchor[0] -= displacement[0];
-    anchor[1] += displacement[1];
-
-    this.normalizedAnchor_ = anchor;
-    return this.normalizedAnchor_;
+    return [anchor[0] - displacement[0], anchor[1] + displacement[1]];
   }
 
   /**

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -204,6 +204,16 @@ class ImageStyle {
   }
 
   /**
+   * Set the displacement.
+   *
+   * @param {Array<number>} displacement Displacement.
+   * @api
+   */
+  setDisplacement(displacement) {
+    this.displacement_ = displacement;
+  }
+
+  /**
    * Set the opacity.
    *
    * @param {number} opacity Opacity.

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -128,12 +128,6 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {Array<number>}
-     */
-    this.anchor_ = null;
-
-    /**
-     * @private
      * @type {import("../size.js").Size}
      */
     this.size_ = null;
@@ -177,7 +171,12 @@ class RegularShape extends ImageStyle {
    * @api
    */
   getAnchor() {
-    return this.anchor_;
+    const size = this.size_;
+    if (!size) {
+      return null;
+    }
+    const displacement = this.getDisplacement();
+    return [size[0] / 2 - displacement[0], size[1] / 2 + displacement[1]];
   }
 
   /**
@@ -467,9 +466,7 @@ class RegularShape extends ImageStyle {
   render() {
     this.renderOptions_ = this.createRenderOptions();
     const size = this.renderOptions_.size;
-    const displacement = this.getDisplacement();
     this.canvas_ = {};
-    this.anchor_ = [size / 2 - displacement[0], size / 2 + displacement[1]];
     this.size_ = [size, size];
   }
 

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -198,6 +198,11 @@ describe('ol.style.Icon', function () {
         size[0] / 2 - 20,
         size[1] / 2 + 10,
       ]);
+      iconStyle.setDisplacement([10, 20]);
+      expect(iconStyle.getAnchor()).to.eql([
+        size[0] / 2 - 10,
+        size[1] / 2 + 20,
+      ]);
     });
   });
 

--- a/test/browser/spec/ol/style/regularshape.test.js
+++ b/test/browser/spec/ol/style/regularshape.test.js
@@ -87,6 +87,7 @@ describe('ol.style.RegularShape', function () {
       expect(style.getDisplacement()).to.an('array');
       expect(style.getDisplacement()[0]).to.eql(0);
       expect(style.getDisplacement()[1]).to.eql(0);
+      expect(style.getAnchor()).to.eql([5, 5]);
     });
     it('will use the larger radius to calculate the size', function () {
       let style = new RegularShape({
@@ -109,6 +110,12 @@ describe('ol.style.RegularShape', function () {
       expect(style.getDisplacement()).to.an('array');
       expect(style.getDisplacement()[0]).to.eql(10);
       expect(style.getDisplacement()[1]).to.eql(20);
+      expect(style.getAnchor()).to.eql([-5, 25]);
+      style.setDisplacement([20, 10]);
+      expect(style.getDisplacement()).to.an('array');
+      expect(style.getDisplacement()[0]).to.eql(20);
+      expect(style.getDisplacement()[1]).to.eql(10);
+      expect(style.getAnchor()).to.eql([-15, 15]);
     });
   });
 


### PR DESCRIPTION
Fixes #12450

There should be no reason why displacement should not be dynamically updateable in the same way as anchor (displacement of regular shapes is equivalent to anchor for icons).  Due to its interaction with anchor and the assumption that its value is fixed some changes to `ol/style/Icon` and `ol/style/RegularShape` are also needed.
