### PR TITLE
Avoid creating context until needed

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -24,7 +24,8 @@ try {
   hasImageData = false;
 }
 
-const context = document.createElement('canvas').getContext('2d');
+/** @type {CanvasRenderingContext2D} */
+let context;
 
 /**
  * @param {Uint8ClampedArray} data Image data.
@@ -35,11 +36,14 @@ const context = document.createElement('canvas').getContext('2d');
 export function newImageData(data, width, height) {
   if (hasImageData) {
     return new ImageData(data, width, height);
-  } else {
-    const imageData = context.createImageData(width, height);
-    imageData.data.set(data);
-    return imageData;
   }
+
+  if (!context) {
+    context = document.createElement('canvas').getContext('2d');
+  }
+  const imageData = context.createImageData(width, height);
+  imageData.data.set(data);
+  return imageData;
 }
 
 /* istanbul ignore next */


### PR DESCRIPTION
This defers creation of the Canvas context until it is needed (see also tschaub/pixelworks#89).

Fixes #12530.