### PR TITLE
Styled nodes

### DIFF
--- a/examples/data/arrow.svg
+++ b/examples/data/arrow.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20">
+    <defs>
+        <polygon id="arrow" points="0 0, 5 1.75, 0 3.5" />
+        <marker id="endarrow" markerWidth="5" markerHeight="3.5" refX="0" refY="1.75" orient="auto">
+            <use xlink:href="#arrow" />
+        </marker>
+    </defs>
+    <g stroke-width="2" stroke="black" transform="translate(10,10) scale(0.5)">
+        <line y2="-10" marker-end="url(#endarrow)"/>
+    </g>
+</svg>

--- a/examples/data/kml/KrasnayaPolyanaResort.kml
+++ b/examples/data/kml/KrasnayaPolyanaResort.kml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document id="root_doc">
+    <name>Krasnaya Polyana Resort</name>
+
+
+    <Style id="easy">
+      <IconStyle>
+        <Icon>
+          <href>../arrow.svg</href>
+        </Icon>
+      </IconStyle>
+      <LineStyle>
+        <color>ffffbf00</color>
+        <width>5</width>
+      </LineStyle>
+
+    </Style>
+
+    <Style id="advanced">
+      <LineStyle>
+        <color>ff000077</color>
+        <width>5</width>
+      </LineStyle>
+    </Style>
+
+    <Style id="expert">
+      <LineStyle>
+        <color>ffFFFFFF</color>
+        <width>4</width>
+      </LineStyle>
+    </Style>
+
+    <Folder>
+      <name>Pistes</name>
+      <Placemark id="piste.8A">
+        <name>8A</name>
+        <Style id="novice">
+          <IconStyle>
+            <Icon>
+              <href>../arrow.svg?rotate</href>
+            </Icon>
+          </IconStyle>
+          <LineStyle>
+            <color>ff00AA00</color>
+            <width>5</width>
+          </LineStyle>
+        </Style>
+        <LineString>
+          <coordinates>40.2484,43.663482,0 40.2484704,43.6637253,0 40.2501226,43.6644059,0 <!--   -->
+            40.2505896,43.664605,0 40.2509943,43.6647594,0 40.2514523,43.6649071,0
+            40.2527156,43.6653144,0 <!--  --> 40.2531046,43.6657745,0 40.2533131,43.6660667,0
+            40.253261,43.6666509,0 40.2530947,43.667249,0 40.2530987,43.6675655,0
+            40.2537758,43.6680395,0 40.2542169,43.6683094,0 40.2547963,43.6685242,0
+            40.2556156,43.6686923,0 40.2561701,43.6687786,0 40.256425,43.6687823,0
+            40.2576022,43.6687587,0 40.2578162,43.6686957,0 40.2580766,43.6686008,0 </coordinates>
+        </LineString>
+      </Placemark>
+
+
+      <Placemark id="piste.2B">
+        <name>2B</name>
+        <Style>
+          <IconStyle>
+            <Icon>
+              <href>../arrow.svg?rotate=1</href>
+            </Icon>
+          </IconStyle>
+          <LineStyle>
+            <color>ffffbf00</color>
+            <width>5</width>
+          </LineStyle>
+
+        </Style>
+        <LineString>
+          <coordinates> 40.2508227,43.6587085,0 40.2506491,43.6587625,0 40.2504748,43.658917,0
+            40.2504301,43.6589566,0 40.2502703,43.6590653,0 40.2502312,43.6591841,0
+            40.2496505,43.6594124,0 40.2489166,43.6596821,0 40.248866,43.6598039,0
+            40.2488662,43.6599076,0 40.2489071,43.660143,0 40.2490697,43.6602525,0
+            40.2501245,43.6607465,0 40.2510103,43.6611234,0 40.2524479,43.6614364,0
+            40.2529766,43.6614613,0 40.2535876,43.6613733,0 40.254205,43.661262,0
+            40.2547291,43.6611727,0 40.2549287,43.6612025,0 40.2549919,43.6612905,0
+            40.2548686,43.6618893,0 40.2546162,43.6623803,0 40.2543583,43.6626698,0
+            40.2541759,43.6628687,0 40.253959,43.6629586,0 40.2532608,43.6630636,0
+            40.2521651,43.6632065,0 40.2514743,43.6634663,0 40.2508426,43.663713,0
+            40.2501187,43.6639347,0 40.2499637,43.6639909,0 40.2499401,43.6641379,0
+            40.2501226,43.6644059,0 </coordinates>
+        </LineString>
+      </Placemark>
+
+    </Folder>
+
+
+    <Placemark id="K8">
+      <name>К8</name>
+      <Style>
+        <IconStyle>
+          <Icon>
+            <href>../simplepost.svg</href>
+          </Icon>
+          <hotSpot y="1" x="0.5"/>
+        </IconStyle>
+        <LineStyle>
+          <color>ffff00ff</color>
+          <width>3</width>
+        </LineStyle>
+      </Style>
+      <LineString>
+        <coordinates>40.2581816,43.6690594,0 40.2577847,43.6688271,0 40.2566954,43.6681942,0
+          40.2553457,43.6674101,0 40.2544412,43.6668846,0 40.2530346,43.6660674,0
+          40.2521884,43.6655759,0 40.2512082,43.6650064,0 40.2496549,43.6641039,0
+          40.248844,43.6636328,0 40.2485845,43.663482,0 </coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="K2">
+      <name>К2</name>
+      <Style>
+        <IconStyle>
+          <Icon>
+            <href>../powerpost.svg</href>
+          </Icon>
+          <hotSpot y="1" x="0.5"/>
+        </IconStyle>
+        <LineStyle>
+          <color>ffff00ff</color>
+          <width>3</width>
+        </LineStyle>
+      </Style>
+      <LineString>
+        <coordinates>40.2583712,43.6680284,0 40.2575942,43.6671071,0 40.2566593,43.6659984,0
+          40.2563625,43.6656478,0 40.2557448,43.6649266,0 40.2545212,43.6634945,0
+          40.2522692,43.6608905,0 40.2512948,43.6597412,0 40.2510062,43.6594067,0
+          40.2508546,43.6592327,0</coordinates>
+      </LineString>
+    </Placemark>
+    <Placemark id="K10">
+      <name>К10</name>
+      <Style>
+        <LineStyle>
+          <color>ffff00ff</color>
+          <width>3</width>
+        </LineStyle>
+      </Style>
+      <LineString>
+        <coordinates> 40.2592856,43.6682493,0 40.2594409,43.668109,0 40.259785,43.6677925,0
+          40.2613836,43.6663224,0 40.2630364,43.6648025,0 40.2641124,43.663813,0
+          40.264319,43.663623,0 </coordinates>
+      </LineString>
+    </Placemark>
+
+  </Document>
+</kml>

--- a/examples/data/powerpost.svg
+++ b/examples/data/powerpost.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+    <g stroke-width="2" stroke="gray">
+        <line y2="10" x2='-3' transform="translate(5,0)"/>
+        <line y2="10" x2='3' transform="translate(5,0)"/>
+    </g>
+</svg>

--- a/examples/data/simplepost.svg
+++ b/examples/data/simplepost.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">
+    <g stroke-width="2" stroke="gray">
+        <line y2="10" transform="translate(5,0)"/>
+    </g>
+</svg>

--- a/examples/kml-nodes.css
+++ b/examples/kml-nodes.css
@@ -1,0 +1,4 @@
+.map
+{
+    height: 700px;
+}

--- a/examples/kml-nodes.html
+++ b/examples/kml-nodes.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: KML with a styled nodes
+shortdesc: Rendering KML with a styled nodes.
+docs: >
+  <p>This example uses the <code>ol/format/KML</code> to parse KML for rendering with a vector source.</p>
+  <p>If <code>IconStyle</code> for LineString is defined then this icon is used for all nodes of LineString o Polygon.</p>
+  <p>When <code>IconStyle/Icon/href</code> contains 'rotate' icon of all nodes will be rotated by tangent of segment.</p>
+tags: "KML, Icon"
+
+---
+<div id="map" class="map"></div>
+<div id="info">&nbsp;</div>

--- a/examples/kml-nodes.js
+++ b/examples/kml-nodes.js
@@ -1,0 +1,29 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import OSM from '../src/ol/source/OSM.js';
+import {fromLonLat} from '../src/ol/proj.js';
+import KML from '../src/ol/format/KML.js';
+import VectorSource from '../src/ol/source/Vector.js';
+import {Vector as VectorLayer} from '../src/ol/layer.js';
+
+
+const vector = new VectorLayer({
+  source: new VectorSource({
+    url: 'data/kml/KrasnayaPolyanaResort.kml',
+    format: new KML()
+  })
+});
+
+const map = new Map({
+  layers: [
+    new TileLayer({ 
+      source: new OSM()
+    }), vector
+  ], 
+  target: 'map',
+  view: new View({
+    center: fromLonLat([40.254,43.664]),
+    zoom: 16
+  })
+});

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1059,7 +1059,46 @@ function createFeatureStyleFunction(
           return [nameStyle, baseStyle].concat(featureStyle.slice(1));
         }
         return nameStyle;
+      } 
+      if (style != undefined && style[0].getImage().getSrc() != DEFAULT_IMAGE_STYLE_SRC) {
+        let geometry = feature.getGeometry();
+        if (geometry.getType() == 'Polygon') {
+          geometry = new LineString(geometry.getCoordinates()[0]);
+        }
+
+        if (geometry.getType() == 'LineString') {
+          let nodestyle = style[0];
+          let canberotated = nodestyle.getImage().getSrc().indexOf('rotate') != -1;
+          let styles = [nodestyle];
+          let theEnd;
+          let dir;
+          geometry.forEachSegment(function (start, end) {
+            theEnd = end;
+           let ni;
+            if (canberotated) {
+              ni=nodestyle.getImage().clone();
+              dir = Math.PI / 2 - Math.atan2( end[1] - start[1], end[0] - start[0]);
+              ni.setRotation(dir);
+            } else ni=nodestyle.getImage();
+             
+            let ns = new Style({
+              geometry: new Point(start),
+              image: ni
+            });
+
+            styles.push(ns);
+          });
+          if (!canberotated) {
+          styles.push(new Style({
+            geometry: new Point(theEnd),
+            image: nodestyle.getImage()
+          }));
+        }
+
+          return styles;
+        }
       }
+
       return featureStyle;
     }
   );


### PR DESCRIPTION
`KML` format supports icon style for LineStrings and Polygons.
Momentarily Openlayers doesn't use icon style for rendering.
I suggest fixing it.
Method `createFeatureStyleFunction` was be modified for rendering each node.
Commented example `kml-nodes` is added for testing it.
