### PR TITLE
Restore simple axis order handling with fixed proj4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "mocha": "9.0.2",
         "pixelmatch": "^5.1.0",
         "pngjs": "^6.0.0",
-        "proj4": "2.7.4",
+        "proj4": "^2.7.5",
         "puppeteer": "10.1.0",
         "rollup": "^2.42.3",
         "rollup-plugin-terser": "^7.0.2",
@@ -8456,9 +8456,9 @@
       }
     },
     "node_modules/proj4": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.4.tgz",
-      "integrity": "sha512-WAY3Rk/PeFrR/Pf2gryrEPFgfo83C4U1ixS8bBr05fJ88z+QsTDR0tzg6k3Q7TBrJUhwB03NMPVT3aVkv9mZ6Q==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
       "dev": true,
       "dependencies": {
         "mgrs": "1.0.0",
@@ -17703,9 +17703,9 @@
       "dev": true
     },
     "proj4": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.4.tgz",
-      "integrity": "sha512-WAY3Rk/PeFrR/Pf2gryrEPFgfo83C4U1ixS8bBr05fJ88z+QsTDR0tzg6k3Q7TBrJUhwB03NMPVT3aVkv9mZ6Q==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.7.5.tgz",
+      "integrity": "sha512-5ecXUXbHAfvdhfBQpU7EhUfPCQGUCPmVup/4gnZA3bJY3JcK/xxzm4QQDz1xiXokN6ux65VDczlCtBtKrTSpAQ==",
       "dev": true,
       "requires": {
         "mgrs": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "mocha": "9.0.2",
     "pixelmatch": "^5.1.0",
     "pngjs": "^6.0.0",
-    "proj4": "2.7.4",
+    "proj4": "^2.7.5",
     "puppeteer": "10.1.0",
     "rollup": "^2.42.3",
     "rollup-plugin-terser": "^7.0.2",

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -10,7 +10,6 @@ import {
   createSafeCoordinateTransform,
   get,
 } from '../proj.js';
-import {assign} from '../obj.js';
 import {get as getTransform} from './transforms.js';
 
 /**
@@ -53,16 +52,10 @@ export function register(proj4) {
       const code2 = projCodes[j];
       const proj2 = get(code2);
       if (!getTransform(code1, code2)) {
-        const def1 = proj4.defs(code1);
-        const def2 = proj4.defs(code2);
-        if (def1 === def2) {
+        if (proj4.defs[code1] === proj4.defs[code2]) {
           addEquivalentProjections([proj1, proj2]);
         } else {
-          // Reset axis because OpenLayers always uses x, y axis order
-          const transform = proj4(
-            assign({}, def1, {axis: undefined}),
-            assign({}, def2, {axis: undefined})
-          );
+          const transform = proj4(code1, code2);
           addCoordinateTransforms(
             proj1,
             proj2,


### PR DESCRIPTION
Now that axis order handling has been fixed in proj4 (see https://github.com/proj4js/proj4js/releases/tag/2.7.5), we can remove the hack we used to avoid flipped axis order.

This pull request essentially reverts the changes made in #11088.