### PR TITLE
Add `grid` tag to examples.

### DIFF
--- a/examples/mapbox-vector-tiles-advanced.html
+++ b/examples/mapbox-vector-tiles-advanced.html
@@ -4,7 +4,7 @@ title: Advanced Mapbox Vector Tiles
 shortdesc: Example of a Mapbox vector tiles map with custom tile grid.
 docs: >
   A vector tiles map which reuses the same source tiles for subsequent zoom levels to save bandwidth on mobile devices. **Note**: No map will be visible when the access token has expired.
-tags: "mapbox, vector, tiles, mobile"
+tags: "mapbox, vector, tiles, mobile, grid"
 resources:
   - resources/mapbox-streets-v6-style.js
 cloak:

--- a/examples/print-to-scale.html
+++ b/examples/print-to-scale.html
@@ -8,7 +8,7 @@ docs: >
   Unlike the <a href="export-pdf.html">Export PDF example</a> the on screen map is only used to set the center and rotation.
   The extent printed depends on the scale and page size. To print the scale bar and attributions the example uses the
   <a href="https://html2canvas.hertzen.com/" target="_blank">html2canvas</a> library.
-tags: "print, printing, scale, scaleline, export, pdf"
+tags: "print, printing, scale, scaleline, export, pdf, grid"
 resources:
   - https://html2canvas.hertzen.com/dist/html2canvas.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.3.1/jspdf.umd.min.js

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -4,7 +4,7 @@ title: Raster Reprojection
 shortdesc: Demonstrates client-side raster reprojection between various projections.
 docs: >
   This example shows client-side raster reprojection between various projections.
-tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi"
+tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi, grid"
 ---
 <div id="map" class="map"></div>
 <form class="form-inline">

--- a/examples/vector-tiles-4326.html
+++ b/examples/vector-tiles-4326.html
@@ -5,7 +5,7 @@ shortdesc: Example showing vector tiles in EPSG:4326 (styled using ol-mapbox-sty
 docs: >
   Example showing vector tiles in EPSG:4326 (styled using `ol-mapbox-style`) loaded from maptiler.com.
   **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example. No map will be visible when the API key has expired.
-tags: "vector tiles, epsg4326, mapbox style, ol-mapbox-style, maptiler"
+tags: "vector tiles, epsg4326, mapbox style, ol-mapbox-style, maptiler, grid"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/

--- a/examples/wms-custom-tilegrid-512x256.html
+++ b/examples/wms-custom-tilegrid-512x256.html
@@ -1,9 +1,9 @@
 ---
 layout: example.html
 title: WMS 512x256 Tiles
-shortdesc: Example of a WMS layer with 512x256px tiles.
+shortdesc: Example of a WMS layer with a custom grid with 512x256px tiles.
 docs: >
   WMS can serve arbitrary tile sizes. This example uses a custom tile grid with non-square tiles.
-tags: "wms, tile, non-square"
+tags: "wms, tile, non-square, grid"
 ---
 <div id="map" class="map"></div>

--- a/examples/wmts-dimensions.html
+++ b/examples/wmts-dimensions.html
@@ -4,7 +4,7 @@ title: WMTS Tile Transitions
 shortdesc: Example of smooth tile transitions when changing the dimension of a WMTS layer.
 docs: >
   Demonstrates smooth reloading of layers when changing a dimension continuously. The demonstration layer is a global sea-level computation (flooding computation from <a href="https://scalgo.com/">SCALGO</a>, underlying data from <a href="https://cgiarcsi.community/data/srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>) where cells that are flooded if the sea-level rises to more than <em>x</em> m are colored blue. The user selects the sea-level dimension using a slider.
-tags: "wmts, parameter, transition"
+tags: "wmts, parameter, transition, grid"
 ---
 <div id="map" class="map"></div>
 <label>

--- a/examples/wmts-ign.html
+++ b/examples/wmts-ign.html
@@ -9,6 +9,6 @@ docs: >
     and
     [Documentation de l’offre de données et services de l’IGN](https://geoservices.ign.fr/documentation/diffusion/documentation-offre.html)
     (french).
-tags: "french, ign, geoportail, wmts"
+tags: "french, ign, geoportail, wmts, grid"
 ---
 <div id="map" class="map"></div>

--- a/examples/wmts.html
+++ b/examples/wmts.html
@@ -4,6 +4,6 @@ title: WMTS
 shortdesc: Example of a WMTS source.
 docs: >
   This example shows how to manually create the configuration for accessing a WMTS. The [WMTS Layer from capabilities example](wmts-layer-from-capabilities.html) shows how to create the configuration from a GetCapabilities response.
-tags: "wmts"
+tags: "wmts, grid"
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
This adds a new tag `grid` to easily find examples that use custom grids.
