### PR TITLE
Handle named colors as string in equal operator

### DIFF
--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -606,6 +606,12 @@ function getEqualOperator(operator) {
         );
       }
 
+      if (type === (ValueTypes.COLOR | ValueTypes.STRING)) {
+        // It's not possible to compare attributes with color values
+        // So force it to be treated as a string
+        type = ValueTypes.STRING;
+      }
+
       return `(${expressionToGlsl(
         context,
         args[0],

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -606,11 +606,9 @@ function getEqualOperator(operator) {
         );
       }
 
-      if (type === (ValueTypes.COLOR | ValueTypes.STRING)) {
-        // It's not possible to compare attributes with color values
-        // So force it to be treated as a string
-        type = ValueTypes.STRING;
-      }
+      // Since it's not possible to have color types here, we can leave it out
+      // This fixes issues in case the value type is ambiguously detected as a color (e.g. the string 'red')
+      type = type ^ ValueTypes.COLOR;
 
       return `(${expressionToGlsl(
         context,

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -250,6 +250,9 @@ describe('ol.style.expressions', function () {
       expect(expressionToGlsl(context, ['==', 10, ['get', 'attr4']])).to.eql(
         '(10.0 == a_attr4)'
       );
+      expect(expressionToGlsl(context, ['==', 'red', ['get', 'attr4']])).to.eql(
+        '(0.0 == a_attr4)'
+      );
       expect(expressionToGlsl(context, ['!=', 10, ['get', 'attr4']])).to.eql(
         '(10.0 != a_attr4)'
       );

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -251,7 +251,7 @@ describe('ol.style.expressions', function () {
         '(10.0 == a_attr4)'
       );
       expect(expressionToGlsl(context, ['==', 'red', ['get', 'attr4']])).to.eql(
-        '(0.0 == a_attr4)'
+        `(${stringToGlsl(context, 'red')} == a_attr4)`
       );
       expect(expressionToGlsl(context, ['!=', 10, ['get', 'attr4']])).to.eql(
         '(10.0 != a_attr4)'


### PR DESCRIPTION
Fixes #12564

Alternatively, I could change the equal operator to take an additional argument to overrule the type, but afaik it never makes sense to have color values here. So I assume we can always treat named strings as strings here.