### PR TITLE
Make attribution getters public.

### DIFF
--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -95,6 +95,7 @@ class Source extends BaseObject {
   /**
    * Get the attribution function for the source.
    * @return {?Attribution} Attribution function.
+   * @api
    */
   getAttributions() {
     return this.attributions_;
@@ -102,6 +103,7 @@ class Source extends BaseObject {
 
   /**
    * @return {boolean} Attributions are collapsible.
+   * @api
    */
   getAttributionsCollapsible() {
     return this.attributionsCollapsible_;


### PR DESCRIPTION
In some applications it is nice to have a custom attribution control that for example can merge attributions for multiple layers. With the current API this is quite cumbersome.

This PR makes the `getAttributions` and `getAttributionsCollapsible` methods of `ol/source/Source` public to enable a custom attribution handling.