### PR TITLE
Some typing improvements

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -22,6 +22,11 @@ import {listen, unlistenByKey} from './events.js';
  *     |'change:geometry', Return>} FeatureOnSignature
  */
 
+/***
+ * @template Geometry
+ * @typedef {Object<string, *> & { geometry?: Geometry }} ObjectWithGeometry
+ */
+
 /**
  * @classdesc
  * A vector object for geographic features with a geometry and other
@@ -69,7 +74,7 @@ import {listen, unlistenByKey} from './events.js';
  */
 class Feature extends BaseObject {
   /**
-   * @param {Geometry|Object<string, *>} [opt_geometryOrProperties]
+   * @param {Geometry|ObjectWithGeometry<Geometry>} [opt_geometryOrProperties]
    *     You may pass a Geometry object directly, or an object literal containing
    *     properties. If you pass an object literal, you may include a Geometry
    *     associated with a `geometry` key.

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -11,7 +11,7 @@ import {listen, unlistenByKey} from './events.js';
  */
 
 /**
- * @typedef {Feature|import("./render/Feature.js").default} FeatureLike
+ * @typedef {Feature<import("./geom/Geometry.js").default>|import("./render/Feature.js").default} FeatureLike
  */
 
 /***

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -144,17 +144,17 @@ class Feature extends BaseObject {
   /**
    * Clone this feature. If the original feature has a geometry it
    * is also cloned. The feature id is not set in the clone.
-   * @return {Feature} The clone.
+   * @return {Feature<Geometry>} The clone.
    * @api
    */
   clone() {
-    const clone = new Feature(
-      this.hasProperties() ? this.getProperties() : null
+    const clone = /** @type {Feature<Geometry>} */ (
+      new Feature(this.hasProperties() ? this.getProperties() : null)
     );
     clone.setGeometryName(this.getGeometryName());
     const geometry = this.getGeometry();
     if (geometry) {
-      clone.setGeometry(geometry.clone());
+      clone.setGeometry(/** @type {Geometry} */ (geometry.clone()));
     }
     const style = this.getStyle();
     if (style) {

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -66,7 +66,7 @@ import {removeNode} from './dom.js';
 
 /**
  * @typedef {Object} AtPixelOptions
- * @property {undefined|function(import("./layer/Layer.js").default): boolean} [layerFilter] Layer filter
+ * @property {undefined|function(import("./layer/Layer.js").default<import("./source/Source").default>): boolean} [layerFilter] Layer filter
  * function. The filter function will receive one argument, the
  * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
@@ -553,7 +553,7 @@ class PluggableMap extends BaseObject {
    * callback with each intersecting feature. Layers included in the detection can
    * be configured through the `layerFilter` option in `opt_options`.
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {function(import("./Feature.js").FeatureLike, import("./layer/Layer.js").default, import("./geom/SimpleGeometry.js").default): T} callback Feature callback. The callback will be
+   * @param {function(import("./Feature.js").FeatureLike, import("./layer/Layer.js").default<import("./source/Source").default>, import("./geom/SimpleGeometry.js").default): T} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
    *     {@link module:ol/Feature feature} or
    *     {@link module:ol/render/Feature render feature} at the pixel, the second is

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -563,7 +563,7 @@ class PluggableMap extends BaseObject {
    * @param {AtPixelOptions} [opt_options] Optional options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.
-   * @template S,T
+   * @template T
    * @api
    */
   forEachFeatureAtPixel(pixel, callback, opt_options) {

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1882,8 +1882,12 @@ function readStyle(node, objectStack) {
           const geometry = feature.getGeometry();
           const type = geometry.getType();
           if (type === GeometryType.GEOMETRY_COLLECTION) {
+            const collection =
+              /** @type {import("../geom/GeometryCollection").default} */ (
+                geometry
+              );
             return new GeometryCollection(
-              geometry
+              collection
                 .getGeometriesArrayRecursive()
                 .filter(function (geometry) {
                   const type = geometry.getType();
@@ -1911,8 +1915,12 @@ function readStyle(node, objectStack) {
           const geometry = feature.getGeometry();
           const type = geometry.getType();
           if (type === GeometryType.GEOMETRY_COLLECTION) {
+            const collection =
+              /** @type {import("../geom/GeometryCollection").default} */ (
+                geometry
+              );
             return new GeometryCollection(
-              geometry
+              collection
                 .getGeometriesArrayRecursive()
                 .filter(function (geometry) {
                   const type = geometry.getType();

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1167,7 +1167,11 @@ class Modify extends PointerInteraction {
       map.forEachFeatureAtPixel(
         pixel,
         (feature, layer, geometry) => {
-          geometry = geometry || feature.getGeometry();
+          geometry =
+            geometry ||
+            /** @type {import("../geom/SimpleGeometry").default} */ (
+              feature.getGeometry()
+            );
           if (
             geometry.getType() === GeometryType.POINT &&
             includes(this.features_.getArray(), feature)

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -30,7 +30,7 @@ const SelectEventType = {
  * {@link module:ol/render/Feature} and an
  * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
- * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default):boolean} FilterFunction
+ * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>):boolean} FilterFunction
  */
 
 /**
@@ -49,7 +49,7 @@ const SelectEventType = {
  * feature removes all from the selection.
  * See `toggle`, `add`, `remove` options for adding/removing extra features to/
  * from the selection.
- * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default): boolean} [layers]
+ * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} [layers]
  * A list of layers from which features should be selected. Alternatively, a
  * filter function can be provided. The function will be called for each layer
  * in the map and should return `true` for layers that you want to be
@@ -252,7 +252,7 @@ class Select extends Interaction {
      */
     this.features_ = options.features || new Collection();
 
-    /** @type {function(import("../layer/Layer.js").default): boolean} */
+    /** @type {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} */
     let layerFilter;
     if (options.layers) {
       if (typeof options.layers === 'function') {
@@ -269,7 +269,7 @@ class Select extends Interaction {
 
     /**
      * @private
-     * @type {function(import("../layer/Layer.js").default): boolean}
+     * @type {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean}
      */
     this.layerFilter_ = layerFilter;
 

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -38,7 +38,7 @@ const TranslateEventType = {
  * {@link module:ol/render/Feature} and an
  * {@link module:ol/layer/Layer} and returns `true` if the feature may be
  * translated or `false` otherwise.
- * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default):boolean} FilterFunction
+ * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>):boolean} FilterFunction
  */
 
 /**
@@ -49,7 +49,7 @@ const TranslateEventType = {
  * Default is {@link module:ol/events/condition.always}.
  * @property {Collection<import("../Feature.js").default>} [features] Only features contained in this collection will be able to be translated. If
  * not specified, all features on the map will be able to be translated.
- * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default): boolean} [layers] A list of layers from which features should be
+ * @property {Array<import("../layer/Layer.js").default>|function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} [layers] A list of layers from which features should be
  * translated. Alternatively, a filter function can be provided. The
  * function will be called for each layer in the map and should return
  * `true` for layers that you want to be translatable. If the option is
@@ -171,7 +171,7 @@ class Translate extends PointerInteraction {
      */
     this.features_ = options.features !== undefined ? options.features : null;
 
-    /** @type {function(import("../layer/Layer.js").default): boolean} */
+    /** @type {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} */
     let layerFilter;
     if (options.layers) {
       if (typeof options.layers === 'function') {
@@ -188,7 +188,7 @@ class Translate extends PointerInteraction {
 
     /**
      * @private
-     * @type {function(import("../layer/Layer.js").default): boolean}
+     * @type {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean}
      */
     this.layerFilter_ = layerFilter;
 

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -153,9 +153,9 @@ class CompositeMapRenderer extends MapRenderer {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
-   * @param {function(import("../layer/Layer.js").default): boolean} layerFilter Layer filter
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
    *     returns `true` will be tested for features.  By default, all visible
    *     layers will be tested.

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -175,7 +175,7 @@ class MapRenderer extends Disposable {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../layer/Layer.js").default<import("../source/Source".).default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
    * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -175,9 +175,9 @@ class MapRenderer extends Disposable {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source".).default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
    *     callback.
-   * @param {function(import("../layer/Layer.js").default): boolean} layerFilter Layer filter
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function
    *     returns `true` will be tested for features.  By default, all visible
    *     layers will be tested.

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -13,7 +13,7 @@ import {getUid} from '../util.js';
  * unmanaged layers. The third is the {@link module:ol/geom/SimpleGeometry} of the feature. For features
  * with a GeometryCollection geometry, it will be the first detected geometry from the collection.
  * @template T
- * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default, import("../geom/SimpleGeometry.js").default): T} FeatureCallback
+ * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>, import("../geom/SimpleGeometry.js").default): T} FeatureCallback
  */
 
 /**


### PR DESCRIPTION
This PR includes:
* `Feature.clone` returns now `Feature<Geometry>` instead of `Feature<any>` (in this case `Geometry` is the generic parameter)
* `FeatureLike` uses `Feature<Geometry>` instead of `Feature<any>`
* `Layer` is now always used as `Layer<Source>` instead of `Layer<any>` (hopefully i did catch everything)

This improves typing as `layer.getSource().someRandomName` now is an error which is not the case if layer has type `Layer<any>`.

* The Feature Options are now typed.

This enables the feature to be properly typed if an object gets passed. i.e.:
```
const feature = new Feature({ geometry: new Point() });
```
will now have type `Feature<Point>` instead of `Feature<any>`. In the apidoc the type of the options object is now missing the `Object<string, *>` part, but it is described in the text:

![image](https://user-images.githubusercontent.com/8100558/128533992-078544b6-c8fb-441f-b846-67d9ecc1aa5f.png)
