### PR TITLE
Declare enums as variables before exporting them

### DIFF
--- a/src/ol/CollectionEventType.js
+++ b/src/ol/CollectionEventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const CollectionEventType = {
   /**
    * Triggered when an item is added to the collection.
    * @event module:ol/Collection.CollectionEvent#add
@@ -19,3 +19,5 @@ export default {
    */
   REMOVE: 'remove',
 };
+
+export default CollectionEventType;

--- a/src/ol/ImageState.js
+++ b/src/ol/ImageState.js
@@ -5,10 +5,12 @@
 /**
  * @enum {number}
  */
-export default {
+const ImageState = {
   IDLE: 0,
   LOADING: 1,
   LOADED: 2,
   ERROR: 3,
   EMPTY: 4,
 };
+
+export default ImageState;

--- a/src/ol/MapBrowserEventType.js
+++ b/src/ol/MapBrowserEventType.js
@@ -7,7 +7,7 @@ import EventType from './events/EventType.js';
  * Constants for event names.
  * @enum {string}
  */
-export default {
+const MapBrowserEventType = {
   /**
    * A true single click with no dragging and no double click. Note that this
    * event is delayed by 250 ms to ensure that it is not a double click.
@@ -57,3 +57,5 @@ export default {
 /***
  * @typedef {'singleclick'|'click'|'dblclick'|'pointerdrag'|'pointermove'} Types
  */
+
+export default MapBrowserEventType;

--- a/src/ol/MapEventType.js
+++ b/src/ol/MapEventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const MapEventType = {
   /**
    * Triggered after a map frame is rendered.
    * @event module:ol/MapEvent~MapEvent#postrender
@@ -27,6 +27,8 @@ export default {
    */
   MOVEEND: 'moveend',
 };
+
+export default MapEventType;
 
 /***
  * @typedef {'postrender'|'movestart'|'moveend'} Types

--- a/src/ol/MapProperty.js
+++ b/src/ol/MapProperty.js
@@ -5,9 +5,11 @@
 /**
  * @enum {string}
  */
-export default {
+const MapProperty = {
   LAYERGROUP: 'layergroup',
   SIZE: 'size',
   TARGET: 'target',
   VIEW: 'view',
 };
+
+export default MapProperty;

--- a/src/ol/ObjectEventType.js
+++ b/src/ol/ObjectEventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const ObjectEventType = {
   /**
    * Triggered when a property is changed.
    * @event module:ol/Object.ObjectEvent#propertychange
@@ -13,6 +13,8 @@ export default {
    */
   PROPERTYCHANGE: 'propertychange',
 };
+
+export default ObjectEventType;
 
 /**
  * @typedef {'propertychange'} Types

--- a/src/ol/OverlayPositioning.js
+++ b/src/ol/OverlayPositioning.js
@@ -8,7 +8,7 @@
  * `'top-center'`, `'top-right'`
  * @enum {string}
  */
-export default {
+const OverlayPositioning = {
   BOTTOM_LEFT: 'bottom-left',
   BOTTOM_CENTER: 'bottom-center',
   BOTTOM_RIGHT: 'bottom-right',
@@ -19,3 +19,5 @@ export default {
   TOP_CENTER: 'top-center',
   TOP_RIGHT: 'top-right',
 };
+
+export default OverlayPositioning;

--- a/src/ol/TileState.js
+++ b/src/ol/TileState.js
@@ -5,7 +5,7 @@
 /**
  * @enum {number}
  */
-export default {
+const TileState = {
   IDLE: 0,
   LOADING: 1,
   LOADED: 2,
@@ -16,3 +16,5 @@ export default {
   ERROR: 3,
   EMPTY: 4,
 };
+
+export default TileState;

--- a/src/ol/ViewHint.js
+++ b/src/ol/ViewHint.js
@@ -5,7 +5,9 @@
 /**
  * @enum {number}
  */
-export default {
+const ViewHint = {
   ANIMATING: 0,
   INTERACTING: 1,
 };
+
+export default ViewHint;

--- a/src/ol/ViewProperty.js
+++ b/src/ol/ViewProperty.js
@@ -5,8 +5,10 @@
 /**
  * @enum {string}
  */
-export default {
+const ViewProperty = {
   CENTER: 'center',
   RESOLUTION: 'resolution',
   ROTATION: 'rotation',
 };
+
+export default ViewProperty;

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -6,7 +6,7 @@
  * @enum {string}
  * @const
  */
-export default {
+const EventType = {
   /**
    * Generic change event. Triggered when the revision counter is increased.
    * @event module:ol/events/Event~BaseEvent#change
@@ -37,3 +37,5 @@ export default {
   TOUCHMOVE: 'touchmove',
   WHEEL: 'wheel',
 };
+
+export default EventType;

--- a/src/ol/events/KeyCode.js
+++ b/src/ol/events/KeyCode.js
@@ -6,9 +6,11 @@
  * @enum {number}
  * @const
  */
-export default {
+const KeyCode = {
   LEFT: 37,
   UP: 38,
   RIGHT: 39,
   DOWN: 40,
 };
+
+export default KeyCode;

--- a/src/ol/extent/Corner.js
+++ b/src/ol/extent/Corner.js
@@ -6,9 +6,11 @@
  * Extent corner.
  * @enum {string}
  */
-export default {
+const Corner = {
   BOTTOM_LEFT: 'bottom-left',
   BOTTOM_RIGHT: 'bottom-right',
   TOP_LEFT: 'top-left',
   TOP_RIGHT: 'top-right',
 };
+
+export default Corner;

--- a/src/ol/extent/Relationship.js
+++ b/src/ol/extent/Relationship.js
@@ -6,7 +6,7 @@
  * Relationship to an extent.
  * @enum {number}
  */
-export default {
+const Relationship = {
   UNKNOWN: 0,
   INTERSECTING: 1,
   ABOVE: 2,
@@ -14,3 +14,5 @@ export default {
   BELOW: 8,
   LEFT: 16,
 };
+
+export default Relationship;

--- a/src/ol/format/FormatType.js
+++ b/src/ol/format/FormatType.js
@@ -5,9 +5,11 @@
 /**
  * @enum {string}
  */
-export default {
+const FormatType = {
   ARRAY_BUFFER: 'arraybuffer',
   JSON: 'json',
   TEXT: 'text',
   XML: 'xml',
 };
+
+export default FormatType;

--- a/src/ol/geom/GeometryLayout.js
+++ b/src/ol/geom/GeometryLayout.js
@@ -8,9 +8,11 @@
  * `'XYZ'`, `'XYM'`, `'XYZM'`.
  * @enum {string}
  */
-export default {
+const GeometryLayout = {
   XY: 'XY',
   XYZ: 'XYZ',
   XYM: 'XYM',
   XYZM: 'XYZM',
 };
+
+export default GeometryLayout;

--- a/src/ol/geom/GeometryType.js
+++ b/src/ol/geom/GeometryType.js
@@ -8,7 +8,7 @@
  * `'GeometryCollection'`, `'Circle'`.
  * @enum {string}
  */
-export default {
+const GeometryType = {
   POINT: 'Point',
   LINE_STRING: 'LineString',
   LINEAR_RING: 'LinearRing',
@@ -19,3 +19,5 @@ export default {
   GEOMETRY_COLLECTION: 'GeometryCollection',
   CIRCLE: 'Circle',
 };
+
+export default GeometryType;

--- a/src/ol/interaction/Property.js
+++ b/src/ol/interaction/Property.js
@@ -5,6 +5,8 @@
 /**
  * @enum {string}
  */
-export default {
+const Property = {
   ACTIVE: 'active',
 };
+
+export default Property;

--- a/src/ol/layer/Property.js
+++ b/src/ol/layer/Property.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const Property = {
   OPACITY: 'opacity',
   VISIBLE: 'visible',
   EXTENT: 'extent',
@@ -16,3 +16,5 @@ export default {
   MIN_ZOOM: 'minZoom',
   SOURCE: 'source',
 };
+
+export default Property;

--- a/src/ol/layer/TileProperty.js
+++ b/src/ol/layer/TileProperty.js
@@ -5,7 +5,9 @@
 /**
  * @enum {string}
  */
-export default {
+const TileProperty = {
   PRELOAD: 'preload',
   USE_INTERIM_TILES_ON_ERROR: 'useInterimTilesOnError',
 };
+
+export default TileProperty;

--- a/src/ol/layer/VectorTileRenderType.js
+++ b/src/ol/layer/VectorTileRenderType.js
@@ -7,7 +7,7 @@
  * Render mode for vector tiles:
  * @api
  */
-export default {
+const VectorTileRenderType = {
   /**
    * Vector tiles are rendered as images. Great performance, but
    * point symbols and texts are always rotated with the view and pixels are
@@ -32,3 +32,5 @@ export default {
    */
   VECTOR: 'vector',
 };
+
+export default VectorTileRenderType;

--- a/src/ol/pointer/EventType.js
+++ b/src/ol/pointer/EventType.js
@@ -6,7 +6,7 @@
  * Constants for event names.
  * @enum {string}
  */
-export default {
+const EventType = {
   POINTERMOVE: 'pointermove',
   POINTERDOWN: 'pointerdown',
   POINTERUP: 'pointerup',
@@ -16,3 +16,5 @@ export default {
   POINTERLEAVE: 'pointerleave',
   POINTERCANCEL: 'pointercancel',
 };
+
+export default EventType;

--- a/src/ol/render/EventType.js
+++ b/src/ol/render/EventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const EventType = {
   /**
    * Triggered before a layer is rendered.
    * @event module:ol/render/Event~RenderEvent#prerender
@@ -45,6 +45,8 @@ export default {
    */
   RENDERCOMPLETE: 'rendercomplete',
 };
+
+export default EventType;
 
 /**
  * @typedef {'postrender'|'precompose'|'postcompose'|'rendercomplete'} MapRenderEventTypes

--- a/src/ol/render/canvas/BuilderType.js
+++ b/src/ol/render/canvas/BuilderType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const BuilderType = {
   CIRCLE: 'Circle',
   DEFAULT: 'Default',
   IMAGE: 'Image',
@@ -13,3 +13,5 @@ export default {
   POLYGON: 'Polygon',
   TEXT: 'Text',
 };
+
+export default BuilderType;

--- a/src/ol/source/State.js
+++ b/src/ol/source/State.js
@@ -6,9 +6,11 @@
  * @enum {string}
  * State of the source, one of 'undefined', 'loading', 'ready' or 'error'.
  */
-export default {
+const State = {
   UNDEFINED: 'undefined',
   LOADING: 'loading',
   READY: 'ready',
   ERROR: 'error',
 };
+
+export default State;

--- a/src/ol/source/TileEventType.js
+++ b/src/ol/source/TileEventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const TileEventType = {
   /**
    * Triggered when a tile starts loading.
    * @event module:ol/source/Tile.TileSourceEvent#tileloadstart
@@ -28,6 +28,8 @@ export default {
    */
   TILELOADERROR: 'tileloaderror',
 };
+
+export default TileEventType;
 
 /**
  * @typedef {'tileloadstart'|'tileloadend'|'tileloaderror'} TileSourceEventTypes

--- a/src/ol/source/VectorEventType.js
+++ b/src/ol/source/VectorEventType.js
@@ -5,7 +5,7 @@
 /**
  * @enum {string}
  */
-export default {
+const VectorEventType = {
   /**
    * Triggered when a feature is added to the source.
    * @event module:ol/source/Vector.VectorSourceEvent#addfeature
@@ -56,6 +56,8 @@ export default {
    */
   FEATURESLOADERROR: 'featuresloaderror',
 };
+
+export default VectorEventType;
 
 /**
  * @typedef {'addfeature'|'changefeature'|'clear'|'removefeature'|'featuresloadstart'|'featuresloadend'|'featuresloaderror'} VectorSourceEventTypes

--- a/src/ol/source/WMSServerType.js
+++ b/src/ol/source/WMSServerType.js
@@ -8,7 +8,7 @@
  *     specification that OpenLayers can make use of.
  * @enum {string}
  */
-export default {
+const WMSServerType = {
   /**
    * HiDPI support for [Carmenta Server](https://www.carmenta.com/en/products/carmenta-server)
    * @api
@@ -30,3 +30,5 @@ export default {
    */
   QGIS: 'qgis',
 };
+
+export default WMSServerType;

--- a/src/ol/source/WMTSRequestEncoding.js
+++ b/src/ol/source/WMTSRequestEncoding.js
@@ -6,7 +6,9 @@
  * Request encoding. One of 'KVP', 'REST'.
  * @enum {string}
  */
-export default {
+const WMTSRequestEncoding = {
   KVP: 'KVP', // see spec §8
   REST: 'REST', // see spec §10
 };
+
+export default WMTSRequestEncoding;

--- a/src/ol/style/IconAnchorUnits.js
+++ b/src/ol/style/IconAnchorUnits.js
@@ -6,7 +6,7 @@
  * Icon anchor units. One of 'fraction', 'pixels'.
  * @enum {string}
  */
-export default {
+const IconAnchorUnits = {
   /**
    * Anchor is a fraction
    * @api
@@ -18,3 +18,5 @@ export default {
    */
   PIXELS: 'pixels',
 };
+
+export default IconAnchorUnits;

--- a/src/ol/style/IconOrigin.js
+++ b/src/ol/style/IconOrigin.js
@@ -6,7 +6,7 @@
  * Icon origin. One of 'bottom-left', 'bottom-right', 'top-left', 'top-right'.
  * @enum {string}
  */
-export default {
+const IconOrigin = {
   /**
    * Origin is at bottom left
    * @api
@@ -28,3 +28,5 @@ export default {
    */
   TOP_RIGHT: 'top-right',
 };
+
+export default IconOrigin;

--- a/src/ol/style/TextPlacement.js
+++ b/src/ol/style/TextPlacement.js
@@ -9,7 +9,9 @@
  * {@link module:ol/geom/MultiPolygon~MultiPolygon}.
  * @enum {string}
  */
-export default {
+const TextPlacement = {
   POINT: 'point',
   LINE: 'line',
 };
+
+export default TextPlacement;

--- a/src/ol/webgl/ContextEventType.js
+++ b/src/ol/webgl/ContextEventType.js
@@ -5,7 +5,9 @@
 /**
  * @enum {string}
  */
-export default {
+const ContextEventType = {
   LOST: 'webglcontextlost',
   RESTORED: 'webglcontextrestored',
 };
+
+export default ContextEventType;


### PR DESCRIPTION
This change is necessary for getting TypeScript to emit a distinct type alias for an
object marked as `@enum`. For example, consider an enum `MyEnum`. With an unnamed
default export binding

```typescript
/**
 * @enum {string}
 */
export default {
  FOO: "foo"
};
```

the resulting `.d.ts` file looks something like this:

```typescript
declare namespace _default {
  const FOO: string;
}
export default _default;
```

This means that there is not a separate `MyEnum` type to refer to. By changing the enum
declaration and the default export to different lines, e.g.

```typescript
/**
 * @enum {string}
 */
const MyEnum = {
  FOO: "foo"
};
export default MyEnum;
```

the resulting type declaration will contain a generated type alias:

```typescript
export default MyEnum;
type MyEnum = string;
declare namespace MyEnum {
  const FOO: string
}
```

The type alias is necessary to be able to use `MyEnum` as a type.

---

This PR changes all enums to use the above approach to generate type aliases for them.
In particular, it fixes TS2694 errors (see https://github.com/openlayers/openlayers/issues/12497) in places where there are references to the enum's type, such as `import("./TileState.js").default`.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
