### PR TITLE
Improve API docs for optional properties

### DIFF
--- a/config/jsdoc/api/template/tmpl/params.tmpl
+++ b/config/jsdoc/api/template/tmpl/params.tmpl
@@ -70,7 +70,7 @@
             <?js if (!param.subparams) {?>
             <td class="type">
             <?js if (param.type && param.type.names) {?>
-                <?js= self.partial('type.tmpl', param.type.names) ?>
+                <?js= self.partial('type.tmpl', param.type.names) + (param.optional && typeof param.defaultvalue === 'undefined' && param.type.names.indexOf('undefined') === -1 ? ' | undefined' : '') ?>
                 <?js if (typeof param.defaultvalue !== 'undefined') { ?>
                     (defaults to <?js= self.htmlsafe(param.defaultvalue) ?>)
                 <?js } ?>


### PR DESCRIPTION
To make it a bit easier to work with the API docs, I think it makes sense to add `undefined` to the list of types when a param is optional and there is no default.

Before:
<img width="728" alt="before" src="https://user-images.githubusercontent.com/211514/129181140-8ab97346-11d0-4fc9-b5e4-83966f7f7181.png">

After:
<img width="728" alt="after" src="https://user-images.githubusercontent.com/211514/129181161-4a9286f9-7874-4c03-b012-ab51b4a823e5.png">
