### PR TITLE
Set canvas style to override problem 3rd party css

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -19,12 +19,16 @@ export function createCanvasContext2D(
   opt_canvasPool,
   opt_Context2DSettings
 ) {
-  const canvas =
+  const canvas = /** @type {HTMLCanvasElement} */ (
     opt_canvasPool && opt_canvasPool.length
       ? opt_canvasPool.shift()
       : WORKER_OFFSCREEN_CANVAS
       ? new OffscreenCanvas(opt_width || 300, opt_height || 300)
-      : document.createElement('canvas');
+      : document.createElement('canvas')
+  );
+  if (canvas.style) {
+    canvas.style.all = 'initial';
+  }
   if (opt_width) {
     canvas.width = opt_width;
   }
@@ -32,9 +36,7 @@ export function createCanvasContext2D(
     canvas.height = opt_height;
   }
   //FIXME Allow OffscreenCanvasRenderingContext2D as return type
-  return /** @type {CanvasRenderingContext2D} */ (
-    canvas.getContext('2d', opt_Context2DSettings)
-  );
+  return canvas.getContext('2d', opt_Context2DSettings);
 }
 
 /**

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -19,14 +19,14 @@ export function createCanvasContext2D(
   opt_canvasPool,
   opt_Context2DSettings
 ) {
-  const canvas = /** @type {HTMLCanvasElement} */ (
-    opt_canvasPool && opt_canvasPool.length
-      ? opt_canvasPool.shift()
-      : WORKER_OFFSCREEN_CANVAS
-      ? new OffscreenCanvas(opt_width || 300, opt_height || 300)
-      : document.createElement('canvas')
-  );
-  if (canvas.style) {
+  /** @type {HTMLCanvasElement|OffscreenCanvas} */
+  let canvas;
+  if (opt_canvasPool && opt_canvasPool.length) {
+    canvas = opt_canvasPool.shift();
+  } else if (WORKER_OFFSCREEN_CANVAS) {
+    canvas = new OffscreenCanvas(opt_width || 300, opt_height || 300);
+  } else {
+    canvas = document.createElement('canvas');
     canvas.style.all = 'initial';
   }
   if (opt_width) {
@@ -36,7 +36,9 @@ export function createCanvasContext2D(
     canvas.height = opt_height;
   }
   //FIXME Allow OffscreenCanvasRenderingContext2D as return type
-  return canvas.getContext('2d', opt_Context2DSettings);
+  return /** @type {CanvasRenderingContext2D} */ (
+    canvas.getContext('2d', opt_Context2DSettings)
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #12439 and #12566
Replaces #12619

Set new canvas styles to `all: initial;` to override problems caused by third party css,  This is possible as OpenLayers only ever sets styles on canvas directly.