### PR TITLE
Only warn of zero size when map should be visible

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -1524,7 +1524,14 @@ class PluggableMap extends BaseObject {
         parseFloat(computedStyle['borderBottomWidth']);
       if (!isNaN(width) && !isNaN(height)) {
         size = [width, height];
-        if (!hasArea(size)) {
+        if (
+          !hasArea(size) &&
+          !!(
+            targetElement.offsetWidth ||
+            targetElement.offsetHeight ||
+            targetElement.getClientRects().length
+          )
+        ) {
           // eslint-disable-next-line
           console.warn(
             "No map visible because the map container's width or height are 0."


### PR DESCRIPTION
Fixes #12625

Solution based on https://stackoverflow.com/questions/19669786/check-if-element-is-visible-in-dom/33456469#33456469
