### PR TITLE
Fix fullscreen in mapbox-style example

### DIFF
--- a/examples/mapbox-style.css
+++ b/examples/mapbox-style.css
@@ -4,3 +4,13 @@
   top: auto;
   right: auto;
 }
+.map:-webkit-full-screen {
+  height: 100%;
+  margin: 0;
+}
+.map:-ms-fullscreen {
+  height: 100%;
+}
+.map:fullscreen {
+  height: 100%;
+}


### PR DESCRIPTION
This adds the same css as in the `fullscreen` example, to make sure the fullscreen map fills 100% of the viewport in browsers other than Chrome.