### PR TITLE
Additional docs and type checking for raster source

### DIFF
--- a/examples/raster.js
+++ b/examples/raster.js
@@ -5,7 +5,7 @@ import XYZ from '../src/ol/source/XYZ.js';
 import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
 
 const minVgi = 0;
-const maxVgi = 0.25;
+const maxVgi = 0.5;
 const bins = 10;
 
 /**
@@ -87,7 +87,7 @@ const raster = new RasterSource({
     summarize: summarize,
   },
 });
-raster.set('threshold', 0.1);
+raster.set('threshold', 0.25);
 
 function createCounts(min, max, num) {
   const values = new Array(num);


### PR DESCRIPTION
When a raster source is configured to use more than one thread, the shape of the data passed to the `afteroperations` listener changes.  For zero or one thread, the `data` property of the event is an object - the same object passed to any `beforeoperations` listener and to the operation itself.  When there is more than a single thread, the `data` property of the `afteroperations` event is an array of objects - one for each thread.  This is confusing, but the library has no way to reduce the user provided data objects into a single object in this case.  This was previously not documented.

The changes in this branch also add more types to the raster source module.

Fixes #12662.