### PR TITLE
Update Google KML icon anchors and correct icon scaling

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -318,7 +318,7 @@ function createStyleDefaults() {
     color: DEFAULT_COLOR,
   });
 
-  DEFAULT_IMAGE_STYLE_ANCHOR = [20, 2]; // FIXME maybe [8, 32] ?
+  DEFAULT_IMAGE_STYLE_ANCHOR = [20, 2];
 
   DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS = IconAnchorUnits.PIXELS;
 
@@ -1276,14 +1276,21 @@ function iconStyleParser(node, objectStack) {
     anchorXUnits = hotSpot.xunits;
     anchorYUnits = hotSpot.yunits;
     anchorOrigin = hotSpot.origin;
-  } else if (src === DEFAULT_IMAGE_STYLE_SRC) {
-    anchor = DEFAULT_IMAGE_STYLE_ANCHOR;
-    anchorXUnits = DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
-    anchorYUnits = DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
   } else if (/^http:\/\/maps\.(?:google|gstatic)\.com\//.test(src)) {
-    anchor = [0.5, 0];
-    anchorXUnits = IconAnchorUnits.FRACTION;
-    anchorYUnits = IconAnchorUnits.FRACTION;
+    // Google hotspots from https://kml4earth.appspot.com/icons.html#notes
+    if (/pushpin/.test(src)) {
+      anchor = DEFAULT_IMAGE_STYLE_ANCHOR;
+      anchorXUnits = DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
+      anchorYUnits = DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
+    } else if (/arrow-reverse/.test(src)) {
+      anchor = [54, 42];
+      anchorXUnits = DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
+      anchorYUnits = DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
+    } else if (/paddle/.test(src)) {
+      anchor = [32, 1];
+      anchorXUnits = DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS;
+      anchorYUnits = DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS;
+    }
   }
 
   let offset;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -314,7 +314,7 @@ export function getDefaultStyleArray() {
 function resizeScaleFunction(size) {
   const scale = 32 / Math.min(size[0], size[1]);
   return [scale, scale];
-};
+}
 
 function createStyleDefaults() {
   DEFAULT_COLOR = [255, 255, 255, 1];
@@ -1316,7 +1316,7 @@ function iconStyleParser(node, objectStack) {
     rotation = toRadians(heading);
   }
 
-  let scale = /** @type {number|undefined} */ (object['scale']);
+  const scale = /** @type {number|undefined} */ (object['scale']);
 
   const color = /** @type {Array<number>|undefined} */ (object['color']);
 

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -948,10 +948,11 @@ function createNameStyleFunction(foundStyle, name) {
     }
     if (imageSize.length == 2) {
       const imageScale = imageStyle.getScaleArray();
+      const resizeScale = resizeScaleFunction(imageSize);
       // Offset the label to be centered to the right of the icon,
       // if there is one.
-      textOffset[0] = (imageScale[0] * imageSize[0]) / 2;
-      textOffset[1] = (-imageScale[1] * imageSize[1]) / 2;
+      textOffset[0] = (imageScale[0] * resizeScale[0] * imageSize[0]) / 2;
+      textOffset[1] = (-imageScale[1] * resizeScale[1] * imageSize[1]) / 2;
       textAlign = 'left';
     }
   }

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -311,7 +311,7 @@ export function getDefaultStyleArray() {
  * @param {import("../size.js").Size} size Image size.
  * @return {import("../size.js").Size} Scale array.
  */
-function resizeScaleFunction(size) {
+export function resizeScaleFunction(size) {
   const scale = 32 / Math.min(size[0], size[1]);
   return [scale, scale];
 }
@@ -943,7 +943,7 @@ function createNameStyleFunction(foundStyle, name) {
   let textAlign = 'start';
   const imageStyle = foundStyle.getImage();
   if (imageStyle) {
-    let imageSize = imageStyle.getImageSize();
+    let imageSize = imageStyle.getSize();
     if (imageSize === null) {
       imageSize = DEFAULT_IMAGE_STYLE_SIZE;
     }
@@ -2629,7 +2629,7 @@ function writeIconStyle(node, style, objectStack) {
 
   let scale = style.getScaleArray()[0];
   if (!style.getResizeScaleFunction()) {
-    let imageSize = iconImageSize;
+    let imageSize = size;
     if (imageSize === null) {
       imageSize = DEFAULT_IMAGE_STYLE_SIZE;
     }

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -232,11 +232,6 @@ let DEFAULT_IMAGE_STYLE_SIZE;
 let DEFAULT_IMAGE_STYLE_SRC;
 
 /**
- * @type {number}
- */
-let DEFAULT_IMAGE_SCALE_MULTIPLIER;
-
-/**
  * @type {import("../style/Image.js").default}
  */
 let DEFAULT_IMAGE_STYLE = null;
@@ -311,6 +306,16 @@ export function getDefaultStyleArray() {
   return DEFAULT_STYLE_ARRAY;
 }
 
+/**
+ * Function that returns the scale needed to normalize an icon image to 32 pixels.
+ * @param {import("../size.js").Size} size Image size.
+ * @return {import("../size.js").Size} Scale array.
+ */
+function resizeScaleFunction(size) {
+  const scale = 32 / Math.min(size[0], size[1]);
+  return [scale, scale];
+};
+
 function createStyleDefaults() {
   DEFAULT_COLOR = [255, 255, 255, 1];
 
@@ -329,16 +334,14 @@ function createStyleDefaults() {
   DEFAULT_IMAGE_STYLE_SRC =
     'https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png';
 
-  DEFAULT_IMAGE_SCALE_MULTIPLIER = 0.5;
-
   DEFAULT_IMAGE_STYLE = new Icon({
     anchor: DEFAULT_IMAGE_STYLE_ANCHOR,
     anchorOrigin: IconOrigin.BOTTOM_LEFT,
     anchorXUnits: DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS,
     anchorYUnits: DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS,
     crossOrigin: 'anonymous',
+    resizeScaleFunction: resizeScaleFunction,
     rotation: 0,
-    scale: DEFAULT_IMAGE_SCALE_MULTIPLIER,
     size: DEFAULT_IMAGE_STYLE_SIZE,
     src: DEFAULT_IMAGE_STYLE_SRC,
   });
@@ -1320,9 +1323,6 @@ function iconStyleParser(node, objectStack) {
   if (drawIcon) {
     if (src == DEFAULT_IMAGE_STYLE_SRC) {
       size = DEFAULT_IMAGE_STYLE_SIZE;
-      if (scale === undefined) {
-        scale = DEFAULT_IMAGE_SCALE_MULTIPLIER;
-      }
     }
 
     const imageStyle = new Icon({
@@ -1333,6 +1333,7 @@ function iconStyleParser(node, objectStack) {
       crossOrigin: this.crossOrigin_,
       offset: offset,
       offsetOrigin: IconOrigin.BOTTOM_LEFT,
+      resizeScaleFunction: resizeScaleFunction,
       rotation: rotation,
       scale: scale,
       size: size,

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -334,7 +334,7 @@ function createStyleDefaults() {
   DEFAULT_IMAGE_STYLE_SRC =
     'https://maps.google.com/mapfiles/kml/pushpin/ylw-pushpin.png';
 
-  DEFAULT_IMAGE_STYLE = new Icon({
+  const imageStyle = new Icon({
     anchor: DEFAULT_IMAGE_STYLE_ANCHOR,
     anchorOrigin: IconOrigin.BOTTOM_LEFT,
     anchorXUnits: DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS,
@@ -344,7 +344,8 @@ function createStyleDefaults() {
     size: DEFAULT_IMAGE_STYLE_SIZE,
     src: DEFAULT_IMAGE_STYLE_SRC,
   });
-  DEFAULT_IMAGE_STYLE.setResizeScaleFunction(resizeScaleFunction);
+  imageStyle.setResizeScaleFunction(resizeScaleFunction);
+  DEFAULT_IMAGE_STYLE = imageStyle;
 
   DEFAULT_NO_IMAGE_STYLE = 'NO_IMAGE';
 

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -340,11 +340,11 @@ function createStyleDefaults() {
     anchorXUnits: DEFAULT_IMAGE_STYLE_ANCHOR_X_UNITS,
     anchorYUnits: DEFAULT_IMAGE_STYLE_ANCHOR_Y_UNITS,
     crossOrigin: 'anonymous',
-    resizeScaleFunction: resizeScaleFunction,
     rotation: 0,
     size: DEFAULT_IMAGE_STYLE_SIZE,
     src: DEFAULT_IMAGE_STYLE_SRC,
   });
+  DEFAULT_IMAGE_STYLE.setResizeScaleFunction(resizeScaleFunction);
 
   DEFAULT_NO_IMAGE_STYLE = 'NO_IMAGE';
 
@@ -1334,13 +1334,13 @@ function iconStyleParser(node, objectStack) {
       crossOrigin: this.crossOrigin_,
       offset: offset,
       offsetOrigin: IconOrigin.BOTTOM_LEFT,
-      resizeScaleFunction: resizeScaleFunction,
       rotation: rotation,
       scale: scale,
       size: size,
       src: this.iconUrlFunction_(src),
       color: color,
     });
+    imageStyle.setResizeScaleFunction(resizeScaleFunction);
     styleObject['imageStyle'] = imageStyle;
   } else {
     // handle the case when we explicitly want to draw no icon.
@@ -2626,7 +2626,17 @@ function writeIconStyle(node, style, objectStack) {
 
   properties['Icon'] = iconProperties;
 
-  const scale = style.getScale();
+  let scale = style.getScaleArray()[0];
+  if (!style.getResizeScaleFunction()) {
+    let imageSize = iconImageSize;
+    if (imageSize === null) {
+      imageSize = DEFAULT_IMAGE_STYLE_SIZE;
+    }
+    if (imageSize.length == 2) {
+      const resizeScale = resizeScaleFunction(imageSize);
+      scale = scale / resizeScale[0];
+    }
+  }
   if (scale !== 1) {
     properties['scale'] = scale;
   }

--- a/src/ol/render/canvas/ImageBuilder.js
+++ b/src/ol/render/canvas/ImageBuilder.js
@@ -242,6 +242,8 @@ class CanvasImageBuilder extends CanvasBuilder {
     const hitDetectionImage = imageStyle.getHitDetectionImage();
     const image = imageStyle.getImage(this.pixelRatio);
     const origin = imageStyle.getOrigin();
+    const scale = imageStyle.getScaleArray();
+    const resizeScale = imageStyle.getResizeScaleArray();
     this.imagePixelRatio_ = imageStyle.getPixelRatio(this.pixelRatio);
     this.anchorX_ = anchor[0];
     this.anchorY_ = anchor[1];
@@ -253,7 +255,7 @@ class CanvasImageBuilder extends CanvasBuilder {
     this.originY_ = origin[1];
     this.rotateWithView_ = imageStyle.getRotateWithView();
     this.rotation_ = imageStyle.getRotation();
-    this.scale_ = imageStyle.getScaleArray();
+    this.scale_ = [scale[0] * resizeScale[0], scale[1] * resizeScale[1]];
     this.width_ = size[0];
     this.declutterImageWithText_ = opt_sharedData;
   }

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -1054,6 +1054,8 @@ class CanvasImmediateRenderer extends VectorContext {
     }
     const imageAnchor = imageStyle.getAnchor();
     const imageOrigin = imageStyle.getOrigin();
+    const scale = imageStyle.getScaleArray();
+    const resizeScale = imageStyle.getResizeScaleArray();
     this.image_ = imageStyle.getImage(this.pixelRatio_);
     this.imageAnchorX_ = imageAnchor[0] * this.pixelRatio_;
     this.imageAnchorY_ = imageAnchor[1] * this.pixelRatio_;
@@ -1063,7 +1065,7 @@ class CanvasImmediateRenderer extends VectorContext {
     this.imageOriginY_ = imageOrigin[1];
     this.imageRotateWithView_ = imageStyle.getRotateWithView();
     this.imageRotation_ = imageStyle.getRotation();
-    this.imageScale_ = imageStyle.getScaleArray();
+    this.imageScale_ = [scale[0] * resizeScale[0], scale[1] * resizeScale[1]];
     this.imageWidth_ = imageSize[0] * this.pixelRatio_;
   }
 

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -223,7 +223,7 @@ class Icon extends ImageStyle {
      * @private
      * @type {ResizeScaleFunction}
      */
-    this.resizeScaleFunction_ = option.resizeScaleFunction;
+    this.resizeScaleFunction_ = options.resizeScaleFunction;
 
     /**
      * @private

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -17,7 +17,6 @@ import {getUid} from '../util.js';
  * normalize to a standard size, for example for KML.
  *
  * @typedef {function(import("../size.js").Size):import("../size.js").Size} ResizeScaleFunction
- * @api
  */
 
 /**
@@ -52,8 +51,6 @@ import {getUid} from '../util.js';
  * sub-rectangle to use from the origin (sprite) icon image.
  * @property {import("../size.js").Size} [imgSize] Image size in pixels. Only required if `img` is set and `src` is not, and
  * for SVG images in Internet Explorer 11. The provided `imgSize` needs to match the actual size of the image.
- * @property {ResizeScaleFunction} [resizeScaleFunction] Function that takes an icon image size
- * and returns the scale array needed to normalize to a standard size, for example for KML.
  * @property {string} [src] Image source URI.
  */
 
@@ -198,6 +195,7 @@ class Icon extends ImageStyle {
      * @type {Array<number>}
      */
     this.offset_ = options.offset !== undefined ? options.offset : [0, 0];
+
     /**
      * @private
      * @type {import("./IconOrigin.js").default}
@@ -223,13 +221,13 @@ class Icon extends ImageStyle {
      * @private
      * @type {ResizeScaleFunction}
      */
-    this.resizeScaleFunction_ = options.resizeScaleFunction;
+    this.resizeScaleFunction_ = undefined;
 
     /**
      * @private
      * @type {import("../size.js").Size}
      */
-    this.resizeScaleArray_ = this.resizeScaleFunction_ ? null : [1, 1];
+    this.resizeScaleArray_ = [1, 1];
   }
 
   /**
@@ -430,6 +428,23 @@ class Icon extends ImageStyle {
    */
   getSize() {
     return !this.size_ ? this.iconImage_.getSize() : this.size_;
+  }
+
+  /**
+   * Set the resizeScaleFunction.
+   * @param {ResizeScaleFunction} resizeScaleFunction.
+   */
+  setResizeScaleFunction(resizeScaleFunction) {
+    this.resizeScaleFunction_ = resizeScaleFunction;
+    this.resizeScaleArray_ = this.resizeScaleFunction_ ? null : [1, 1];
+  }
+
+  /**
+   * Get the resizeScaleFunction.
+   * @return {ResizeScaleFunction} resizeScaleFunction.
+   */
+  getResizeScaleFunction() {
+    return this.resizeScaleFunction_;
   }
 
   /**

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -237,7 +237,7 @@ class Icon extends ImageStyle {
    */
   clone() {
     const scale = this.getScale();
-    return new Icon({
+    const style = new Icon({
       anchor: this.anchor_.slice(),
       anchorOrigin: this.anchorOrigin_,
       anchorXUnits: this.anchorXUnits_,
@@ -253,10 +253,11 @@ class Icon extends ImageStyle {
       size: this.size_ !== null ? this.size_.slice() : undefined,
       opacity: this.getOpacity(),
       scale: Array.isArray(scale) ? scale.slice() : scale,
-      resizeScaleFunction: this.resizeScaleFunction_,
       rotation: this.getRotation(),
       rotateWithView: this.getRotateWithView(),
     });
+    style.setResizeScaleFunction(this.resizeScaleFunction_);
+    return style;
   }
 
   /**
@@ -432,7 +433,7 @@ class Icon extends ImageStyle {
 
   /**
    * Set the resizeScaleFunction.
-   * @param {ResizeScaleFunction} resizeScaleFunction.
+   * @param {ResizeScaleFunction} resizeScaleFunction resizeScaleFunction.
    */
   setResizeScaleFunction(resizeScaleFunction) {
     this.resizeScaleFunction_ = resizeScaleFunction;

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -124,6 +124,14 @@ class ImageStyle {
   }
 
   /**
+   * Get the scale needed to normalize the image.
+   * @return {import("../size.js").Size} Scale array.
+   */
+  getResizeScaleArray() {
+    return [1, 1];
+  }
+
+  /**
    * Get the displacement of the shape
    * @return {Array<number>} Shape's center displacement
    * @api

--- a/test/browser/spec/ol/format/kml.test.js
+++ b/test/browser/spec/ol/format/kml.test.js
@@ -14,6 +14,7 @@ import KML, {
   getDefaultStyleArray,
   getDefaultTextStyle,
   readFlatCoordinates,
+  resizeScaleFunction,
 } from '../../../../../src/ol/format/KML.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import LinearRing from '../../../../../src/ol/geom/LinearRing.js';
@@ -2996,7 +2997,62 @@ describe('ol.format.KML', function () {
           expect(style.getText().getText()).to.eql("Joe's Test");
         });
 
-        it("can write an feature's icon style", function () {
+        it("can write an feature's icon style from a style using resizeScaleFunction", function () {
+          const style = new Style({
+            image: new Icon({
+              anchor: [0.25, 36],
+              anchorOrigin: 'top-left',
+              anchorXUnits: 'fraction',
+              anchorYUnits: 'pixels',
+              crossOrigin: 'anonymous',
+              offset: [96, 96],
+              offsetOrigin: 'top-left',
+              rotation: 45,
+              scale: 0.5,
+              size: [48, 48],
+              src: 'http://foo.png',
+              color: 'rgba(255,0,0,1)',
+            }),
+          });
+          const imageStyle = style.getImage();
+          imageStyle.setResizeScaleFunction(resizeScaleFunction);
+          imageStyle.iconImage_.size_ = [192, 144]; // sprite de 12 images(4*3)
+          const feature = new Feature();
+          feature.setStyle([style]);
+          const node = format.writeFeaturesNode([feature]);
+          const text =
+            '<kml xmlns="http://www.opengis.net/kml/2.2"' +
+            ' xmlns:gx="http://www.google.com/kml/ext/2.2"' +
+            ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' +
+            ' xsi:schemaLocation="http://www.opengis.net/kml/2.2' +
+            ' https://developers.google.com/kml/schema/kml22gx.xsd">' +
+            '  <Placemark>' +
+            '    <Style>' +
+            '      <IconStyle>' +
+            '        <scale>0.5</scale>' +
+            '        <heading>45</heading>' +
+            '        <Icon>' +
+            '          <href>http://foo.png</href>' +
+            '          <gx:x>96</gx:x>' +
+            '          <gx:y>0</gx:y>' +
+            '          <gx:w>48</gx:w>' +
+            '          <gx:h>48</gx:h>' +
+            '        </Icon>' +
+            '        <color>ff0000ff</color>' +
+            '        <hotSpot x="12" y="12" xunits="pixels" ' +
+            '                 yunits="pixels"/>' +
+            '      </IconStyle>' +
+            '      <PolyStyle>' +
+            '        <fill>0</fill>' +
+            '        <outline>0</outline>' +
+            '      </PolyStyle>' +
+            '    </Style>' +
+            '  </Placemark>' +
+            '</kml>';
+          expect(node).to.xmleql(parse(text));
+        });
+
+        it("can write an feature's icon style from a style without resizeScaleFunction", function () {
           const style = new Style({
             image: new Icon({
               anchor: [0.25, 36],
@@ -3027,7 +3083,7 @@ describe('ol.format.KML', function () {
             '  <Placemark>' +
             '    <Style>' +
             '      <IconStyle>' +
-            '        <scale>0.5</scale>' +
+            '        <scale>0.75</scale>' +
             '        <heading>45</heading>' +
             '        <Icon>' +
             '          <href>http://foo.png</href>' +


### PR DESCRIPTION
Fixes #12670

Use the hotspots listed in https://kml4earth.appspot.com/icons.html#notes as the default anchors for Google icons.

Add `resizeScaleFunction` option to `ol/Style/Icon` to normalize a KML icon images to 32 pixels as described in https://groups.google.com/g/google-earth-browser-plugin/c/bj_9poNvB2A and https://stackoverflow.com/a/22569590/10118270. Replace `DEFAULT_IMAGE_SCALE_MULTIPLIER` in `ol/format/KML` with a `resizeScaleFunction`.  Apply the resize scale in renderers.
