### PR TITLE
Fix view resolutions in example

### DIFF
--- a/examples/offscreen-canvas.js
+++ b/examples/offscreen-canvas.js
@@ -92,7 +92,7 @@ const map = new Map({
   ],
   target: 'map',
   view: new View({
-    resolutions: createXYZ({tileSize: 512}).getResolutions89,
+    resolutions: createXYZ({tileSize: 512}).getResolutions(),
     center: [0, 0],
     zoom: 2,
   }),


### PR DESCRIPTION
Presumably the shift key was not working (a corresponding change to initial zoom may be needed depending on what was intended).