### PR TITLE
Fix return stride of forEachSegment

### DIFF
--- a/src/ol/geom/flat/segments.js
+++ b/src/ol/geom/flat/segments.js
@@ -16,18 +16,16 @@
  * @template T
  */
 export function forEach(flatCoordinates, offset, end, stride, callback) {
-  const point1 = [flatCoordinates[offset], flatCoordinates[offset + 1]];
-  const point2 = [];
   let ret;
-  for (; offset + stride < end; offset += stride) {
-    point2[0] = flatCoordinates[offset + stride];
-    point2[1] = flatCoordinates[offset + stride + 1];
-    ret = callback(point1, point2);
+  offset += stride;
+  for (; offset < end; offset += stride) {
+    ret = callback(
+      flatCoordinates.slice(offset - stride, offset),
+      flatCoordinates.slice(offset, offset + stride)
+    );
     if (ret) {
       return ret;
     }
-    point1[0] = point2[0];
-    point1[1] = point2[1];
   }
   return false;
 }

--- a/test/node/ol/geom/flat/segments.test.js
+++ b/test/node/ol/geom/flat/segments.test.js
@@ -50,5 +50,18 @@ describe('ol/geom/flat/segments.js', function () {
         expect(ret).to.be(true);
       });
     });
+    it('returns coordinates with the correct stride', function () {
+      const spy = sinon.spy();
+      forEachSegment([0, 0, 0, 1, 1, 1, 2, 2, 2], 0, 9, 3, spy);
+      expect(spy.callCount).to.be(2);
+      expect(spy.firstCall.args).to.eql([
+        [0, 0, 0],
+        [1, 1, 1],
+      ]);
+      expect(spy.secondCall.args).to.eql([
+        [1, 1, 1],
+        [2, 2, 2],
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This pull request simplifies the `segments.forEach()` function, and changes it so it returns coordinates with the same dimensions as the input coordinates. Previously it only returned two dimensions.

Fixes #12689. Also fixes #11371.