### PR TITLE
Move description above type tag

### DIFF
--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -104,8 +104,8 @@ class MousePosition extends Control {
     }
 
     /**
-     * @type {boolean}
      * Change this to `false` when removing the deprecated `undefinedHTML` option.
+     * @type {boolean}
      */
     let renderOnMouseOut = true;
 


### PR DESCRIPTION
This removes a warning from JSDoc about `@type` tags not being able to have a description.