### PR TITLE
Test GeoTiffs without projection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /coverage/
 /dist/
 node_modules/
+.vscode/launch.json

--- a/examples/oblique.html
+++ b/examples/oblique.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: Cloud Optimized GeoTIFF Without georeference (COG)
+shortdesc: Rendering a COG as a tiled layer without georeference.
+docs: >
+  Tiled data from a Cloud Optimized GeoTIFF (COG) can be rendered as a layer.  In this
+  example, an oblique geotiff without georeference is used, RGB.
+tags: "cog"
+---
+<div id="map" class="map"></div>

--- a/examples/oblique.js
+++ b/examples/oblique.js
@@ -1,0 +1,44 @@
+import GeoTIFF from "../src/ol/source/GeoTIFF.js";
+import Map from "../src/ol/Map.js";
+import Projection from "../src/ol/proj/Projection.js";
+import TileLayer from "../src/ol/layer/WebGLTile.js";
+import View from "../src/ol/View.js";
+import proj4 from "proj4";
+import { getCenter } from "../src/ol/extent.js";
+import { register } from "../src/ol/proj/proj4.js";
+
+
+// In reality this does not matter as GeoTIFF.js nulls the projection...
+// It would however be nice if you could send a flag to use the supplied projection, with extent
+// Instead of assuming that the geoKeys attribute is present, when for oblique imagery it might not. 
+const projection = new Projection({
+  code: "oblique-image",
+  extent: [0,0,13470,8670],
+});
+
+const cogExtent = [0,0,13470,8670]; // Correspond to the width and height of the image [xmin, ymin, xmax, ymax] 
+const cogUrl =
+  "https://tmp-asger-public.s3.eu-central-1.amazonaws.com/2017_84_40_1_0015_00008062.cog.tif";
+const cog_layer =  new TileLayer({
+    source: new GeoTIFF({
+      sources: [
+        {
+          test: true, // To test stuff that wont break existing functionality
+          projection: projection,
+          url: cogUrl,
+        },
+      ],
+    }),
+    extent: cogExtent,
+  });
+const map = new Map({
+  target: "map",
+  layers: [
+    cog_layer,
+  ],
+  view: new View({
+    center: getCenter(cogExtent),
+    extent: cogExtent,
+    zoom: 12, //Not sure how this value correspond to relative zoom
+  }),
+});


### PR DESCRIPTION
In relation to #12644 and the newly merged #12008 it seems that COG's without supplied projection / geokeys does not work because the methods used to grab the extent, origin etc. assumes that geokeys are set. An excpetion regarding "missing affine transformation" is raised on the source. 

In the example "oblique.html" we have tried to hack the `ol/GeoTiff.js` implementation, to show that with fairly minimal changes to the code and a passed flag we can probably display COG's in a local coordinate system instead where the resolution is something like 1 meter = 1 pixel. 

There seems to be a bug with the RGB channels, which i do not know the source of. Any help to get this kind of functionality into OpenLayers would be appreaciated. 