### PR TITLE
Use band numbers starting with one

### DIFF
--- a/examples/cog-math-multisource.js
+++ b/examples/cog-math-multisource.js
@@ -7,14 +7,14 @@ const source = new GeoTIFF({
   sources: [
     {
       url: 'https://s2downloads.eox.at/demo/Sentinel-2/3857/R10m.tif',
-      bands: [2, 3],
+      bands: [3, 4],
       min: 0,
       nodata: 0,
       max: 65535,
     },
     {
       url: 'https://s2downloads.eox.at/demo/Sentinel-2/3857/R60m.tif',
-      bands: [8],
+      bands: [9],
       min: 0,
       nodata: 0,
       max: 65535,


### PR DESCRIPTION
The `band` operator in raster style expressions works with band numbers starting with 1.  This is for consistency with the use of band numbers in GDAL and related software.  This branch updates the `bands` option for the GeoTIFF source to work with one-based band numbers as well (as opposed to a zero-based band index).  This is likely to trip people up, but I think we should at least be consistent between the `band` operator and the `bands` option.