### PR TITLE
Add convertToRGB option to GeoTIFF source

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.6.2-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "geotiff": "^1.0.4",
+        "geotiff": "^1.0.5",
         "ol-mapbox-style": "^6.4.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -5354,12 +5354,13 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.4.tgz",
-      "integrity": "sha512-JmtpvVHlxvyrWgT6Uf0sy7flmXhjWtG0cqVv+G9fMcupV4DAPdTv7tkhsoMnn9RpIIwolveB/VnyII8cRMOD7A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
+      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
       "dependencies": {
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",
+        "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
         "pako": "^1.0.11",
         "parse-headers": "^2.0.2",
@@ -7068,6 +7069,11 @@
       "bin": {
         "lcov-parse": "bin/cli.js"
       }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -15568,12 +15574,13 @@
       "dev": true
     },
     "geotiff": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.4.tgz",
-      "integrity": "sha512-JmtpvVHlxvyrWgT6Uf0sy7flmXhjWtG0cqVv+G9fMcupV4DAPdTv7tkhsoMnn9RpIIwolveB/VnyII8cRMOD7A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
+      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
       "requires": {
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",
+        "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
         "pako": "^1.0.11",
         "parse-headers": "^2.0.2",
@@ -16855,6 +16862,11 @@
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
       "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
       "dev": true
+    },
+    "lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://opencollective.com/openlayers"
   },
   "dependencies": {
-    "geotiff": "^1.0.4",
+    "geotiff": "^1.0.5",
     "ol-mapbox-style": "^6.4.1",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"

--- a/test/browser/spec/ol/source/geotiff.test.js
+++ b/test/browser/spec/ol/source/geotiff.test.js
@@ -3,46 +3,72 @@ import State from '../../../../../src/ol/source/State.js';
 import TileState from '../../../../../src/ol/TileState.js';
 
 describe('ol/source/GeoTIFF', function () {
-  /** @type {GeoTIFFSource} */
-  let source;
-  beforeEach(function () {
-    source = new GeoTIFFSource({
-      sources: [
-        {
-          url: 'spec/ol/source/images/0-0-0.tif',
-        },
-      ],
+  describe('constructor', function () {
+    it('configures readMethod_ to read rasters', function () {
+      const source = new GeoTIFFSource({
+        sources: [
+          {
+            url: 'spec/ol/source/images/0-0-0.tif',
+          },
+        ],
+      });
+      expect(source.readMethod_).to.be('readRasters');
+    });
+    it('configures readMethod_ to read RGB', function () {
+      const source = new GeoTIFFSource({
+        convertToRGB: true,
+        sources: [
+          {
+            url: 'spec/ol/source/images/0-0-0.tif',
+          },
+        ],
+      });
+      expect(source.readMethod_).to.be('readRGB');
     });
   });
 
-  it('manages load states', function (done) {
-    expect(source.getState()).to.be(State.LOADING);
-    source.on('change', () => {
-      expect(source.getState()).to.be(State.READY);
-      done();
+  describe('loading', function () {
+    /** @type {GeoTIFFSource} */
+    let source;
+    beforeEach(function () {
+      source = new GeoTIFFSource({
+        sources: [
+          {
+            url: 'spec/ol/source/images/0-0-0.tif',
+          },
+        ],
+      });
     });
-  });
 
-  it('configures itself from source metadata', function (done) {
-    source.on('change', () => {
-      expect(source.addAlpha_).to.be(true);
-      expect(source.bandCount).to.be(4);
-      expect(source.nodataValues_).to.eql([[0]]);
-      expect(source.getTileGrid().getResolutions().length).to.be(1);
-      expect(source.projection.getCode()).to.be('EPSG:4326');
-      expect(source.projection.getUnits()).to.be('degrees');
-      done();
-    });
-  });
-
-  it('loads tiles', function (done) {
-    source.on('change', () => {
-      const tile = source.getTile(0, 0, 0);
-      source.on('tileloadend', () => {
-        expect(tile.getState()).to.be(TileState.LOADED);
+    it('manages load states', function (done) {
+      expect(source.getState()).to.be(State.LOADING);
+      source.on('change', () => {
+        expect(source.getState()).to.be(State.READY);
         done();
       });
-      tile.load();
+    });
+
+    it('configures itself from source metadata', function (done) {
+      source.on('change', () => {
+        expect(source.addAlpha_).to.be(true);
+        expect(source.bandCount).to.be(4);
+        expect(source.nodataValues_).to.eql([[0]]);
+        expect(source.getTileGrid().getResolutions().length).to.be(1);
+        expect(source.projection.getCode()).to.be('EPSG:4326');
+        expect(source.projection.getUnits()).to.be('degrees');
+        done();
+      });
+    });
+
+    it('loads tiles', function (done) {
+      source.on('change', () => {
+        const tile = source.getTile(0, 0, 0);
+        source.on('tileloadend', () => {
+          expect(tile.getState()).to.be(TileState.LOADED);
+          done();
+        });
+        tile.load();
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request adds a new option, `convertToRGB`, to the GeoTIFF source. When set to true, the `readRGB` function is used instead of `readRasters` when reading data from geotiff.js.

I'm marking this as draft until geotiffjs/geotiff.js#236 is merged and we can update geotiff.js to a new release.

Depends on geotiffjs/geotiff.js#236
Fixes #12700.