### PR TITLE
Check for GeoTIFF CRS starting with last image

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -357,13 +357,17 @@ class GeoTIFFSource extends DataTile {
     }
 
     if (!this.getProjection()) {
-      const firstImage = sources[0][0];
-      if (firstImage.geoKeys) {
-        const code =
-          firstImage.geoKeys.ProjectedCSTypeGeoKey ||
-          firstImage.geoKeys.GeographicTypeGeoKey;
-        if (code) {
-          this.projection = getProjection(`EPSG:${code}`);
+      const firstSource = sources[0];
+      for (let i = firstSource.length - 1; i >= 0; --i) {
+        const image = firstSource[i];
+        if (image.geoKeys) {
+          const code =
+            image.geoKeys.ProjectedCSTypeGeoKey ||
+            image.geoKeys.GeographicTypeGeoKey;
+          if (code) {
+            this.projection = getProjection(`EPSG:${code}`);
+            break;
+          }
         }
       }
     }


### PR DESCRIPTION
Currently, the GeoTIFF source only checks the first image when trying to assign a projection to the source.  In practice, it looks like it is typically the last image that has projection-related metadata (if any) – the overviews do not generally have this metadata.

This branch makes it so we check all images for CRS metadata, starting with the last.