### PR TITLE
Avoid creating duplicate projections in COG examples

### DIFF
--- a/examples/cog-math.js
+++ b/examples/cog-math.js
@@ -1,6 +1,5 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
-import Projection from '../src/ol/proj/Projection.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
 import proj4 from 'proj4';
@@ -9,11 +8,6 @@ import {register} from '../src/ol/proj/proj4.js';
 
 proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
 register(proj4);
-
-const projection = new Projection({
-  code: 'EPSG:32636',
-  extent: [166021.44, 0.0, 534994.66, 9329005.18],
-});
 
 // metadata from https://s3.us-west-2.amazonaws.com/sentinel-cogs/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/S2A_36QWD_20200701_0_L2A.json
 const sourceExtent = [499980, 1790220, 609780, 1900020];
@@ -93,9 +87,9 @@ const map = new Map({
     }),
   ],
   view: new View({
+    projection: 'EPSG:32636',
     center: getCenter(sourceExtent),
     extent: sourceExtent,
     zoom: 9,
-    projection: projection,
   }),
 });

--- a/examples/cog-overviews.js
+++ b/examples/cog-overviews.js
@@ -1,6 +1,5 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
-import Projection from '../src/ol/proj/Projection.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
 import proj4 from 'proj4';
@@ -9,11 +8,6 @@ import {register} from '../src/ol/proj/proj4.js';
 
 proj4.defs('EPSG:32645', '+proj=utm +zone=45 +datum=WGS84 +units=m +no_defs');
 register(proj4);
-
-const projection = new Projection({
-  code: 'EPSG:32645',
-  extent: [166021.44, 0.0, 534994.66, 9329005.18],
-});
 
 const sourceExtent = [382200, 2279370, 610530, 2512500];
 
@@ -60,9 +54,9 @@ const map = new Map({
     }),
   ],
   view: new View({
+    projection: 'EPSG:32645',
     center: getCenter(sourceExtent),
     extent: sourceExtent,
     zoom: 8,
-    projection: projection,
   }),
 });

--- a/examples/cog.js
+++ b/examples/cog.js
@@ -1,6 +1,5 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
-import Projection from '../src/ol/proj/Projection.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
 import proj4 from 'proj4';
@@ -9,11 +8,6 @@ import {register} from '../src/ol/proj/proj4.js';
 
 proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
 register(proj4);
-
-const projection = new Projection({
-  code: 'EPSG:32636',
-  extent: [166021.44, 0.0, 534994.66, 9329005.18],
-});
 
 // metadata from https://s3.us-west-2.amazonaws.com/sentinel-cogs/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/S2A_36QWD_20200701_0_L2A.json
 const sourceExtent = [499980, 1790220, 609780, 1900020];
@@ -33,9 +27,9 @@ const map = new Map({
     }),
   ],
   view: new View({
+    projection: 'EPSG:32636',
     center: getCenter(sourceExtent),
     extent: sourceExtent,
     zoom: 9,
-    projection: projection,
   }),
 });

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -424,7 +424,7 @@ class GeoTIFFSource extends DataTile {
             image.geoKeys.ProjectedCSTypeGeoKey ||
             image.geoKeys.GeographicTypeGeoKey;
           if (code) {
-            this.projection = getProjection(`EPSG:${code}`);
+            this.projection = getProjection('EPSG:' + code);
             break;
           }
         }


### PR DESCRIPTION
This simplifies the COG examples by removing the duplicate projection creation.  Subtle, but the projection (registered with proj) had units but no extent, and the projection on the view had an extent but no units.