### PR TITLE
Try harder to get the projection from GeoTIFF headers

### DIFF
--- a/src/ol/proj/Units.js
+++ b/src/ol/proj/Units.js
@@ -9,6 +9,11 @@
  */
 const Units = {
   /**
+   * Radians
+   * @api
+   */
+  RADIANS: 'radians',
+  /**
    * Degrees
    * @api
    */
@@ -41,6 +46,26 @@ const Units = {
 };
 
 /**
+ * See http://duff.ess.washington.edu/data/raster/drg/docs/geotiff.txt
+ * @type {Object<number, Units>}
+ */
+const unitByCode = {
+  '9001': Units.METERS,
+  '9002': Units.FEET,
+  '9003': Units.USFEET,
+  '9101': Units.RADIANS,
+  '9102': Units.DEGREES,
+};
+
+/**
+ * @param {number} code Unit code.
+ * @return {Units} Units.
+ */
+export function fromCode(code) {
+  return unitByCode[code];
+}
+
+/**
  * Meters per unit lookup table.
  * @const
  * @type {Object<Units, number>}
@@ -48,6 +73,7 @@ const Units = {
  */
 export const METERS_PER_UNIT = {};
 // use the radius of the Normal sphere
+METERS_PER_UNIT[Units.RADIANS] = 6370997 / (2 * Math.PI);
 METERS_PER_UNIT[Units.DEGREES] = (2 * Math.PI * 6370997) / 360;
 METERS_PER_UNIT[Units.FEET] = 0.3048;
 METERS_PER_UNIT[Units.METERS] = 1;

--- a/test/browser/spec/ol/source/geotiff.test.js
+++ b/test/browser/spec/ol/source/geotiff.test.js
@@ -2,7 +2,7 @@ import GeoTIFFSource from '../../../../../src/ol/source/GeoTIFF.js';
 import State from '../../../../../src/ol/source/State.js';
 import TileState from '../../../../../src/ol/TileState.js';
 
-describe('ol.source.GeoTIFF', function () {
+describe('ol/source/GeoTIFF', function () {
   /** @type {GeoTIFFSource} */
   let source;
   beforeEach(function () {
@@ -30,6 +30,7 @@ describe('ol.source.GeoTIFF', function () {
       expect(source.nodataValues_).to.eql([[0]]);
       expect(source.getTileGrid().getResolutions().length).to.be(1);
       expect(source.projection.getCode()).to.be('EPSG:4326');
+      expect(source.projection.getUnits()).to.be('degrees');
       done();
     });
   });


### PR DESCRIPTION
This adds logic to extract the CRS units from GeoTIFF headers when configuring a source.