### PR TITLE
Add <meta charset="utf-8"> to Quick Start

### DIFF
--- a/doc/quickstart.hbs
+++ b/doc/quickstart.hbs
@@ -18,6 +18,7 @@ Below you'll find a complete working example.  Create a new file, copy in the co
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/{{ latest }}/css/ol.css" type="text/css">
     <style>
       .map {


### PR DESCRIPTION
While this is not currently needed with the jsdelivr build (when it is working) since v6.7.0 it is needed when a downloaded legacy build is used, and is good practice in all cases.