### PR TITLE
OnSignatures return more specific type

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -81,12 +81,12 @@ class Collection extends BaseObject {
     super();
 
     /***
-     * @type {CollectionOnSignature<import("./Observable.js").OnReturn>}
+     * @type {CollectionOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {CollectionOnSignature<import("./Observable.js").OnReturn>}
+     * @type {CollectionOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -83,12 +83,12 @@ class Feature extends BaseObject {
     super();
 
     /***
-     * @type {FeatureOnSignature<import("./Observable.js").OnReturn>}
+     * @type {FeatureOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {FeatureOnSignature<import("./Observable.js").OnReturn>}
+     * @type {FeatureOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -107,12 +107,12 @@ class Geolocation extends BaseObject {
     super();
 
     /***
-     * @type {GeolocationOnSignature<import("./Observable.js").OnReturn>}
+     * @type {GeolocationOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {GeolocationOnSignature<import("./Observable.js").OnReturn>}
+     * @type {GeolocationOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -95,12 +95,12 @@ class BaseObject extends Observable {
     super();
 
     /***
-     * @type {ObjectOnSignature<import("./Observable.js").OnReturn>}
+     * @type {ObjectOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ObjectOnSignature<import("./Observable.js").OnReturn>}
+     * @type {ObjectOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -9,21 +9,22 @@ import {listen, listenOnce, unlistenByKey} from './events.js';
  * @template {string} Type
  * @template {Event|import("./events/Event.js").default} EventClass
  * @template Return
- * @typedef {(type: Type|Type[], listener: (event: EventClass) => ?) => Return} OnSignature
+ * @typedef {(type: Type, listener: (event: EventClass) => ?) => Return} OnSignature
  */
 
 /***
  * @template {string} Type
  * @template Return
- * @typedef {(type: Type[], listener: (event: Event|import("./events/Event").default) => ?) => Return} CombinedOnSignature
- */
-
-/***
- * @typedef {import("./events").EventsKey|Array<import("./events").EventsKey>} OnReturn
+ * @typedef {(type: Type[], listener: (event: Event|import("./events/Event").default) => ?) => Return extends void ? void : Return[]} CombinedOnSignature
  */
 
 /**
  * @typedef {'change'|'error'} EventTypes
+ */
+
+/***
+ * @template Return
+ * @typedef {OnSignature<EventTypes, import("./events/Event.js").default, Return> & CombinedOnSignature<EventTypes, Return>} ObservableOnSignature
  */
 
 /**
@@ -41,20 +42,17 @@ class Observable extends EventTarget {
   constructor() {
     super();
 
-    /***
-     * @type {OnSignature<EventTypes, import("./events/Event.js").default, OnReturn>}
-     */
-    this.on = this.onInternal;
+    this.on =
+      /** @type {ObservableOnSignature<import("./events").EventsKey>} */ (
+        this.onInternal
+      );
 
-    /***
-     * @type {OnSignature<EventTypes, import("./events/Event.js").default, OnReturn>}
-     */
-    this.once = this.onceInternal;
+    this.once =
+      /** @type {ObservableOnSignature<import("./events").EventsKey>} */ (
+        this.onceInternal
+      );
 
-    /***
-     * @type {OnSignature<EventTypes, import("./events/Event.js").default, void>}
-     */
-    this.un = this.unInternal;
+    this.un = /** @type {ObservableOnSignature<void>} */ (this.unInternal);
 
     /**
      * @private
@@ -84,7 +82,7 @@ class Observable extends EventTarget {
 
   /**
    * @param {string|Array<string>} type Type.
-   * @param {function(?): ?} listener Listener.
+   * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Event key.
    * @protected
    */
@@ -103,7 +101,7 @@ class Observable extends EventTarget {
 
   /**
    * @param {string|Array<string>} type Type.
-   * @param {function(?): ?} listener Listener.
+   * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Event key.
    * @protected
    */
@@ -125,7 +123,7 @@ class Observable extends EventTarget {
   /**
    * Unlisten for a certain type of event.
    * @param {string|Array<string>} type Type.
-   * @param {function(?): ?} listener Listener.
+   * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @protected
    */
   unInternal(type, listener) {

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -123,12 +123,12 @@ class Overlay extends BaseObject {
     super();
 
     /***
-     * @type {OverlayOnSignature<import("./Observable").OnReturn>}
+     * @type {OverlayOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {OverlayOnSignature<import("./Observable").OnReturn>}
+     * @type {OverlayOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -158,12 +158,12 @@ class PluggableMap extends BaseObject {
     super();
 
     /***
-     * @type {PluggableMapOnSignature<import("./Observable.js").OnReturn>}
+     * @type {PluggableMapOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {PluggableMapOnSignature<import("./Observable.js").OnReturn>}
+     * @type {PluggableMapOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -309,12 +309,12 @@ class View extends BaseObject {
     super();
 
     /***
-     * @type {ViewOnSignature<import("./Observable.js").OnReturn>}
+     * @type {ViewOnSignature<import("./events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ViewOnSignature<import("./Observable.js").OnReturn>}
+     * @type {ViewOnSignature<import("./events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -90,12 +90,12 @@ class FullScreen extends Control {
     });
 
     /***
-     * @type {FullScreenOnSignature<import("../Observable.js").OnReturn>}
+     * @type {FullScreenOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {FullScreenOnSignature<import("../Observable.js").OnReturn>}
+     * @type {FullScreenOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -80,12 +80,12 @@ class MousePosition extends Control {
     });
 
     /***
-     * @type {MousePositionOnSignature<import("../Observable.js").OnReturn>}
+     * @type {MousePositionOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {MousePositionOnSignature<import("../Observable.js").OnReturn>}
+     * @type {MousePositionOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -100,12 +100,12 @@ class ScaleLine extends Control {
     });
 
     /***
-     * @type {ScaleLineOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ScaleLineOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ScaleLineOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ScaleLineOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -108,12 +108,12 @@ class DragAndDrop extends Interaction {
     });
 
     /***
-     * @type {DragAndDropOnSignature<import("../Observable").OnReturn>}
+     * @type {DragAndDropOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {DragAndDropOnSignature<import("../Observable").OnReturn>}
+     * @type {DragAndDropOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -123,12 +123,12 @@ class DragBox extends PointerInteraction {
     super();
 
     /***
-     * @type {DragBoxOnSignature<import("../Observable").OnReturn>}
+     * @type {DragBoxOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {DragBoxOnSignature<import("../Observable").OnReturn>}
+     * @type {DragBoxOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -204,12 +204,12 @@ class Draw extends PointerInteraction {
     super(pointerOptions);
 
     /***
-     * @type {DrawOnSignature<import("../Observable").OnReturn>}
+     * @type {DrawOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {DrawOnSignature<import("../Observable").OnReturn>}
+     * @type {DrawOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -103,12 +103,12 @@ class Extent extends PointerInteraction {
     super(/** @type {import("./Pointer.js").Options} */ (options));
 
     /***
-     * @type {ExtentOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ExtentOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ExtentOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ExtentOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -46,12 +46,12 @@ class Interaction extends BaseObject {
     super();
 
     /***
-     * @type {InteractionOnSignature<import("../Observable.js").OnReturn>}
+     * @type {InteractionOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {InteractionOnSignature<import("../Observable.js").OnReturn>}
+     * @type {InteractionOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -203,12 +203,12 @@ class Modify extends PointerInteraction {
     super(/** @type {import("./Pointer.js").Options} */ (options));
 
     /***
-     * @type {ModifyOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ModifyOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ModifyOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ModifyOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -167,12 +167,12 @@ class Select extends Interaction {
     super();
 
     /***
-     * @type {SelectOnSignature<import("../Observable.js").OnReturn>}
+     * @type {SelectOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {SelectOnSignature<import("../Observable.js").OnReturn>}
+     * @type {SelectOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -140,12 +140,12 @@ class Translate extends PointerInteraction {
     super(/** @type {import("./Pointer.js").Options} */ (options));
 
     /***
-     * @type {TranslateOnSignature<import("../Observable.js").OnReturn>}
+     * @type {TranslateOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {TranslateOnSignature<import("../Observable.js").OnReturn>}
+     * @type {TranslateOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -60,12 +60,12 @@ class BaseLayer extends BaseObject {
     super();
 
     /***
-     * @type {BaseLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {BaseLayerOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {BaseLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {BaseLayerOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -72,12 +72,12 @@ class BaseTileLayer extends Layer {
     super(baseOptions);
 
     /***
-     * @type {BaseTileLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {BaseTileLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -73,12 +73,12 @@ class LayerGroup extends BaseLayer {
     super(baseOptions);
 
     /***
-     * @type {GroupOnSignature<import("../Observable.js").OnReturn>}
+     * @type {GroupOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {GroupOnSignature<import("../Observable.js").OnReturn>}
+     * @type {GroupOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -107,12 +107,12 @@ class Layer extends BaseLayer {
     super(baseOptions);
 
     /***
-     * @type {LayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {LayerOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {LayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {LayerOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -106,12 +106,12 @@ class VectorTileLayer extends BaseVectorLayer {
     );
 
     /***
-     * @type {VectorTileLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {VectorTileLayerOnSignature<import("../Observable.js").OnReturn>}
+     * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -103,12 +103,12 @@ class ImageSource extends Source {
     });
 
     /***
-     * @type {ImageSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ImageSourceOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {ImageSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {ImageSourceOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -548,12 +548,12 @@ class RasterSource extends ImageSource {
     });
 
     /***
-     * @type {RasterSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {RasterSourceOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {RasterSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {RasterSourceOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -62,12 +62,12 @@ class TileSource extends Source {
     });
 
     /***
-     * @type {TileSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {TileSourceOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {TileSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {TileSourceOnSignature<import("../events").EventsKey>}
      */
     this.once;
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -187,12 +187,12 @@ class VectorSource extends Source {
     });
 
     /***
-     * @type {VectorSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {VectorSourceOnSignature<import("../events").EventsKey>}
      */
     this.on;
 
     /***
-     * @type {VectorSourceOnSignature<import("../Observable.js").OnReturn>}
+     * @type {VectorSourceOnSignature<import("../events").EventsKey>}
      */
     this.once;
 


### PR DESCRIPTION
If `on` is called without an array it now returns a `EventsKey` and if it is called with an array it returns `EventsKey[]`.

Also fixes a bug in the `OnSignature` of `Observable` and removes the `OnReturn` typedef which is not needed anymore.

![image](https://user-images.githubusercontent.com/8100558/132867749-5f7489e3-11cb-4547-be11-71fd9d601f3c.png)

Fixes #12733 
