### PR TITLE
Change canvas style from initial to unset

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -27,7 +27,7 @@ export function createCanvasContext2D(
     canvas = new OffscreenCanvas(opt_width || 300, opt_height || 300);
   } else {
     canvas = document.createElement('canvas');
-    canvas.style.all = 'initial';
+    canvas.style.all = 'unset';
   }
   if (opt_width) {
     canvas.width = opt_width;


### PR DESCRIPTION
Fixes #12735

Unset achieves the same results as #12626 over unwanted css such as min-width without interfering with desired inherited properties.
