### PR TITLE
Remove docs reference to unmanaged layer and Select

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -154,8 +154,6 @@ const originalFeatureStyles = {};
  * `toggle`, `add`/`remove`, and `multi` options; a `layers` filter; and a
  * further feature filter using the `filter` option.
  *
- * Selected features are added to an internal unmanaged layer.
- *
  * @fires SelectEvent
  * @api
  */

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -79,7 +79,7 @@ import {listen, unlistenByKey} from '../events.js';
  * displayed, irrespective of the source of that data.
  *
  * Layers are usually added to a map with {@link import("../PluggableMap.js").default#addLayer map.addLayer()}. Components
- * like {@link module:ol/interaction/Select~Select} use unmanaged layers
+ * like {@link module:ol/interaction/Draw~Draw} use unmanaged layers
  * internally. These unmanaged layers are associated with the map using
  * {@link module:ol/layer/Layer~Layer#setMap} instead.
  *


### PR DESCRIPTION
Fixes #12742

Remove unmanaged layer reference from Select documentation, and change Layer description to use Draw
