### PR TITLE
Add Float Textures for GL Rendering / DataTiles

### DIFF
--- a/doc/errors/index.md
+++ b/doc/errors/index.md
@@ -235,7 +235,7 @@ A `WebGLArrayBuffer` must either be of type `ELEMENT_ARRAY_BUFFER` or `ARRAY_BUF
 
 ### 63
 
-Support for the `OES_element_index_uint` WebGL extension is mandatory for WebGL layers.
+Support for the `OES_element_index_uint`, `OES_texture_float`, and `OES_texture_float_linear` WebGL extensions are mandatory for WebGL layers.
 
 ### 64
 

--- a/examples/numpytile.css
+++ b/examples/numpytile.css
@@ -1,0 +1,3 @@
+input[type="range"] {
+  vertical-align: text-bottom;
+}

--- a/examples/numpytile.html
+++ b/examples/numpytile.html
@@ -1,20 +1,22 @@
 ---
 layout: example.html
 title: Rendering 16-bit NumpyTiles
-shortdesc: Renders a multi-byte depth source image directly using webGL.
+shortdesc: Renders a multi-byte depth source image directly using WebGL.
 docs: >
-  Use the NumpyTile format to render multibyte raster data.
-tags: "numpytiles"
+  This example uses a <code>ol/source/DataTile</code> source to load multi-byte raster data in the
+  <a href="https://github.com/planetlabs/numpytiles-spec/"></a>NumpyTile</a> format.
+  The source is rendered with a <code>ol/layer/WebGLTile</code> layer.  Adjusting the sliders above
+  performs a contrast stretch by adjusting the style variables set on the layer.
+tags: "numpytiles, webgl"
+resources:
+  - https://unpkg.com/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js
 ---
 <div id="map" class="map"></div>
 
 <div>
-  <h5>Adjust colors</h5>
+  <h5>Contrast stretch</h5>
   <ul>
-    <li><b>Min:</b> <input type="range" min="1000" max="10000" id="color-floor"/></li>
-    <li><b>Max:</b> <input type="range" min="10000" max="50000" id="color-ceil"/></li>
+    <li>Min <input type="range" min="1000" max="10000" id="input-min"/> <span id="output-min"></span></li>
+    <li>Max <input type="range" min="10000" max="50000" id="input-max"/> <span id="output-max"></span></li>
   </ul>
-
 </div>
-
-<script type="text/javascript" src="https://unpkg.com/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js"></script>

--- a/examples/numpytile.html
+++ b/examples/numpytile.html
@@ -1,0 +1,20 @@
+---
+layout: example.html
+title: Rendering 16-bit NumpyTiles
+shortdesc: Renders a multi-byte depth source image directly using webGL.
+docs: >
+  Use the NumpyTile format to render multibyte raster data.
+tags: "numpytiles"
+---
+<div id="map" class="map"></div>
+
+<div>
+  <h5>Adjust colors</h5>
+  <ul>
+    <li><b>Min:</b> <input type="range" min="1000" max="10000" id="color-floor"/></li>
+    <li><b>Max:</b> <input type="range" min="10000" max="50000" id="color-ceil"/></li>
+  </ul>
+
+</div>
+
+<script type="text/javascript" src="https://unpkg.com/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js"></script>

--- a/examples/numpytile.js
+++ b/examples/numpytile.js
@@ -3,7 +3,6 @@ import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
 
 import DataTileSource from '../src/ol/source/DataTile.js';
-import OsmSource from '../src/ol/source/OSM.js';
 import {fromLonLat} from '../src/ol/proj.js';
 
 // 16-bit COG
@@ -45,25 +44,26 @@ const interpolateBand = (bandIdx) => [
   ['var', 'bMin'],
   0,
   ['var', 'bMax'],
-  1.0,
+  1,
 ];
 
-const createNumpyStyle = (bandMin, bandMax) => ({
-  color: [
-    'array',
-    interpolateBand(3),
-    interpolateBand(2),
-    interpolateBand(1),
-    ['band', 5],
-  ],
-  variables: {
-    'bMin': bandMin,
-    'bMax': bandMax,
-  },
-});
+const initialMin = 3000;
+const initialMax = 18000;
 
 const numpyLayer = new TileLayer({
-  style: createNumpyStyle(3000, 18000),
+  style: {
+    color: [
+      'array',
+      interpolateBand(3),
+      interpolateBand(2),
+      interpolateBand(1),
+      ['band', 5],
+    ],
+    variables: {
+      'bMin': initialMin,
+      'bMax': initialMax,
+    },
+  },
   source: new DataTileSource({
     loader: numpyTileLoader,
     bandCount: 5,
@@ -72,34 +72,35 @@ const numpyLayer = new TileLayer({
 
 const map = new Map({
   target: 'map',
-  layers: [
-    new TileLayer({
-      source: new OsmSource(),
-    }),
-    numpyLayer,
-  ],
+  layers: [numpyLayer],
   view: new View({
     center: fromLonLat([172.933, 1.3567]),
     zoom: 15,
   }),
 });
 
-const configureInputs = () => {
-  const colorFloor = document.getElementById('color-floor');
-  const colorCeil = document.getElementById('color-ceil');
+const inputMin = document.getElementById('input-min');
+const inputMax = document.getElementById('input-max');
+const outputMin = document.getElementById('output-min');
+const outputMax = document.getElementById('output-max');
 
-  colorFloor.addEventListener('input', (evt) => {
-    numpyLayer.updateStyleVariables({
-      'bMin': parseFloat(evt.target.value),
-      'bMax': parseFloat(colorCeil.value),
-    });
+inputMin.addEventListener('input', (evt) => {
+  numpyLayer.updateStyleVariables({
+    'bMin': parseFloat(evt.target.value),
+    'bMax': parseFloat(inputMax.value),
   });
+  outputMin.innerText = evt.target.value;
+});
 
-  colorCeil.addEventListener('input', (evt) => {
-    numpyLayer.updateStyleVariables({
-      'bMin': parseFloat(colorFloor.value),
-      'bMax': parseFloat(evt.target.value),
-    });
+inputMax.addEventListener('input', (evt) => {
+  numpyLayer.updateStyleVariables({
+    'bMin': parseFloat(inputMin.value),
+    'bMax': parseFloat(evt.target.value),
   });
-};
-configureInputs();
+  outputMax.innerText = evt.target.value;
+});
+
+inputMin.value = initialMin;
+inputMax.value = initialMax;
+outputMin.innerText = initialMin;
+outputMax.innerText = initialMax;

--- a/examples/numpytile.js
+++ b/examples/numpytile.js
@@ -1,0 +1,105 @@
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+
+import DataTileSource from '../src/ol/source/DataTile.js';
+import OsmSource from '../src/ol/source/OSM.js';
+import {fromLonLat} from '../src/ol/proj.js';
+
+// 16-bit COG
+// Which will be served as NumpyTiles.
+const COG =
+  'https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif';
+
+function numpyTileLoader(z, x, y) {
+  const url = `https://api.cogeo.xyz/cog/tiles/WebMercatorQuad/${z}/${x}/${y}@1x?format=npy&url=${encodeURIComponent(
+    COG
+  )}`;
+
+  return fetch(url)
+    .then((r) => r.arrayBuffer())
+    .then((buffer) => NumpyLoader.fromArrayBuffer(buffer)) // eslint-disable-line no-undef
+    .then((numpyData) => {
+      // flatten the numpy data
+      const dataTile = new Float32Array(256 * 256 * 5);
+      const bandSize = 256 * 256;
+      for (let x = 0; x < 256; x++) {
+        for (let y = 0; y < 256; y++) {
+          const px = x + y * 256;
+          dataTile[px * 5 + 0] = numpyData.data[y * 256 + x];
+          dataTile[px * 5 + 1] = numpyData.data[bandSize + y * 256 + x];
+          dataTile[px * 5 + 2] = numpyData.data[bandSize * 2 + y * 256 + x];
+          dataTile[px * 5 + 3] = numpyData.data[bandSize * 3 + y * 256 + x];
+          dataTile[px * 5 + 4] =
+            numpyData.data[bandSize * 4 + y * 256 + x] > 0 ? 1.0 : 0;
+        }
+      }
+      return dataTile;
+    });
+}
+
+const interpolateBand = (bandIdx) => [
+  'interpolate',
+  ['linear'],
+  ['band', bandIdx],
+  ['var', 'bMin'],
+  0,
+  ['var', 'bMax'],
+  1.0,
+];
+
+const createNumpyStyle = (bandMin, bandMax) => ({
+  color: [
+    'array',
+    interpolateBand(3),
+    interpolateBand(2),
+    interpolateBand(1),
+    ['band', 5],
+  ],
+  variables: {
+    'bMin': bandMin,
+    'bMax': bandMax,
+  },
+});
+
+const numpyLayer = new TileLayer({
+  style: createNumpyStyle(3000, 18000),
+  source: new DataTileSource({
+    loader: numpyTileLoader,
+    bandCount: 5,
+  }),
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [
+    new TileLayer({
+      source: new OsmSource(),
+    }),
+    numpyLayer,
+  ],
+  view: new View({
+    center: fromLonLat([172.933, 1.3567]),
+    zoom: 15,
+  }),
+});
+
+const configureInputs = () => {
+  const colorFloor = document.getElementById('color-floor');
+  const colorCeil = document.getElementById('color-ceil');
+
+  colorFloor.addEventListener('input', (evt) => {
+    numpyLayer.updateStyleVariables({
+      'bMin': parseFloat(evt.target.value),
+      'bMax': parseFloat(colorCeil.value),
+    });
+  });
+
+  colorCeil.addEventListener('input', (evt) => {
+    numpyLayer.updateStyleVariables({
+      'bMin': parseFloat(colorFloor.value),
+      'bMax': parseFloat(evt.target.value),
+    });
+  });
+};
+configureInputs();

--- a/src/ol/DataTile.js
+++ b/src/ol/DataTile.js
@@ -6,7 +6,7 @@ import TileState from './TileState.js';
 
 /**
  * Data that can be used with a DataTile.
- * @typedef {Uint8Array|Uint8ClampedArray|DataView} Data
+ * @typedef {Uint8Array|Uint8ClampedArray|Float32Array|DataView} Data
  */
 
 /**

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -426,7 +426,10 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
           const uniformName = Uniforms.TILE_TEXTURE_PREFIX + textureIndex;
           gl.activeTexture(gl[textureProperty]);
           gl.bindTexture(gl.TEXTURE_2D, tileTexture.textures[textureIndex]);
-          gl.uniform1i(this.helper.getUniformLocation(uniformName), 0);
+          gl.uniform1i(
+            this.helper.getUniformLocation(uniformName),
+            textureIndex
+          );
         }
 
         const alpha =

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -26,6 +26,7 @@ import {getUid} from '../util.js';
  * @property {number} [tilePixelRatio] Tile pixel ratio.
  * @property {boolean} [wrapX=true] Render tiles beyond the antimeridian.
  * @property {number} [transition] Transition time when fading in new tiles (in miliseconds).
+ * @property {number} [bandCount=4] Number of bands represented in the data.
  */
 
 /**
@@ -81,7 +82,7 @@ class DataTileSource extends TileSource {
     /**
      * @type {number}
      */
-    this.bandCount = 4; // assume RGBA
+    this.bandCount = options.bandCount === undefined ? 4 : options.bandCount; // assume RGBA if undefined
   }
 
   /**

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -279,7 +279,12 @@ class WebGLHelper extends Disposable {
     this.currentProgram_ = null;
 
     assert(includes(getSupportedExtensions(), 'OES_element_index_uint'), 63);
+    assert(includes(getSupportedExtensions(), 'OES_texture_float'), 63);
+    assert(includes(getSupportedExtensions(), 'OES_texture_float_linear'), 63);
+
     gl.getExtension('OES_element_index_uint');
+    gl.getExtension('OES_texture_float');
+    gl.getExtension("OES_texture_float_linear");
 
     this.canvas_.addEventListener(
       ContextEventType.LOST,

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -284,7 +284,7 @@ class WebGLHelper extends Disposable {
 
     gl.getExtension('OES_element_index_uint');
     gl.getExtension('OES_texture_float');
-    gl.getExtension("OES_texture_float_linear");
+    gl.getExtension('OES_texture_float_linear');
 
     this.canvas_.addEventListener(
       ContextEventType.LOST,


### PR DESCRIPTION
1. Adds the ability to use a `Float32Array` data type in the texture.
2. Fixes bug with > 4 band imagery textures not being set properly.
3. Allows `DataTile` to accept a variable number of bands through an option.
4. Includes an exmaple of using a 5-band floating point source with NumpyTiles.