### PR TITLE
Fix ImageInformationResponse typedef

### DIFF
--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -40,7 +40,7 @@ import {includes} from '../array.js';
  */
 
 /**
- * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>|Array<TileInfo>>}
+ * @typedef {Object<string,string|number|Array<number|string|IiifProfile|Object<string, number>|TileInfo>>}
  *    ImageInformationResponse
  */
 

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -40,7 +40,7 @@ import {includes} from '../array.js';
  */
 
 /**
- * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>|TileInfo>}
+ * @typedef {Object<string,string|number|Array<number|string|IiifProfile>|Object<string, number>|Array<TileInfo>>}
  *    ImageInformationResponse
  */
 


### PR DESCRIPTION
`TileInfo` should be an array to conform to https://iiif.io/api/image.

For more information see: https://github.com/openlayers/openlayers/issues/12763