### PR TITLE
Use only Uint8Array with gl.UNSIGNED_BYTE for browser compatibility

### DIFF
--- a/src/ol/webgl/TileTexture.js
+++ b/src/ol/webgl/TileTexture.js
@@ -70,7 +70,7 @@ function uploadDataTexture(gl, texture, data, size, bandCount) {
     0,
     format,
     gl.UNSIGNED_BYTE,
-    data
+    data instanceof Uint8Array ? data : new Uint8Array(data.buffer)
   );
 }
 


### PR DESCRIPTION
Fixes a compatibility issue with can be seen on the Data Tiles example with IE11 and some less old Chromium based Android browsers

![image](https://user-images.githubusercontent.com/49240900/133622471-ac62cfdb-297f-4baf-a87f-1a0d03817d4b.png)
https://bugs.chromium.org/p/chromium/issues/detail?id=961658