### PR TITLE
Fix offscreen-canvas example

### DIFF
--- a/examples/offscreen-canvas.worker.js
+++ b/examples/offscreen-canvas.worker.js
@@ -88,6 +88,9 @@ function loadStyles() {
               this.context = context;
               this.container = {
                 firstElementChild: canvas,
+                style: {
+                  opacity: layer.getOpacity(),
+                },
               };
               rendererTransform = transform;
             };


### PR DESCRIPTION
#12760 broke the offscreen-canvas example. Now we need to add a style with opacity to the container mock.