### PR TITLE
Do not render vector tiles unless they are being used

### DIFF
--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -299,7 +299,6 @@ describe('ol.renderer.canvas.VectorTileLayer', function () {
       layer.changed();
       renderer.renderFrame(frameState, null);
       expect(replayState.renderedTileRevision).to.be(revision + 1);
-      expect(Object.keys(renderer.tileListenerKeys_).length).to.be(0);
     });
   });
 


### PR DESCRIPTION
This pull request removes code that causes quite a bit of overhead in the vector tile renderer: rendering a tile immediately after loading bypasses our logic that makes sure we only render tiles that are actually being used (`frameState.usedTiles`). That code originally was meant for better making use of a render frame, but in practice, it causes more work because it renders tiles during/after zoom animations that are not needed for rendering the target resolution.

This pull request is best reviewed [without looking at whitespace changes](https://github.com/openlayers/openlayers/pull/12778/files?diff=unified&w=1).