### PR TITLE
Allow maps to be configured with a promise for view props

### DIFF
--- a/examples/cog-math-multisource.js
+++ b/examples/cog-math-multisource.js
@@ -1,7 +1,6 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
-import View from '../src/ol/View.js';
 
 const source = new GeoTIFF({
   sources: [
@@ -57,9 +56,5 @@ const map = new Map({
       source,
     }),
   ],
-  view: new View({
-    center: [1900000, 6100000],
-    zoom: 13,
-    minZoom: 10,
-  }),
+  view: source.getView(),
 });

--- a/examples/cog-math.js
+++ b/examples/cog-math.js
@@ -1,16 +1,21 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
-import View from '../src/ol/View.js';
-import proj4 from 'proj4';
-import {getCenter} from '../src/ol/extent.js';
-import {register} from '../src/ol/proj/proj4.js';
 
-proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
-register(proj4);
-
-// metadata from https://s3.us-west-2.amazonaws.com/sentinel-cogs/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/S2A_36QWD_20200701_0_L2A.json
-const sourceExtent = [499980, 1790220, 609780, 1900020];
+const source = new GeoTIFF({
+  sources: [
+    {
+      // visible red, band 1 in the style expression above
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B04.tif',
+      max: 10000,
+    },
+    {
+      // near infrared, band 2 in the style expression above
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B08.tif',
+      max: 10000,
+    },
+  ],
+});
 
 const map = new Map({
   target: 'map',
@@ -69,27 +74,8 @@ const map = new Map({
           [0, 69, 0],
         ],
       },
-      source: new GeoTIFF({
-        sources: [
-          {
-            // visible red, band 1 in the style expression above
-            url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B04.tif',
-            max: 10000,
-          },
-          {
-            // near infrared, band 2 in the style expression above
-            url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B08.tif',
-            max: 10000,
-          },
-        ],
-      }),
-      extent: sourceExtent,
+      source: source,
     }),
   ],
-  view: new View({
-    projection: 'EPSG:32636',
-    center: getCenter(sourceExtent),
-    extent: sourceExtent,
-    zoom: 9,
-  }),
+  view: source.getView(),
 });

--- a/examples/cog-overviews.js
+++ b/examples/cog-overviews.js
@@ -1,62 +1,49 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
-import View from '../src/ol/View.js';
-import proj4 from 'proj4';
-import {getCenter} from '../src/ol/extent.js';
-import {register} from '../src/ol/proj/proj4.js';
-
-proj4.defs('EPSG:32645', '+proj=utm +zone=45 +datum=WGS84 +units=m +no_defs');
-register(proj4);
-
-const sourceExtent = [382200, 2279370, 610530, 2512500];
-
-const base =
-  'https://landsat-pds.s3.amazonaws.com/c1/L8/139/045/LC08_L1TP_139045_20170304_20170316_01_T1/LC08_L1TP_139045_20170304_20170316_01_T1';
 
 // scale values in this range to 0 - 1
 const min = 10000;
 const max = 15000;
 
+const base =
+  'https://landsat-pds.s3.amazonaws.com/c1/L8/139/045/LC08_L1TP_139045_20170304_20170316_01_T1/LC08_L1TP_139045_20170304_20170316_01_T1';
+
+const source = new GeoTIFF({
+  sources: [
+    {
+      url: `${base}_B6.TIF`,
+      overviews: [`${base}_B6.TIF.ovr`],
+      min: min,
+      max: max,
+      nodata: 0,
+    },
+    {
+      url: `${base}_B5.TIF`,
+      overviews: [`${base}_B5.TIF.ovr`],
+      min: min,
+      max: max,
+      nodata: 0,
+    },
+    {
+      url: `${base}_B3.TIF`,
+      overviews: [`${base}_B3.TIF.ovr`],
+      min: min,
+      max: max,
+      nodata: 0,
+    },
+  ],
+});
+
 const map = new Map({
   target: 'map',
   layers: [
     new TileLayer({
-      extent: sourceExtent,
       style: {
         saturation: -0.3,
       },
-      source: new GeoTIFF({
-        sources: [
-          {
-            url: `${base}_B6.TIF`,
-            overviews: [`${base}_B6.TIF.ovr`],
-            min: min,
-            max: max,
-            nodata: 0,
-          },
-          {
-            url: `${base}_B5.TIF`,
-            overviews: [`${base}_B5.TIF.ovr`],
-            min: min,
-            max: max,
-            nodata: 0,
-          },
-          {
-            url: `${base}_B3.TIF`,
-            overviews: [`${base}_B3.TIF.ovr`],
-            min: min,
-            max: max,
-            nodata: 0,
-          },
-        ],
-      }),
+      source: source,
     }),
   ],
-  view: new View({
-    projection: 'EPSG:32645',
-    center: getCenter(sourceExtent),
-    extent: sourceExtent,
-    zoom: 8,
-  }),
+  view: source.getView(),
 });

--- a/examples/cog.js
+++ b/examples/cog.js
@@ -1,35 +1,21 @@
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
-import View from '../src/ol/View.js';
-import proj4 from 'proj4';
-import {getCenter} from '../src/ol/extent.js';
-import {register} from '../src/ol/proj/proj4.js';
 
-proj4.defs('EPSG:32636', '+proj=utm +zone=36 +datum=WGS84 +units=m +no_defs');
-register(proj4);
-
-// metadata from https://s3.us-west-2.amazonaws.com/sentinel-cogs/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/S2A_36QWD_20200701_0_L2A.json
-const sourceExtent = [499980, 1790220, 609780, 1900020];
+const source = new GeoTIFF({
+  sources: [
+    {
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/TCI.tif',
+    },
+  ],
+});
 
 const map = new Map({
   target: 'map',
   layers: [
     new TileLayer({
-      source: new GeoTIFF({
-        sources: [
-          {
-            url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/TCI.tif',
-          },
-        ],
-      }),
-      extent: sourceExtent,
+      source: source,
     }),
   ],
-  view: new View({
-    projection: 'EPSG:32636',
-    center: getCenter(sourceExtent),
-    extent: sourceExtent,
-    zoom: 9,
-  }),
+  view: source.getView(),
 });

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -90,6 +90,28 @@ class Source extends BaseObject {
      * @type {boolean}
      */
     this.wrapX_ = options.wrapX !== undefined ? options.wrapX : false;
+
+    /**
+     * @protected
+     * @type {function(import("../View.js").ViewOptions):void}
+     */
+    this.viewResolver = null;
+
+    /**
+     * @protected
+     * @type {function(Error):void}
+     */
+    this.viewRejector = null;
+
+    const self = this;
+    /**
+     * @private
+     * @type {Promise<import("../View.js").ViewOptions>}
+     */
+    this.viewPromise_ = new Promise(function (resolve, reject) {
+      self.viewResolver = resolve;
+      self.viewRejector = reject;
+    });
   }
 
   /**
@@ -124,6 +146,13 @@ class Source extends BaseObject {
    */
   getResolutions() {
     return abstract();
+  }
+
+  /**
+   * @return {Promise<import("../View.js").ViewOptions>} A promise for view-related properties.
+   */
+  getView() {
+    return this.viewPromise_;
   }
 
   /**

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -33,11 +33,71 @@ import {createXYZ} from '../../../../src/ol/tilegrid.js';
 import {defaults as defaultInteractions} from '../../../../src/ol/interaction.js';
 import {tile as tileStrategy} from '../../../../src/ol/loadingstrategy.js';
 
-describe('ol.Map', function () {
+describe('ol/Map', function () {
   describe('constructor', function () {
     it('creates a new map', function () {
       const map = new Map({});
       expect(map).to.be.a(Map);
+    });
+
+    it('accepts a promise for view options', (done) => {
+      let resolve;
+
+      const map = new Map({
+        view: new Promise((r) => {
+          resolve = r;
+        }),
+      });
+
+      expect(map.getView()).to.be.a(View);
+      expect(map.getView().isDef()).to.be(false);
+
+      map.once('change:view', () => {
+        const view = map.getView();
+        expect(view).to.be.a(View);
+        expect(view.isDef()).to.be(true);
+        expect(view.getCenter()).to.eql([1, 2]);
+        expect(view.getZoom()).to.be(3);
+        done();
+      });
+
+      resolve({
+        center: [1, 2],
+        zoom: 3,
+      });
+    });
+
+    it('allows the view to be set with a promise later after construction', (done) => {
+      const map = new Map({
+        view: new View({zoom: 1, center: [0, 0]}),
+      });
+
+      expect(map.getView()).to.be.a(View);
+      expect(map.getView().isDef()).to.be(true);
+
+      let resolve;
+      map.setView(
+        new Promise((r) => {
+          resolve = r;
+        })
+      );
+
+      expect(map.getView()).to.be.a(View);
+      expect(map.getView().isDef()).to.be(false);
+
+      map.once('change:view', () => {
+        const view = map.getView();
+        expect(view).to.be.a(View);
+        expect(view.isDef()).to.be(true);
+        expect(view.getCenter()).to.eql([1, 2]);
+        expect(view.getZoom()).to.be(3);
+        done();
+      });
+
+      resolve({
+        center: [1, 2],
+        zoom: 3,
+      });
     });
 
     it('creates a set of default interactions', function () {

--- a/test/browser/spec/ol/source/geotiff.test.js
+++ b/test/browser/spec/ol/source/geotiff.test.js
@@ -60,6 +60,18 @@ describe('ol/source/GeoTIFF', function () {
       });
     });
 
+    it('resolves view properties', function (done) {
+      source.getView().then((viewOptions) => {
+        const projection = viewOptions.projection;
+        expect(projection.getCode()).to.be('EPSG:4326');
+        expect(projection.getUnits()).to.be('degrees');
+        expect(viewOptions.extent).to.eql([-180, -90, 180, 90]);
+        expect(viewOptions.center).to.eql([0, 0]);
+        expect(viewOptions.resolutions).to.eql([0.703125]);
+        done();
+      });
+    });
+
     it('loads tiles', function (done) {
       source.on('change', () => {
         const tile = source.getTile(0, 0, 0);


### PR DESCRIPTION
This allows maps to be configured with a promise for view properties.  Where appropriate, sources can resolve view-related properties.  The `source.getView()` method is currently only marked as part of the API in the GeoTIFF source - where we can get relevant projection, center, and resolution information from the source.

Fixes #12644.