### PR TITLE
Do not do any canvas work when there are no features to render

### DIFF
--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -97,11 +97,7 @@ class CanvasLayerRenderer extends LayerRenderer {
         context = canvas.getContext('2d');
       }
     }
-    if (
-      context &&
-      (context.canvas.width === 0 ||
-        context.canvas.style.transform === transform)
-    ) {
+    if (context && context.canvas.style.transform === transform) {
       // Container of the previous layer renderer can be used.
       this.container = target;
       this.context = context;

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -256,10 +256,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       (!replayGroup || replayGroup.isEmpty()) &&
       (!declutterExecutorGroup || declutterExecutorGroup.isEmpty())
     ) {
-      if (!this.containerReused && canvas.width > 0) {
-        canvas.width = 0;
-      }
-      return this.container;
+      return null;
     }
 
     // resize and clear


### PR DESCRIPTION
Currently the vector layer renderer resizes the canvas to a width of 0 when there are no features to render. Instead, it could simply not touch the canvas at all and return `null` as rendered container, to avoid any rendering work.

Fixes #12791.