### PR TITLE
Add a method to set the map layers

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -848,6 +848,23 @@ class PluggableMap extends BaseObject {
   }
 
   /**
+   * Clear any existing layers and add layers to the map.
+   * @param {Array<import("./layer/Base.js").default>|Collection<import("./layer/Base.js").default>} layers The layers to be added to the map.
+   * @api
+   */
+  setLayers(layers) {
+    const group = this.getLayerGroup();
+    if (layers instanceof Collection) {
+      group.setLayers(layers);
+      return;
+    }
+
+    const collection = group.getLayers();
+    collection.clear();
+    collection.extend(layers);
+  }
+
+  /**
    * Get the collection of layers associated with this map.
    * @return {!Collection<import("./layer/Base.js").default>} Layers.
    * @api

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1,3 +1,4 @@
+import Collection from '../../../../src/ol/Collection.js';
 import Control from '../../../../src/ol/control/Control.js';
 import DoubleClickZoom from '../../../../src/ol/interaction/DoubleClickZoom.js';
 import DragPan from '../../../../src/ol/interaction/DragPan.js';
@@ -176,6 +177,42 @@ describe('ol/Map', function () {
         map.addLayer(layer);
       };
       expect(call).to.throwException();
+    });
+  });
+
+  describe('#setLayers()', function () {
+    it('adds an array of layers to the map', function () {
+      const map = new Map({});
+
+      const layer0 = new TileLayer();
+      const layer1 = new TileLayer();
+      map.setLayers([layer0, layer1]);
+
+      const collection = map.getLayers();
+      expect(collection.getLength()).to.be(2);
+      expect(collection.item(0)).to.be(layer0);
+      expect(collection.item(1)).to.be(layer1);
+    });
+
+    it('clears any existing layers', function () {
+      const map = new Map({layers: [new TileLayer()]});
+
+      map.setLayers([new TileLayer(), new TileLayer()]);
+
+      expect(map.getLayers().getLength()).to.be(2);
+    });
+
+    it('also works with collections', function () {
+      const map = new Map({});
+
+      const layer0 = new TileLayer();
+      const layer1 = new TileLayer();
+      map.setLayers(new Collection([layer0, layer1]));
+
+      const collection = map.getLayers();
+      expect(collection.getLength()).to.be(2);
+      expect(collection.item(0)).to.be(layer0);
+      expect(collection.item(1)).to.be(layer1);
     });
   });
 


### PR DESCRIPTION
This adds a `map.setLayers()` method that lets people set map layers.  Any existing layers are cleared when setting new layers.