### PR TITLE
New tile source for the WMTS example

### DIFF
--- a/examples/wmts.js
+++ b/examples/wmts.js
@@ -10,9 +10,9 @@ import {getTopLeft, getWidth} from '../src/ol/extent.js';
 const projection = getProjection('EPSG:3857');
 const projectionExtent = projection.getExtent();
 const size = getWidth(projectionExtent) / 256;
-const resolutions = new Array(14);
-const matrixIds = new Array(14);
-for (let z = 0; z < 14; ++z) {
+const resolutions = new Array(19);
+const matrixIds = new Array(19);
+for (let z = 0; z < 19; ++z) {
   // generate resolutions and matrixIds arrays for this WMTS
   resolutions[z] = size / Math.pow(2, z);
   matrixIds[z] = z;
@@ -22,19 +22,16 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new OSM(),
-      opacity: 0.7,
     }),
     new TileLayer({
       opacity: 0.7,
       source: new WMTS({
         attributions:
-          'Tiles © <a href="https://services.arcgisonline.com/arcgis/rest/' +
-          'services/Demographics/USA_Population_Density/MapServer/">ArcGIS</a>',
-        url:
-          'https://services.arcgisonline.com/arcgis/rest/' +
-          'services/Demographics/USA_Population_Density/MapServer/WMTS/',
-        layer: '0',
-        matrixSet: 'EPSG:3857',
+          'Tiles © <a href="https://mrdata.usgs.gov/geology/state/"' +
+          ' target="_blank">USGS</a>',
+        url: 'https://mrdata.usgs.gov/mapcache/wmts',
+        layer: 'sgmc2',
+        matrixSet: 'GoogleMapsCompatible',
         format: 'image/png',
         projection: projection,
         tileGrid: new WMTSTileGrid({


### PR DESCRIPTION
Fixes #12767

The demographics service has been withdrawn from https://services.arcgisonline.com/arcgis/rest/services/  Alternative demographics sources are either slow, basic or require a subscription, so I have replaced it with a geology overlay for the same region.


