### PR TITLE
Update geotiff

### DIFF
--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import frontMatter from 'front-matter';
+import fs from 'fs';
 import fse from 'fs-extra';
 import handlebars from 'handlebars';
 import marked from 'marked';
@@ -16,6 +17,11 @@ const importRegEx = /^import .* from '(.*)';$/;
 const isTemplateJs =
   /\/(jquery(-\d+\.\d+\.\d+)?|(bootstrap(\.bundle)?))(\.min)?\.js(\?.*)?$/;
 const isTemplateCss = /\/bootstrap(\.min)?\.css(\?.*)?$/;
+
+const exampleDirContents = fs
+  .readdirSync(path.join(baseDir, '..'))
+  .filter((name) => /^(?!index).*\.html$/.test(name))
+  .map((name) => name.replace(/\.html$/, ''));
 
 let cachedPackageInfo = null;
 async function getPackageInfo() {
@@ -188,7 +194,7 @@ export default class ExampleBuilder {
       }
 
       const name = filename.replace(/\.js$/, '');
-      if (name === 'index' || name === this.common) {
+      if (!exampleDirContents.includes(name)) {
         continue;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3748,9 +3748,9 @@
       "dev": true
     },
     "node_modules/dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dev": true,
       "dependencies": {
         "ip": "^1.1.0",
@@ -8184,9 +8184,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-to-regexp": {
@@ -14203,9 +14203,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
-      "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
+      "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
       "dev": true,
       "requires": {
         "ip": "^1.1.0",
@@ -17602,9 +17602,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.7.1-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "geotiff": "^1.0.5",
+        "geotiff": "1.0.6",
         "ol-mapbox-style": "^6.5.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -68,6 +68,7 @@
         "shx": "^0.3.2",
         "sinon": "^11.1.1",
         "terser-webpack-plugin": "^5.1.1",
+        "threads": "^1.6.5",
         "url-polyfill": "^1.1.5",
         "walk": "^2.3.9",
         "webpack": "^5.27.2",
@@ -3288,11 +3289,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -5296,18 +5292,17 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
-      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
       "dependencies": {
         "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
         "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "threads": "^1.3.1",
-        "txml": "^3.1.2"
+        "txml": "^5.0.0"
       },
       "engines": {
         "browsers": "defaults",
@@ -8118,9 +8113,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10422,9 +10417,9 @@
       "dev": true
     },
     "node_modules/txml": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.5.tgz",
-      "integrity": "sha512-AtN8AgJLiDanttIXJaQlxH8/R0NOCNwto8kcO7BaxdLgsN9b7itM9lnTD7c2O3TadP+hHB9j7ra5XGFRPNnk/g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
       "dependencies": {
         "through2": "^3.0.1"
       }
@@ -13865,11 +13860,6 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
-    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -15423,18 +15413,17 @@
       "dev": true
     },
     "geotiff": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.5.tgz",
-      "integrity": "sha512-PK1dA22HJrgSjpDKXCcmihi/3NOTvAwZRV93pDCAI/bu3JYhgealCPMmzRQ6zJ/osfrrd9U4WXl3IHrwA9hqfg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
+      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
       "requires": {
         "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
         "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "threads": "^1.3.1",
-        "txml": "^3.1.2"
+        "txml": "^5.0.0"
       }
     },
     "get-caller-file": {
@@ -17560,9 +17549,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -19362,9 +19351,9 @@
       "dev": true
     },
     "txml": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.5.tgz",
-      "integrity": "sha512-AtN8AgJLiDanttIXJaQlxH8/R0NOCNwto8kcO7BaxdLgsN9b7itM9lnTD7c2O3TadP+hHB9j7ra5XGFRPNnk/g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
       "requires": {
         "through2": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://opencollective.com/openlayers"
   },
   "dependencies": {
-    "geotiff": "^1.0.5",
+    "geotiff": "1.0.6",
     "ol-mapbox-style": "^6.5.0",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
@@ -104,6 +104,7 @@
     "shx": "^0.3.2",
     "sinon": "^11.1.1",
     "terser-webpack-plugin": "^5.1.1",
+    "threads": "^1.6.5",
     "url-polyfill": "^1.1.5",
     "walk": "^2.3.9",
     "webpack": "^5.27.2",

--- a/src/ol/worker/geotiff-decoder.js
+++ b/src/ol/worker/geotiff-decoder.js
@@ -1,5 +1,16 @@
-/* eslint-disable sort-imports-es6-autofix/sort-imports-es6 */
 import 'regenerator-runtime/runtime.js';
-import 'geotiff/src/decoder.worker.js';
+
+// BEGIN copied from geotiff/src/decoder.worker.js
+import {Transfer, expose} from 'threads/worker';
+import {getDecoder} from 'geotiff/src/compression';
+
+async function decode(fileDirectory, buffer) {
+  const decoder = await getDecoder(fileDirectory);
+  const decoded = await decoder.decode(fileDirectory, buffer);
+  return Transfer(decoded);
+}
+
+expose(decode);
+// END copied from geotiff/src/decoder.worker.js
 
 export let create;

--- a/tasks/serialize-workers.cjs
+++ b/tasks/serialize-workers.cjs
@@ -53,7 +53,11 @@ async function build(input, {minify = true} = {}) {
     },
   });
 
-  const bundle = await rollup.rollup({input, plugins});
+  const bundle = await rollup.rollup({
+    input,
+    plugins,
+    inlineDynamicImports: true,
+  });
   const {output} = await bundle.generate({format: 'es'});
 
   if (output.length !== 1) {


### PR DESCRIPTION
This pull request brings in the latest version of geotiff.js, which requires changes to how we build the worker and the examples because of new dynamic imports for image decoders and an added `"sideEffects": false` hint in `package.json`.

We now also peg the geotiff dependency to a specific version, to avoid potential future issues with incompatible dependency updates.

Fixes #12796.