### PR TITLE
All layers now call dispose on the renderer

### DIFF
--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -113,14 +113,6 @@ class WebGLPointsLayer extends Layer {
       attributes: this.parseResult_.attributes,
     });
   }
-
-  /**
-   * Clean up.
-   */
-  disposeInternal() {
-    this.getRenderer().disposeInternal();
-    super.disposeInternal();
-  }
 }
 
 export default WebGLPointsLayer;


### PR DESCRIPTION
Now that all layers call `renderer.dispose()` when `layer.dispose()` is called, we no longer need to do this explicitly in the WebGL points layer.

I meant to include this in #12798 but didn't.