### PR TITLE
Update ol-mapbox-style to latest version without ol peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "1.0.6",
-        "ol-mapbox-style": "^6.5.0",
+        "ol-mapbox-style": "^6.5.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -7902,32 +7902,14 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "node_modules/ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
-      "peer": true,
-      "dependencies": {
-        "ol-mapbox-style": "^6.1.1",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/openlayers"
-      }
-    },
     "node_modules/ol-mapbox-style": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.0.tgz",
-      "integrity": "sha512-/iz8NP4Zk6sxyV3r37T6hxB/TG9yBqVeRx01r49FcZXlE0E8phNo8VPEYfUiRvCa9z8tJhavmOdc6QoAwCA63w==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
+      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
         "webfont-matcher": "^1.1.0"
-      },
-      "peerDependencies": {
-        "ol": ">= 6.1.0 < 7"
       }
     },
     "node_modules/on-finished": {
@@ -17402,21 +17384,10 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
-    "ol": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-6.5.0.tgz",
-      "integrity": "sha512-a5ebahrjF5yCPFle1rc0aHzKp/9A4LlUnjh+S3I+x4EgcvcddDhpOX3WDOs0Pg9/wEElrikHSGEvbeej2Hh4Ug==",
-      "peer": true,
-      "requires": {
-        "ol-mapbox-style": "^6.1.1",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
-      }
-    },
     "ol-mapbox-style": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.0.tgz",
-      "integrity": "sha512-/iz8NP4Zk6sxyV3r37T6hxB/TG9yBqVeRx01r49FcZXlE0E8phNo8VPEYfUiRvCa9z8tJhavmOdc6QoAwCA63w==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.1.tgz",
+      "integrity": "sha512-diGjCUlYjCA855vJjQjPzxXLn/skm0iQLD2/yDsXaKdNxFd35hNfRm5Li+Vxh/FxraCodxRvd8IplhrhvXoqbQ==",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "geotiff": "1.0.6",
-    "ol-mapbox-style": "^6.5.0",
+    "ol-mapbox-style": "^6.5.1",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
   },

--- a/test/browser/karma.config.cjs
+++ b/test/browser/karma.config.cjs
@@ -72,6 +72,9 @@ module.exports = function (karma) {
       devtool: 'inline-source-map',
       mode: 'development',
       resolve: {
+        alias: {
+          ol: path.resolve(__dirname, '../../src/ol/'),
+        },
         fallback: {
           fs: false,
           http: false,


### PR DESCRIPTION
To make it easier for users to use `ol@dev`, i.e. to avoid peer dependency errors, this pull request updates `ol-mapbox-style` to the latest version, which does not list `ol` as peer dependency any more.

To make the new version work in our browser tests, we need to add an alias for `ol` to the webpack config, pointing to the `src/ol` directory. Doing this will also resolve issues with `instanceof` checks, that would previously return `false`.