### PR TITLE
Enqueue tiles at the next step in the animation

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -48,6 +48,7 @@ import {removeNode} from './dom.js';
  * @property {import("./transform.js").Transform} coordinateToPixelTransform CoordinateToPixelTransform.
  * @property {import("rbush").default} declutterTree DeclutterTree.
  * @property {null|import("./extent.js").Extent} extent Extent.
+ * @property {import("./extent.js").Extent} [nextExtent] Next extent during an animation series.
  * @property {number} index Index.
  * @property {Array<import("./layer/Layer.js").State>} layerStatesArray LayerStatesArray.
  * @property {number} layerIndex LayerIndex.
@@ -1436,6 +1437,18 @@ class PluggableMap extends BaseObject {
         viewHints: viewHints,
         wantedTiles: {},
       };
+      if (viewState.nextCenter && viewState.nextResolution) {
+        const rotation = isNaN(viewState.nextRotation)
+          ? viewState.rotation
+          : viewState.nextRotation;
+
+        frameState.nextExtent = getForViewAndSize(
+          viewState.nextCenter,
+          viewState.nextResolution,
+          rotation,
+          size
+        );
+      }
     }
 
     this.frameState_ = frameState;

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -12,7 +12,7 @@ import ViewHint from '../../../../src/ol/ViewHint.js';
 import {clearUserProjection, useGeographic} from '../../../../src/ol/proj.js';
 import {createEmpty} from '../../../../src/ol/extent.js';
 
-describe('ol.View', function () {
+describe('ol/View', function () {
   describe('constructor (defaults)', function () {
     let view;
 
@@ -688,13 +688,15 @@ describe('ol.View', function () {
         },
         function (complete) {
           expect(complete).to.be(true);
+          expect(isNaN(view.nextResolution_)).to.be(true);
           expect(view.getCenter()).to.eql([0, 0]);
           expect(view.getZoom()).to.eql(4);
-          expect(view.getAnimating()).to.eql(false);
+          expect(view.getAnimating()).to.be(false);
           done();
         }
       );
       expect(view.getAnimating()).to.eql(true);
+      expect(isNaN(view.nextResolution_)).to.be(false);
     });
 
     it('allows duration to be zero', function (done) {


### PR DESCRIPTION
This change makes it so the WebGL tile layer renderer enqueues tiles at the next step in an animation series.  In cases where an animation covers several zoom levels or is outside the initial extent, this makes it so destination tiles have a chance to start loading before the animation finishes.
