### PR TITLE
Add support for arbitrary GLSL functions

### DIFF
--- a/examples/webgl-custom-func.html
+++ b/examples/webgl-custom-func.html
@@ -1,0 +1,17 @@
+---
+layout: example.html
+title: Add a custom function to the fragment shader
+shortdesc: Renders a DataTile layer with a custom WebGL function.
+docs: >
+  This example uses a <code>ol/source/DataTile</code> source to load multi-byte raster data in the
+  <a href="https://github.com/planetlabs/numpytiles-spec/">NumpyTile</a> format.
+  The source is rendered with a <code>ol/layer/WebGLTile</code> layer.  Blurring can be turned on or off.
+tags: "numpytiles, webgl"
+resources:
+  - https://unpkg.com/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js
+---
+<div id="map" class="map"></div>
+
+<div>
+  <input id="set-blur" type="checkbox" /> Blur?
+</div>

--- a/examples/webgl-custom-func.js
+++ b/examples/webgl-custom-func.js
@@ -1,0 +1,119 @@
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+
+import DataTileSource from '../src/ol/source/DataTile.js';
+import {fromLonLat} from '../src/ol/proj.js';
+
+// 16-bit COG
+// Which will be served as NumpyTiles.
+const COG =
+  'https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2_analytic.tif';
+
+function numpyTileLoader(z, x, y) {
+  const url = `https://api.cogeo.xyz/cog/tiles/WebMercatorQuad/${z}/${x}/${y}@1x?format=npy&url=${encodeURIComponent(
+    COG
+  )}`;
+
+  return fetch(url)
+    .then((r) => r.arrayBuffer())
+    .then((buffer) => NumpyLoader.fromArrayBuffer(buffer)) // eslint-disable-line no-undef
+    .then((numpyData) => {
+      // flatten the numpy data
+      const dataTile = new Float32Array(256 * 256 * 5);
+      const bandSize = 256 * 256;
+      for (let x = 0; x < 256; x++) {
+        for (let y = 0; y < 256; y++) {
+          const px = x + y * 256;
+          dataTile[px * 5 + 0] = numpyData.data[y * 256 + x];
+          dataTile[px * 5 + 1] = numpyData.data[bandSize + y * 256 + x];
+          dataTile[px * 5 + 2] = numpyData.data[bandSize * 2 + y * 256 + x];
+          dataTile[px * 5 + 3] = numpyData.data[bandSize * 3 + y * 256 + x];
+          dataTile[px * 5 + 4] =
+            numpyData.data[bandSize * 4 + y * 256 + x] > 0 ? 1.0 : 0;
+        }
+      }
+      return dataTile;
+    });
+}
+
+const BLUR = `
+
+vec4 scaleColor(in vec4 clr) {
+  vec4 n = clr;
+  n /= 18000.0;
+  return n;
+}
+
+vec4 blur(in float doBlur, in float alpha) {
+  vec4 out_color = vec4(0.0, 0.0, 0.0, 0.0);
+  vec2 px_coord;
+  vec4 color0;
+  vec4 color1;
+
+  if (doBlur == 0.0) {
+    color0 = texture2D(u_tileTexture0, v_textureCoord);
+    color1 = texture2D(u_tileTexture1, v_textureCoord);
+    out_color = scaleColor(vec4(color0.b, color0.g, color0.r, color1.r));
+    out_color.a = alpha;
+  }
+
+  if (doBlur > 0.0 && alpha > 0.0) {
+    float n_px = 0.0;
+    for (float ky = -0.02; ky < 0.02; ky += 0.001) {
+      for (float kx = -0.02; kx < 0.02; kx += 0.001) {
+        px_coord.x = v_textureCoord.x + kx;
+        px_coord.y = v_textureCoord.y + ky;
+        color0 = texture2D(u_tileTexture0, px_coord);
+        color1 = texture2D(u_tileTexture1, px_coord);
+        if (color1.r > 0.0) {
+          out_color.r += color0.r;
+          out_color.g += color0.g;
+          out_color.b += color0.b;
+          n_px += 1.0;
+        }
+      }
+    }
+    out_color /= n_px;
+    out_color = scaleColor(out_color);
+    // swap the red and blue bands
+    out_color.rb = out_color.br;
+    out_color.a = alpha;
+  }
+
+  return out_color;
+}
+`;
+
+const numpyLayer = new TileLayer({
+  style: {
+    color: ['func', 'blur', ['var', 'doBlur'], ['band', 5]],
+    variables: {
+      'doBlur': 0.0,
+    },
+    functions: [BLUR],
+  },
+  source: new DataTileSource({
+    loader: numpyTileLoader,
+    bandCount: 5,
+  }),
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [numpyLayer],
+  view: new View({
+    center: fromLonLat([172.933, 1.3567]),
+    zoom: 15,
+  }),
+});
+
+const inputBlur = document.getElementById('set-blur');
+
+inputBlur.addEventListener('change', (evt) => {
+  numpyLayer.updateStyleVariables({
+    'doBlur': evt.target.checked ? 1.0 : 0.0,
+  });
+});
+
+inputBlur.checked = false;

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -19,6 +19,7 @@ import {assign} from '../obj.js';
  * Translates tile data to rendered pixels.
  *
  * @property {Object<string, number>} [variables] Style variables.  Each variable must hold a number.  These
+ * @property {Array<string>} [functions] GLSL function text. These are functions that can be added to the fragment shader.
  * variables can be used in the `color`, `brightness`, `contrast`, `exposure`, `saturation` and `gamma`
  * {@link import("../style/expressions.js").ExpressionValue expressions}, using the `['var', 'varName']` operator.
  * To update style variables, use the {@link import("./WebGLTile.js").default#updateStyleVariables} method.
@@ -169,6 +170,8 @@ function parseStyle(style, bandCount) {
     );
   }
 
+  const functionDeclarations = style.functions || [];
+
   /** @type {Object<string,import("../webgl/Helper").UniformValue>} */
   const uniforms = {};
 
@@ -223,6 +226,8 @@ function parseStyle(style, bandCount) {
     uniform float ${Uniforms.ZOOM};
 
     ${uniformDeclarations.join('\n')}
+
+    ${functionDeclarations.join('\n')}
 
     void main() {
       ${colorAssignments.join('\n')}

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -417,6 +417,19 @@ Operators['var'] = {
   },
 };
 
+Operators['func'] = {
+  getReturnType: function (args) {
+    return ValueTypes.ANY;
+  },
+  toGlsl: function (context, args) {
+    const fnName = args[0].toString();
+    const parsedArgs = args.slice(1).map(function (val) {
+      return expressionToGlsl(context, val, ValueTypes.ANY);
+    });
+    return `${fnName}(${parsedArgs.join(', ')})`;
+  },
+};
+
 Operators['band'] = {
   getReturnType: function (args) {
     return ValueTypes.NUMBER;


### PR DESCRIPTION
Add support for calling a function in the GLSL pipeline.

 * Adds the `func` operator to call the function in the style.
 * Adds a `functions` list to append function text to the fragment shader.
 * Includes an example which allows the user to blur the data.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
