### PR TITLE
Update to the WebGL sea level example

### DIFF
--- a/examples/webgl-sea-level.html
+++ b/examples/webgl-sea-level.html
@@ -11,7 +11,7 @@ docs: >
     values ranging from 0 to 1.  The <code>band</code> operator is used to select normalized values
     from a single band.
   </p><p>
-    After converting the normalized RGB values to elevation, the <code>interpolate</code> expression
+    After converting the normalized RGB values to elevation, the <code>case</code> expression
     is used to pick colors to apply at a given elevation.  Instead of using constant
     numeric values as the stops in the colors array, the <code>var</code> operator allows you to
     use a value that can be modified by your application.  When the user drags the


### PR DESCRIPTION
This updates the WebGL sea level example to use a `case` expression instead of `interpolate` to color elevations above and below sea level.