### PR TITLE
Controls inherit font size from parent

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -133,6 +133,7 @@
   color: white;
   font-weight: bold;
   text-decoration: none;
+  font-size: inherit;
   text-align: center;
   height: 1.375em;
   width: 1.375em;


### PR DESCRIPTION
In #12807, the `.ol-control button` font size was removed.  In some browsers, the default button font size is pretty small, and this change makes buttons hard to find for some.  This change makes it so buttons inherit the computed font size from their parent elements.  This is a compromise between the old 114% bigger buttons and more modestly sized buttons.

Note that this change doesn't have any effect on our examples where our css reset already sets the button font size to `inherit` (but it does change other examples that don't have that css reset).