### PR TITLE
Do not replace icon color if image not loaded

### DIFF
--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -219,7 +219,11 @@ class IconImage extends EventTarget {
    * @private
    */
   replaceColor_(pixelRatio) {
-    if (!this.color_ || this.canvas_[pixelRatio]) {
+    if (
+      !this.color_ ||
+      this.canvas_[pixelRatio] ||
+      this.imageState_ !== ImageState.LOADED
+    ) {
       return;
     }
 


### PR DESCRIPTION
Attempting to set an icon color before the image has loaded, as can happen with the immediate renderer https://codesandbox.io/s/icon-color-forked-sgbvf creates an invalid zero size canvas.