### PR TITLE
Support a normalize option on the GeoTIFF source

### DIFF
--- a/test/browser/spec/ol/source/GeoTIFF.test.js
+++ b/test/browser/spec/ol/source/GeoTIFF.test.js
@@ -14,6 +14,7 @@ describe('ol/source/GeoTIFF', function () {
       });
       expect(source.readMethod_).to.be('readRasters');
     });
+
     it('configures readMethod_ to read RGB', function () {
       const source = new GeoTIFFSource({
         convertToRGB: true,
@@ -24,6 +25,37 @@ describe('ol/source/GeoTIFF', function () {
         ],
       });
       expect(source.readMethod_).to.be('readRGB');
+    });
+
+    it('generates Float32Array data if normalize is set to false', (done) => {
+      const source = new GeoTIFFSource({
+        normalize: false,
+        sources: [{url: 'spec/ol/source/images/0-0-0.tif'}],
+      });
+      source.on('change', () => {
+        const tile = source.getTile(0, 0, 0);
+        source.on('tileloadend', () => {
+          expect(tile.getState()).to.be(TileState.LOADED);
+          expect(tile.getData()).to.be.a(Float32Array);
+          done();
+        });
+        tile.load();
+      });
+    });
+
+    it('generates Uint8Array data if normalize is not set to false', (done) => {
+      const source = new GeoTIFFSource({
+        sources: [{url: 'spec/ol/source/images/0-0-0.tif'}],
+      });
+      source.on('change', () => {
+        const tile = source.getTile(0, 0, 0);
+        source.on('tileloadend', () => {
+          expect(tile.getState()).to.be(TileState.LOADED);
+          expect(tile.getData()).to.be.a(Uint8Array);
+          done();
+        });
+        tile.load();
+      });
     });
   });
 


### PR DESCRIPTION
By default, we normalize values in GeoTIFF sources so that style expressions on the layer work with values between 0 and 1.  This change makes it so the GeoTIFF source accepts a `normalize` option to control this behavior.  If `normalize` is set to `false`, then the raw GeoTIFF values will be make available to style expressions on the layer.

The current implementation uses 8-bit values for normalized data and 32-bit otherwise.  In the future, we may change this to support higher bit depth for normalized values as well.  But this implementation detail is not exposed to users.

I haven't had any luck finding a CORS-friendly source of elevation data hosted as GeoTIFF.  Both the AWS [Terrain Tiles](https://registry.opendata.aws/terrain-tiles/) and [Copernicus DEM data](https://registry.opendata.aws/copernicus-dem/) are not CORS-friendly.  But here is a movie of a elevation tile from the Terrain Tiles with a CORS proxy in front:

![elevation](https://user-images.githubusercontent.com/41094/135331555-68b79dc1-fa56-4555-b21c-47bcdf16ca03.gif)

Fixes #12834.