### PR TITLE
forEachLayerAtPixel return null for unsupported layer types

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -130,7 +130,7 @@ class LayerRenderer extends Observable {
    *    returned, and empty array will be returned.
    */
   getDataAtPixel(pixel, frameState, hitTolerance) {
-    return abstract();
+    return null;
   }
 
   /**


### PR DESCRIPTION
Fixes the error in #12833

Ensure the getDataAtPixel return is null unless the layer is supported as the documentation states "will be null for layer types that do not currently support this argument" instead of throwing an error.

WebGL layers could be supported in the same way as 2d canvas layers if the context is created `preserveDrawingBuffer: true`  That would be best done via an option in the Heatmap, WebGLTile and WebGLPoints layer constructors instead of patching the HTMLCanvasElement prototype.  Since it is also necessary to export maps, both by html2canvas and the Export Map method, adding that is beyond the scope of this fix.
