### PR TITLE
Fix maximum call stack error when parsing very long arc arrays

### DIFF
--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -200,7 +200,9 @@ function concatenateArcs(indices, arcs) {
       // reverse arc
       arc = arcs[~index].slice().reverse();
     }
-    coordinates.push.apply(coordinates, arc);
+    for (p of arc) {
+      coordinates.push(p);
+    }
   }
   // provide fresh copies of coordinate arrays
   for (let j = 0, jj = coordinates.length; j < jj; ++j) {

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -186,7 +186,7 @@ const GEOMETRY_READERS = {
 function concatenateArcs(indices, arcs) {
   /** @type {Array<import("../coordinate.js").Coordinate>} */
   const coordinates = [];
-  let index, arc;
+  let index, arc, vertex;
   for (let i = 0, ii = indices.length; i < ii; ++i) {
     index = indices[i];
     if (i > 0) {
@@ -200,8 +200,8 @@ function concatenateArcs(indices, arcs) {
       // reverse arc
       arc = arcs[~index].slice().reverse();
     }
-    for (p of arc) {
-      coordinates.push(p);
+    for (vertex of arc) {
+      coordinates.push(vertex);
     }
   }
   // provide fresh copies of coordinate arrays


### PR DESCRIPTION
This fixes a bug caused when concatenating arc segments using `push.apply()` for arcs that are very large (100,000-200,000 points), see eg: https://stackoverflow.com/questions/61740599/rangeerror-maximum-call-stack-size-exceeded-with-array-push

See #12842 for more details. 

I have only tested that the fix works by copying the relevant functions to a separate js script, not within the context of the entire OpenLayers library. 