### PR TITLE
Preserve drawing buffer

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -1,8 +1,12 @@
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
+import {
+  Heatmap as HeatmapLayer,
+  Tile as TileLayer,
+  Vector as VectorLayer,
+} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const map = new Map({
   layers: [
@@ -15,6 +19,19 @@ const map = new Map({
         format: new GeoJSON(),
       }),
       opacity: 0.5,
+    }),
+    new HeatmapLayer({
+      source: new VectorSource({
+        url: 'data/geojson/world-cities.geojson',
+        format: new GeoJSON(),
+      }),
+      weight: function (feature) {
+        return feature.get('population') / 1e7;
+      },
+      radius: 15,
+      blur: 15,
+      opacity: 0.5,
+      preserveDrawingBuffer: true,
     }),
   ],
   target: 'map',
@@ -32,17 +49,30 @@ document.getElementById('export-png').addEventListener('click', function () {
     mapCanvas.height = size[1];
     const mapContext = mapCanvas.getContext('2d');
     Array.prototype.forEach.call(
-      document.querySelectorAll('.ol-layer canvas'),
+      document.querySelectorAll('.ol-layer canvas, canvas.ol-layer'),
       function (canvas) {
         if (canvas.width > 0) {
-          const opacity = canvas.parentNode.style.opacity;
+          const opacity =
+            canvas.parentNode.style.opacity || canvas.style.opacity;
           mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
+          let matrix;
           const transform = canvas.style.transform;
-          // Get the transform parameters from the style's transform matrix
-          const matrix = transform
-            .match(/^matrix\(([^\(]*)\)$/)[1]
-            .split(',')
-            .map(Number);
+          if (transform) {
+            // Get the transform parameters from the style's transform matrix
+            matrix = transform
+              .match(/^matrix\(([^\(]*)\)$/)[1]
+              .split(',')
+              .map(Number);
+          } else {
+            matrix = [
+              parseFloat(canvas.style.width) / canvas.width,
+              0,
+              0,
+              parseFloat(canvas.style.height) / canvas.height,
+              0,
+              0,
+            ];
+          }
           // Apply the transform to the export map context
           CanvasRenderingContext2D.prototype.setTransform.apply(
             mapContext,

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -34,6 +34,8 @@ import {createCanvasContext2D} from '../dom.js';
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
  * @property {import("../source/Vector.js").default} [source] Source.
+ * @property {boolean} [preserveDrawingBuffer] The preserveDrawingBuffer WebGL context attributes.
+ * Must be `true` if you want to access pixel data after rendering.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
@@ -77,6 +79,7 @@ class Heatmap extends VectorLayer {
     delete baseOptions.radius;
     delete baseOptions.blur;
     delete baseOptions.weight;
+    delete baseOptions.preserveDrawingBuffer;
     super(baseOptions);
 
     /**
@@ -84,6 +87,12 @@ class Heatmap extends VectorLayer {
      * @type {HTMLCanvasElement}
      */
     this.gradient_ = null;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.preserveDrawingBuffer_ = options.preserveDrawingBuffer;
 
     this.addChangeListener(Property.GRADIENT, this.handleGradientChanged_);
 
@@ -305,6 +314,9 @@ class Heatmap extends VectorLayer {
           },
         },
       ],
+      contextAttributes: {
+        preserveDrawingBuffer: this.preserveDrawingBuffer_,
+      },
     });
   }
 

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -30,6 +30,8 @@ import {parseLiteralStyle} from '../webgl/ShaderBuilder.js';
  * @property {VectorSourceType} [source] Source.
  * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
  * prevent all hit detection on the layer.
+ * @property {boolean} [preserveDrawingBuffer] The preserveDrawingBuffer WebGL context attributes.
+ * Must be `true` if you want to access pixel data after rendering.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
@@ -79,6 +81,7 @@ class WebGLPointsLayer extends Layer {
   constructor(options) {
     const baseOptions = assign({}, options);
 
+    delete baseOptions.preserveDrawingBuffer;
     super(baseOptions);
 
     /**
@@ -92,6 +95,12 @@ class WebGLPointsLayer extends Layer {
      * @type {boolean}
      */
     this.hitDetectionDisabled_ = !!options.disableHitDetection;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.preserveDrawingBuffer_ = options.preserveDrawingBuffer;
   }
 
   /**
@@ -111,6 +120,9 @@ class WebGLPointsLayer extends Layer {
         this.parseResult_.builder.getSymbolFragmentShader(true),
       uniforms: this.parseResult_.uniforms,
       attributes: this.parseResult_.attributes,
+      contextAttributes: {
+        preserveDrawingBuffer: this.preserveDrawingBuffer_,
+      },
     });
   }
 }

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -65,6 +65,9 @@ import {assign} from '../obj.js';
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  * @property {number} [cacheSize=512] The internal texture cache size.  This needs to be large enough to render
  * two zoom levels worth of tiles.
+ * @property {boolean} [preserveDrawingBuffer] The preserveDrawingBuffer WebGL context attributes.
+ * Must be `true` if you want to access pixel data after rendering.
+ * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
 /**
@@ -274,6 +277,9 @@ class WebGLTileLayer extends BaseTileLayer {
     const cacheSize = options.cacheSize;
     delete options.cacheSize;
 
+    const preserveDrawingBuffer = options.preserveDrawingBuffer;
+    delete options.preserveDrawingBuffer;
+
     super(options);
 
     /**
@@ -287,6 +293,12 @@ class WebGLTileLayer extends BaseTileLayer {
      * @private
      */
     this.cacheSize_ = cacheSize;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.preserveDrawingBuffer_ = preserveDrawingBuffer;
   }
 
   /**
@@ -309,6 +321,9 @@ class WebGLTileLayer extends BaseTileLayer {
       uniforms: parsedStyle.uniforms,
       className: this.getClassName(),
       cacheSize: this.cacheSize_,
+      contextAttributes: {
+        preserveDrawingBuffer: this.preserveDrawingBuffer_,
+      },
     });
   }
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -40,7 +40,7 @@ export const WebGLWorkerMessageType = {
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
  * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
- * @property {Object} [contextAttributes] WebGL context attributes.
+ * @property {WebGLContextAttributes} [contextAttributes] WebGL context attributes.
  */
 
 /**

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -40,6 +40,7 @@ export const WebGLWorkerMessageType = {
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
  * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
+ * @property {Object} [contextAttributes] WebGL context attributes.
  */
 
 /**
@@ -65,6 +66,7 @@ class WebGLLayerRenderer extends LayerRenderer {
     this.helper = new WebGLHelper({
       postProcesses: options.postProcesses,
       uniforms: options.uniforms,
+      contextAttributes: options.contextAttributes,
     });
 
     if (options.className !== undefined) {

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -57,7 +57,7 @@ import {listen, unlistenByKey} from '../../events.js';
  * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * Please note that `u_texture` is reserved for the main texture slot.
  * @property {Array<import("./Layer").PostProcessesOptions>} [postProcesses] Post-processes definitions
- * @property {Object} [contextAttributes] WebGL context attributes.
+ * @property {WebGLContextAttributes} [contextAttributes] WebGL context attributes.
  */
 
 /**

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -57,6 +57,7 @@ import {listen, unlistenByKey} from '../../events.js';
  * @property {Object<string,import("../../webgl/Helper").UniformValue>} [uniforms] Uniform definitions for the post process steps
  * Please note that `u_texture` is reserved for the main texture slot.
  * @property {Array<import("./Layer").PostProcessesOptions>} [postProcesses] Post-processes definitions
+ * @property {Object} [contextAttributes] WebGL context attributes.
  */
 
 /**
@@ -135,6 +136,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       className: options.className,
       uniforms: uniforms,
       postProcesses: options.postProcesses,
+      contextAttributes: options.contextAttributes,
     });
 
     this.sourceRevision_ = -1;

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -105,7 +105,7 @@ function getRenderExtent(frameState, extent) {
  * made available to shaders.
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
  * @property {number} [cacheSize=512] The texture cache size.
- * @property {Object} [contextAttributes] WebGL context attributes.
+ * @property {WebGLContextAttributes} [contextAttributes] WebGL context attributes.
  */
 
 /**

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -105,6 +105,7 @@ function getRenderExtent(frameState, extent) {
  * made available to shaders.
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
  * @property {number} [cacheSize=512] The texture cache size.
+ * @property {Object} [contextAttributes] WebGL context attributes.
  */
 
 /**
@@ -121,6 +122,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     super(tileLayer, {
       uniforms: options.uniforms,
       className: options.className,
+      contextAttributes: options.contextAttributes,
     });
 
     /**

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -85,7 +85,7 @@ const CONTEXT_IDS = ['experimental-webgl', 'webgl', 'webkit-3d', 'moz-webgl'];
 
 /**
  * @param {HTMLCanvasElement} canvas Canvas.
- * @param {Object} [opt_attributes] Attributes.
+ * @param {WebGLContextAttributes} [opt_attributes] Attributes.
  * @return {WebGLRenderingContext} WebGL rendering context.
  */
 export function getContext(canvas, opt_attributes) {

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -97,6 +97,7 @@ export const AttributeType = {
  * @property {Object<string,UniformValue>} [uniforms] Uniform definitions; property names must match the uniform
  * names in the provided or default shaders.
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
+ * @property {Object} [contextAttributes] WebGL context attributes.
  */
 
 /**
@@ -260,7 +261,7 @@ class WebGLHelper extends Disposable {
      * @private
      * @type {WebGLRenderingContext}
      */
-    this.gl_ = getContext(this.canvas_);
+    this.gl_ = getContext(this.canvas_, options.contextAttributes);
     const gl = this.getGL();
 
     /**

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -97,7 +97,7 @@ export const AttributeType = {
  * @property {Object<string,UniformValue>} [uniforms] Uniform definitions; property names must match the uniform
  * names in the provided or default shaders.
  * @property {Array<PostProcessesOptions>} [postProcesses] Post-processes definitions
- * @property {Object} [contextAttributes] WebGL context attributes.
+ * @property {WebGLContextAttributes} [contextAttributes] WebGL context attributes.
  */
 
 /**


### PR DESCRIPTION
Adds a `preserveDrawingBuffer` option to the Heatmap, WebGLPoints and WebGLTile layer options to make the canvases exportable (and compatible with a future PR to support `forEachLayerAtPixel`).  Add a simple Heatmap layer to the Export Map example.