### PR TITLE
Use nodata values in the GeoTIFF headers for fill value

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -25,8 +25,10 @@ import {fromCode as unitsFromCode} from '../proj/Units.js';
  * the configured min and max.
  * @property {number} [max] The maximum source data value.  Rendered values are scaled from 0 to 1 based on
  * the configured min and max.
- * @property {number} [nodata] Values to discard. When provided, an additional band (alpha) will be added
- * to the data.
+ * @property {number} [nodata] Values to discard (overriding any nodata values in the metadata).
+ * When provided, an additional alpha band will be added to the data.  Often the GeoTIFF metadata
+ * will include information about nodata values, so you should only need to set this property if
+ * you find that it is not already extracted from the metadata.
  * @property {Array<number>} [bands] Band numbers to be read from (where the first band is `1`). If not provided, all bands will
  * be read. For example, if a GeoTIFF has blue (1), green (2), red (3), and near-infrared (4) bands, and you only need the
  * near-infrared band, configure `bands: [4]`.


### PR DESCRIPTION
We currently use the `nodata` value from a source config object when reading rasters with geotiff.js.  If this config property is set, it is passed as the `fillValue` property to `readRasters` - so areas outside the image extent get filled with the user-configured `nodata` value.

We can make it easier to provide the appropriate `fillValue` by using the header-parsed `nodata` values.  This means people shouldn't need to configure a source with `nodata` unless the value is not provided in the image headers.

See #12838 for some more detail.