### PR TITLE
Update geotiff to 1.0.8; allow version range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.8.2-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "geotiff": "1.0.6",
+        "geotiff": "^1.0.8",
         "ol-mapbox-style": "^6.5.1",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
@@ -1839,13 +1839,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "dependencies": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.4.7.tgz",
+      "integrity": "sha512-Mir0MAKxg5v6BUIg9SI5VAyrIa/3uptf7aPyvPhHNh0RMYMevrWbaLrsVSZ1f92C39hWd8v7GrjvvOT+WG5VUQ=="
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -5292,17 +5288,17 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
-      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.8.tgz",
+      "integrity": "sha512-3YA6NpGuuXF+WwwgA7moSHIw1U0XHxBY8W5bjjoSGBCVuw6s+DOgt7Z95Y3bf5k19RHixv6zW8KpW/yrRno43Q==",
       "dependencies": {
-        "@petamoriken/float16": "^1.0.7",
+        "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^5.0.0"
+        "threads": "^1.7.0",
+        "xml-utils": "^1.0.2"
       },
       "engines": {
         "browsers": "defaults",
@@ -5903,7 +5899,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-ip": {
       "version": "6.2.0",
@@ -7102,12 +7099,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -8858,6 +8851,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -9896,6 +9890,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -9904,6 +9899,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10255,9 +10251,9 @@
       "dev": true
     },
     "node_modules/threads": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
-      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
       "dependencies": {
         "callsites": "^3.1.0",
         "debug": "^4.2.0",
@@ -10276,15 +10272,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -10397,14 +10384,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
-    },
-    "node_modules/txml": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
-      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
-      "dependencies": {
-        "through2": "^3.0.1"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10613,7 +10592,8 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -11335,6 +11315,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
+      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
     },
     "node_modules/xmlcreate": {
       "version": "2.0.3",
@@ -12660,13 +12645,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "requires": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.4.7.tgz",
+      "integrity": "sha512-Mir0MAKxg5v6BUIg9SI5VAyrIa/3uptf7aPyvPhHNh0RMYMevrWbaLrsVSZ1f92C39hWd8v7GrjvvOT+WG5VUQ=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.0",
@@ -15395,17 +15376,17 @@
       "dev": true
     },
     "geotiff": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.6.tgz",
-      "integrity": "sha512-QpThfg270taZirnyZyN3INoo5OfUOtedYEbiotML5ts1Qou7rxtHrU9nUW2J07biEuSV6qWq784z7brUH7/gRQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-1.0.8.tgz",
+      "integrity": "sha512-3YA6NpGuuXF+WwwgA7moSHIw1U0XHxBY8W5bjjoSGBCVuw6s+DOgt7Z95Y3bf5k19RHixv6zW8KpW/yrRno43Q==",
       "requires": {
-        "@petamoriken/float16": "^1.0.7",
+        "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
         "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^5.0.0"
+        "threads": "^1.7.0",
+        "xml-utils": "^1.0.2"
       }
     },
     "get-caller-file": {
@@ -15855,7 +15836,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-ip": {
       "version": "6.2.0",
@@ -16759,12 +16741,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -18108,6 +18086,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -18944,6 +18923,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -18951,7 +18931,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
         }
       }
     },
@@ -19202,9 +19183,9 @@
       "dev": true
     },
     "threads": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.6.5.tgz",
-      "integrity": "sha512-yL1NN4qZ25crW8wDoGn7TqbENJ69w3zCEjIGXpbqmQ4I+QHrG8+DLaZVKoX74OQUXWCI2lbbrUxDxAbr1xjDGQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
+      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
       "requires": {
         "callsites": "^3.1.0",
         "debug": "^4.2.0",
@@ -19218,15 +19199,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
-    },
-    "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
     },
     "thunky": {
       "version": "1.1.0",
@@ -19320,14 +19292,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
-    },
-    "txml": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
-      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
-      "requires": {
-        "through2": "^3.0.1"
-      }
     },
     "type-check": {
       "version": "0.4.0",
@@ -19483,7 +19447,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -19990,6 +19955,11 @@
       "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
       "dev": true,
       "requires": {}
+    },
+    "xml-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
+      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
     },
     "xmlcreate": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://opencollective.com/openlayers"
   },
   "dependencies": {
-    "geotiff": "1.0.6",
+    "geotiff": "^1.0.8",
     "ol-mapbox-style": "^6.5.1",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"


### PR DESCRIPTION
The `geotiff@1.0.8` release brings in a couple fixes for issues people have noticed here.

 * https://github.com/geotiffjs/geotiff.js/pull/245 fixes #12852.
 * https://github.com/geotiffjs/geotiff.js/pull/248 fixes #12838.