### PR TITLE
Add a note about installing git before using create-ol-app

### DIFF
--- a/doc/tutorials/bundle.md
+++ b/doc/tutorials/bundle.md
@@ -15,6 +15,8 @@ Create a new empty directory for your project and navigate to it by running `mkd
 
     npx create-ol-app
 
+*You will need to have `git` installed for the above command to work.  If you receive an error, make that [Git is installed](https://github.com/git-guides/install-git) on your system.*
+
 This will install the `ol` package, set up a development environment with additional dependencies, and give you an `index.html` and `main.js` starting point for your application.  By default, [Parcel](https://parceljs.org) will be used as a module loader and bundler.  See the [`create-ol-app`](https://github.com/openlayers/create-ol-app) documentation for details on using another bundler.
 
 To start the development server


### PR DESCRIPTION
The `create-ol-app` program depends on `git`.  This branch adds a link from our docs to the Git installation docs.

See #12860.