### PR TITLE
Add a style convenience function

### DIFF
--- a/examples/geojson.js
+++ b/examples/geojson.js
@@ -3,78 +3,65 @@ import Feature from '../src/ol/Feature.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
-
-const image = new CircleStyle({
-  radius: 5,
-  fill: null,
-  stroke: new Stroke({color: 'red', width: 1}),
-});
+import {style} from '../src/ol/style.js';
 
 const styles = {
-  'Point': new Style({
-    image: image,
+  Point: style({
+    circle: {radius: 10, stroke: {color: 'red', width: 1}},
   }),
-  'LineString': new Style({
-    stroke: new Stroke({
+  LineString: style({
+    stroke: {
       color: 'green',
-      width: 1,
-    }),
+    },
   }),
-  'MultiLineString': new Style({
-    stroke: new Stroke({
+  MultiLineString: style({
+    stroke: {
       color: 'green',
-      width: 1,
-    }),
+    },
   }),
-  'MultiPoint': new Style({
-    image: image,
-  }),
-  'MultiPolygon': new Style({
-    stroke: new Stroke({
+  MultiPolygon: style({
+    stroke: {
       color: 'yellow',
-      width: 1,
-    }),
-    fill: new Fill({
+    },
+    fill: {
       color: 'rgba(255, 255, 0, 0.1)',
-    }),
+    },
   }),
-  'Polygon': new Style({
-    stroke: new Stroke({
+  Polygon: style({
+    stroke: {
       color: 'blue',
       lineDash: [4],
       width: 3,
-    }),
-    fill: new Fill({
+    },
+    fill: {
       color: 'rgba(0, 0, 255, 0.1)',
-    }),
+    },
   }),
-  'GeometryCollection': new Style({
-    stroke: new Stroke({
+  GeometryCollection: style({
+    stroke: {
       color: 'magenta',
       width: 2,
-    }),
-    fill: new Fill({
+    },
+    fill: {
       color: 'magenta',
-    }),
-    image: new CircleStyle({
-      radius: 10,
-      fill: null,
-      stroke: new Stroke({
+    },
+    circle: {
+      radius: 15,
+      stroke: {
         color: 'magenta',
-      }),
-    }),
+      },
+    },
   }),
-  'Circle': new Style({
-    stroke: new Stroke({
+  Circle: style({
+    stroke: {
       color: 'red',
       width: 2,
-    }),
-    fill: new Fill({
+    },
+    fill: {
       color: 'rgba(255,0,0,0.2)',
-    }),
+    },
   }),
 };
 
@@ -83,46 +70,40 @@ const styleFunction = function (feature) {
 };
 
 const geojsonObject = {
-  'type': 'FeatureCollection',
-  'crs': {
-    'type': 'name',
-    'properties': {
-      'name': 'EPSG:3857',
-    },
-  },
-  'features': [
+  type: 'FeatureCollection',
+  features: [
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'Point',
-        'coordinates': [0, 0],
+      type: 'Feature',
+      geometry: {
+        type: 'Point',
+        coordinates: [0, 0],
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'LineString',
-        'coordinates': [
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
           [4e6, -2e6],
           [8e6, 2e6],
         ],
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'LineString',
-        'coordinates': [
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
           [4e6, 2e6],
           [8e6, -2e6],
         ],
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'Polygon',
-        'coordinates': [
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
           [
             [-5e6, -1e6],
             [-3e6, -1e6],
@@ -133,10 +114,10 @@ const geojsonObject = {
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'MultiLineString',
-        'coordinates': [
+      type: 'Feature',
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: [
           [
             [-1e6, -7.5e5],
             [-1e6, 7.5e5],
@@ -157,10 +138,10 @@ const geojsonObject = {
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'MultiPolygon',
-        'coordinates': [
+      type: 'Feature',
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
           [
             [
               [-5e6, 6e6],
@@ -192,24 +173,24 @@ const geojsonObject = {
       },
     },
     {
-      'type': 'Feature',
-      'geometry': {
-        'type': 'GeometryCollection',
-        'geometries': [
+      type: 'Feature',
+      geometry: {
+        type: 'GeometryCollection',
+        geometries: [
           {
-            'type': 'LineString',
-            'coordinates': [
+            type: 'LineString',
+            coordinates: [
               [-5e6, -5e6],
               [0, -5e6],
             ],
           },
           {
-            'type': 'Point',
-            'coordinates': [4e6, -5e6],
+            type: 'Point',
+            coordinates: [4e6, -5e6],
           },
           {
-            'type': 'Polygon',
-            'coordinates': [
+            type: 'Polygon',
+            coordinates: [
               [
                 [1e6, -6e6],
                 [3e6, -6e6],

--- a/src/ol/style.js
+++ b/src/ol/style.js
@@ -1,13 +1,54 @@
 /**
  * @module ol/style
  */
+import Circle from './style/Circle.js';
+import Fill from './style/Fill.js';
+import Icon from './style/Icon.js';
+import RegularShape from './style/RegularShape.js';
+import Stroke from './style/Stroke.js';
+import Style from './style/Style.js';
+import Text from './style/Text.js';
 
-export {default as Circle} from './style/Circle.js';
-export {default as Fill} from './style/Fill.js';
-export {default as Icon} from './style/Icon.js';
 export {default as IconImage} from './style/IconImage.js';
 export {default as Image} from './style/Image.js';
-export {default as RegularShape} from './style/RegularShape.js';
-export {default as Stroke} from './style/Stroke.js';
-export {default as Style} from './style/Style.js';
-export {default as Text} from './style/Text.js';
+
+/**
+ * @typedef {Object} Config
+ * @property {import("./style/Fill.js").Options} [fill] Fill style.
+ * @property {import("./style/Stroke.js").Options} [stroke] Stroke style.
+ * @property {import("./style/Icon.js").Options} [icon] Icon style.
+ * @property {import("./style/Circle.js").Options} [circle] Circle style.  This property is ignored if `icon` is provided.
+ * @property {import("./style/RegularShape.js").Options} [shape] Shape style.  This property is ignored if `icon` or `circle` is provided.
+ * @property {import("./style/Text.js").Options} [text] Text style.
+ */
+
+/**
+ * @param {Config} config The style configuration.
+ * @return {import("./style/Style.js").default} A new style.
+ */
+function style(config) {
+  const options = {};
+  if (config.fill) {
+    options.fill = new Fill(config.fill);
+  }
+
+  if (config.stroke) {
+    options.stroke = new Stroke(config.stroke);
+  }
+
+  if (config.text) {
+    options.text = new Text(config.text);
+  }
+
+  if (config.icon) {
+    options.image = new Icon(config.icon);
+  } else if (config.circle) {
+    options.image = new Circle(config.circle);
+  } else if (config.shape) {
+    options.image = new RegularShape(config.shape);
+  }
+
+  return new Style(options);
+}
+
+export {Style, Text, RegularShape, Circle, Stroke, Icon, Fill, style};

--- a/src/ol/style/Circle.js
+++ b/src/ol/style/Circle.js
@@ -6,9 +6,9 @@ import RegularShape from './RegularShape.js';
 
 /**
  * @typedef {Object} Options
- * @property {import("./Fill.js").default} [fill] Fill style.
- * @property {number} radius Circle radius.
- * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./Fill.js").default|import("./Fill.js").Options} [fill] Fill style.
+ * @property {number} [radius=5] Circle radius.
+ * @property {import("./Stroke.js").default|import("./Stroke.js").Options} [stroke] Stroke style.
  * @property {Array<number>} [displacement=[0,0]] displacement
  * @property {number|import("../size.js").Size} [scale=1] Scale. A two dimensional scale will produce an ellipse.
  * Unless two dimensional scaling is required a better result may be obtained with an appropriate setting for `radius`.
@@ -28,12 +28,13 @@ class CircleStyle extends RegularShape {
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
+    /** @type {Options} */
     const options = opt_options ? opt_options : {};
 
     super({
       points: Infinity,
       fill: options.fill,
-      radius: options.radius,
+      radius: options.radius !== undefined ? options.radius : 5,
       stroke: options.stroke,
       scale: options.scale !== undefined ? options.scale : 1,
       rotation: options.rotation !== undefined ? options.rotation : 0,

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -37,11 +37,13 @@ class IconImage extends EventTarget {
      * @private
      * @type {HTMLImageElement|HTMLCanvasElement}
      */
-    this.image_ = !image ? new Image() : image;
+    this.image_ = image;
 
-    if (crossOrigin !== null) {
-      /** @type {HTMLImageElement} */ (this.image_).crossOrigin = crossOrigin;
-    }
+    /**
+     * @private
+     * @type {string|null}
+     */
+    this.crossOrigin_ = crossOrigin;
 
     /**
      * @private
@@ -199,19 +201,28 @@ class IconImage extends EventTarget {
    * Load not yet loaded URI.
    */
   load() {
-    if (this.imageState_ == ImageState.IDLE) {
-      this.imageState_ = ImageState.LOADING;
-      try {
-        /** @type {HTMLImageElement} */ (this.image_).src = this.src_;
-      } catch (e) {
-        this.handleImageError_();
-      }
-      this.unlisten_ = listenImage(
-        this.image_,
-        this.handleImageLoad_.bind(this),
-        this.handleImageError_.bind(this)
-      );
+    if (this.imageState_ !== ImageState.IDLE) {
+      return;
     }
+
+    if (!this.image_) {
+      this.image_ = new Image();
+      if (this.crossOrigin_ !== null) {
+        this.image_.crossOrigin = this.crossOrigin_;
+      }
+    }
+
+    this.imageState_ = ImageState.LOADING;
+    try {
+      /** @type {HTMLImageElement} */ (this.image_).src = this.src_;
+    } catch (e) {
+      this.handleImageError_();
+    }
+    this.unlisten_ = listenImage(
+      this.image_,
+      this.handleImageLoad_.bind(this),
+      this.handleImageError_.bind(this)
+    );
   }
 
   /**

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -2,8 +2,10 @@
  * @module ol/style/RegularShape
  */
 
+import Fill from './Fill.js';
 import ImageState from '../ImageState.js';
 import ImageStyle from './Image.js';
+import Stroke from './Stroke.js';
 import {asArray} from '../color.js';
 import {asColorLike} from '../colorlike.js';
 import {createCanvasContext2D} from '../dom.js';
@@ -18,7 +20,7 @@ import {
 /**
  * Specify radius for regular polygons, or radius1 and radius2 for stars.
  * @typedef {Object} Options
- * @property {import("./Fill.js").default} [fill] Fill style.
+ * @property {import("./Fill.js").default|import("./Fill.js").Options} [fill] Fill style.
  * @property {number} points Number of points for stars and regular polygons. In case of a polygon, the number of points
  * is the number of sides.
  * @property {number} [radius] Radius of a regular polygon.
@@ -26,7 +28,7 @@ import {
  * @property {number} [radius2] Second radius of a star.
  * @property {number} [angle=0] Shape's angle in radians. A value of 0 will have one of the shape's point facing up.
  * @property {Array<number>} [displacement=[0,0]] Displacement of the shape
- * @property {import("./Stroke.js").default} [stroke] Stroke style.
+ * @property {import("./Stroke.js").default|import("./Stroke.js").Options} [stroke] Stroke style.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {boolean} [rotateWithView=false] Whether to rotate the shape with the view.
  * @property {number|import("../size.js").Size} [scale=1] Scale. Unless two dimensional scaling is required a better
@@ -83,11 +85,22 @@ class RegularShape extends ImageStyle {
      */
     this.hitDetectionCanvas_ = null;
 
+    /** @type {import("./Fill.js").default} */
+    let fill = null;
+
+    if (options.fill) {
+      if (options.fill instanceof Fill) {
+        fill = options.fill;
+      } else {
+        fill = new Fill(options.fill);
+      }
+    }
+
     /**
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.fill_ = options.fill !== undefined ? options.fill : null;
+    this.fill_ = fill;
 
     /**
      * @private
@@ -120,11 +133,22 @@ class RegularShape extends ImageStyle {
      */
     this.angle_ = options.angle !== undefined ? options.angle : 0;
 
+    /** @type {import("./Stroke.js").default} */
+    let stroke = null;
+
+    if (options.stroke) {
+      if (options.stroke instanceof Stroke) {
+        stroke = options.stroke;
+      } else {
+        stroke = new Stroke(options.stroke);
+      }
+    }
+
     /**
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.stroke_ = options.stroke !== undefined ? options.stroke : null;
+    this.stroke_ = stroke;
 
     /**
      * @private

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -2,6 +2,7 @@
  * @module ol/style/Text
  */
 import Fill from './Fill.js';
+import Stroke from './Stroke.js';
 import TextPlacement from './TextPlacement.js';
 import {toSize} from '../size.js';
 
@@ -33,11 +34,11 @@ const DEFAULT_FILL_COLOR = '#333';
  * placement where `maxAngle` is not exceeded.
  * @property {string} [textBaseline='middle'] Text base line. Possible values: 'bottom', 'top', 'middle', 'alphabetic',
  * 'hanging', 'ideographic'.
- * @property {import("./Fill.js").default} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
- * @property {import("./Stroke.js").default} [stroke] Stroke style.
- * @property {import("./Fill.js").default} [backgroundFill] Fill style for the text background when `placement` is
+ * @property {import("./Fill.js").default|import("./Fill.js").Options} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
+ * @property {import("./Stroke.js").default|import("./Stroke.js").Options} [stroke] Stroke style.
+ * @property {import("./Fill.js").default|import("./Fill.js").Options} [backgroundFill] Fill style for the text background when `placement` is
  * `'point'`. Default is no fill.
- * @property {import("./Stroke.js").default} [backgroundStroke] Stroke style for the text background  when `placement`
+ * @property {import("./Stroke.js").default|import("./Stroke.js").Options} [backgroundStroke] Stroke style for the text background  when `placement`
  * is `'point'`. Default is no stroke.
  * @property {Array<number>} [padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
@@ -103,14 +104,24 @@ class Text {
      */
     this.textBaseline_ = options.textBaseline;
 
+    /** @type {import("./Fill.js").default} */
+    let fill = null;
+
+    if (options.fill) {
+      if (options.fill instanceof Fill) {
+        fill = options.fill;
+      } else {
+        fill = new Fill(options.fill);
+      }
+    } else {
+      fill = new Fill({color: DEFAULT_FILL_COLOR});
+    }
+
     /**
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.fill_ =
-      options.fill !== undefined
-        ? options.fill
-        : new Fill({color: DEFAULT_FILL_COLOR});
+    this.fill_ = fill;
 
     /**
      * @private
@@ -132,11 +143,22 @@ class Text {
      */
     this.overflow_ = !!options.overflow;
 
+    /** @type {import("./Stroke.js").default} */
+    let stroke = null;
+
+    if (options.stroke) {
+      if (options.stroke instanceof Stroke) {
+        stroke = options.stroke;
+      } else {
+        stroke = new Stroke(options.stroke);
+      }
+    }
+
     /**
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.stroke_ = options.stroke !== undefined ? options.stroke : null;
+    this.stroke_ = stroke;
 
     /**
      * @private
@@ -150,21 +172,39 @@ class Text {
      */
     this.offsetY_ = options.offsetY !== undefined ? options.offsetY : 0;
 
+    /** @type {import("./Fill.js").default} */
+    let backgroundFill = null;
+
+    if (options.backgroundFill) {
+      if (options.backgroundFill instanceof Fill) {
+        backgroundFill = options.backgroundFill;
+      } else {
+        backgroundFill = new Fill(options.backgroundFill);
+      }
+    }
+
     /**
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.backgroundFill_ = options.backgroundFill
-      ? options.backgroundFill
-      : null;
+    this.backgroundFill_ = backgroundFill;
+
+    /** @type {import("./Stroke.js").default} */
+    let backgroundStroke = null;
+
+    if (options.backgroundStroke) {
+      if (options.backgroundStroke instanceof Stroke) {
+        backgroundStroke = options.backgroundStroke;
+      } else {
+        backgroundStroke = new Stroke(options.backgroundStroke);
+      }
+    }
 
     /**
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.backgroundStroke_ = options.backgroundStroke
-      ? options.backgroundStroke
-      : null;
+    this.backgroundStroke_ = backgroundStroke;
 
     /**
      * @private

--- a/test/node/ol/style.test.js
+++ b/test/node/ol/style.test.js
@@ -1,0 +1,143 @@
+import expect from '../expect.js';
+import {
+  Circle,
+  Fill,
+  Icon,
+  RegularShape,
+  Stroke,
+  Style,
+  Text,
+  style,
+} from '../../../src/ol/style.js';
+
+describe('ol/style.js', () => {
+  describe('style()', () => {
+    it('constructs a style with a fill', () => {
+      const s = style({
+        fill: {
+          color: 'green',
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const fill = s.getFill();
+      expect(fill).to.be.a(Fill);
+      expect(fill.getColor()).to.be('green');
+    });
+
+    it('constructs a style with a stroke', () => {
+      const s = style({
+        stroke: {
+          width: 42,
+          color: 'blue',
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const stroke = s.getStroke();
+      expect(stroke).to.be.a(Stroke);
+      expect(stroke.getColor()).to.be('blue');
+      expect(stroke.getWidth()).to.be(42);
+    });
+
+    it('constructs a style with a stroke and a fill', () => {
+      const s = style({
+        stroke: {
+          width: 10,
+          color: 'yellow',
+        },
+        fill: {
+          color: 'orange',
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const stroke = s.getStroke();
+      expect(stroke).to.be.a(Stroke);
+      expect(stroke.getColor()).to.be('yellow');
+      expect(stroke.getWidth()).to.be(10);
+
+      const fill = s.getFill();
+      expect(fill).to.be.a(Fill);
+      expect(fill.getColor()).to.be('orange');
+    });
+
+    it('constructs a style with a text', () => {
+      const s = style({
+        text: {
+          fill: {color: 'purple'},
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const text = s.getText();
+      expect(text).to.be.a(Text);
+
+      const fill = text.getFill();
+      expect(fill.getColor()).to.be('purple');
+    });
+
+    it('constructs a style with an icon', () => {
+      const s = style({
+        icon: {
+          src: 'https://example.com/icon.png',
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const icon = s.getImage();
+      expect(icon).to.be.a(Icon);
+      expect(icon.getSrc()).to.be('https://example.com/icon.png');
+    });
+
+    it('constructs a style with a circle', () => {
+      const s = style({
+        circle: {
+          stroke: {color: 'black'},
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const circle = s.getImage();
+      expect(circle).to.be.a(Circle);
+      expect(circle.getRadius()).to.be(5);
+
+      const stroke = circle.getStroke();
+      expect(stroke).to.be.a(Stroke);
+      expect(stroke.getColor()).to.be('black');
+    });
+
+    it('constructs a style with a shape', () => {
+      const s = style({
+        shape: {
+          points: 10,
+          stroke: {color: 'red'},
+          fill: {color: 'white'},
+          radius1: 12,
+          radius2: 8,
+        },
+      });
+
+      expect(s).to.be.an(Style);
+
+      const shape = s.getImage();
+      expect(shape).to.be.a(RegularShape);
+      expect(shape.getRadius()).to.be(12);
+      expect(shape.getRadius2()).to.be(8);
+
+      const stroke = shape.getStroke();
+      expect(stroke).to.be.a(Stroke);
+      expect(stroke.getColor()).to.be('red');
+
+      const fill = shape.getFill();
+      expect(fill).to.be.a(Fill);
+      expect(fill.getColor()).to.be('white');
+    });
+  });
+});


### PR DESCRIPTION
This adds a new `style` function as a convenience for constructing `Style` objects.

```js
// before
import {Stroke, Fill, Circle, Style} from 'ol/style.js';

const s = new Style({
  fill: new Fill({color: 'orange'}),
  stroke: new Stroke({width: 15, color: 'red'}),
  image: new Circle({
    radius: 42,
    stroke: new Stroke({width: 10, color: 'yellow'}),
    fill: new Fill({color: 'white'}),
  }),
});
```

```js
// after
import {style} from 'ol/style.js';

const s = style({
  fill: {color: 'orange'},
  stroke: {width: 15, color: 'red'},
  circle: {
    radius: 42,
    stroke: {width: 10, color: 'yellow'},
    fill: {color: 'white'},
  },
});
```

Alternatively, we could support a completely flat object:

```js
// alternatively (not implemented)
import {style} from 'ol/style.js';

const s = style({
  fillColor: 'orange',
  strokeWidth: 15,
  strokeColor: 'red',
  circleRadius: 42,
  circleStrokeWidth: 10, 
  circleStrokeColor: 'yellow',
  circleFillColor: 'white',
});
```

The flat style would require more duplication in terms of types and documentation.  And whenever we modified the options for the traditional style constructors, we'd also need to remember to update the options taken by the new `style` function.  This is probably manageable, but I wanted to try out the simpler implementation first.

We could also make it so this `style` function was called internally.  Then people could just return object literals from their style functions, for example.  (The downside of doing this is that it encourages a lot of garbage creation, but maybe people are already creating new `Style` objects on every call.)
