### PR TITLE
Only trigger change event if animating a tile transition

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -862,7 +862,9 @@ class RasterSource extends ImageSource {
     this.dispatchEvent(
       new RasterSourceEvent(RasterEventType.AFTEROPERATIONS, frameState, data)
     );
-    requestAnimationFrame(this.changed.bind(this));
+    if (frameState.animate) {
+      requestAnimationFrame(this.changed.bind(this));
+    }
   }
 
   disposeInternal() {


### PR DESCRIPTION
When raster sources are configured with a source that has a tile transition, the raster source needs to trigger the change event to keep the underlying source animation going.  This was not happening in the 6.6.1 release (and earlier probably).  #12596 was opened and #12597 was proposed to fix it.

The change in #12597 made it so the raster source always triggers a change event after updating its rendered revision counter.  This results in an endless loop as noted in #12874.

This change makes it so the raster source triggers another change event only if the `frameState.animate` property is `true`.  This happens when the underlying tile source is still in an animation transition.  After the transition is complete, `frameState.animate` is `false`, and the raster source stops firing change events.

Fixes #12874.