### PR TITLE
Exposing clearLoadedExtents in Vector source

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -1015,7 +1015,7 @@ class VectorSource extends Source {
    * Removes all extents from the list of loaded extents.
    */
   clearLoadedExtents() {
-    if(this.loadedExtentsRtree_) {
+    if (this.loadedExtentsRtree_) {
       this.loadedExtentsRtree_.clear();
     }
   }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -2,24 +2,24 @@
  * @module ol/source/Vector
  */
 
-import { extend } from '../array.js';
-import { assert } from '../asserts.js';
 import Collection from '../Collection.js';
 import CollectionEventType from '../CollectionEventType.js';
-import { listen, unlistenByKey } from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
-import { containsExtent, equals } from '../extent.js';
-import { xhr } from '../featureloader.js';
-import { TRUE, VOID } from '../functions.js';
-import { all as allStrategy } from '../loadingstrategy.js';
-import { getValues, isEmpty } from '../obj.js';
 import ObjectEventType from '../ObjectEventType.js';
 import RBush from '../structs/RBush.js';
-import { getUid } from '../util.js';
 import Source from './Source.js';
 import SourceState from './State.js';
 import VectorEventType from './VectorEventType.js';
+import {TRUE, VOID} from '../functions.js';
+import {all as allStrategy} from '../loadingstrategy.js';
+import {assert} from '../asserts.js';
+import {containsExtent, equals} from '../extent.js';
+import {extend} from '../array.js';
+import {getUid} from '../util.js';
+import {getValues, isEmpty} from '../obj.js';
+import {listen, unlistenByKey} from '../events.js';
+import {xhr} from '../featureloader.js';
 
 /**
  * A function that takes an {@link module:ol/extent~Extent} and a resolution as arguments, and

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -2,24 +2,24 @@
  * @module ol/source/Vector
  */
 
+import { extend } from '../array.js';
+import { assert } from '../asserts.js';
 import Collection from '../Collection.js';
 import CollectionEventType from '../CollectionEventType.js';
+import { listen, unlistenByKey } from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
+import { containsExtent, equals } from '../extent.js';
+import { xhr } from '../featureloader.js';
+import { TRUE, VOID } from '../functions.js';
+import { all as allStrategy } from '../loadingstrategy.js';
+import { getValues, isEmpty } from '../obj.js';
 import ObjectEventType from '../ObjectEventType.js';
 import RBush from '../structs/RBush.js';
+import { getUid } from '../util.js';
 import Source from './Source.js';
 import SourceState from './State.js';
 import VectorEventType from './VectorEventType.js';
-import {TRUE, VOID} from '../functions.js';
-import {all as allStrategy} from '../loadingstrategy.js';
-import {assert} from '../asserts.js';
-import {containsExtent, equals} from '../extent.js';
-import {extend} from '../array.js';
-import {getUid} from '../util.js';
-import {getValues, isEmpty} from '../obj.js';
-import {listen, unlistenByKey} from '../events.js';
-import {xhr} from '../featureloader.js';
 
 /**
  * A function that takes an {@link module:ol/extent~Extent} and a resolution as arguments, and
@@ -988,7 +988,7 @@ class VectorSource extends Source {
 
   refresh() {
     this.clear(true);
-    this.loadedExtentsRtree_.clear();
+    this.clearLoadedExtents();
     super.refresh();
   }
 
@@ -1008,6 +1008,15 @@ class VectorSource extends Source {
     });
     if (obj) {
       loadedExtentsRtree.remove(obj);
+    }
+  }
+
+  /**
+   * Removes all extents from the list of loaded extents.
+   */
+  clearLoadedExtents() {
+    if(this.loadedExtentsRtree_) {
+      this.loadedExtentsRtree_.clear();
     }
   }
 

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -1,20 +1,20 @@
 import Collection from '../../../../../src/ol/Collection.js';
+import { listen } from '../../../../../src/ol/events.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
-import Map from '../../../../../src/ol/Map.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
-import VectorSource from '../../../../../src/ol/source/Vector.js';
-import View from '../../../../../src/ol/View.js';
-import {bbox as bboxStrategy} from '../../../../../src/ol/loadingstrategy.js';
+import { bbox as bboxStrategy } from '../../../../../src/ol/loadingstrategy.js';
+import Map from '../../../../../src/ol/Map.js';
 import {
   fromLonLat,
   get as getProjection,
-  transformExtent,
+  transformExtent
 } from '../../../../../src/ol/proj.js';
-import {getUid} from '../../../../../src/ol/util.js';
-import {listen} from '../../../../../src/ol/events.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
+import { getUid } from '../../../../../src/ol/util.js';
+import View from '../../../../../src/ol/View.js';
 
 describe('ol.source.Vector', function () {
   let pointFeature;
@@ -710,6 +710,23 @@ describe('ol.source.Vector', function () {
           setTimeout(function () {
             expect(source.loadedExtentsRtree_.getAll()).to.have.length(1);
             source.removeLoadedExtent(bbox);
+            expect(source.loadedExtentsRtree_.getAll()).to.have.length(0);
+            done();
+          }, 0);
+        });
+        source.loadFeatures(
+          [-10000, -10000, 10000, 10000],
+          1,
+          getProjection('EPSG:3857')
+        );
+      });
+
+      it('removes all extents with #clearLoadedExtents()', function (done) {
+        const source = new VectorSource();
+        source.setLoader(function (bbox, resolution, projection) {
+          setTimeout(function () {
+            expect(source.loadedExtentsRtree_.getAll()).to.have.length(1);
+            source.clearLoadedExtents();
             expect(source.loadedExtentsRtree_.getAll()).to.have.length(0);
             done();
           }, 0);

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -1,20 +1,20 @@
 import Collection from '../../../../../src/ol/Collection.js';
-import { listen } from '../../../../../src/ol/events.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
+import Map from '../../../../../src/ol/Map.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
-import { bbox as bboxStrategy } from '../../../../../src/ol/loadingstrategy.js';
-import Map from '../../../../../src/ol/Map.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
+import View from '../../../../../src/ol/View.js';
+import {bbox as bboxStrategy} from '../../../../../src/ol/loadingstrategy.js';
 import {
   fromLonLat,
   get as getProjection,
-  transformExtent
+  transformExtent,
 } from '../../../../../src/ol/proj.js';
-import VectorSource from '../../../../../src/ol/source/Vector.js';
-import { getUid } from '../../../../../src/ol/util.js';
-import View from '../../../../../src/ol/View.js';
+import {getUid} from '../../../../../src/ol/util.js';
+import {listen} from '../../../../../src/ol/events.js';
 
 describe('ol.source.Vector', function () {
   let pointFeature;


### PR DESCRIPTION
In very large datasets, it might be needed to refetch data based on
certain conditions. Such a condition could be a change in zoom level on
the map, leading to more finegrained, server-side clustered data.

Right now, it is not possible to reload data with a loader function
after a zoom change, as the loadedExtentsRtree would see the requested
BBox as already loaded, not forwarding the request to the loader
function.

In order to be able to listen to map events outside the vector source
and refetch data based on custom event conditions, the
clearLoadedExtents function was added, so the user can manually decide
when to reset the already fetched extents.

See this stackoverflow issue for reference:
https://stackoverflow.com/questions/68543574/openlayers-slow-performance-with-140k-features/68555759#68555759
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
