### PR TITLE
Build site preview as a GitHub action

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -1,0 +1,22 @@
+name: Build Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build-site
+      - uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: build/site

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,33 @@
+name: Deploy Preview
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm install --global netlify-cli
+      - uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{github.ref}}
+          check-name: 'build-preview'
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          wait-interval: 10
+      - uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: build-preview.yml
+          pr: ${{github.event.number}}
+          name: site
+          path: build/site
+      - env:
+          NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
+          NETLIFY_SITE_ID: ${{secrets.NETLIFY_SITE_ID}}
+        run: netlify deploy --dir=build/site --alias=deploy-preview-${{github.event.number}}


### PR DESCRIPTION
We are limited to 1,000 build minutes in our Netlify plan and are exceeding this with our pull request deploy previews.  Instead of running our site builds on Netlify, we can do this as part of our GitHub workflows.

I've stopped the integrated deploys from Netlify while we test this alternative method.