### PR TITLE
Make removeFeature consistent with other remove methods

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -544,10 +544,10 @@ class VectorSource extends Source {
       }
     } else {
       if (this.featuresRtree_) {
-        // use Array forEach to ignore return
-        this.featuresRtree_
-          .getAll()
-          .forEach(this.removeFeatureInternal.bind(this));
+        const removeAndIgnoreReturn = function (feature) {
+          this.removeFeatureInternal(feature);
+        }.bind(this);
+        this.featuresRtree_.forEach(removeAndIgnoreReturn);
         for (const id in this.nullGeometryFeatures_) {
           this.removeFeatureInternal(this.nullGeometryFeatures_[id]);
         }
@@ -1037,9 +1037,6 @@ class VectorSource extends Source {
     if (result) {
       this.changed();
     }
-    // TODO at full version for consistency with other remove methods
-    // (would be breaking change if used as callback in forEachFeatureAtPixel)
-    //return result;
   }
 
   /**

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -339,6 +339,19 @@ describe('ol.source.Vector', function () {
         vectorSource.removeFeature(features[0]);
         expect(listener.called).to.be(true);
       });
+
+      it('accepts features that are not in the source', function () {
+        const changeListener = sinon.spy();
+        listen(vectorSource, 'change', changeListener);
+
+        const removeFeatureListener = sinon.spy();
+        listen(vectorSource, 'removefeature', removeFeatureListener);
+
+        const feature = new Feature(new Point([0, 0]));
+        vectorSource.removeFeature(feature);
+        expect(changeListener.called).to.be(false);
+        expect(removeFeatureListener.called).to.be(false);
+      });
     });
 
     describe("modifying a feature's geometry", function () {


### PR DESCRIPTION
Fixes #12723
Replaces #12726

Similar to `removeLayer`, `removeInteraction`, etc. avoid errors if the feature is not defined or has already been removed.  Clean rebased replacement for #12726.

There is a TODO comment to return the removed feature if it is successfully removed in the next full version, a potential breaking change if for example `map.forEachFeatureAtPixel(pixel, source.removeFeature.bind(source));` was used as `forEachFeatureAtPixel` would stop after the first feature.