### PR TITLE
Include WebGL context in render events for WebGL layers

### DIFF
--- a/examples/webgl-layer-swipe.html
+++ b/examples/webgl-layer-swipe.html
@@ -1,0 +1,16 @@
+---
+layout: example.html
+title: Layer Swipe (WebGL)
+shortdesc: Cropping a WebGL tile layer
+docs: >
+  The <code>prerender</code> and <code>postrender</code> events on a WebGL tile layer can be
+  used to manipulate the WebGL context before and after rendering.  In this case, the 
+  <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/scissor"><code>gl.scissor()</code></a>
+  method is called to clip the top layer based on the position of a slider.
+tags: "swipe, webgl"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
+---
+<div id="map" class="map"></div>
+<input id="swipe" type="range" style="width: 100%">

--- a/examples/webgl-layer-swipe.js
+++ b/examples/webgl-layer-swipe.js
@@ -1,0 +1,61 @@
+import Map from '../src/ol/Map.js';
+import OSM from '../src/ol/source/OSM.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+import XYZ from '../src/ol/source/XYZ.js';
+import {getRenderPixel} from '../src/ol/render.js';
+
+const osm = new TileLayer({
+  source: new OSM({wrapX: true}),
+});
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+
+const imagery = new TileLayer({
+  source: new XYZ({
+    url: 'https://api.maptiler.com/tiles/satellite/{z}/{x}/{y}.jpg?key=' + key,
+    attributions:
+      '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> ' +
+      '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>',
+    crossOrigin: '',
+    maxZoom: 20,
+  }),
+});
+
+const map = new Map({
+  layers: [osm, imagery],
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 2,
+  }),
+});
+
+const swipe = document.getElementById('swipe');
+
+imagery.on('prerender', function (event) {
+  const gl = event.context;
+  gl.enable(gl.SCISSOR_TEST);
+
+  const mapSize = map.getSize(); // [width, height] in CSS pixels
+
+  // get render coordinates and dimensions given CSS coordinates
+  const bottomLeft = getRenderPixel(event, [0, mapSize[1]]);
+  const topRight = getRenderPixel(event, [mapSize[0], 0]);
+
+  const width = Math.round((topRight[0] - bottomLeft[0]) * (swipe.value / 100));
+  const height = topRight[1] - bottomLeft[1];
+
+  gl.scissor(bottomLeft[0], bottomLeft[1], width, height);
+});
+
+imagery.on('postrender', function (event) {
+  const gl = event.context;
+  gl.disable(gl.SCISSOR_TEST);
+});
+
+const listener = function () {
+  map.render();
+};
+swipe.addEventListener('input', listener);
+swipe.addEventListener('change', listener);

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -88,6 +88,10 @@ export function toContext(context, opt_options) {
  * @api
  */
 export function getVectorContext(event) {
+  if (!(event.context instanceof CanvasRenderingContext2D)) {
+    throw new Error('Only works for render events from Canvas 2D layers');
+  }
+
   // canvas may be at a different pixel ratio than frameState.pixelRatio
   const canvasPixelRatio = event.inversePixelTransform[0];
   const frameState = event.frameState;
@@ -107,6 +111,7 @@ export function getVectorContext(event) {
       frameState.viewState.projection
     );
   }
+
   return new CanvasImmediateRenderer(
     event.context,
     canvasPixelRatio,
@@ -127,7 +132,5 @@ export function getVectorContext(event) {
  * @api
  */
 export function getRenderPixel(event, pixel) {
-  const result = pixel.slice(0);
-  applyTransform(event.inversePixelTransform.slice(), result);
-  return result;
+  return applyTransform(event.inversePixelTransform, pixel.slice(0));
 }

--- a/src/ol/render/Event.js
+++ b/src/ol/render/Event.js
@@ -10,7 +10,7 @@ class RenderEvent extends Event {
    * @param {import("../transform.js").Transform} [opt_inversePixelTransform] Transform for
    *     CSS pixels to rendered pixels.
    * @param {import("../PluggableMap.js").FrameState} [opt_frameState] Frame state.
-   * @param {?CanvasRenderingContext2D} [opt_context] Context.
+   * @param {?(CanvasRenderingContext2D|WebGLRenderingContext)} [opt_context] Context.
    */
   constructor(type, opt_inversePixelTransform, opt_frameState, opt_context) {
     super(type);
@@ -31,9 +31,10 @@ class RenderEvent extends Event {
     this.frameState = opt_frameState;
 
     /**
-     * Canvas context. Not available when the event is dispatched by the map. Only available
-     * when a Canvas renderer is used, null otherwise.
-     * @type {CanvasRenderingContext2D|null|undefined}
+     * Canvas context. Not available when the event is dispatched by the map. For Canvas 2D layers,
+     * the context will be the 2D rendering context.  For WebGL layers, the context will be the WebGL
+     * context.
+     * @type {CanvasRenderingContext2D|WebGLRenderingContext|undefined}
      * @api
      */
     this.context = opt_context;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -411,7 +411,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
    * @return {HTMLElement} The rendered element.
    */
   renderFrame(frameState) {
-    this.preRender(frameState);
+    const gl = this.helper.getGL();
+    this.preRender(gl, frameState);
 
     const renderCount = this.indicesBuffer_.getSize();
     this.helper.drawElements(0, renderCount);
@@ -429,7 +430,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       this.hitRenderTarget_.clearCachedData();
     }
 
-    this.postRender(frameState);
+    this.postRender(gl, frameState);
 
     return canvas;
   }

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -292,7 +292,8 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
    * @return {HTMLElement} The rendered element.
    */
   renderFrame(frameState) {
-    this.preRender(frameState);
+    const gl = this.helper.getGL();
+    this.preRender(gl, frameState);
 
     const viewState = frameState.viewState;
     const layerState = frameState.layerStatesArray[frameState.layerIndex];
@@ -385,8 +386,6 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     const zs = Object.keys(tileTexturesByZ)
       .map(Number)
       .sort(numberSafeCompareFunction);
-
-    const gl = this.helper.getGL();
 
     const centerX = viewState.center[0];
     const centerY = viewState.center[1];
@@ -509,7 +508,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
 
     frameState.postRenderFunctions.push(postRenderFunction);
 
-    this.postRender(frameState);
+    this.postRender(gl, frameState);
     return canvas;
   }
 


### PR DESCRIPTION
This updates the `prerender` and `postrender` events for WebGL layers to include the WebGL context as `event.context`.  In addition, the event now has the inverse pixel transform so CSS pixel locations can be transformed to render pixels.  The new [WebGL layer swipe example](https://deploy-preview-12933--ol-site.netlify.app/examples/webgl-layer-swipe.html) shows how the `getRenderPixel()` function can be used with these render events to get WebGL coordinates for clipping one of the layers.