### PR TITLE
Bugfix for GML parsing with multiple property elements with XML attributes

### DIFF
--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -304,6 +304,15 @@ class GMLBase extends XMLFeature {
         }
       }
 
+      const len = n.attributes.length;
+      if (len > 0) {
+        value = {_content_: value};
+        for (let i = 0; i < len; i++) {
+          const attName = n.attributes[i].name;
+          value[attName] = n.attributes[i].value;
+        }
+      }
+
       if (values[localName]) {
         if (!(values[localName] instanceof Array)) {
           values[localName] = [values[localName]];
@@ -311,15 +320,6 @@ class GMLBase extends XMLFeature {
         values[localName].push(value);
       } else {
         values[localName] = value;
-      }
-
-      const len = n.attributes.length;
-      if (len > 0) {
-        values[localName] = {_content_: values[localName]};
-        for (let i = 0; i < len; i++) {
-          const attName = n.attributes[i].name;
-          values[localName][attName] = n.attributes[i].value;
-        }
       }
     }
     if (!asFeature) {

--- a/test/browser/spec/ol/format/gml.test.js
+++ b/test/browser/spec/ol/format/gml.test.js
@@ -1840,6 +1840,10 @@ describe('ol.format.GML3', function () {
       expect(features[0].values_['name']).to.have.length(2);
     });
 
+    it('parses mutliple simple elements to strings', function () {
+      expect(features[0].values_['name'][0]).to.be.a('string');
+    });
+
     it('creates nested property', function () {
       expect(
         features[0].values_['observationMethod']['CGI_TermValue']['value'][
@@ -2900,6 +2904,51 @@ describe('ol.format.GML32', function () {
 
     it('converts XML attribute to text', function () {
       expect(features[0].get('cdata')).to.be('<a>b</a>');
+    });
+  });
+
+  describe('when parsing multiple complex attributes', function () {
+    let features;
+    let gmlFormat;
+    before(function (done) {
+      afterLoadText('spec/ol/format/gml/gml32-complex.xml', function (xml) {
+        try {
+          gmlFormat = new GML32();
+          features = gmlFormat.readFeatures(xml);
+        } catch (e) {
+          done(e);
+        }
+        done();
+      });
+    });
+
+    it('creates 2 features', function () {
+      expect(features).to.have.length(2);
+    });
+
+    it('creates feature with three attributeA properties and two attributeB properties', function () {
+      expect(features[0].values_['attributeA']).to.have.length(3);
+      expect(features[0].values_['attributeB']).to.have.length(2);
+    });
+
+    it('parses mutliple complex elements to an array of objects', function () {
+      expect(features[0].values_['attributeA'][0]).to.be.a('object');
+    });
+
+    it('correctly structures multiple elements with attributes', function () {
+      expect(features[0].values_['attributeA'][0]['xlink:href']).to.be(
+        'http://www.example.com/extern/1'
+      );
+      expect(features[0].values_['attributeA'][0]._content_).to.be(undefined);
+      expect(features[0].values_['attributeA'][1]['xlink:href']).to.be(
+        'http://www.example.com/extern/2'
+      );
+      expect(features[0].values_['attributeA'][2]._content_).to.be(undefined);
+    });
+
+    it('correctly structures multiple elements with complex content', function () {
+      expect(features[0].values_['attributeB'][0].Attribute.value).to.be('foo');
+      expect(features[0].values_['attributeB'][1].Attribute.value).to.be('bar');
     });
   });
 });

--- a/test/browser/spec/ol/format/gml/gml32-complex.xml
+++ b/test/browser/spec/ol/format/gml/gml32-complex.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<gml:FeatureCollection gml:id="collection.0" xmlns:ex="http://www.example.com" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <gml:featureMember>
+    <ex:FeatureA gml:id="feature.a">
+      <gml:identifier codeSpace="http://www.example.com">featureA</gml:identifier>
+      <ex:attributeA xlink:href="http://www.example.com/extern/1" />
+      <ex:attributeA xlink:href="http://www.example.com/extern/2" />
+      <ex:attributeA xlink:href="http://www.example.com/extern/3" />
+      <ex:attributeB>
+        <ex:Attribute>
+          <ex:value>foo</ex:value>
+        </ex:Attribute>
+      </ex:attributeB>
+      <ex:attributeB>
+        <ex:Attribute>
+          <ex:value>bar</ex:value>
+        </ex:Attribute>
+      </ex:attributeB>
+      <ex:location>
+        <gml:Point gml:id="point.0" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+          <gml:pos srsDimensions="2">0 0</gml:pos>
+        </gml:Point>
+      </ex:location>
+    </ex:FeatureA>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ex:FeatureB gml:id="feature.b">
+      <gml:identifier codeSpace="http://www.example.com">featureB</gml:identifier>
+      <ex:attributeA xlink:href="http://www.example.com/extern/4" />
+      <ex:attributeA xlink:href="http://www.example.com/extern/5" />
+      <ex:attributeA xlink:href="http://www.example.com/extern/6" />
+      <ex:attributeB>
+        <ex:Attribute>
+          <ex:value>foobar</ex:value>
+        </ex:Attribute>
+      </ex:attributeB>
+      <ex:attributeB>
+        <ex:Attribute>
+          <ex:value>barfoo</ex:value>
+        </ex:Attribute>
+      </ex:attributeB>
+      <ex:location>
+        <gml:Point gml:id="point.1" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+          <gml:pos srsDimensions="2">1 1</gml:pos>
+        </gml:Point>
+      </ex:location>
+    </ex:FeatureB>
+  </gml:featureMember>
+</gml:FeatureCollection>


### PR DESCRIPTION
This PR fixes a problem with parsing GML Features containing multiple properties with XML attibutes, e.g.
```xml
<ns:Feature gml:id="f1">
<ns:Link xlink:href="http://example.com/a">
<ns:Link xlink:href="http://example.com/b">
</ns:Feature>
```
Such constructs are found often in INSPIRE themes and in the German AAA model.

I included a test case with some simplified synthetic data. The bug was spotted in the wild whilst attempting to parse the result of a [GetFeatureInfo-Request to a WMS providing AAA-structured responses](
https://www.geodaten-mv.de/dienste/alkis_wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=adv_alkis_gesetzl_festlegungen%2Cadv_alkis_weiteres%2Cadv_alkis_gebaeude%2Cadv_alkis_flurstuecke&LAYERS=adv_alkis_gesetzl_festlegungen%2Cadv_alkis_weiteres%2Cadv_alkis_gebaeude%2Cadv_alkis_flurstuecke&INFO_FORMAT=text%2Fxml%3Bsubtype%3Dgml%2F3.2.1&I=50&J=50&CRS=EPSG%3A25833&STYLES=&WIDTH=101&HEIGHT=101&BBOX=293849.5404071358%2C6004185.0609577745%2C293918.4150123862%2C6004253.935563024) (particularly the repeated `adv:gehoertZu`-properties of the `adv:AX_LagebezeichnungOhneHausnummer` object - the depth of the resulting nested array before this fix was causing recursion problems in the browser whilst processing).