### PR TITLE
Preserve drawing buffer

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -1,8 +1,12 @@
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
+import {
+  Heatmap as HeatmapLayer,
+  Tile as TileLayer,
+  Vector as VectorLayer,
+} from '../src/ol/layer.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
-import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const map = new Map({
   layers: [
@@ -14,6 +18,18 @@ const map = new Map({
         url: 'data/geojson/countries.geojson',
         format: new GeoJSON(),
       }),
+      opacity: 0.5,
+    }),
+    new HeatmapLayer({
+      source: new VectorSource({
+        url: 'data/geojson/world-cities.geojson',
+        format: new GeoJSON(),
+      }),
+      weight: function (feature) {
+        return feature.get('population') / 1e7;
+      },
+      radius: 15,
+      blur: 15,
       opacity: 0.5,
     }),
   ],
@@ -32,17 +48,30 @@ document.getElementById('export-png').addEventListener('click', function () {
     mapCanvas.height = size[1];
     const mapContext = mapCanvas.getContext('2d');
     Array.prototype.forEach.call(
-      document.querySelectorAll('.ol-layer canvas'),
+      document.querySelectorAll('.ol-layer canvas, canvas.ol-layer'),
       function (canvas) {
         if (canvas.width > 0) {
-          const opacity = canvas.parentNode.style.opacity;
+          const opacity =
+            canvas.parentNode.style.opacity || canvas.style.opacity;
           mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
+          let matrix;
           const transform = canvas.style.transform;
-          // Get the transform parameters from the style's transform matrix
-          const matrix = transform
-            .match(/^matrix\(([^\(]*)\)$/)[1]
-            .split(',')
-            .map(Number);
+          if (transform) {
+            // Get the transform parameters from the style's transform matrix
+            matrix = transform
+              .match(/^matrix\(([^\(]*)\)$/)[1]
+              .split(',')
+              .map(Number);
+          } else {
+            matrix = [
+              parseFloat(canvas.style.width) / canvas.width,
+              0,
+              0,
+              parseFloat(canvas.style.height) / canvas.height,
+              0,
+              0,
+            ];
+          }
           // Apply the transform to the export map context
           CanvasRenderingContext2D.prototype.setTransform.apply(
             mapContext,

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -179,7 +179,11 @@ class WebGLLayerRenderer extends LayerRenderer {
       }
     }
 
-    if (!gl || !gl.getContextAttributes().preserveDrawingBuffer) {
+    if (!gl) {
+      return null;
+    }
+    const attributes = gl.getContextAttributes();
+    if (!attributes || !attributes.preserveDrawingBuffer) {
       // we assume there is data at the given pixel (although there might not be)
       return new Uint8Array();
     }

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -74,12 +74,6 @@ class WebGLLayerRenderer extends LayerRenderer {
 
     /**
      * @private
-     * @type {CanvasRenderingContext2D}
-     */
-    this.pixelContext_ = null;
-
-    /**
-     * @private
      */
     this.postProcesses_ = options.postProcesses;
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -6,9 +6,11 @@ import RenderEvent from '../../render/Event.js';
 import RenderEventType from '../../render/EventType.js';
 import WebGLHelper from '../../webgl/Helper.js';
 import {
+  apply as applyTransform,
   compose as composeTransform,
   create as createTransform,
 } from '../../transform.js';
+import {containsCoordinate} from '../../extent.js';
 
 /**
  * @enum {string}
@@ -69,6 +71,12 @@ class WebGLLayerRenderer extends LayerRenderer {
      * @type {import("../../transform.js").Transform}
      */
     this.inversePixelTransform_ = createTransform();
+
+    /**
+     * @private
+     * @type {CanvasRenderingContext2D}
+     */
+    this.pixelContext_ = null;
 
     /**
      * @type {WebGLHelper}
@@ -140,6 +148,65 @@ class WebGLLayerRenderer extends LayerRenderer {
    */
   postRender(context, frameState) {
     this.dispatchRenderEvent_(RenderEventType.POSTRENDER, context, frameState);
+  }
+
+  /**
+   * @param {import("../../pixel.js").Pixel} pixel Pixel.
+   * @param {import("../../PluggableMap.js").FrameState} frameState FrameState.
+   * @param {number} hitTolerance Hit tolerance in pixels.
+   * @return {Uint8ClampedArray|Uint8Array} The result.  If there is no data at the pixel
+   *    location, null will be returned.  If there is data, but pixel values cannot be
+   *    returned, and empty array will be returned.
+   */
+  getDataAtPixel(pixel, frameState, hitTolerance) {
+    const renderPixel = applyTransform(
+      [frameState.pixelRatio, 0, 0, frameState.pixelRatio, 0, 0],
+      pixel.slice()
+    );
+    const gl = this.helper.getGL();
+
+    const layer = this.getLayer();
+    const layerExtent = layer.getExtent();
+    if (layerExtent) {
+      const renderCoordinate = applyTransform(
+        frameState.pixelToCoordinateTransform,
+        pixel.slice()
+      );
+
+      /** get only data inside of the layer extent */
+      if (!containsCoordinate(layerExtent, renderCoordinate)) {
+        return null;
+      }
+    }
+
+    if (!gl.getContextAttributes().preserveDrawingBuffer) {
+      // we assume there is data at the given pixel (although there might not be)
+      return new Uint8Array();
+    }
+
+    const x = Math.round(renderPixel[0]);
+    const y = Math.round(renderPixel[1]);
+    let pixelContext = this.pixelContext_;
+    if (!pixelContext) {
+      const pixelCanvas = document.createElement('canvas');
+      pixelCanvas.width = 1;
+      pixelCanvas.height = 1;
+      pixelContext = pixelCanvas.getContext('2d');
+      this.pixelContext_ = pixelContext;
+    }
+    pixelContext.clearRect(0, 0, 1, 1);
+    let data;
+    try {
+      pixelContext.drawImage(gl.canvas, x, y, 1, 1, 0, 0, 1, 1);
+      data = pixelContext.getImageData(0, 0, 1, 1).data;
+    } catch (err) {
+      return data;
+    }
+
+    if (data[3] === 0) {
+      return null;
+    }
+    return data;
   }
 }
 

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -179,7 +179,7 @@ class WebGLLayerRenderer extends LayerRenderer {
       }
     }
 
-    if (!gl.getContextAttributes().preserveDrawingBuffer) {
+    if (!gl || !gl.getContextAttributes().preserveDrawingBuffer) {
       // we assume there is data at the given pixel (although there might not be)
       return new Uint8Array();
     }

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -79,6 +79,16 @@ class WebGLLayerRenderer extends LayerRenderer {
     this.pixelContext_ = null;
 
     /**
+     * @private
+     */
+    this.postProcesses_ = options.postProcesses;
+
+    /**
+     * @private
+     */
+    this.uniforms_ = options.uniforms;
+
+    /**
      * @type {WebGLHelper}
      * @protected
      */

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -2,6 +2,8 @@
  * @module ol/webgl
  */
 
+import {assign} from './obj.js';
+
 /**
  * Constants taken from goog.webgl
  */
@@ -78,6 +80,20 @@ export const FLOAT = 0x1406;
  */
 
 /**
+ * @type {boolean}
+ */
+let preserveDrawingBuffer = true;
+
+/**
+ * Disable the `preserveDrawingBuffer` context attribute when creating WebGL contexts.
+ * This may improve performance but will prevent access to pixel data after rendering.
+ * @api
+ */
+export function disablePreserveDrawingBuffer() {
+  preserveDrawingBuffer = false;
+}
+
+/**
  * @const
  * @type {Array<string>}
  */
@@ -89,10 +105,12 @@ const CONTEXT_IDS = ['experimental-webgl', 'webgl', 'webkit-3d', 'moz-webgl'];
  * @return {WebGLRenderingContext} WebGL rendering context.
  */
 export function getContext(canvas, opt_attributes) {
+  const attributes = {preserveDrawingBuffer: preserveDrawingBuffer};
+  assign(attributes, opt_attributes);
   const ii = CONTEXT_IDS.length;
   for (let i = 0; i < ii; ++i) {
     try {
-      const context = canvas.getContext(CONTEXT_IDS[i], opt_attributes);
+      const context = canvas.getContext(CONTEXT_IDS[i], attributes);
       if (context) {
         return /** @type {!WebGLRenderingContext} */ (context);
       }


### PR DESCRIPTION
Replaces #12845

Sets `preserveDrawingBuffer: true`.as default in WebGL context attributes to make the canvases exportable and compatible with `forEachLayerAtPixel` along with a `disablePreserveDrawingBuffer()` fallback method as suggested in https://github.com/openlayers/openlayers/pull/12845#issuecomment-939544606

Add a simple Heatmap layer to the Export Map example showing changes to the export needed to handle WebGL canvases..
