### PR TITLE
Handle ReprojTile in ol/layer/WebGLTile

### DIFF
--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -503,7 +503,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
      * @param {import("../../PluggableMap.js").FrameState} frameState Frame state.
      */
     const postRenderFunction = function (map, frameState) {
-      tileSource.expireCache(tileSource.getProjection(), empty);
+      tileSource.expireCache(frameState.viewState.projection, empty);
     };
 
     frameState.postRenderFunctions.push(postRenderFunction);

--- a/src/ol/webgl/TileTexture.js
+++ b/src/ol/webgl/TileTexture.js
@@ -5,6 +5,7 @@
 import EventTarget from '../events/Target.js';
 import EventType from '../events/EventType.js';
 import ImageTile from '../ImageTile.js';
+import ReprojTile from '../reproj/Tile.js';
 import TileState from '../TileState.js';
 import WebGLArrayBuffer from './Buffer.js';
 import {ARRAY_BUFFER, STATIC_DRAW} from '../webgl.js';
@@ -152,7 +153,7 @@ class TileTexture extends EventTarget {
     const gl = helper.getGL();
     const tile = this.tile;
 
-    if (tile instanceof ImageTile) {
+    if (tile instanceof ImageTile || tile instanceof ReprojTile) {
       const texture = gl.createTexture();
       this.textures.push(texture);
       this.bandCount = 4;


### PR DESCRIPTION
Fixes #12975

The WebGL tile layer renderer handles instances of `ImageTile` as in the WebGL Tiles example but if the tile source is reprojected the tiles are instances of `ReprojTile` which should be handled in the same way.  Also as the tile cache is always that for the view projection tile grid, that is what should be expired, if it is different to the tile source projection that cache is needed for further reprojection.
