### PR TITLE
Fix for image smoothing disabled / hardware acceleration / reprojection issue

### DIFF
--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -248,20 +248,36 @@ export function render(
 
   const stitchScale = pixelRatio / sourceResolution;
 
+  let imageContext;
+  if (opt_contextOptions === IMAGE_SMOOTHING_DISABLED) {
+    imageContext = createCanvasContext2D(1, 1);
+    assign(imageContext, opt_contextOptions);
+  }
+
   sources.forEach(function (src, i, arr) {
     const xPos = src.extent[0] - sourceDataExtent[0];
     const yPos = -(src.extent[3] - sourceDataExtent[3]);
     const srcWidth = getWidth(src.extent);
     const srcHeight = getHeight(src.extent);
+    let image = src.image;
 
     // This test should never fail -- but it does. Need to find a fix the upstream condition
-    if (src.image.width > 0 && src.image.height > 0) {
+    if (image.width > 0 && image.height > 0) {
+      // Due to inconsistent browser behavior always use a canvas image when smoothing disabled
+      if (imageContext && !(image instanceof HTMLCanvasElement)) {
+        imageContext.canvas.width = image.width;
+        imageContext.canvas.height = image.height;
+        imageContext.clearRect(0, 0, image.width, image.height);
+        imageContext.drawImage(image, 0, 0, image.width, image.height);
+        image = imageContext.canvas;
+      }
+
       stitchContext.drawImage(
-        src.image,
+        image,
         gutter,
         gutter,
-        src.image.width - 2 * gutter,
-        src.image.height - 2 * gutter,
+        image.width - 2 * gutter,
+        image.height - 2 * gutter,
         xPos * stitchScale,
         yPos * stitchScale,
         srcWidth * stitchScale,


### PR DESCRIPTION
The issue with hardware acceleration and Chrome noted in https://github.com/openlayers/openlayers/pull/10990#issuecomment-623567917 is still there and now affects Edge as well.

This happens when all of these are simultaneously true:

- Chromium-based browser with hardware acceleration enabled
- Same tile in browser cache in two or more OpenLayers source caches.
- Tile sources are reprojected.
- Used with image smoothing enabled, then disabled.

I have found that drawing the image unscaled to a temporary canvas before drawing that scaled to the stitchContext produces consistent results with smoothing disabled.  The pixels chosen when smoothing is disabled do differ between browsers and their settings, including hardware acceleration, but the values are in the expected range (there are no depressions deeper than  the Dead Sea on the slopes of Mont Blanc). 