### PR TITLE
Add a map property to layers

### DIFF
--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -4,6 +4,7 @@
 import BaseLayer from './Base.js';
 import Collection from '../Collection.js';
 import CollectionEventType from '../CollectionEventType.js';
+import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import ObjectEventType from '../ObjectEventType.js';
 import SourceState from '../source/State.js';
@@ -12,6 +13,33 @@ import {assign, clear} from '../obj.js';
 import {getIntersection} from '../extent.js';
 import {getUid} from '../util.js';
 import {listen, unlistenByKey} from '../events.js';
+
+/**
+ * @typedef {'addlayer'|'removelayer'} EventType
+ */
+
+/**
+ * @classdesc
+ * A layer group triggers 'addlayer' and 'removelayer' events when layers are added to or removed from
+ * the group or one of its child groups.  When a layer group is added to or removed from another layer group,
+ * a single event will be triggered (instead of one per layer in the group added or removed).
+ */
+export class GroupEvent extends Event {
+  /**
+   * @param {EventType} type The event type.
+   * @param {BaseLayer} layer The layer.
+   */
+  constructor(type, layer) {
+    super(type);
+
+    /**
+     * The added or removed layer.
+     * @type {BaseLayer}
+     * @api
+     */
+    this.layer = layer;
+  }
+}
 
 /***
  * @template Return
@@ -142,18 +170,48 @@ class LayerGroup extends BaseLayer {
     const layersArray = layers.getArray();
     for (let i = 0, ii = layersArray.length; i < ii; i++) {
       const layer = layersArray[i];
-      this.listenerKeys_[getUid(layer)] = [
-        listen(
-          layer,
-          ObjectEventType.PROPERTYCHANGE,
-          this.handleLayerChange_,
-          this
-        ),
-        listen(layer, EventType.CHANGE, this.handleLayerChange_, this),
-      ];
+      this.registerLayerListeners_(layer);
+      this.dispatchEvent(new GroupEvent('addlayer', layer));
+    }
+    this.changed();
+  }
+
+  /**
+   * @param {BaseLayer} layer The layer.
+   */
+  registerLayerListeners_(layer) {
+    const listenerKeys = [
+      listen(
+        layer,
+        ObjectEventType.PROPERTYCHANGE,
+        this.handleLayerChange_,
+        this
+      ),
+      listen(layer, EventType.CHANGE, this.handleLayerChange_, this),
+    ];
+
+    if (layer instanceof LayerGroup) {
+      listenerKeys.push(
+        listen(layer, 'addlayer', this.handleLayerGroupAdd_, this),
+        listen(layer, 'removelayer', this.handleLayerGroupRemove_, this)
+      );
     }
 
-    this.changed();
+    this.listenerKeys_[getUid(layer)] = listenerKeys;
+  }
+
+  /**
+   * @param {GroupEvent} event The layer group event.
+   */
+  handleLayerGroupAdd_(event) {
+    this.dispatchEvent(new GroupEvent('addlayer', event.layer));
+  }
+
+  /**
+   * @param {GroupEvent} event The layer group event.
+   */
+  handleLayerGroupRemove_(event) {
+    this.dispatchEvent(new GroupEvent('removelayer', event.layer));
   }
 
   /**
@@ -164,15 +222,8 @@ class LayerGroup extends BaseLayer {
     const layer = /** @type {import("./Base.js").default} */ (
       collectionEvent.element
     );
-    this.listenerKeys_[getUid(layer)] = [
-      listen(
-        layer,
-        ObjectEventType.PROPERTYCHANGE,
-        this.handleLayerChange_,
-        this
-      ),
-      listen(layer, EventType.CHANGE, this.handleLayerChange_, this),
-    ];
+    this.registerLayerListeners_(layer);
+    this.dispatchEvent(new GroupEvent('addlayer', layer));
     this.changed();
   }
 
@@ -187,6 +238,7 @@ class LayerGroup extends BaseLayer {
     const key = getUid(layer);
     this.listenerKeys_[key].forEach(unlistenByKey);
     delete this.listenerKeys_[key];
+    this.dispatchEvent(new GroupEvent('removelayer', layer));
     this.changed();
   }
 
@@ -213,6 +265,14 @@ class LayerGroup extends BaseLayer {
    * @api
    */
   setLayers(layers) {
+    const collection = this.getLayers();
+    if (collection) {
+      const currentLayers = collection.getArray();
+      for (let i = 0, ii = currentLayers.length; i < ii; ++i) {
+        this.dispatchEvent(new GroupEvent('removelayer', currentLayers[i]));
+      }
+    }
+
     this.set(Property.LAYERS, layers);
   }
 

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -259,6 +259,22 @@ class Layer extends BaseLayer {
   }
 
   /**
+   * For use inside the library only.
+   * @param {import("../PluggableMap.js").default} map Map.
+   */
+  setMapInternal(map) {
+    this.set(LayerProperty.MAP, map);
+  }
+
+  /**
+   * For use inside the library only.
+   * @return {import("../PluggableMap.js").default} Map.
+   */
+  getMapInternal() {
+    return this.get(LayerProperty.MAP);
+  }
+
+  /**
    * Sets the layer to be rendered on top of other layers on a map. The map will
    * not manage this layer in its layers collection, and the callback in
    * {@link module:ol/Map~Map#forEachLayerAtPixel} will receive `null` as layer. This

--- a/src/ol/layer/Property.js
+++ b/src/ol/layer/Property.js
@@ -15,4 +15,5 @@ export default {
   MAX_ZOOM: 'maxZoom',
   MIN_ZOOM: 'minZoom',
   SOURCE: 'source',
+  MAP: 'map',
 };

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -8,12 +8,15 @@ import ImageLayer from '../../../../src/ol/layer/Image.js';
 import ImageState from '../../../../src/ol/ImageState.js';
 import ImageStatic from '../../../../src/ol/source/ImageStatic.js';
 import Interaction from '../../../../src/ol/interaction/Interaction.js';
+import Layer from '../../../../src/ol/layer/Layer.js';
+import LayerGroup from '../../../../src/ol/layer/Group.js';
 import Map from '../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../src/ol/MapBrowserEvent.js';
 import MapEvent from '../../../../src/ol/MapEvent.js';
 import MouseWheelZoom from '../../../../src/ol/interaction/MouseWheelZoom.js';
 import Overlay from '../../../../src/ol/Overlay.js';
 import PinchZoom from '../../../../src/ol/interaction/PinchZoom.js';
+import Property from '../../../../src/ol/layer/Property.js';
 import Select from '../../../../src/ol/interaction/Select.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import TileLayerRenderer from '../../../../src/ol/renderer/canvas/TileLayer.js';
@@ -166,6 +169,7 @@ describe('ol/Map', function () {
       map.addLayer(layer);
 
       expect(map.getLayers().item(0)).to.be(layer);
+      expect(layer.get(Property.MAP)).to.be(map);
     });
 
     it('throws if a layer is added twice', function () {
@@ -177,6 +181,55 @@ describe('ol/Map', function () {
         map.addLayer(layer);
       };
       expect(call).to.throwException();
+    });
+  });
+
+  describe('#removeLayer()', function () {
+    it('removes a layer from the map', function () {
+      const map = new Map({});
+      const layer = new TileLayer();
+      map.addLayer(layer);
+
+      expect(layer.get(Property.MAP)).to.be(map);
+      map.removeLayer(layer);
+      expect(layer.get(Property.MAP)).to.be(null);
+    });
+
+    it('removes a layer group from the map', function () {
+      const map = new Map({});
+      const layer = new TileLayer();
+      const group = new LayerGroup({layers: [layer]});
+      map.addLayer(group);
+      expect(layer.get(Property.MAP)).to.be(map);
+
+      map.removeLayer(group);
+      expect(layer.get(Property.MAP)).to.be(null);
+    });
+  });
+
+  describe('#setLayerGroup()', function () {
+    it('sets the layer group', function () {
+      const map = new Map({});
+
+      const layer = new Layer({});
+      const group = new LayerGroup({layers: [layer]});
+      map.setLayerGroup(group);
+
+      expect(map.getLayerGroup()).to.be(group);
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('removes the map property from old layers', function () {
+      const oldLayer = new Layer({});
+      const map = new Map({layers: [oldLayer]});
+      expect(oldLayer.get(Property.MAP)).to.be(map);
+
+      const layer = new Layer({});
+      const group = new LayerGroup({layers: [layer]});
+      map.setLayerGroup(group);
+
+      expect(layer.get(Property.MAP)).to.be(map);
+      expect(oldLayer.get(Property.MAP)).to.be(null);
     });
   });
 
@@ -192,12 +245,21 @@ describe('ol/Map', function () {
       expect(collection.getLength()).to.be(2);
       expect(collection.item(0)).to.be(layer0);
       expect(collection.item(1)).to.be(layer1);
+      expect(layer0.get(Property.MAP)).to.be(map);
+      expect(layer1.get(Property.MAP)).to.be(map);
     });
 
     it('clears any existing layers', function () {
-      const map = new Map({layers: [new TileLayer()]});
+      const oldLayer = new TileLayer();
+      const map = new Map({layers: [oldLayer]});
+      expect(oldLayer.get(Property.MAP)).to.be(map);
 
-      map.setLayers([new TileLayer(), new TileLayer()]);
+      const newLayer1 = new TileLayer();
+      const newLayer2 = new TileLayer();
+      map.setLayers([newLayer1, newLayer2]);
+      expect(newLayer1.get(Property.MAP)).to.be(map);
+      expect(newLayer2.get(Property.MAP)).to.be(map);
+      expect(oldLayer.get(Property.MAP)).to.be(null);
 
       expect(map.getLayers().getLength()).to.be(2);
     });

--- a/test/browser/spec/ol/layer/Layer.test.js
+++ b/test/browser/spec/ol/layer/Layer.test.js
@@ -1,10 +1,12 @@
+import Group from '../../../../../src/ol/layer/Group.js';
 import Layer, {inView} from '../../../../../src/ol/layer/Layer.js';
 import Map from '../../../../../src/ol/Map.js';
+import Property from '../../../../../src/ol/layer/Property.js';
 import RenderEvent from '../../../../../src/ol/render/Event.js';
 import Source from '../../../../../src/ol/source/Source.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
 
-describe('ol.layer.Layer', function () {
+describe('ol/layer/Layer', function () {
   describe('constructor (defaults)', function () {
     let layer;
 
@@ -617,6 +619,79 @@ describe('ol.layer.Layer', function () {
 
       layer.setVisible(true);
       expect(listener.callCount).to.be(2);
+    });
+  });
+
+  describe('map property', () => {
+    it('is set when a layer is added to a map', () => {
+      const map = new Map({});
+      const layer = new Layer({});
+      map.addLayer(layer);
+
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('is set when a layer is added to a map in the constructor', () => {
+      const layer = new Layer({});
+      const map = new Map({layers: [layer]});
+
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('is set when a layer is added to a group', () => {
+      const layer = new Layer({});
+      const group = new Group();
+      const map = new Map({});
+      map.addLayer(group);
+      group.getLayers().push(layer);
+
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('is set when a layer is added to a group set in the constructor', () => {
+      const layer = new Layer({});
+      const group = new Group();
+      const map = new Map({layers: [group]});
+      group.getLayers().push(layer);
+
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('is set when a layer already added to a group set in the constructor', () => {
+      const layer = new Layer({});
+      const group = new Group({layers: [layer]});
+      const map = new Map({layers: [group]});
+
+      expect(layer.get(Property.MAP)).to.be(map);
+    });
+
+    it('is removed when a layer is removed from the map', () => {
+      const map = new Map({});
+      const layer = new Layer({});
+      map.addLayer(layer);
+      expect(layer.get(Property.MAP)).to.be(map);
+
+      map.removeLayer(layer);
+      expect(layer.get(Property.MAP)).to.be(null);
+    });
+
+    it('is removed when a layer added in the constructor is removed from the map', () => {
+      const layer = new Layer({});
+      const map = new Map({layers: [layer]});
+      expect(layer.get(Property.MAP)).to.be(map);
+
+      map.removeLayer(layer);
+      expect(layer.get(Property.MAP)).to.be(null);
+    });
+
+    it('is removed when a layer is removed from a group', () => {
+      const layer = new Layer({});
+      const group = new Group({layers: [layer]});
+      const map = new Map({layers: [group]});
+      expect(layer.get(Property.MAP)).to.be(map);
+
+      group.getLayers().remove(layer);
+      expect(layer.get(Property.MAP)).to.be(null);
     });
   });
 


### PR DESCRIPTION
Layers can only be rendered on a single map.  Layer renders have access to the layer, but not the corresponding map.  This makes it awkward for renderers to clean up after themselves when a layer is removed from a map, for example.

By adding a "map" property to layers, renderers can listen for changes in this property and clean up when necessary.

This was originally part of #12965.  I pulled it out to make for easier review.