### PR TITLE
Align labels with the Select elements in the Raster Reprojection example

### DIFF
--- a/examples/reprojection.css
+++ b/examples/reprojection.css
@@ -1,0 +1,3 @@
+.form-inline label {
+  justify-content: left;
+}

--- a/examples/reprojection.html
+++ b/examples/reprojection.html
@@ -37,8 +37,12 @@ tags: "reprojection, projection, proj4js, osm, wms, wmts, hidpi, grid"
       <option value="EPSG:5479">RSRGD2000 / MSLC2000 (EPSG:5479)</option>
     </select>
   </div>
-  <label>
-    Render reprojection edges
-    <input type="checkbox" id="render-edges">
-  </label>
+</form>
+<form class="form-inline">
+  <div class="col-md-auto">
+    <label>
+      Render reprojection edges:&nbsp;
+      <input type="checkbox" id="render-edges" />
+    </label>
+  </div>
 </form>


### PR DESCRIPTION
Center aligned labels do not work well in columns above left aligned Select elements on a wide screen where the column widths may be much wider than the Selects.