### PR TITLE
Lazily create the WebGL helper

### DIFF
--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -100,7 +100,6 @@ class WebGLPointsLayer extends Layer {
    */
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
-      className: this.getClassName(),
       vertexShader: this.parseResult_.builder.getSymbolVertexShader(),
       fragmentShader: this.parseResult_.builder.getSymbolFragmentShader(),
       hitVertexShader:

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -311,7 +311,6 @@ class WebGLTileLayer extends BaseTileLayer {
       vertexShader: parsedStyle.vertexShader,
       fragmentShader: parsedStyle.fragmentShader,
       uniforms: parsedStyle.uniforms,
-      className: this.getClassName(),
       cacheSize: this.cacheSize_,
     });
   }

--- a/test/browser/spec/ol/layer/Heatmap.test.js
+++ b/test/browser/spec/ol/layer/Heatmap.test.js
@@ -5,24 +5,53 @@ import Point from '../../../../../src/ol/geom/Point.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
 import View from '../../../../../src/ol/View.js';
 
-describe('ol.layer.Heatmap', function () {
+describe('ol/layer/Heatmap', function () {
   describe('constructor', function () {
+    let target, map;
+    beforeEach(() => {
+      target = document.createElement('div');
+      target.style.width = '300px';
+      target.style.height = '300px';
+      document.body.appendChild(target);
+
+      map = new Map({
+        view: new View({
+          center: [0, 0],
+          resolution: 0.1,
+        }),
+        target: target,
+      });
+    });
+
+    afterEach(() => {
+      map.dispose();
+      document.body.removeChild(target);
+    });
+
     it('can be constructed without arguments', function () {
       const instance = new HeatmapLayer();
       expect(instance).to.be.an(HeatmapLayer);
     });
+
     it('has a default className', function () {
       const layer = new HeatmapLayer({
         source: new VectorSource(),
       });
+      map.addLayer(layer);
+      map.renderSync();
+
       const canvas = layer.getRenderer().helper.getCanvas();
       expect(canvas.className).to.eql('ol-layer');
     });
+
     it('accepts a custom className', function () {
       const layer = new HeatmapLayer({
         source: new VectorSource(),
         className: 'a-class-name',
       });
+      map.addLayer(layer);
+      map.renderSync();
+
       const canvas = layer.getRenderer().helper.getCanvas();
       expect(canvas.className).to.eql('a-class-name');
     });

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -4,6 +4,7 @@ import View from '../../../../../src/ol/View.js';
 import WebGLHelper from '../../../../../src/ol/webgl/Helper.js';
 import WebGLTileLayer from '../../../../../src/ol/layer/WebGLTile.js';
 import {createCanvasContext2D} from '../../../../../src/ol/dom.js';
+import {getForViewAndSize} from '../../../../../src/ol/extent.js';
 import {getRenderPixel} from '../../../../../src/ol/render.js';
 
 describe('ol/layer/WebGLTile', function () {
@@ -62,7 +63,21 @@ describe('ol/layer/WebGLTile', function () {
 
   it('creates fragment and vertex shaders', function () {
     const compileShaderSpy = sinon.spy(WebGLHelper.prototype, 'compileShader');
-    layer.createRenderer();
+    const renderer = layer.createRenderer();
+    const viewState = map.getView().getState();
+    const size = map.getSize();
+    const frameState = {
+      viewState: viewState,
+      extent: getForViewAndSize(
+        viewState.center,
+        viewState.resolution,
+        viewState.rotation,
+        size
+      ),
+      layerStatesArray: map.getLayerGroup().getLayerStatesArray(),
+      layerIndex: 0,
+    };
+    renderer.prepareFrame(frameState);
     compileShaderSpy.restore();
     expect(compileShaderSpy.callCount).to.be(2);
     expect(compileShaderSpy.getCall(0).args[0].replace(/[ \n]+/g, ' ')).to.be(

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -75,7 +75,7 @@ const hitFragmentShader = `
     gl_FragColor = v_hitColor;
   }`;
 
-describe('ol.renderer.webgl.PointsLayer', function () {
+describe('ol/renderer/webgl/PointsLayer', function () {
   describe('constructor', function () {
     let target;
 
@@ -116,16 +116,16 @@ describe('ol.renderer.webgl.PointsLayer', function () {
         hitVertexShader: hitVertexShader,
         hitFragmentShader: hitFragmentShader,
       });
-      frameState = Object.assign(
-        {
-          size: [2, 2],
-          extent: [-100, -100, 100, 100],
-        },
-        baseFrameState
-      );
+      frameState = Object.assign({}, baseFrameState, {
+        size: [2, 2],
+        extent: [-100, -100, 100, 100],
+        layerStatesArray: [layer.getLayerState()],
+      });
     });
 
     it('calls WebGlHelper#prepareDraw', function () {
+      renderer.prepareFrame(frameState);
+
       const spy = sinon.spy(renderer.helper, 'prepareDraw');
       renderer.prepareFrame(frameState);
       expect(spy.called).to.be(true);
@@ -327,14 +327,12 @@ describe('ol.renderer.webgl.PointsLayer', function () {
         0,
         0
       );
-      const frameState = Object.assign(
-        {
-          extent: [-20, -20, 20, 20],
-          size: [40, 40],
-          coordinateToPixelTransform: transform,
-        },
-        baseFrameState
-      );
+      const frameState = Object.assign({}, baseFrameState, {
+        extent: [-20, -20, 20, 20],
+        size: [40, 40],
+        coordinateToPixelTransform: transform,
+        layerStatesArray: [layer.getLayerState()],
+      });
 
       renderer.prepareFrame(frameState);
       renderer.worker_.addEventListener('message', function () {
@@ -391,15 +389,14 @@ describe('ol.renderer.webgl.PointsLayer', function () {
         0,
         0
       );
-      const frameState = Object.assign(
-        {
-          pixelRatio: 3,
-          extent: [-20, -20, 20, 20],
-          size: [40, 40],
-          coordinateToPixelTransform: transform,
-        },
-        baseFrameState
-      );
+      const frameState = Object.assign({}, baseFrameState, {
+        pixelRatio: 3,
+        extent: [-20, -20, 20, 20],
+        size: [40, 40],
+        coordinateToPixelTransform: transform,
+        layerStatesArray: [layer.getLayerState()],
+      });
+
       let found;
       const cb = function (feature) {
         found = feature;
@@ -445,6 +442,13 @@ describe('ol.renderer.webgl.PointsLayer', function () {
         vertexShader: simpleVertexShader,
         fragmentShader: simpleFragmentShader,
       });
+
+      const frameState = Object.assign({}, baseFrameState, {
+        size: [2, 2],
+        extent: [-100, -100, 100, 100],
+        layerStatesArray: [layer.getLayerState()],
+      });
+      renderer.prepareFrame(frameState);
 
       const spyHelper = sinon.spy(renderer.helper, 'disposeInternal');
       const spyWorker = sinon.spy(renderer.worker_, 'terminate');

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -7,7 +7,7 @@ import {create} from '../../../../../../src/ol/transform.js';
 import {createCanvasContext2D} from '../../../../../../src/ol/dom.js';
 import {get} from '../../../../../../src/ol/proj.js';
 
-describe('ol.renderer.webgl.TileLayer', function () {
+describe('ol/renderer/webgl/TileLayer', function () {
   /** @type {import("../../../../../../src/ol/renderer/webgl/TileLayer.js").default} */
   let renderer;
   /** @type {WebGLTileLayer} */
@@ -74,6 +74,9 @@ describe('ol.renderer.webgl.TileLayer', function () {
   });
 
   it('#renderFrame()', function () {
+    const ready = renderer.prepareFrame(frameState);
+    expect(ready).to.be(true);
+
     const rendered = renderer.renderFrame(frameState);
     expect(rendered).to.be.a(HTMLCanvasElement);
     expect(frameState.tileQueue.getCount()).to.be(1);

--- a/test/browser/spec/ol/webgl/TileTexture.test.js
+++ b/test/browser/spec/ol/webgl/TileTexture.test.js
@@ -5,11 +5,15 @@ import TileState from '../../../../../src/ol/TileState.js';
 import TileTexture from '../../../../../src/ol/webgl/TileTexture.js';
 import WebGLArrayBuffer from '../../../../../src/ol/webgl/Buffer.js';
 import WebGLTileLayer from '../../../../../src/ol/layer/WebGLTile.js';
+import {EXTENT as EPSG3857_EXTENT} from '../../../../../src/ol/proj/epsg3857.js';
 import {createCanvasContext2D} from '../../../../../src/ol/dom.js';
 
-describe('ol.webgl.TileTexture', function () {
+describe('ol/webgl/TileTexture', function () {
   /** @type {TileTexture} */
   let tileTexture;
+
+  /** @type {import("../../../../../src/ol/renderer/webgl/TileLayer.js").default} */
+  let renderer;
 
   beforeEach(function () {
     const layer = new WebGLTileLayer({
@@ -24,15 +28,25 @@ describe('ol.webgl.TileTexture', function () {
         },
       }),
     });
-    const renderer =
-      /** @type {import("../../../../../src/ol/renderer/webgl/TileLayer.js").default} */ (
-        layer.createRenderer()
-      );
+
+    renderer = layer.createRenderer();
+    renderer.prepareFrame({
+      extent: EPSG3857_EXTENT,
+      layerIndex: 0,
+      layerStatesArray: [layer.getLayerState()],
+      size: [256, 256],
+      mapId: 'map-1',
+    });
+
     tileTexture = new TileTexture(
       layer.getSource().getTile(3, 2, 1),
       layer.getSource().getTileGrid(),
       renderer.helper
     );
+  });
+
+  afterEach(() => {
+    renderer.dispose();
   });
 
   it('constructor', function () {


### PR DESCRIPTION
Currently, WebGL renderers create their helpers (and underlying canvas elements) in the constructor.  In order to support shared contexts between renderers, we can instead create the helpers on first render, when we have more information about the layer state and render order.  This also allows us to dispose of a helper and recreate it as needed.

The changes in this branch don't do anything about sharing contexts.  The helper creation is just moved from the constructor to the `prepareFrame` method.

Previously the render sequence looked like this:
```js
const renderer = layer.getRenderer(); <-- helper created here
renderer.prepareFrame(frameState);
```

Now the render sequence looks like this:
```js
const renderer = layer.getRenderer();
renderer.prepareFrame(frameState); <-- helper created here
```

This was originally part of #12965.  I've pulled it out to make for easier review.

The change in logic here would also allow us to add a `layer.setStyle()` method to WebGL layers.  While we wouldn't want people calling this method on every render frame, we could add a method that reparsed the style and removed the helper - allowing a new one to be created on the next render.  I'm not going to take that on in this change, but this has come up as [a feature request](https://gitter.im/openlayers/openlayers?at=617fab7ecd4972068b7fb97d).