### PR TITLE
Fix style related apidoc issues

### DIFF
--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -30,13 +30,13 @@ import {toUserExtent} from '../proj.js';
  * @property {import("../extent.js").Extent} [extent] Initial extent. Defaults to no
  * initial extent.
  * @property {import("../style/Style.js").StyleLike} [boxStyle]
- * Style for the drawn extent box. Defaults to
- * {@link module:ol/style/Style~createEditing()['Polygon']}
+ * Style for the drawn extent box. Defaults to the `Polygon` editing style
+ * documented in {@link module:ol/style/Style~Style}
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {import("../style/Style.js").StyleLike} [pointerStyle]
- * Style for the cursor used to draw the extent. Defaults to
- * {@link module:ol/style/Style~createEditing()['Point']}
+ * Style for the cursor used to draw the extent. Defaults to the `Point` editing style
+ * documented in {@link module:ol/style/Style~Style}
  * @property {boolean} [wrapX=false] Wrap the drawn extent across multiple maps
  * in the X direction? Only affects visuals, not functionality.
  */

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -110,7 +110,7 @@ const ModifyEventType = {
  * @property {import("../style/Style.js").StyleLike} [style]
  * Style used for the modification point or vertex. For linestrings and polygons, this will
  * be the affected vertex, for circles a point along the circle, and for points the actual
- * point. If not configured, the default edit style is used (see {@link module:ol/style}).
+ * point. If not configured, the default edit style is used (see {@link module:ol/style/Style~Style}).
  * When using a style function, the point feature passed to the function will have a `features`
  * property - an array whose entries are the features that are being modified, and a `geometries`
  * property - an array whose entries are the geometries that are being modified. Both arrays are

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -57,7 +57,7 @@ const SelectEventType = {
  * selectable.
  * @property {import("../style/Style.js").StyleLike|null} [style]
  * Style for the selected features. By default the default edit style is used
- * (see {@link module:ol/style}). Set to `null` if this interaction should not apply
+ * (see {@link module:ol/style/Style~Style}). Set to `null` if this interaction should not apply
  * any style changes for selected features.
  * If set to a falsey value, the selected feature's style will not change.
  * @property {import("../events/condition.js").Condition} [removeCondition] A function

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -46,7 +46,7 @@ import {
  * Higher z-index means higher priority. Within the same z-index, a feature rendered before another has
  * higher priority.
  * @property {import("../style/Style.js").StyleLike|null} [style] Layer style. When set to `null`, only
- * features that have their own style will be rendered. See {@link module:ol/style} for default style
+ * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will
  * be recreated during animations. This means that no vectors will be shown clipped, but the
@@ -242,7 +242,7 @@ class BaseVectorLayer extends Layer {
    * an array of styles. If set to `null`, the layer has no style (a `null` style),
    * so only features that have their own styles will be rendered in the layer. Call
    * `setStyle()` without arguments to reset to the default style. See
-   * {@link module:ol/style} for information on the default style.
+   * {@link module:ol/style/Style~Style} for information on the default style.
    * @param {import("../style/Style.js").StyleLike|null} [opt_style] Layer style.
    * @api
    */

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -40,7 +40,7 @@ import {assign} from '../obj.js';
  * by the `zIndex` of the style and the render order of features. Higher z-index means higher priority.
  * Within the same z-index, a feature rendered before another has higher priority.
  * @property {import("../style/Style.js").StyleLike|null} [style] Layer style. When set to `null`, only
- * features that have their own style will be rendered. See {@link module:ol/style} for default style
+ * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.
  * @property {number} [imageRatio=1] Ratio by which the rendered extent should be larger than the
  * viewport extent. A larger ratio avoids cut images during panning, but will cause a decrease in performance.

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -63,7 +63,7 @@ import {assign} from '../obj.js';
  * Higher z-index means higher priority. Within the same z-index, a feature rendered before another has
  * higher priority.
  * @property {import("../style/Style.js").StyleLike|null} [style] Layer style. When set to `null`, only
- * features that have their own style will be rendered. See {@link module:ol/style} for default style
+ * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -11,7 +11,7 @@ import {assert} from '../asserts.js';
 /**
  * A function that takes an {@link module:ol/Feature} and a `{number}`
  * representing the view's resolution. The function should return a
- * {@link module:ol/style/Style} or an array of them. This way e.g. a
+ * {@link module:ol/style/Style~Style} or an array of them. This way e.g. a
  * vector layer can be styled. If the function returns `undefined`, the
  * feature will not be rendered.
  *
@@ -66,83 +66,86 @@ import {assert} from '../asserts.js';
  *
  * If no style is defined, the following default style is used:
  * ```js
- *  import {Fill, Stroke, Circle, Style} from 'ol/style';
+ *  import {Circle, Fill, Stroke, Style} from 'ol/style';
  *
- *  var fill = new Fill({
- *    color: 'rgba(255,255,255,0.4)'
+ *  const fill = new Fill({
+ *    color: 'rgba(255,255,255,0.4)',
  *  });
- *  var stroke = new Stroke({
+ *  const stroke = new Stroke({
  *    color: '#3399CC',
- *    width: 1.25
+ *    width: 1.25,
  *  });
- *  var styles = [
+ *  const styles = [
  *    new Style({
  *      image: new Circle({
  *        fill: fill,
  *        stroke: stroke,
- *        radius: 5
+ *        radius: 5,
  *      }),
  *      fill: fill,
- *      stroke: stroke
- *    })
+ *      stroke: stroke,
+ *    }),
  *  ];
  * ```
  *
  * A separate editing style has the following defaults:
  * ```js
- *  import {Fill, Stroke, Circle, Style} from 'ol/style';
  *  import GeometryType from 'ol/geom/GeometryType';
+ *  import {Circle, Fill, Stroke, Style} from 'ol/style';
  *
- *  var white = [255, 255, 255, 1];
- *  var blue = [0, 153, 255, 1];
- *  var width = 3;
+ *  const styles = {};
+ *  const white = [255, 255, 255, 1];
+ *  const blue = [0, 153, 255, 1];
+ *  const width = 3;
  *  styles[GeometryType.POLYGON] = [
  *    new Style({
  *      fill: new Fill({
- *        color: [255, 255, 255, 0.5]
- *      })
- *    })
+ *        color: [255, 255, 255, 0.5],
+ *      }),
+ *    }),
  *  ];
- *  styles[GeometryType.MULTI_POLYGON] =
- *      styles[GeometryType.POLYGON];
+ *  styles[GeometryType.MULTI_POLYGON] = styles[GeometryType.POLYGON];
+ *
  *  styles[GeometryType.LINE_STRING] = [
  *    new Style({
  *      stroke: new Stroke({
  *        color: white,
- *        width: width + 2
- *      })
+ *        width: width + 2,
+ *      }),
  *    }),
  *    new Style({
  *      stroke: new Stroke({
  *        color: blue,
- *        width: width
- *      })
- *    })
+ *        width: width,
+ *      }),
+ *    }),
  *  ];
- *  styles[GeometryType.MULTI_LINE_STRING] =
- *      styles[GeometryType.LINE_STRING];
+ *  styles[GeometryType.MULTI_LINE_STRING] = styles[GeometryType.LINE_STRING];
+ *
+ *  styles[GeometryType.CIRCLE] = styles[GeometryType.POLYGON].concat(
+ *    styles[GeometryType.LINE_STRING]
+ *  );
+ *
  *  styles[GeometryType.POINT] = [
  *    new Style({
  *      image: new Circle({
  *        radius: width * 2,
  *        fill: new Fill({
- *          color: blue
+ *          color: blue,
  *        }),
  *        stroke: new Stroke({
  *          color: white,
- *          width: width / 2
- *        })
+ *          width: width / 2,
+ *        }),
  *      }),
- *      zIndex: Infinity
- *    })
+ *      zIndex: Infinity,
+ *    }),
  *  ];
- *  styles[GeometryType.MULTI_POINT] =
- *      styles[GeometryType.POINT];
- *  styles[GeometryType.GEOMETRY_COLLECTION] =
- *      styles[GeometryType.POLYGON].concat(
- *          styles[GeometryType.LINE_STRING],
- *          styles[GeometryType.POINT]
- *      );
+ *  styles[GeometryType.MULTI_POINT] = styles[GeometryType.POINT];
+ *
+ *  styles[GeometryType.GEOMETRY_COLLECTION] = styles[
+ *    GeometryType.POLYGON
+ *  ].concat(styles[GeometryType.LINE_STRING], styles[GeometryType.POINT]);
  * ```
  *
  * @api


### PR DESCRIPTION
- the links to the default style were broken
- the `Circle` style was missing from the documented editing style
- the `styles` variable was not declared in the documentation