### PR TITLE
Use workflow_run event to deploy pull request previews

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -9,14 +9,21 @@ jobs:
   build-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
+          node-version: '16'
       - run: npm ci
       - run: npm run build-site
       - uses: actions/upload-artifact@v2
         with:
           name: site
           path: build/site
+      - name: Store pull request number for later use
+        run: |
+          mkdir -p build/pr
+          echo ${{github.event.number}} > build/pr/number
+      - uses: actions/upload-artifact@v2
+        with:
+          name: pr
+          path: build/pr

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,45 +1,102 @@
 name: Deploy Preview
 
 on:
-  pull_request_target:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["Build Preview"]
+    types:
+      - completed
 
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    if: ${{github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'}}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
-      - run: npm install --global netlify-cli
-      - uses: lewagon/wait-on-check-action@v1.1.1
+          node-version: '16'
+      - run: npm install --global netlify-cli@6
+      - run: npm install unzipper@0.10
+
+      - name: Get pull request number
+        uses: actions/github-script@v5
+        id: pull-request-number
         with:
-          ref: ${{github.event.pull_request.head.sha}}
-          check-name: 'build-preview'
-          repo-token: ${{secrets.GITHUB_TOKEN}}
-          wait-interval: 10
+          result-encoding: string
+          script: |
+            const unzipper = require('unzipper');
+
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id}}
+            });
+
+            const artifact = artifacts.data.artifacts.filter(
+              artifact => artifact.name === 'pr'
+            )[0];
+
+            if (!artifact) {
+              throw new Error('No pr artifact found');
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip'
+            });
+
+            const directory = await unzipper.Open.buffer(Buffer.from(download.data));
+            const file = directory.files.find(d => d.path === 'number');
+            const content = await file.buffer();
+            return content.toString();
+
       - uses: dawidd6/action-download-artifact@v2
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow: build-preview.yml
-          pr: ${{github.event.number}}
+          pr: ${{steps.pull-request-number.outputs.result}}
           name: site
           path: build/site
-      - env:
+
+      - name: Deploy to Netlify
+        env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
           NETLIFY_SITE_ID: ${{secrets.NETLIFY_SITE_ID}}
-        run: netlify deploy --dir=build/site --alias=deploy-preview-${{github.event.number}}
-      - uses: octokit/request-action@v2.x
+        run: netlify deploy --dir=build/site --alias=deploy-preview-${{steps.pull-request-number.outputs.result}}
+
+      - name: Add comment to pull request
+        uses: actions/github-script@v5
         with:
-          route: POST /repos/{owner}/{repo}/statuses/{sha}
-          owner: openlayers
-          repo: openlayers
-          sha: ${{github.event.pull_request.head.sha}}
-          state: "success"
-          target_url: https://deploy-preview-${{github.event.number}}--ol-site.netlify.app
-          context: "Deploy Preview"
-          description: "Preview URL"
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const pullRequestNumber = parseInt(${{steps.pull-request-number.outputs.result}}, 10);
+
+            const start = ':package:';
+            const author = 'github-actions[bot]';
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pullRequestNumber
+            });
+
+            const commentExists = comments.data.some(
+              comment => comment.user.login === author && comment.body.startsWith(start)
+            );
+
+            if (!commentExists) {
+              const body = [
+                `${start} Preview the [examples](https://deploy-preview-${pullRequestNumber}--ol-site.netlify.app/examples/) and`,
+                `[docs](https://deploy-preview-${pullRequestNumber}--ol-site.netlify.app/apidoc/) from this branch`,
+                `here: https://deploy-preview-${pullRequestNumber}--ol-site.netlify.app/.`
+              ].join(' ');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pullRequestNumber,
+                body: body
+              });
+            } else {
+              console.log(`Preview URL comment already added to PR #${pullRequestNumber}`);
+            }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,11 +9,10 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
+          node-version: '16'
       - name: Install dependencies
         run: npm ci
       - name: Publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -59,9 +59,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -94,9 +94,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -129,9 +129,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
 
       - name: Determine Cache Directory
         id: npm-cache
@@ -167,9 +167,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set Node.js Version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '16'
 
       - name: Determine Cache Directory
         id: npm-cache


### PR DESCRIPTION
This branch updates our **Deploy Preview** workflow so that it is triggered by the [`workflow_run` event](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_run).  Previously, this workflow was triggered by the `pull_request_target` event.  Both events run based on the workflow configured in the default branch and have access to secrets (since they do not run on PR-submitters code).  The benefit of the `workflow_run` event is that it is triggered after other workflows run - so we can wait for the **Build Preview** workflow to complete before deploying.  The previous solution relied on polling for the build step to complete.  The shortcoming of this is that the deploy workflow would time out while the build workflow was awaiting approval for first time contributors.

I've also updated the deploy preview workflow so that it adds a comment to a pull request with links to the deployed examples and API docs.  I think this is easier to find than the current link at the bottom of the list of checks for a pull request.  The comment should only appear once (even though the deploy is updated for each new commit pushed after the PR is opened).

![image](https://user-images.githubusercontent.com/41094/141863343-a6da41f4-8487-40a2-a7e5-a1cff9bf38bc.png)

Fixes #12991.

We won't see this new comment on this pull request since the deploy preview workflow in the default branch is the one being run.  So unfortunately we can't fully validate this until it is in `main` and we open another pull request.  If I've made any typos, I may make changes directly in `main` to correct them.