### PR TITLE
Add the renderer type to generic layer template variables

### DIFF
--- a/src/ol/layer/BaseImage.js
+++ b/src/ol/layer/BaseImage.js
@@ -40,7 +40,8 @@ import Layer from './Layer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Image.js").default} ImageSourceType
- * @extends {Layer<ImageSourceType>}
+ * @template {import("../renderer/Layer.js").default} RendererType
+ * @extends {Layer<ImageSourceType, RendererType>}
  * @api
  */
 class BaseImageLayer extends Layer {

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -55,7 +55,8 @@ import {assign} from '../obj.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Tile.js").default} TileSourceType
- * @extends {Layer<TileSourceType>}
+ * @template {import("../renderer/Layer.js").default} RendererType
+ * @extends {Layer<TileSourceType, RendererType>}
  * @api
  */
 class BaseTileLayer extends Layer {

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -73,7 +73,8 @@ const Property = {
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Vector.js").default|import("../source/VectorTile.js").default} VectorSourceType
- * @extends {Layer<VectorSourceType>}
+ * @template {import("../renderer/Layer.js").default} RendererType
+ * @extends {Layer<VectorSourceType, RendererType>}
  * @api
  */
 class BaseVectorLayer extends Layer {

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/layer/Heatmap
  */
-import VectorLayer from './Vector.js';
+import BaseVector from './BaseVector.js';
 import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 import {assign} from '../obj.js';
 import {clamp} from '../math.js';
@@ -61,10 +61,10 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * options means that `title` is observable, and has get/set accessors.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @extends {VectorLayer<import("../source/Vector.js").default>}
+ * @extends {BaseVector<import("../source/Vector.js").default, WebGLPointsLayerRenderer>}
  * @api
  */
-class Heatmap extends VectorLayer {
+class Heatmap extends BaseVector {
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -174,10 +174,6 @@ class Heatmap extends VectorLayer {
     this.set(Property.RADIUS, radius);
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {WebGLPointsLayerRenderer} A layer renderer.
-   */
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
       className: this.getClassName(),

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -13,7 +13,7 @@ import CanvasImageLayerRenderer from '../renderer/canvas/ImageLayer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Image.js").default} ImageSourceType
- * @extends {BaseImageLayer<ImageSourceType>}
+ * @extends {BaseImageLayer<ImageSourceType, CanvasImageLayerRenderer>}
  * @api
  */
 class ImageLayer extends BaseImageLayer {
@@ -24,10 +24,6 @@ class ImageLayer extends BaseImageLayer {
     super(opt_options);
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   */
   createRenderer() {
     return new CanvasImageLayerRenderer(this);
   }

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -94,6 +94,7 @@ import {listen, unlistenByKey} from '../events.js';
  * @fires import("../render/Event.js").RenderEvent#postrender
  *
  * @template {import("../source/Source.js").default} SourceType
+ * @template {import("../renderer/Layer.js").default} RendererType
  * @api
  */
 class Layer extends BaseLayer {
@@ -141,7 +142,7 @@ class Layer extends BaseLayer {
 
     /**
      * @private
-     * @type {import("../renderer/Layer.js").default}
+     * @type {RendererType}
      */
     this.renderer_ = null;
 
@@ -335,7 +336,7 @@ class Layer extends BaseLayer {
 
   /**
    * Get the renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} The layer renderer.
+   * @return {RendererType} The layer renderer.
    */
   getRenderer() {
     if (!this.renderer_) {
@@ -353,7 +354,7 @@ class Layer extends BaseLayer {
 
   /**
    * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
+   * @return {RendererType} A layer renderer.
    * @protected
    */
   createRenderer() {

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -13,7 +13,7 @@ import CanvasTileLayerRenderer from '../renderer/canvas/TileLayer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Tile.js").default} TileSourceType
- * @extends {BaseTileLayer<TileSourceType>}
+ * @extends BaseTileLayer<TileSourceType, CanvasTileLayerRenderer>
  * @api
  */
 class TileLayer extends BaseTileLayer {
@@ -24,11 +24,6 @@ class TileLayer extends BaseTileLayer {
     super(opt_options);
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
-   */
   createRenderer() {
     return new CanvasTileLayerRenderer(this);
   }

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -12,7 +12,7 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Vector.js").default} VectorSourceType
- * @extends {BaseVectorLayer<VectorSourceType>}
+ * @extends {BaseVectorLayer<VectorSourceType, CanvasVectorLayerRenderer>}
  * @api
  */
 class VectorLayer extends BaseVectorLayer {
@@ -23,10 +23,6 @@ class VectorLayer extends BaseVectorLayer {
     super(opt_options);
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   */
   createRenderer() {
     return new CanvasVectorLayerRenderer(this);
   }

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -55,7 +55,7 @@ import {assign} from '../obj.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Vector.js").default} VectorSourceType
- * @extends {BaseVectorLayer<VectorSourceType>}
+ * @extends {BaseVectorLayer<VectorSourceType, CanvasVectorImageLayerRenderer>}
  * @api
  */
 class VectorImageLayer extends BaseVectorLayer {
@@ -84,10 +84,6 @@ class VectorImageLayer extends BaseVectorLayer {
     return this.imageRatio_;
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   */
   createRenderer() {
     return new CanvasVectorImageLayerRenderer(this);
   }

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -85,7 +85,7 @@ import {assign} from '../obj.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @param {Options} [opt_options] Options.
- * @extends {BaseVectorLayer<import("../source/VectorTile.js").default>}
+ * @extends {BaseVectorLayer<import("../source/VectorTile.js").default, CanvasVectorTileLayerRenderer>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
@@ -147,11 +147,6 @@ class VectorTileLayer extends BaseVectorLayer {
     );
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
-   */
   createRenderer() {
     return new CanvasVectorTileLayerRenderer(this);
   }

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -69,7 +69,7 @@ import {parseLiteralStyle} from '../webgl/ShaderBuilder.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @template {import("../source/Vector.js").default} VectorSourceType
- * @extends {Layer<VectorSourceType>}
+ * @extends {Layer<VectorSourceType, WebGLPointsLayerRenderer>}
  * @fires import("../render/Event.js").RenderEvent
  */
 class WebGLPointsLayer extends Layer {
@@ -94,10 +94,6 @@ class WebGLPointsLayer extends Layer {
     this.hitDetectionDisabled_ = !!options.disableHitDetection;
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {WebGLPointsLayerRenderer} A layer renderer.
-   */
   createRenderer() {
     return new WebGLPointsLayerRenderer(this, {
       vertexShader: this.parseResult_.builder.getSymbolVertexShader(),

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -259,7 +259,7 @@ function parseStyle(style, bandCount) {
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @extends BaseTileLayer<SourceType>
+ * @extends BaseTileLayer<SourceType, WebGLTileLayerRenderer>
  * @api
  */
 class WebGLTileLayer extends BaseTileLayer {
@@ -296,11 +296,6 @@ class WebGLTileLayer extends BaseTileLayer {
     this.styleVariables_ = this.style_.variables || {};
   }
 
-  /**
-   * Create a renderer for this layer.
-   * @return {import("../renderer/Layer.js").default} A layer renderer.
-   * @protected
-   */
   createRenderer() {
     const source = this.getSource();
     const parsedStyle = parseStyle(

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -49,7 +49,7 @@ import {wrapX as wrapCoordinateX} from '../../coordinate.js';
  */
 class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   /**
-   * @param {import("../../layer/Vector.js").default} vectorLayer Vector layer.
+   * @param {import("../../layer/BaseVector.js").default} vectorLayer Vector layer.
    */
   constructor(vectorLayer) {
     super(vectorLayer);


### PR DESCRIPTION
This change makes it so the `layer.getRenderer()` return type is specific for the layers that create specific renderers.