### PR TITLE
Add background to MapboxVector layer

### DIFF
--- a/examples/mapbox-vector-layer.css
+++ b/examples/mapbox-vector-layer.css
@@ -1,3 +1,0 @@
-.map {
-  background: #f8f4f0;
-}

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -43,6 +43,11 @@ class RenderFeature {
    */
   constructor(type, flatCoordinates, ends, properties, id) {
     /**
+     * @type {import("../style/Style.js").StyleFunction|undefined}
+     */
+    this.styleFunction;
+
+    /**
      * @private
      * @type {import("../extent.js").Extent|undefined}
      */
@@ -259,10 +264,10 @@ class RenderFeature {
   }
 
   /**
-   * @return {undefined}
+   * @return {import('../style/Style.js').StyleFunction|undefined} Style
    */
   getStyleFunction() {
-    return undefined;
+    return this.styleFunction;
   }
 
   /**

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -90,7 +90,6 @@ class TileSource extends Source {
       options.tilePixelRatio !== undefined ? options.tilePixelRatio : 1;
 
     /**
-     * @protected
      * @type {import("../tilegrid/TileGrid.js").default}
      */
     this.tileGrid = options.tileGrid !== undefined ? options.tileGrid : null;


### PR DESCRIPTION
This pull request makes it so the `MapboxVector` layer picks up the background from the style. This is achieved by adding a polygon as first feature to each tile, which covers the whole tile extent and is filled with the background's color and opacity.

Fixes #13023.