### PR TITLE
Correctly set popover position in geographic example

### DIFF
--- a/examples/geographic.js
+++ b/examples/geographic.js
@@ -63,10 +63,15 @@ map.on('moveend', function () {
 });
 
 map.on('click', function (event) {
+  $(element).popover('dispose');
+
   const feature = map.getFeaturesAtPixel(event.pixel)[0];
   if (feature) {
     const coordinate = feature.getGeometry().getCoordinates();
-    popup.setPosition(coordinate);
+    popup.setPosition([
+      coordinate[0] + Math.round(event.coordinate[0] / 360) * 360,
+      coordinate[1],
+    ]);
     $(element).popover({
       container: element.parentElement,
       html: true,
@@ -75,8 +80,6 @@ map.on('click', function (event) {
       placement: 'top',
     });
     $(element).popover('show');
-  } else {
-    $(element).popover('dispose');
   }
 });
 


### PR DESCRIPTION
Fixes #13029

Popover is only initialized once, calling `popover` again does not change the content unless the popover was disposed.
Not necessary for this example as there is only one feature, but feels like a good idea to have it anyways.