### PR TITLE
Fix tiles and background handling

### DIFF
--- a/src/ol/layer/MapboxVector.js
+++ b/src/ol/layer/MapboxVector.js
@@ -405,10 +405,7 @@ class MapboxVectorLayer extends VectorTileLayer {
     }
 
     const source = this.getSource();
-    if (
-      styleSource.url.indexOf('mapbox://') === 0 ||
-      styleSource.url.indexOf('{z}') !== -1
-    ) {
+    if (styleSource.url && styleSource.url.indexOf('mapbox://') === 0) {
       // Tile source url, handle it directly
       source.setUrl(
         normalizeSourceUrl(
@@ -433,11 +430,13 @@ class MapboxVectorLayer extends VectorTileLayer {
       }
       setupVectorSource(
         styleSource,
-        normalizeSourceUrl(
-          styleSource.url,
-          this.accessToken,
-          this.accessTokenParam_
-        )
+        styleSource.url
+          ? normalizeSourceUrl(
+              styleSource.url,
+              this.accessToken,
+              this.accessTokenParam_
+            )
+          : undefined
       ).then((source) => {
         applyStyle(this, style, sourceIdOrLayersList)
           .then(() => {
@@ -470,9 +469,8 @@ class MapboxVectorLayer extends VectorTileLayer {
       (layer) => layer.type === 'background'
     );
     if (
-      !background ||
-      !background.layout ||
-      background.layout.visibility !== 'none'
+      background &&
+      (!background.layout || background.layout.visibility !== 'none')
     ) {
       const style = new Style({
         fill: new Fill(),

--- a/test/rendering/data/styles/bright-v9.json
+++ b/test/rendering/data/styles/bright-v9.json
@@ -69,7 +69,7 @@
   },
   "sources": {
     "mapbox": {
-      "url": "/data/tiles/mapbox-streets-v6/{z}/{x}/{y}.vector.pbf",
+      "tiles": ["/data/tiles/mapbox-streets-v6/{z}/{x}/{y}.vector.pbf"],
       "type": "vector"
     }
   },

--- a/test/rendering/data/styles/bright-v9/style.json
+++ b/test/rendering/data/styles/bright-v9/style.json
@@ -69,7 +69,7 @@
   },
   "sources": {
     "mapbox": {
-      "url": "/data/styles/bright-v9/mapbox-streets-v7/{z}/{x}/{y}.vector.pbf",
+      "tiles": ["/data/styles/bright-v9/mapbox-streets-v7/{z}/{x}/{y}.vector.pbf"],
       "type": "vector"
     }
   },


### PR DESCRIPTION
This pull request fixes two issues with the MapboxVector layer:
* Error on styles without `background` because of a faulty boolean expression
* Error on sources with `tiles` but without `url`, because we always expected a `url`

I added regression tests for both fixes.