### PR TITLE
Use source minzoom if not configured otherwise

### DIFF
--- a/src/ol/layer/MapboxVector.js
+++ b/src/ol/layer/MapboxVector.js
@@ -197,9 +197,11 @@ const SourceType = {
  * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
  * visible.
  * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
- * be visible.
- * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will be
- * visible.
+ * be visible. If neither `maxResolution` nor `minZoom` are defined, the layer's `maxResolution` will
+ * match the style source's `minzoom`.
+ * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will
+ * be visible. If neither `maxResolution` nor `minZoom` are defined, the layer's `minZoom` will match
+ * the style source's `minzoom`.
  * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
  * be visible.
  * @property {import("../render.js").OrderFunction} [renderOrder] Render order. Function to be used when sorting
@@ -297,6 +299,9 @@ class MapboxVectorLayer extends VectorTileLayer {
       useInterimTilesOnError: options.useInterimTilesOnError,
       properties: options.properties,
     });
+
+    this.setMaxResolutionFromTileGrid_ =
+      options.maxResolution === undefined && options.minZoom === undefined;
 
     this.sourceId = options.source;
     this.layers = options.layers;
@@ -516,6 +521,10 @@ class MapboxVectorLayer extends VectorTileLayer {
         renderFeature.styleFunction = styleFuntion;
         tile.getFeatures().unshift(renderFeature);
       });
+    }
+    if (this.setMaxResolutionFromTileGrid_) {
+      const tileGrid = targetSource.getTileGrid();
+      this.setMaxResolution(tileGrid.getResolution(tileGrid.getMinZoom()));
     }
     targetSource.setState(SourceState.READY);
   }

--- a/test/browser/spec/ol/layer/MapboxVector.test.js
+++ b/test/browser/spec/ol/layer/MapboxVector.test.js
@@ -131,6 +131,55 @@ describe('ol/layer/MapboxVector', () => {
     });
   });
 
+  describe('maxResolution', function () {
+    const styleUrl =
+      'data:,' +
+      encodeURIComponent(
+        JSON.stringify({
+          version: 8,
+          sources: {
+            'foo': {
+              tiles: ['/spec/ol/data/{z}-{x}-{y}.vector.pbf'],
+              type: 'vector',
+              minzoom: 6,
+            },
+          },
+          layers: [],
+        })
+      );
+
+    it('accepts minZoom from configuration', function (done) {
+      const layer = new MapboxVectorLayer({
+        minZoom: 5,
+        styleUrl: styleUrl,
+      });
+      const source = layer.getSource();
+      source.on('change', function onchange() {
+        if (source.getState() === 'ready') {
+          source.un('change', onchange);
+          expect(layer.getMaxResolution()).to.be(Infinity);
+          done();
+        }
+      });
+    });
+
+    it('uses minZoom from source', function (done) {
+      const layer = new MapboxVectorLayer({
+        styleUrl: styleUrl,
+      });
+      const source = layer.getSource();
+      source.on('change', function onchange() {
+        if (source.getState() === 'ready') {
+          source.un('change', onchange);
+          expect(layer.getMaxResolution()).to.be(
+            source.getTileGrid().getResolution(6)
+          );
+          done();
+        }
+      });
+    });
+  });
+
   describe('background', function () {
     it('adds a feature for the background', function (done) {
       const layer = new MapboxVectorLayer({


### PR DESCRIPTION
For vector tile sources that do not provide tiles from zoom 0, it is good practice to not show the layer when viewed at a lower zoom then the source's minzoom. Otherwise too many tiles will be loaded.

This pull request makes it so if neither `minZoom` nor `maxResolution` is specified on the `MapboxVector` layer, a `maxResolution` that matches the source's `minzoom` will be configured.