### PR TITLE
Add layer background

### DIFF
--- a/config/tsconfig-build.json
+++ b/config/tsconfig-build.json
@@ -51,8 +51,8 @@
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": false                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
+    "inlineSources": false,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+    "skipLibCheck": true
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^1.0.8",
-        "ol-mapbox-style": "^6.5.1",
+        "ol-mapbox-style": "^6.7.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -7168,9 +7168,9 @@
       "dev": true
     },
     "node_modules/ol-mapbox-style": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.3.tgz",
-      "integrity": "sha512-2SNJQ/7acgACC4nnuKCm9qeMXK2LEeUQWZWRKlXNCstjRf7SDcQvSFXrNSlDLvzhtQ0Gv3QTX5L7plE2wm7Z3Q==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.7.0.tgz",
+      "integrity": "sha512-O8Gq3q1CvzklikL0mYVjGGg6xNOlmpOwzemBwXUzTGf9i14G/WVcDo3JSLySedFHekRIpp5vw7gk+FFd21nqVw==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",
@@ -15559,9 +15559,9 @@
       "dev": true
     },
     "ol-mapbox-style": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.5.3.tgz",
-      "integrity": "sha512-2SNJQ/7acgACC4nnuKCm9qeMXK2LEeUQWZWRKlXNCstjRf7SDcQvSFXrNSlDLvzhtQ0Gv3QTX5L7plE2wm7Z3Q==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.7.0.tgz",
+      "integrity": "sha512-O8Gq3q1CvzklikL0mYVjGGg6xNOlmpOwzemBwXUzTGf9i14G/WVcDo3JSLySedFHekRIpp5vw7gk+FFd21nqVw==",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "geotiff": "^1.0.8",
-    "ol-mapbox-style": "^6.5.1",
+    "ol-mapbox-style": "^6.7.0",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
   },

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -213,7 +213,7 @@ export function toString(color) {
   if (b != (b | 0)) {
     b = (b + 0.5) | 0;
   }
-  const a = color[3] === undefined ? 1 : color[3];
+  const a = color[3] === undefined ? 1 : Math.round(color[3] * 100) / 100;
   return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
 }
 

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -9,6 +9,13 @@ import {assign} from '../obj.js';
 import {clamp} from '../math.js';
 
 /**
+ * A css color, or a function called with a view resolution returning a css color.
+ *
+ * @typedef {string|function(number):string} BackgroundColor
+ * @api
+ */
+
+/**
  * @typedef {import("../ObjectEventType").Types|'change:extent'|'change:maxResolution'|'change:maxZoom'|
  *    'change:minResolution'|'change:minZoom'|'change:opacity'|'change:visible'|'change:zIndex'} BaseLayerObjectEventTypes
  */
@@ -39,6 +46,8 @@ import {clamp} from '../math.js';
  * visible.
  * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
  * be visible.
+ * @property {BackgroundColor} [background] Background color for the layer. If not specified, no background
+ * will be rendered.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
@@ -73,6 +82,12 @@ class BaseLayer extends BaseObject {
      * @type {BaseLayerOnSignature<void>}
      */
     this.un;
+
+    /**
+     * @type {BackgroundColor|false}
+     * @private
+     */
+    this.background_ = options.background;
 
     /**
      * @type {Object<string, *>}
@@ -114,6 +129,14 @@ class BaseLayer extends BaseObject {
      * @private
      */
     this.state_ = null;
+  }
+
+  /**
+   * Get the background for this layer.
+   * @return {BackgroundColor|false} Layer background.
+   */
+  getBackground() {
+    return this.background_;
   }
 
   /**
@@ -263,6 +286,15 @@ class BaseLayer extends BaseObject {
    */
   getZIndex() {
     return /** @type {number} */ (this.get(LayerProperty.Z_INDEX));
+  }
+
+  /**
+   * Sets the backgrlound color.
+   * @param {BackgroundColor} [opt_background] Background color.
+   */
+  setBackground(opt_background) {
+    this.background_ = opt_background;
+    this.changed();
   }
 
   /**

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -48,6 +48,8 @@ import {
  * @property {import("../style/Style.js").StyleLike|null} [style] Layer style. When set to `null`, only
  * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.
+ * @property {import("./Base.js").BackgroundColor} [background] Background color for the layer. If not specified, no background
+ * will be rendered.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will
  * be recreated during animations. This means that no vectors will be shown clipped, but the
  * setting will have a performance impact for large amounts of vector data. When set to `false`,

--- a/src/ol/layer/MapboxVector.js
+++ b/src/ol/layer/MapboxVector.js
@@ -7,9 +7,7 @@ import MVT from '../format/MVT.js';
 import SourceState from '../source/State.js';
 import VectorTileLayer from '../layer/VectorTile.js';
 import VectorTileSource from '../source/VectorTile.js';
-import {applyStyle, setupVectorSource} from 'ol-mapbox-style';
-import {getValue} from 'ol-mapbox-style/dist/stylefunction.js';
-import {toString} from '../color.js';
+import {applyBackground, applyStyle, setupVectorSource} from 'ol-mapbox-style';
 
 const mapboxBaseUrl = 'https://api.mapbox.com';
 
@@ -489,40 +487,8 @@ class MapboxVectorLayer extends VectorTileLayer {
       targetSource.setTileLoadFunction(source.getTileLoadFunction());
       targetSource.tileGrid = source.tileGrid;
     }
-    const background = style.layers.find(
-      (layer) => layer.type === 'background'
-    );
-    if (
-      this.getBackground() === undefined &&
-      background &&
-      (!background.layout || background.layout.visibility !== 'none')
-    ) {
-      const colorFunction = (resolution) => {
-        const opacity =
-          /** @type {number} */ (
-            getValue(
-              background,
-              'paint',
-              'background-opacity',
-              this.getSource().getTileGrid().getZForResolution(resolution)
-            )
-          ) || 1;
-        const color = /** @type {*} */ (
-          getValue(
-            background,
-            'paint',
-            'background-color',
-            this.getSource().getTileGrid().getZForResolution(resolution)
-          )
-        );
-        return toString([
-          color.r * 255,
-          color.g * 255,
-          color.b * 255,
-          color.a * opacity,
-        ]);
-      };
-      this.setBackground(colorFunction);
+    if (this.getBackground() === undefined) {
+      applyBackground(this, style);
     }
     if (this.setMaxResolutionFromTileGrid_) {
       const tileGrid = targetSource.getTileGrid();

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -65,6 +65,8 @@ import {assign} from '../obj.js';
  * @property {import("../style/Style.js").StyleLike|null} [style] Layer style. When set to `null`, only
  * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.
+ * @property {import("./Base.js").BackgroundColor|false} [background] Background color for the layer. If not specified, no
+ * background will be rendered.
  * @property {boolean} [updateWhileAnimating=false] When set to `true`, feature batches will be
  * recreated during animations. This means that no vectors will be shown clipped, but the setting
  * will have a performance impact for large amounts of vector data. When set to `false`, batches
@@ -145,6 +147,20 @@ class VectorTileLayer extends BaseVectorLayer {
         ? options.useInterimTilesOnError
         : true
     );
+
+    /**
+     * @return {import("./Base.js").BackgroundColor} Background color.
+     * @function
+     * @api
+     */
+    this.getBackground;
+
+    /**
+     * @param {import("./Base.js").BackgroundColor} background Background color.
+     * @function
+     * @api
+     */
+    this.setBackground;
   }
 
   createRenderer() {

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -283,7 +283,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     const canvasTransform = toTransformString(this.pixelTransform);
 
-    this.useContainer(target, canvasTransform, layerState.opacity);
+    this.useContainer(
+      target,
+      canvasTransform,
+      layerState.opacity,
+      this.getBackground(frameState)
+    );
     const context = this.context;
     const canvas = context.canvas;
 


### PR DESCRIPTION
This pull request adds a `background` property along with `setBackground()` and `getBackground()` methods to `ol/layer/VectorTile`.

For `ol/layer/MapboxVector`, this is used for easier handling of the Mapbox style's background. As an improvement over the current implementation, the background can also be ignored when `background` is set to false.

The update to the latest ol-mapbox-style version allows us to use its `applyBackground` function, instead of calculating the background ourselves.