### PR TITLE
Use correct terrain-rgb tile size and update max zoom

### DIFF
--- a/examples/disable-image-smoothing.js
+++ b/examples/disable-image-smoothing.js
@@ -15,7 +15,8 @@ const disabledLayer = new TileLayer({
     attributions: attributions,
     url:
       'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
-    maxZoom: 10,
+    tileSize: 512,
+    maxZoom: 12,
     crossOrigin: '',
     imageSmoothing: false,
   }),
@@ -36,7 +37,8 @@ const enabledLayer = new TileLayer({
     attributions: attributions,
     url:
       'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
-    maxZoom: 10,
+    tileSize: 512,
+    maxZoom: 12,
     crossOrigin: '',
   }),
 });

--- a/examples/sea-level.js
+++ b/examples/sea-level.js
@@ -30,7 +30,8 @@ const elevation = new TileLayer({
   source: new XYZ({
     url:
       'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
-    maxZoom: 10,
+    tileSize: 512,
+    maxZoom: 12,
     crossOrigin: '',
   }),
 });
@@ -52,6 +53,7 @@ const map = new Map({
         attributions: attributions,
         url: 'https://api.maptiler.com/maps/streets/{z}/{x}/{y}.png?key=' + key,
         tileSize: 512,
+        maxZoom: 22,
       }),
     }),
     new ImageLayer({

--- a/examples/webgl-sea-level.js
+++ b/examples/webgl-sea-level.js
@@ -31,8 +31,8 @@ const layer = new TileLayer({
   source: new XYZ({
     url:
       'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
-    maxZoom: 10,
     tileSize: 512,
+    maxZoom: 12,
     crossOrigin: 'anonymous',
   }),
   style: {
@@ -58,6 +58,7 @@ const map = new Map({
         attributions: attributions,
         crossOrigin: 'anonymous',
         tileSize: 512,
+        maxZoom: 22,
       }),
     }),
     layer,


### PR DESCRIPTION
Replaces #12990

Two examples (Disable Image Smoothing and Sea Level) do not specify the correct tile size for the MapTiler terrain-rgb source, which should be 512.  While there is undoubtedly a browser bug as described in #12990 it does not manifest itself when the correct tile size is specified, so no further workaround is needed.  Additionally the max zoom of the tileset has recently been increased to 12 which allows more precision in the examples (and potential for a global Shaded Relief example?). The max zoom of the background layer source in the sea level examples should also be specified as it is less then the `ol/source/XYZ` default and 404 errors appear in the log.
