### PR TITLE
Fix View set center to undefined

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1738,6 +1738,7 @@ class View extends BaseObject {
       this.set(ViewProperty.RESOLUTION, newResolution);
     }
     if (
+      !newCenter ||
       !this.get(ViewProperty.CENTER) ||
       !equals(this.get(ViewProperty.CENTER), newCenter)
     ) {

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -562,6 +562,17 @@ describe('ol/View', function () {
     });
   });
 
+  describe('#setCenter()', function () {
+    it('allows setting undefined center', function () {
+      const view = new View({
+        center: [0, 0],
+        resolution: 1,
+      });
+      view.setCenter(undefined);
+      expect(view.getCenter()).to.be(undefined);
+    });
+  });
+
   describe('#setHint()', function () {
     it('changes a view hint', function () {
       const view = new View({


### PR DESCRIPTION
Calling `setCenter` with `undefined` failed if the view had a center because `equals` expects an array.