### PR TITLE
Assume limited precision when rounding

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -204,3 +204,47 @@ export function modulo(a, b) {
 export function lerp(a, b, x) {
   return a + x * (b - a);
 }
+
+/**
+ * Returns a number with a limited number of decimal digits.
+ * @param {number} n The input number.
+ * @param {number} decimals The maximum number of decimal digits.
+ * @return {number} The input number with a limited number of decimal digits.
+ */
+export function toFixed(n, decimals) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(n * factor) / factor;
+}
+
+/**
+ * Rounds a number to the nearest integer value considering only the given number
+ * of decimal digits (with rounding on the final digit).
+ * @param {number} n The input number.
+ * @param {number} decimals The maximum number of decimal digits.
+ * @return {number} The nearest integer.
+ */
+export function round(n, decimals) {
+  return Math.round(toFixed(n, decimals));
+}
+
+/**
+ * Rounds a number to the next smaller integer considering only the given number
+ * of decimal digits (with rounding on the final digit).
+ * @param {number} n The input number.
+ * @param {number} decimals The maximum number of decimal digits.
+ * @return {number} The next smaller integer.
+ */
+export function floor(n, decimals) {
+  return Math.floor(toFixed(n, decimals));
+}
+
+/**
+ * Rounds a number to the next bigger integer considering only the given number
+ * of decimal digits (with rounding on the final digit).
+ * @param {number} n The input number.
+ * @param {number} decimals The maximum number of decimal digits.
+ * @return {number} The next bigger integer.
+ */
+export function ceil(n, decimals) {
+  return Math.ceil(toFixed(n, decimals));
+}

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -12,6 +12,7 @@ import {appendParams} from '../uri.js';
 import {assert} from '../asserts.js';
 import {assign} from '../obj.js';
 import {calculateSourceResolution} from '../reproj.js';
+import {ceil, floor, round} from '../math.js';
 import {compareVersions} from '../string.js';
 import {
   containsExtent,
@@ -21,6 +22,12 @@ import {
   getWidth,
 } from '../extent.js';
 import {get as getProjection, transform} from '../proj.js';
+
+/**
+ * Number of decimal digits to consider in integer values when rounding.
+ * @type {number}
+ */
+const DECIMALS = 4;
 
 /**
  * @const
@@ -197,8 +204,8 @@ class ImageWMS extends ImageSource {
     };
     assign(baseParams, this.params_, params);
 
-    const x = Math.floor((coordinate[0] - extent[0]) / resolution);
-    const y = Math.floor((extent[3] - coordinate[1]) / resolution);
+    const x = floor((coordinate[0] - extent[0]) / resolution, DECIMALS);
+    const y = floor((extent[3] - coordinate[1]) / resolution, DECIMALS);
     baseParams[this.v13_ ? 'I' : 'X'] = x;
     baseParams[this.v13_ ? 'J' : 'Y'] = y;
 
@@ -290,17 +297,19 @@ class ImageWMS extends ImageSource {
     const imageResolution = resolution / pixelRatio;
 
     const center = getCenter(extent);
-    const viewWidth = Math.ceil(getWidth(extent) / imageResolution);
-    const viewHeight = Math.ceil(getHeight(extent) / imageResolution);
+    const viewWidth = ceil(getWidth(extent) / imageResolution, DECIMALS);
+    const viewHeight = ceil(getHeight(extent) / imageResolution, DECIMALS);
     const viewExtent = getForViewAndSize(center, imageResolution, 0, [
       viewWidth,
       viewHeight,
     ]);
-    const requestWidth = Math.ceil(
-      (this.ratio_ * getWidth(extent)) / imageResolution
+    const requestWidth = ceil(
+      (this.ratio_ * getWidth(extent)) / imageResolution,
+      DECIMALS
     );
-    const requestHeight = Math.ceil(
-      (this.ratio_ * getHeight(extent)) / imageResolution
+    const requestHeight = ceil(
+      (this.ratio_ * getHeight(extent)) / imageResolution,
+      DECIMALS
     );
     const requestExtent = getForViewAndSize(center, imageResolution, 0, [
       requestWidth,
@@ -327,8 +336,14 @@ class ImageWMS extends ImageSource {
     };
     assign(params, this.params_);
 
-    this.imageSize_[0] = Math.round(getWidth(requestExtent) / imageResolution);
-    this.imageSize_[1] = Math.round(getHeight(requestExtent) / imageResolution);
+    this.imageSize_[0] = round(
+      getWidth(requestExtent) / imageResolution,
+      DECIMALS
+    );
+    this.imageSize_[1] = round(
+      getHeight(requestExtent) / imageResolution,
+      DECIMALS
+    );
 
     const url = this.getRequestUrl_(
       requestExtent,

--- a/test/node/ol/math.test.js
+++ b/test/node/ol/math.test.js
@@ -1,12 +1,16 @@
 import expect from '../expect.js';
 import {
+  ceil,
   clamp,
   cosh,
+  floor,
   lerp,
   log2,
   modulo,
+  round,
   solveLinearSystem,
   toDegrees,
+  toFixed,
   toRadians,
 } from '../../../src/ol/math.js';
 
@@ -161,5 +165,83 @@ describe('ol/math.js', () => {
       expect(lerp(0, 1, 0.5)).to.be(0.5);
       expect(lerp(0.25, 0.75, 0.5)).to.be(0.5);
     });
+  });
+
+  describe('toFixed', () => {
+    it('returns a number with a limited number of decimals', () => {
+      expect(toFixed(0.123456789, 3)).to.be(0.123);
+    });
+
+    it('rounds up', () => {
+      expect(toFixed(0.123456789, 4)).to.be(0.1235);
+    });
+
+    const cases = [
+      [1.23456789, 0],
+      [1.23456789, 1],
+      [1.23456789, 2],
+      [1.23456789, 3],
+      [1.23456789, 4],
+      [1.23456789, 5],
+      [1.23456789, 6],
+      [1.23456789, 7],
+      [1.23456789, 8],
+      [1.23456789, 9],
+      [1.23456789, 10],
+    ];
+    for (const c of cases) {
+      it(`provides numeric equivalent of (${c[0]}).toFixed(${c[1]})`, () => {
+        const string = c[0].toFixed(c[1]);
+        const expected = parseFloat(string);
+        const actual = toFixed(c[0], c[1]);
+        expect(actual).to.be(expected);
+      });
+    }
+  });
+
+  describe('round', () => {
+    const cases = [
+      [1.23, 2, 1],
+      [3.45, 1, 4],
+      [3.45, 2, 3],
+      [-3.45, 1, -3],
+      [-3.45, 2, -3],
+    ];
+
+    for (const c of cases) {
+      it(`works for round(${c[0]}, ${c[1]})`, () => {
+        expect(round(c[0], c[1])).to.be(c[2]);
+      });
+    }
+  });
+
+  describe('floor', () => {
+    const cases = [
+      [3.999, 4, 3],
+      [3.999, 2, 4],
+      [-3.01, 2, -4],
+      [-3.01, 1, -3],
+    ];
+
+    for (const c of cases) {
+      it(`works for floor(${c[0]}, ${c[1]})`, () => {
+        expect(floor(c[0], c[1])).to.be(c[2]);
+      });
+    }
+  });
+
+  describe('ceil', () => {
+    const cases = [
+      [4.001, 4, 5],
+      [4.001, 2, 4],
+      [-3.99, 3, -3],
+      [-3.99, 1, -4],
+    ];
+
+    for (const c of cases) {
+      it(`works for ceil(${c[0]}, ${c[1]})`, () => {
+        expect(ceil(c[0], c[1])).to.be(c[2]);
+      });
+    }
   });
 });


### PR DESCRIPTION
We use the `Math.round()`, `Math.floor()`, and `Math.ceil()` functions throughout the library assuming that we can rely on the full 64-bit precision of the passed values.  In most cases, we should likely be rounding to the nearest, smaller, or bigger integer values only considering a limited number of decimal places.

This branch adds `round`, `floor`, and `ceil` functions to the `ol/math.js` module for this purpose.

I've added a regression test to demonstrate that the ImageWMS source is able to request images that match the viewport size.  Before this change, this test fails (we request an extra row of pixels due to floating point issues).

Fixes #13098.