### PR TITLE
Lazily create resources for worker

### DIFF
--- a/tasks/serialize-workers.cjs
+++ b/tasks/serialize-workers.cjs
@@ -43,10 +43,10 @@ async function build(input, {minify = true} = {}) {
     name: 'serialize worker and export create function',
     renderChunk(code) {
       return `
-        const source = ${JSON.stringify(code)};
-        const blob = new Blob([source], {type: 'application/javascript'});
-        const url = URL.createObjectURL(blob);
         export function create() {
+          const source = ${JSON.stringify(code)};
+          const blob = new Blob([source], {type: 'application/javascript'});
+          const url = URL.createObjectURL(blob);
           return new Worker(url);
         }
       `;


### PR DESCRIPTION
This change makes it so `import`ing a `create` function from one of the worker modules doesn't create a `Blob` or reference `URL`.  This makes it possible to import these modules outside of a browser (even if the `create` function still doesn't work) - removing a bit of friction when using the `ol` package with server-side frameworks.