### PR TITLE
Populate view's object properties

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -480,8 +480,7 @@ class View extends BaseObject {
     );
     if (options.resolution !== undefined) {
       this.setResolution(options.resolution);
-    }
-    if (options.zoom !== undefined) {
+    } else if (options.zoom !== undefined) {
       this.setZoom(options.zoom);
     }
   }
@@ -530,8 +529,7 @@ class View extends BaseObject {
     // preserve resolution (or zoom)
     if (options.resolution !== undefined) {
       options.resolution = this.getResolution();
-    }
-    if (options.zoom !== undefined) {
+    } else {
       options.zoom = this.getZoom();
     }
 
@@ -1731,6 +1729,7 @@ class View extends BaseObject {
     }
     if (this.get(ViewProperty.RESOLUTION) !== newResolution) {
       this.set(ViewProperty.RESOLUTION, newResolution);
+      this.set('zoom', this.getZoom(), true);
     }
     if (
       !newCenter ||

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -416,10 +416,11 @@ class View extends BaseObject {
    * @param {ViewOptions} options View options.
    */
   applyOptions_(options) {
-    /**
-     * @type {Object<string, *>}
-     */
-    const properties = {};
+    const properties = assign({}, options);
+    for (const key in ViewProperty) {
+      delete properties[key];
+    }
+    this.setProperties(properties, true);
 
     const resolutionConstraintInfo = createResolutionConstraint(options);
 
@@ -479,17 +480,10 @@ class View extends BaseObject {
     );
     if (options.resolution !== undefined) {
       this.setResolution(options.resolution);
-    } else if (options.zoom !== undefined) {
+    }
+    if (options.zoom !== undefined) {
       this.setZoom(options.zoom);
     }
-
-    this.setProperties(properties);
-
-    /**
-     * @private
-     * @type {ViewOptions}
-     */
-    this.options_ = options;
   }
 
   /**
@@ -531,12 +525,13 @@ class View extends BaseObject {
    * @return {ViewOptions} New options updated with the current view state.
    */
   getUpdatedOptions_(newOptions) {
-    const options = assign({}, this.options_);
+    const options = this.getProperties();
 
     // preserve resolution (or zoom)
     if (options.resolution !== undefined) {
       options.resolution = this.getResolution();
-    } else {
+    }
+    if (options.zoom !== undefined) {
       options.zoom = this.getZoom();
     }
 
@@ -973,7 +968,7 @@ class View extends BaseObject {
    * @return {boolean} Resolution constraint is set
    */
   getConstrainResolution() {
-    return this.options_.constrainResolution;
+    return this.get('constrainResolution');
   }
 
   /**

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -617,6 +617,19 @@ describe('ol/View', function () {
       expect(options.zoom).to.eql(10);
     });
 
+    it('returns the current properties with getProperties()', function () {
+      const view = new View({
+        center: [0, 0],
+        minZoom: 2,
+        zoom: 10,
+      });
+      const options = view.getProperties();
+
+      expect(options.center).to.eql([0, 0]);
+      expect(options.minZoom).to.eql(2);
+      expect(options.zoom).to.eql(10);
+    });
+
     it('applies the current zoom', function () {
       const view = new View({
         center: [0, 0],
@@ -1874,8 +1887,8 @@ describe('ol/View', function () {
       expect(view.getCenter()[1]).to.be(1500);
     });
     it('fits correctly to the extent when a view extent is configured', function () {
-      view.options_.extent = [1500, 0, 2500, 10000];
-      view.applyOptions_(view.options_);
+      view.set('extent', [1500, 0, 2500, 10000]);
+      view.applyOptions_(view.getProperties());
       view.fit([1000, 1000, 2000, 2000]);
       expect(view.calculateExtent()).eql([1500, 1000, 2500, 2000]);
     });

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -623,11 +623,15 @@ describe('ol/View', function () {
         minZoom: 2,
         zoom: 10,
       });
-      const options = view.getProperties();
+      view.setZoom(8);
+      view.setCenter([1, 2]);
+      view.setRotation(1);
 
-      expect(options.center).to.eql([0, 0]);
+      const options = view.getProperties();
       expect(options.minZoom).to.eql(2);
-      expect(options.zoom).to.eql(10);
+      expect(options.zoom).to.eql(8);
+      expect(options.center).to.eql([1, 2]);
+      expect(options.rotation).to.eql(1);
     });
 
     it('applies the current zoom', function () {


### PR DESCRIPTION
Often it is useful to be able to create a new view with some properties from an existing view. Currently, calling `View#getProperties()` often returns an empty object, so this is not really possible. This pull request makes it so the the properties are populated with the options that the view currently maintains in the private `options_` member (which is removed), so users can obtain all options the view was constructed with, updated to the current view state.