### PR TITLE
Fix for range slider on IE

### DIFF
--- a/examples/layer-opacity.js
+++ b/examples/layer-opacity.js
@@ -38,5 +38,5 @@ function update() {
   opacityOutput.innerText = opacity.toFixed(2);
 }
 opacityInput.addEventListener('input', update);
-
+opacityInput.addEventListener('change', update);
 update();


### PR DESCRIPTION
#13126 seems to be working well on all platforms for the heatmap, but the opacity example was not working on IE.
