### PR TITLE
Unset canvas css in stylesheet

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -27,7 +27,6 @@ export function createCanvasContext2D(
     canvas = new OffscreenCanvas(opt_width || 300, opt_height || 300);
   } else {
     canvas = document.createElement('canvas');
-    canvas.style.all = 'unset';
   }
   if (opt_width) {
     canvas.width = opt_width;

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -76,6 +76,9 @@
   user-select: none;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
+.ol-viewport canvas {
+  all: unset;
+}
 .ol-selectable {
   -webkit-touch-callout: default;
   -webkit-user-select: text;


### PR DESCRIPTION
For a long time, I've found it hard to debug DOM issues because `canvas.style.all = 'unset'` adds all css properties to the canvas element we use to render layers. By setting that in the stylesheet instead, we avoid this inconvenience. Also, this fixes #13125.

The only downside is that users who have heavy css that modifies canvas `min-height` etc., they'll need `ol.css`, which is a good idea anyway.

Closes #13129.