### PR TITLE
Replace deprecated syntax in example

### DIFF
--- a/examples/popup.js
+++ b/examples/popup.js
@@ -18,9 +18,10 @@ const closer = document.getElementById('popup-closer');
  */
 const overlay = new Overlay({
   element: container,
-  autoPan: true,
-  autoPanAnimation: {
-    duration: 250,
+  autoPan: {
+    animation: {
+      duration: 250,
+    },
   },
 });
 


### PR DESCRIPTION
The `ol/Overlay` documentation describes `autoPan: true` as deprecated, but it is still being used in the Popup example.
