### PR TITLE
Add layer also for programmatically selected features

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -665,6 +665,25 @@ class PluggableMap extends BaseObject {
   }
 
   /**
+   * Get all layers from all layer groups.
+   * @return {Array<import("./layer/Layer.js").default>} Layers.
+   */
+  getAllLayers() {
+    const layers = [];
+    function addLayersFrom(layerGroup) {
+      layerGroup.forEach(function (layer) {
+        if (layer instanceof LayerGroup) {
+          addLayersFrom(layer.getLayers());
+        } else {
+          layers.push(layer);
+        }
+      });
+    }
+    addLayersFrom(this.getLayers());
+    return layers;
+  }
+
+  /**
    * Detect layers that have a color value at a pixel on the viewport, and
    * execute a callback with each matching layer. Layers included in the
    * detection can be configured through `opt_layerFilter`.

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -233,6 +233,19 @@ describe('ol/Map', function () {
     });
   });
 
+  describe('#getAllLayers()', function () {
+    it('returns all layers, also from inside groups', function () {
+      const map = new Map({});
+      const layer = new TileLayer();
+      const group = new LayerGroup({layers: [layer]});
+      map.addLayer(group);
+
+      const allLayers = map.getAllLayers();
+      expect(allLayers.length).to.be(1);
+      expect(allLayers[0]).to.be(layer);
+    });
+  });
+
   describe('#setLayers()', function () {
     it('adds an array of layers to the map', function () {
       const map = new Map({});

--- a/test/browser/spec/ol/interaction/select.test.js
+++ b/test/browser/spec/ol/interaction/select.test.js
@@ -375,6 +375,13 @@ describe('ol.interaction.Select', function () {
       // Select again to make sure the style change does not break selection
       simulateEvent('singleclick', 10, -20);
     });
+
+    it('returns a layer from a programmatically selected feature', function () {
+      const feature = source.getFeatures()[0];
+      interaction.getFeatures().push(feature);
+      const layerWithSelectedFeature = interaction.getLayer(feature);
+      expect(layerWithSelectedFeature).to.equal(layer);
+    });
   });
 
   describe('#setActive()', function () {


### PR DESCRIPTION
Fixes #13146.

This pull request makes it so when features are programmatically pushed to the `features` collection of a Select interaction, it will find the feature's layer and add it to the feature-layer association object, so the `getLayer(feature)` method will properly return the feature's layer.