### PR TITLE
Avoid error accessing attributes when context is lost

### DIFF
--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -273,7 +273,7 @@ class WebGLPostProcessingPass {
       const canvasId = getUid(gl.canvas);
       if (!frameState.renderTargets[canvasId]) {
         const attributes = gl.getContextAttributes();
-        if (attributes.preserveDrawingBuffer) {
+        if (attributes && attributes.preserveDrawingBuffer) {
           gl.clearColor(0.0, 0.0, 0.0, 0.0);
           gl.clear(gl.COLOR_BUFFER_BIT);
         }


### PR DESCRIPTION
This error occurs in codesandbox with latest version when another example is opened causing context to be lost (I saw similar error when testing the `getDataAtPixel` method in #13000).
![image](https://user-images.githubusercontent.com/49240900/146972515-aa71076b-63ce-4aa6-80cf-1c3db10e4d5e.png)

