### PR TITLE
Refine offset used for point resolution calculation

### DIFF
--- a/test/browser/spec/ol/control/scaleline.test.js
+++ b/test/browser/spec/ol/control/scaleline.test.js
@@ -682,7 +682,7 @@ describe('ol.control.ScaleLine', function () {
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
       expect(text.slice(0, 4)).to.be('1 : ');
-      expect(text.replace(/^1|\D/g, '')).to.eql(104710728);
+      expect(text.replace(/^1|\D/g, '')).to.eql(104710769);
     });
   });
 });

--- a/test/node/ol/proj.test.js
+++ b/test/node/ol/proj.test.js
@@ -421,7 +421,17 @@ describe('ol/proj.js', function () {
       let pointResolution = getPointResolution('EPSG:4326', 1, [0, 0], 'm');
       expect(pointResolution).to.roughlyEqual(111195.0802335329, 1e-5);
       pointResolution = getPointResolution('EPSG:4326', 1, [0, 52], 'm');
-      expect(pointResolution).to.roughlyEqual(89826.53390979706, 1e-5);
+      expect(pointResolution).to.roughlyEqual(89826.803688743, 1e-5);
+    });
+    it('returns point resolution for EPSG:4326 consistent with resolution', function () {
+      let pointResolution = getPointResolution('EPSG:4326', 30, [0, 0], 'm');
+      expect(pointResolution / 30).to.roughlyEqual(111195.0802335329, 1e-5);
+      pointResolution = getPointResolution('EPSG:4326', 1e-8, [0, 0], 'm');
+      expect(pointResolution / 1e-8).to.roughlyEqual(111195.0802335329, 1e-5);
+      pointResolution = getPointResolution('EPSG:4326', 30, [0, 52], 'm');
+      expect(pointResolution / 30).to.roughlyEqual(89826.803688743, 1e-5);
+      pointResolution = getPointResolution('EPSG:4326', 1e-8, [0, 52], 'm');
+      expect(pointResolution / 1e-8).to.roughlyEqual(89826.803688743, 1e-5);
     });
     it('returns the correct point resolution for EPSG:3857', function () {
       let pointResolution = getPointResolution('EPSG:3857', 1, [0, 0]);


### PR DESCRIPTION
Fixes the inconsistencies noted in https://github.com/openlayers/openlayers/issues/13167#issuecomment-1002588857

Calculating point resolution as the average resolution across a distance offset from the point is more precise when the offset is closer to the point.  An offset of 0.5 pixel (distance range of 1 pixel) gives a results consistent to better than 5 digits, but an offset of 0.01 pixel gives a consistent result in a scale bar at OSM zoom level 0 (about 1 : 500,000,000)
