### PR TITLE
Use dynamic import for geotiff

### DIFF
--- a/src/ol/worker/geotiff-decoder.js
+++ b/src/ol/worker/geotiff-decoder.js
@@ -1,16 +1,14 @@
 import 'regenerator-runtime/runtime.js';
 
-// BEGIN copied from geotiff/src/decoder.worker.js
 import {Transfer, expose} from 'threads/worker';
-import {getDecoder} from 'geotiff/src/compression';
 
 async function decode(fileDirectory, buffer) {
+  const {getDecoder} = await import('geotiff/src/compression');
   const decoder = await getDecoder(fileDirectory);
   const decoded = await decoder.decode(fileDirectory, buffer);
   return Transfer(decoded);
 }
 
 expose(decode);
-// END copied from geotiff/src/decoder.worker.js
 
 export let create;


### PR DESCRIPTION
This pull request is an attempt to avoid treeshaking problems on
```js
import { AnySource } from 'ol/source';
```
I'm hoping that this fixes #13046, at least for the case where `ol/source/GeoTIFF` is not actually used.