### PR TITLE
Use Buffer and data uri when Blob is not available

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -151,9 +151,12 @@ function createWorker(config, onMessage) {
     '});',
   ]);
 
-  const blob = new Blob(lines, {type: 'text/javascript'});
-  const source = URL.createObjectURL(blob);
-  const worker = new Worker(source);
+  const worker = new Worker(
+    typeof Blob === 'undefined'
+      ? 'data:text/javascript;base64,' +
+        Buffer.from(lines.join('\n'), 'binary').toString('base64')
+      : URL.createObjectURL(new Blob(lines, {type: 'text/javascript'}))
+  );
   worker.addEventListener('message', onMessage);
   return worker;
 }

--- a/tasks/serialize-workers.cjs
+++ b/tasks/serialize-workers.cjs
@@ -45,9 +45,9 @@ async function build(input, {minify = true} = {}) {
       return `
         export function create() {
           const source = ${JSON.stringify(code)};
-          const blob = new Blob([source], {type: 'application/javascript'});
-          const url = URL.createObjectURL(blob);
-          return new Worker(url);
+          return new Worker(typeof Blob === 'undefined'
+            ? 'data:application/javascript;base64,' + Buffer.from(source, 'binary').toString('base64')
+            : URL.createObjectURL(new Blob([source], {type: 'application/javascript'})));
         }
       `;
     },


### PR DESCRIPTION
This pull request makes our workers work in Node, where `Blob` is not available.

See https://github.com/openlayers/openlayers/issues/13114#issuecomment-994134162.