### PR TITLE
Always use ES modules from geotiff.js

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -4,7 +4,11 @@
 import DataTile from './DataTile.js';
 import State from './State.js';
 import TileGrid from '../tilegrid/TileGrid.js';
-import {Pool, fromUrl as tiffFromUrl, fromUrls as tiffFromUrls} from 'geotiff';
+import {
+  Pool,
+  fromUrl as tiffFromUrl,
+  fromUrls as tiffFromUrls,
+} from 'geotiff/src/geotiff.js';
 import {
   Projection,
   get as getCachedProjection,


### PR DESCRIPTION
When geotiffjs/geotiff.js#267 is released and both this pull request and #13179 are merged, server side rendering scenarios and other uses of OpenLayers with Node will work even with imports from `ol/source.js`. See https://github.com/openlayers/openlayers/issues/13114#issuecomment-994134162.