### PR TITLE
typo fix for cog-stretch example

### DIFF
--- a/examples/cog-stretch.html
+++ b/examples/cog-stretch.html
@@ -1,7 +1,7 @@
 ---
 layout: example.html
-title: Band Constrast Stretch
-shortdesc: Choosing bands and applying constrast stretch
+title: Band Contrast Stretch
+shortdesc: Choosing bands and applying contrast stretch
 docs: >
   This example uses the `layer.updateStyleVariables()` method to update the rendering
   of a GeoTIFF based on user selected bands and contrast stretch parameters.


### PR DESCRIPTION
Documentation label only change
