### PR TITLE
Format the changelog so contributors can be highlighted

### DIFF
--- a/tasks/changelog.sh
+++ b/tasks/changelog.sh
@@ -49,12 +49,12 @@ main() {
         number="${BASH_REMATCH[1]}"
         author="${BASH_REMATCH[2]}"
         summary="${BASH_REMATCH[3]}"
-        declare $output+=" * [#${number}](${PULLS_URL}/${number}) - ${summary} ([@${author}](${GITHUB_URL}/${author}))\n"
+        declare $output+=" * ${summary} (by @${author} in ${PULLS_URL}/${number})\n"
       elif [[ ${l} =~ ${SQUASH_RE} ]] ; then
         number="${BASH_REMATCH[3]}"
         author="${BASH_REMATCH[1]}"
         summary="${BASH_REMATCH[2]}"
-        declare $output+=" * [#${number}](${PULLS_URL}/${number}) - ${summary} ([${author}](${GITHUB_URL}/search?q=${author}&type=Users))\n"
+        declare $output+=" * ${summary} (by @${author} in ${PULLS_URL}/${number})\n"
       fi
     done
 


### PR DESCRIPTION
This updates the formatting of our changelog so GitHub highlights the contributors in the summary cards.

Before (makes it look like only one person contributed)

![image](https://user-images.githubusercontent.com/41094/148667243-006ab925-b2ce-47ea-ab2f-c43ce2030184.png)

After (all contributors shown)

![image](https://user-images.githubusercontent.com/41094/148667225-95e700e6-df8f-417f-bf21-c8a9fb3c182a.png)
