### PR TITLE
WebGL interpolation example

### DIFF
--- a/examples/webgl-interpolation.html
+++ b/examples/webgl-interpolation.html
@@ -1,0 +1,29 @@
+---
+layout: example.html
+title: Interpolation (with WebGL)
+shortdesc: Example of WebGL data interpolation
+docs: >
+  <p>
+    Example of data resampling when using raster DEM (digital elevation model) data with WebGL.
+    The data is interpolated by calculating the values represented by the RGB bands of
+    the pixels and the interpolated values are styled back as RGB so they can be accessed by
+    <b>forEachLayerAtPixel</b>.
+  </p><p>
+    Special consideration is needed when reprojecting raster sources whose pixels represent data values.
+    If the reprojected source zooms beyond the level of detail of the source data it will not be useful
+    for subsequent interpolation by WebGL.  The reprojection should also preserve the pixel data
+    values for interpolation.  <b>setTileGridForProjection</b> is be used to restrict reprojection to a
+    zoom level comparable to the original detail and to preserve pixel data values.
+  </p>
+tags: "image interpolation, xyz, maptiler, reprojection"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
+---
+<div id="map" class="map"></div>
+<div>
+  <label>
+    Elevation
+    <span id="info">0.0</span> meters
+  </label>
+</div>

--- a/examples/webgl-interpolation.js
+++ b/examples/webgl-interpolation.js
@@ -1,0 +1,90 @@
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+import XYZ from '../src/ol/source/XYZ.js';
+import {createXYZ} from '../src/ol/tilegrid.js';
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const attributions =
+  '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> ' +
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+
+const source = new XYZ({
+  attributions: attributions,
+  url: 'https://api.maptiler.com/tiles/terrain-rgb/{z}/{x}/{y}.png?key=' + key,
+  tileSize: 512,
+  maxZoom: 12,
+  crossOrigin: '',
+});
+
+const view = new View({
+  center: [6.893, 45.8295],
+  zoom: 16,
+  projection: 'EPSG:4326',
+});
+
+source.setTileGridForProjection(
+  view.getProjection(),
+  createXYZ({
+    extent: view.getProjection().getExtent(),
+    tileSize: 512,
+    maxZoom: 12,
+  }),
+  true
+);
+
+// The elevation is (pixelValue * 0.1) - 10000
+// but pixelValue is sufficient for interpolation
+const pixelValue = [
+  '*',
+  255,
+  [
+    '+',
+    ['*', 256 * 256, ['band', 1]],
+    ['+', ['*', 256, ['band', 2]], ['band', 3]],
+  ],
+];
+
+const style = {
+  color: [
+    'array',
+    ['/', ['floor', ['/', pixelValue, 256 * 256]], 255],
+    ['/', ['floor', ['/', ['%', pixelValue, 256 * 256], 256]], 255],
+    ['/', ['%', pixelValue, 256], 255],
+    1,
+  ],
+};
+
+const interpolated = new TileLayer({
+  style: style,
+  source: source,
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [interpolated],
+  view: view,
+});
+
+const info = document.getElementById('info');
+
+const showElevations = function (evt) {
+  if (evt.dragging) {
+    return;
+  }
+  map.forEachLayerAtPixel(
+    evt.pixel,
+    function (layer, pixel) {
+      const height =
+        -10000 + (pixel[0] * 256 * 256 + pixel[1] * 256 + pixel[2]) * 0.1;
+      info.innerText = height.toFixed(1);
+    },
+    {
+      layerFilter: function (layer) {
+        return layer === interpolated;
+      },
+    }
+  );
+};
+
+map.on('pointermove', showElevations);

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -40,6 +40,7 @@ class ReprojTile extends Tile {
    * @param {number} [opt_errorThreshold] Acceptable reprojection error (in px).
    * @param {boolean} [opt_renderEdges] Render reprojection edges.
    * @param {boolean} [opt_interpolate] Use linear interpolation when resampling.
+   * @param {boolean} [opt_pixelData] Preserve pixel data when reprojecting with interpolation.
    */
   constructor(
     sourceProj,
@@ -53,7 +54,8 @@ class ReprojTile extends Tile {
     getTileFunction,
     opt_errorThreshold,
     opt_renderEdges,
-    opt_interpolate
+    opt_interpolate,
+    opt_pixelData
   ) {
     super(tileCoord, TileState.IDLE, {interpolate: !!opt_interpolate});
 
@@ -62,6 +64,12 @@ class ReprojTile extends Tile {
      * @type {boolean}
      */
     this.renderEdges_ = opt_renderEdges !== undefined ? opt_renderEdges : false;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.pixelData_ = opt_pixelData !== undefined ? opt_pixelData : false;
 
     /**
      * @private
@@ -279,7 +287,7 @@ class ReprojTile extends Tile {
         sources,
         this.gutter_,
         this.renderEdges_,
-        this.interpolate
+        this.interpolate && !this.pixelData_
       );
 
       this.state = TileState.LOADED;

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -38,6 +38,7 @@ import {log2} from '../math.js';
  *   * `['%', value1, value2]` returns the result of `value1 % value2` (modulo)
  *   * `['^', value1, value2]` returns the value of `value1` raised to the `value2` power
  *   * `['abs', value1]` returns the absolute value of `value1`
+ *   * `['floor', value1]` returns the nearest integer less than or equal to `value1`
  *   * `['sin', value1]` returns the sine of `value1`
  *   * `['cos', value1]` returns the cosine of `value1`
  *   * `['atan', value1, value2]` returns `atan2(value1, value2)`. If `value2` is not provided, returns `atan(value1)`
@@ -664,6 +665,17 @@ Operators['abs'] = {
     assertArgsCount(args, 1);
     assertNumbers(args);
     return `abs(${expressionToGlsl(context, args[0])})`;
+  },
+};
+
+Operators['floor'] = {
+  getReturnType: function (args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function (context, args) {
+    assertArgsCount(args, 1);
+    assertNumbers(args);
+    return `floor(${expressionToGlsl(context, args[0])})`;
   },
 };
 

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -243,6 +243,7 @@ describe('ol/style/expressions', function () {
           ['-', ['get', 'attr3'], ['get', 'attr2']],
         ])
       ).to.eql('abs((a_attr3 - a_attr2))');
+      expect(expressionToGlsl(context, ['floor', 1])).to.eql('floor(1.0)');
       expect(expressionToGlsl(context, ['sin', 1])).to.eql('sin(1.0)');
       expect(expressionToGlsl(context, ['cos', 1])).to.eql('cos(1.0)');
       expect(expressionToGlsl(context, ['atan', 1])).to.eql('atan(1.0)');


### PR DESCRIPTION
This adds a WebGL version of the Interpolation example, interpolating the reprojected source based on the combined values of the RGB bands similar to the WebGL Sea Level example.  Supporting changes are a `floor` operator for styling and a pixelData option for the `ol/source/TileImage` `setTileGridForProjection` method to preserve pixels representing data values when reprojecting with interpolation.
