### PR TITLE
Re-enable image smoothing after rendering

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -4,7 +4,7 @@
 import CanvasLayerRenderer from './Layer.js';
 import ViewHint from '../../ViewHint.js';
 import {ENABLE_RASTER_REPROJECTION} from '../../reproj/common.js';
-import {IMAGE_SMOOTHING_DISABLED} from './common.js';
+import {IMAGE_SMOOTHING_DISABLED, IMAGE_SMOOTHING_ENABLED} from './common.js';
 import {assign} from '../../obj.js';
 import {compose as composeTransform, makeInverse} from '../../transform.js';
 import {containsExtent, intersects as intersectsExtent} from '../../extent.js';
@@ -219,6 +219,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     if (clipped) {
       context.restore();
     }
+    assign(context, IMAGE_SMOOTHING_ENABLED);
 
     if (canvasTransform !== canvas.style.transform) {
       canvas.style.transform = canvasTransform;

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -4,7 +4,7 @@
 import CanvasLayerRenderer from './Layer.js';
 import TileRange from '../../TileRange.js';
 import TileState from '../../TileState.js';
-import {IMAGE_SMOOTHING_DISABLED} from './common.js';
+import {IMAGE_SMOOTHING_DISABLED, IMAGE_SMOOTHING_ENABLED} from './common.js';
 import {
   apply as applyTransform,
   compose as composeTransform,
@@ -457,6 +457,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     if (layerState.extent) {
       context.restore();
     }
+    assign(context, IMAGE_SMOOTHING_ENABLED);
 
     if (canvasTransform !== canvas.style.transform) {
       canvas.style.transform = canvasTransform;

--- a/src/ol/renderer/canvas/common.js
+++ b/src/ol/renderer/canvas/common.js
@@ -10,3 +10,12 @@ export const IMAGE_SMOOTHING_DISABLED = {
   imageSmoothingEnabled: false,
   msImageSmoothingEnabled: false,
 };
+
+/**
+ * Context options to enable image smoothing.
+ * @type {Object}
+ */
+export const IMAGE_SMOOTHING_ENABLED = {
+  imageSmoothingEnabled: true,
+  msImageSmoothingEnabled: true,
+};

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -181,6 +181,7 @@ class VectorSource extends Source {
 
     super({
       attributions: options.attributions,
+      interpolate: true,
       projection: undefined,
       state: SourceState.READY,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,

--- a/test/browser/spec/ol/renderer/canvas/imagelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/imagelayer.test.js
@@ -301,6 +301,18 @@ describe('ol.renderer.canvas.ImageLayer', function () {
         done();
       });
     });
+
+    it('image smoothing is re-enabled after rendering', function (done) {
+      let context;
+      layer.on('postrender', function (e) {
+        context = e.context;
+        context.imageSmoothingEnabled = false;
+      });
+      map.on('postrender', function () {
+        expect(context.imageSmoothingEnabled).to.be(true);
+        done();
+      });
+    });
   });
 
   describe('Vector image rendering', function () {

--- a/test/browser/spec/ol/renderer/canvas/tilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/tilelayer.test.js
@@ -87,5 +87,17 @@ describe('ol.renderer.canvas.TileLayer', function () {
         done();
       });
     });
+
+    it('image smoothing is re-enabled after rendering', function (done) {
+      let context;
+      layer.on('postrender', function (e) {
+        context = e.context;
+        context.imageSmoothingEnabled = false;
+      });
+      map.on('postrender', function () {
+        expect(context.imageSmoothingEnabled).to.be(true);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
Fixes #13234

Reset interpolation after rendering Image and TileImage sources as the canvas may be shared.

Set interpolation for Vector sources as these may be rendered by VectorImage layers.
