### PR TITLE
Add crossOrigin option to LiteralSymbolStyle

### DIFF
--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -32,6 +32,7 @@ export const SymbolType = {
  * @property {ExpressionValue|Array<ExpressionValue, ExpressionValue>} size Size, mandatory.
  * @property {SymbolType} symbolType Symbol type to use, either a regular shape or an image.
  * @property {string} [src] Path to the image to be used for the symbol. Only required with `symbolType: 'image'`.
+ * @property {string} [crossOrigin='anonymous'] The `crossOrigin` attribute for loading `src`.
  * @property {import("../color.js").Color|Array<ExpressionValue>|string} [color='#FFFFFF'] Color used for the representation (either fill, line or symbol).
  * @property {ExpressionValue} [opacity=1] Opacity.
  * @property {ExpressionValue} [rotation=0] Symbol rotation in radians.

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -548,6 +548,8 @@ export function parseLiteralStyle(style) {
 
   if (symbStyle.symbolType === 'image' && symbStyle.src) {
     const texture = new Image();
+    texture.crossOrigin =
+      symbStyle.crossOrigin === undefined ? 'anonymous' : symbStyle.crossOrigin;
     texture.src = symbStyle.src;
     builder
       .addUniform('sampler2D u_texture')


### PR DESCRIPTION
Fixes #13256

Add `crossOrigin` option to `LiteralSymbolStyle` and apply it (defaulting to anonymous) when loading icon or sprite.  The example will not need updating but should work again in CodeSandbox which redirects to the original url for images.
