### PR TITLE
Remove unneeded `src=""`

### DIFF
--- a/examples/utfgrid.html
+++ b/examples/utfgrid.html
@@ -15,6 +15,6 @@ cloak:
   <!-- Overlay with the country info -->
   <div id="country-info">
     <div id="country-name">&nbsp;</div>
-    <img id="country-flag" src="" />
+    <img id="country-flag" />
   </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/13270#issuecomment-1019285139

Using an unneeded `src=""` on an `img` tag causes an obscure error in CodeSandbox