### PR TITLE
Fix 81 "Property 'X' is used before being assigned" TS errors

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -73,27 +73,27 @@ export class CollectionEvent extends Event {
  * @api
  */
 class Collection extends BaseObject {
+  /***
+   * @type {CollectionOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {CollectionOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {CollectionOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Array<T>} [opt_array] Array.
    * @param {Options} [opt_options] Collection options.
    */
   constructor(opt_array, opt_options) {
     super();
-
-    /***
-     * @type {CollectionOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {CollectionOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {CollectionOnSignature<void>}
-     */
-    this.un;
 
     const options = opt_options || {};
 

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -73,6 +73,21 @@ import {listen, unlistenByKey} from './events.js';
  * @template {import("./geom/Geometry.js").default} [Geometry=import("./geom/Geometry.js").default]
  */
 class Feature extends BaseObject {
+  /***
+   * @type {FeatureOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {FeatureOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {FeatureOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Geometry|ObjectWithGeometry<Geometry>} [opt_geometryOrProperties]
    *     You may pass a Geometry object directly, or an object literal containing
@@ -81,21 +96,6 @@ class Feature extends BaseObject {
    */
   constructor(opt_geometryOrProperties) {
     super();
-
-    /***
-     * @type {FeatureOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {FeatureOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {FeatureOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -100,26 +100,26 @@ class GeolocationError extends BaseEvent {
  * @api
  */
 class Geolocation extends BaseObject {
+  /***
+   * @type {GeolocationOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {GeolocationOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {GeolocationOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
-
-    /***
-     * @type {GeolocationOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {GeolocationOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {GeolocationOnSignature<void>}
-     */
-    this.un;
 
     const options = opt_options || {};
 

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -88,26 +88,26 @@ export class ObjectEvent extends Event {
  * @api
  */
 class BaseObject extends Observable {
+  /***
+   * @type {ObjectOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ObjectOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ObjectOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Object<string, *>} [opt_values] An object with key-value pairs.
    */
   constructor(opt_values) {
     super();
-
-    /***
-     * @type {ObjectOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ObjectOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ObjectOnSignature<void>}
-     */
-    this.un;
 
     // Call {@link module:ol/util.getUid} to ensure that the order of objects' ids is
     // the same as the order in which they were created.  This also helps to

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -116,26 +116,26 @@ const Property = {
  * @api
  */
 class Overlay extends BaseObject {
+  /***
+   * @type {OverlayOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {OverlayOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {OverlayOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Overlay options.
    */
   constructor(options) {
     super();
-
-    /***
-     * @type {OverlayOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {OverlayOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {OverlayOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @protected

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -186,26 +186,26 @@ function setLayerMapProperty(layer, map) {
  * @api
  */
 class PluggableMap extends BaseObject {
+  /***
+   * @type {PluggableMapOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {PluggableMapOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {PluggableMapOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {MapOptions} options Map options.
    */
   constructor(options) {
     super();
-
-    /***
-     * @type {PluggableMapOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {PluggableMapOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {PluggableMapOnSignature<void>}
-     */
-    this.un;
 
     const optionsInternal = createOptionsInternal(options);
 

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -305,26 +305,26 @@ const DEFAULT_MIN_ZOOM = 0;
  * @api
  */
 class View extends BaseObject {
+  /***
+   * @type {ViewOnSignature<import("./events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ViewOnSignature<import("./events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ViewOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {ViewOptions} [opt_options] View options.
    */
   constructor(opt_options) {
     super();
-
-    /***
-     * @type {ViewOnSignature<import("./events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ViewOnSignature<import("./events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ViewOnSignature<void>}
-     */
-    this.un;
 
     const options = assign({}, opt_options);
 

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -79,6 +79,21 @@ const FullScreenEventType = {
  * @api
  */
 class FullScreen extends Control {
+  /***
+   * @type {FullScreenOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {FullScreenOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {FullScreenOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -89,21 +104,6 @@ class FullScreen extends Control {
       element: document.createElement('div'),
       target: options.target,
     });
-
-    /***
-     * @type {FullScreenOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {FullScreenOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {FullScreenOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -63,6 +63,21 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * @api
  */
 class MousePosition extends Control {
+  /***
+   * @type {MousePositionOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {MousePositionOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {MousePositionOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Mouse position options.
    */
@@ -78,21 +93,6 @@ class MousePosition extends Control {
       render: options.render,
       target: options.target,
     });
-
-    /***
-     * @type {MousePositionOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {MousePositionOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {MousePositionOnSignature<void>}
-     */
-    this.un;
 
     this.addChangeListener(PROJECTION, this.handleProjectionChanged_);
 

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -80,6 +80,21 @@ const DEFAULT_DPI = 25.4 / 0.28;
  * @api
  */
 class ScaleLine extends Control {
+  /***
+   * @type {ScaleLineOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ScaleLineOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ScaleLineOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Scale line options.
    */
@@ -98,21 +113,6 @@ class ScaleLine extends Control {
       render: options.render,
       target: options.target,
     });
-
-    /***
-     * @type {ScaleLineOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ScaleLineOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ScaleLineOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/interaction/DragAndDrop.js
+++ b/src/ol/interaction/DragAndDrop.js
@@ -97,6 +97,21 @@ export class DragAndDropEvent extends Event {
  * @fires DragAndDropEvent
  */
 class DragAndDrop extends Interaction {
+  /***
+   * @type {DragAndDropOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {DragAndDropOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {DragAndDropOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -106,21 +121,6 @@ class DragAndDrop extends Interaction {
     super({
       handleEvent: TRUE,
     });
-
-    /***
-     * @type {DragAndDropOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {DragAndDropOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {DragAndDropOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -116,26 +116,26 @@ export class DragBoxEvent extends Event {
  * @api
  */
 class DragBox extends PointerInteraction {
+  /***
+   * @type {DragBoxOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {DragBoxOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {DragBoxOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
-
-    /***
-     * @type {DragBoxOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {DragBoxOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {DragBoxOnSignature<void>}
-     */
-    this.un;
 
     const options = opt_options ? opt_options : {};
 

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -190,6 +190,21 @@ export class DrawEvent extends Event {
  * @api
  */
 class Draw extends PointerInteraction {
+  /***
+   * @type {DrawOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {DrawOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {DrawOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Options.
    */
@@ -202,21 +217,6 @@ class Draw extends PointerInteraction {
     }
 
     super(pointerOptions);
-
-    /***
-     * @type {DrawOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {DrawOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {DrawOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @type {boolean}

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -94,6 +94,21 @@ export class ExtentEvent extends Event {
  * @api
  */
 class Extent extends PointerInteraction {
+  /***
+   * @type {ExtentOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ExtentOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ExtentOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -101,21 +116,6 @@ class Extent extends PointerInteraction {
     const options = opt_options || {};
 
     super(/** @type {import("./Pointer.js").Options} */ (options));
-
-    /***
-     * @type {ExtentOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ExtentOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ExtentOnSignature<void>}
-     */
-    this.un;
 
     /**
      * Condition

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -39,26 +39,26 @@ import {easeOut, linear} from '../easing.js';
  * @api
  */
 class Interaction extends BaseObject {
+  /***
+   * @type {InteractionOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {InteractionOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {InteractionOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {InteractionOptions} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
-
-    /***
-     * @type {InteractionOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {InteractionOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {InteractionOnSignature<void>}
-     */
-    this.un;
 
     if (opt_options && opt_options.handleEvent) {
       this.handleEvent = opt_options.handleEvent;

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -196,26 +196,26 @@ export class ModifyEvent extends Event {
  * @api
  */
 class Modify extends PointerInteraction {
+  /***
+   * @type {ModifyOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ModifyOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ModifyOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Options.
    */
   constructor(options) {
     super(/** @type {import("./Pointer.js").Options} */ (options));
-
-    /***
-     * @type {ModifyOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ModifyOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ModifyOnSignature<void>}
-     */
-    this.un;
 
     /** @private */
     this.boundHandleFeatureChange_ = this.handleFeatureChange_.bind(this);

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -159,26 +159,26 @@ const originalFeatureStyles = {};
  * @api
  */
 class Select extends Interaction {
+  /***
+   * @type {SelectOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {SelectOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {SelectOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
     super();
-
-    /***
-     * @type {SelectOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {SelectOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {SelectOnSignature<void>}
-     */
-    this.un;
 
     const options = opt_options ? opt_options : {};
 

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -131,6 +131,21 @@ export class TranslateEvent extends Event {
  * @api
  */
 class Translate extends PointerInteraction {
+  /***
+   * @type {TranslateOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {TranslateOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {TranslateOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -138,21 +153,6 @@ class Translate extends PointerInteraction {
     const options = opt_options ? opt_options : {};
 
     super(/** @type {import("./Pointer.js").Options} */ (options));
-
-    /***
-     * @type {TranslateOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {TranslateOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {TranslateOnSignature<void>}
-     */
-    this.un;
 
     /**
      * The last position we translated to.

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -62,26 +62,26 @@ import {clamp} from '../math.js';
  * @api
  */
 class BaseLayer extends BaseObject {
+  /***
+   * @type {BaseLayerOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {BaseLayerOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {BaseLayerOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Layer options.
    */
   constructor(options) {
     super();
-
-    /***
-     * @type {BaseLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {BaseLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {BaseLayerOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @type {BackgroundColor|false}

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -60,6 +60,21 @@ import {assign} from '../obj.js';
  * @api
  */
 class BaseTileLayer extends Layer {
+  /***
+   * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {BaseTileLayerOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options<TileSourceType>} [opt_options] Tile layer options.
    */
@@ -71,21 +86,6 @@ class BaseTileLayer extends Layer {
     delete baseOptions.preload;
     delete baseOptions.useInterimTilesOnError;
     super(baseOptions);
-
-    /***
-     * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {BaseTileLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {BaseTileLayerOnSignature<void>}
-     */
-    this.un;
 
     this.setPreload(options.preload !== undefined ? options.preload : 0);
     this.setUseInterimTilesOnError(

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -88,6 +88,21 @@ const Property = {
  * @api
  */
 class LayerGroup extends BaseLayer {
+  /***
+   * @type {GroupOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {GroupOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {GroupOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Layer options.
    */
@@ -99,21 +114,6 @@ class LayerGroup extends BaseLayer {
     let layers = options.layers;
 
     super(baseOptions);
-
-    /***
-     * @type {GroupOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {GroupOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {GroupOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -98,6 +98,21 @@ import {listen, unlistenByKey} from '../events.js';
  * @api
  */
 class Layer extends BaseLayer {
+  /***
+   * @type {LayerOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {LayerOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {LayerOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options<SourceType>} options Layer options.
    */
@@ -106,21 +121,6 @@ class Layer extends BaseLayer {
     delete baseOptions.source;
 
     super(baseOptions);
-
-    /***
-     * @type {LayerOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {LayerOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {LayerOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -96,6 +96,21 @@ import {assign} from '../obj.js';
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
+  /***
+   * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {VectorTileLayerOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Options.
    */
@@ -111,21 +126,6 @@ class VectorTileLayer extends BaseVectorLayer {
         baseOptions
       )
     );
-
-    /***
-     * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {VectorTileLayerOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {VectorTileLayerOnSignature<void>}
-     */
-    this.un;
 
     if (options.renderMode === VectorTileRenderType.IMAGE) {
       //FIXME deprecated - remove this check in v7.

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -93,6 +93,21 @@ export class ImageSourceEvent extends Event {
  * @api
  */
 class ImageSource extends Source {
+  /***
+   * @type {ImageSourceOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {ImageSourceOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {ImageSourceOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Single image source options.
    */
@@ -109,21 +124,6 @@ class ImageSource extends Source {
       state: options.state,
       interpolate: interpolate,
     });
-
-    /***
-     * @type {ImageSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {ImageSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {ImageSourceOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -543,6 +543,21 @@ export class RasterSourceEvent extends Event {
  * @api
  */
 class RasterSource extends ImageSource {
+  /***
+   * @type {RasterSourceOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {RasterSourceOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {RasterSourceOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options Options.
    */
@@ -550,21 +565,6 @@ class RasterSource extends ImageSource {
     super({
       projection: null,
     });
-
-    /***
-     * @type {RasterSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {RasterSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {RasterSourceOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -51,6 +51,21 @@ import {scale as scaleSize, toSize} from '../size.js';
  * @api
  */
 class TileSource extends Source {
+  /***
+   * @type {TileSourceOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {TileSourceOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {TileSourceOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} options SourceTile source options.
    */
@@ -63,21 +78,6 @@ class TileSource extends Source {
       wrapX: options.wrapX,
       interpolate: options.interpolate,
     });
-
-    /***
-     * @type {TileSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {TileSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {TileSourceOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -173,6 +173,21 @@ export class VectorSourceEvent extends Event {
  * @template {import("../geom/Geometry.js").default} [Geometry=import("../geom/Geometry.js").default]
  */
 class VectorSource extends Source {
+  /***
+   * @type {VectorSourceOnSignature<import("../events").EventsKey>}
+   */
+  on;
+
+  /***
+   * @type {VectorSourceOnSignature<import("../events").EventsKey>}
+   */
+  once;
+
+  /***
+   * @type {VectorSourceOnSignature<void>}
+   */
+  un;
+
   /**
    * @param {Options} [opt_options] Vector source options.
    */
@@ -186,21 +201,6 @@ class VectorSource extends Source {
       state: SourceState.READY,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,
     });
-
-    /***
-     * @type {VectorSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.on;
-
-    /***
-     * @type {VectorSourceOnSignature<import("../events").EventsKey>}
-     */
-    this.once;
-
-    /***
-     * @type {VectorSourceOnSignature<void>}
-     */
-    this.un;
 
     /**
      * @private


### PR DESCRIPTION
Resulting from Observable type narrowing.

The results of this will be noticeable when strictNullChecks are enabled in the future. 