### PR TITLE
Fix typo CSS class name for the expanded attributions button

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -110,7 +110,7 @@ class Attribution extends Control {
     const collapseClassName =
       options.collapseClassName !== undefined
         ? options.collapseClassName
-        : className + '-collpase';
+        : className + '-collapse';
 
     if (typeof collapseLabel === 'string') {
       /**


### PR DESCRIPTION
See #11403
