### PR TITLE
Avoid canvas memory overflow on iOS devices, to avoid the 'Total canvas memory use exceeds the maximum limit' warning 

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -37,7 +37,7 @@ import {fromUserCoordinate, toUserCoordinate} from './proj.js';
 import {getUid} from './util.js';
 import {hasArea} from './size.js';
 import {listen, unlistenByKey} from './events.js';
-import {removeNode} from './dom.js';
+import {releaseAllCanvasMemory, removeNode} from './dom.js';
 
 /**
  * State of the current frame. Only `pixelRatio`, `time` and `viewState` should
@@ -599,6 +599,7 @@ class PluggableMap extends BaseObject {
    * Clean up.
    */
   disposeInternal() {
+    releaseAllCanvasMemory(); //In the 'unload|beforeunload' event it is recommended to call map.dispose() to try to completely free the canvas memory.
     this.setTarget(null);
     super.disposeInternal();
   }

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -2,7 +2,7 @@
  * @module ol/TileCache
  */
 import LRUCache from './structs/LRUCache.js';
-import {fromKey, getKey} from './tilecoord.js';
+import { fromKey, getKey } from './tilecoord.js';
 
 class TileCache extends LRUCache {
   /**
@@ -38,6 +38,19 @@ class TileCache extends LRUCache {
       }.bind(this)
     );
   }
+
+  /**
+  * Removes the canvas from all the TileCache and releases for each one leaving its canvas reduced to 1x1 to avoid overflow of canvas memory of IOS
+  */
+  releaseAllTileCacheCanvas() {
+    if (this.getCount() === 0) {
+      return;
+    }
+    this.forEach(function (tile) {
+      this.remove(getKey(tile.tileCoord));
+      tile.release();
+    }.bind(this));
+  };
 }
 
 export default TileCache;

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -2,8 +2,8 @@
  * @module ol/VectorRenderTile
  */
 import Tile from './Tile.js';
-import {createCanvasContext2D} from './dom.js';
-import {getUid} from './util.js';
+import { createCanvasContext2D, releaseCanvas } from './dom.js';
+import { getUid } from './util.js';
 
 /**
  * @typedef {Object} ReplayState
@@ -30,7 +30,7 @@ class VectorRenderTile extends Tile {
    * to get source tiles for this tile.
    */
   constructor(tileCoord, state, urlTileCoord, getSourceTiles) {
-    super(tileCoord, state, {transition: 0});
+    super(tileCoord, state, { transition: 0 });
 
     /**
      * @private
@@ -154,6 +154,9 @@ class VectorRenderTile extends Tile {
    */
   release() {
     for (const key in this.context_) {
+     //Release the canvas making the size 1x1. It's necessary for IOS, as it doesn't manage the canvas memory well and causes it to overflow very quickly.
+     //It is useless to delete or assign null to the canvas, the only option we have is to minimize its memory as it did not disappear from memory until the collector garbage is activated, which seems to never happen until ios to page refresh (sometimes not even refreshing, memory is freed!)
+      releaseCanvas(this.context_[key].canvas);
       canvasPool.push(this.context_[key].canvas);
       delete this.context_[key];
     }

--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -1,4 +1,4 @@
-import {WORKER_OFFSCREEN_CANVAS} from './has.js';
+import { WORKER_OFFSCREEN_CANVAS } from './has.js';
 
 /**
  * @module ol/dom
@@ -13,6 +13,41 @@ import {WORKER_OFFSCREEN_CANVAS} from './has.js';
  * @param {CanvasRenderingContext2DSettings} [opt_Context2DSettings] CanvasRenderingContext2DSettings
  * @return {CanvasRenderingContext2D} The context.
  */
+
+let allCanvasRef = []; //keeps all references to the created canvas inside the createCanvasContext2D function
+
+/**
+ * Make a calculation of the memory used by all the canvas we currently in 'allCanvasRef' array and return the total Mb (approx)
+ * A single canvas requires  canvas.width * canvas.height * 4(red, green, blue, alpha) bytes. 
+ * @return {number} Total memory canvas in MB (the sum of size of all canvas on allCanvasRef)
+ */
+export function getCanvasMemorySize() {
+  let canvas, totalSizeMb = 0;
+  for (let i in allCanvasRef) {
+    canvas = allCanvasRef[i];
+    totalSizeMb += (canvas.width * canvas.height * 4) / Math.pow(10, 6);
+  }
+  return Math.round(totalSizeMb);
+}
+
+/** 
+* Release all canvas memory
+*/
+export function releaseAllCanvasMemory() {
+  for (let i in allCanvasRef) {
+    releaseCanvas(allCanvasRef[i]);
+  }
+}
+
+/** 
+* Release a single canvas.
+*/
+export function releaseCanvas(canvas) {
+  canvas.width = 1;
+  canvas.height = 1;
+  canvas.getContext('2d').clearRect(0, 0, 1, 1);
+}
+
 export function createCanvasContext2D(
   opt_width,
   opt_height,
@@ -27,6 +62,7 @@ export function createCanvasContext2D(
     canvas = new OffscreenCanvas(opt_width || 300, opt_height || 300);
   } else {
     canvas = document.createElement('canvas');
+    allCanvasRef.push(canvas);
   }
   if (opt_width) {
     canvas.width = opt_width;

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -228,6 +228,7 @@ class VectorTile extends UrlTile {
    * @api
    */
   clear() {
+    this.tileCache.releaseAllTileCacheCanvas();
     this.tileCache.clear();
     this.sourceTileCache.clear();
   }


### PR DESCRIPTION
Workaround to avoid canvas memory overflow on iOS devices, to avoid the 'Total canvas memory use exceeds the maximum limit (xxx MB)' warning that causes VectorTile layers to stop painting elements on the map correctly.
Tests have been done on 2 iPads with  Safari:

- iOS 12 with max canvas memory:224MB 
- iOS 15 with max canvas memory:480MB

My solution is based on maintaining the reference to all the canvases created by the TileCache and on their correct release in memory when they are no longer needed and when total canvas memory usage exceeds 200MB (after that the rendering becomes unstable and sometimes the application crashes). This link has helped me a lot to understand how canvas works in iOS:
https://pqina.nl/blog/total-canvas-memory-use-exceeds-the-maximum-limit/

This is a problem that Apple should have fixed many years ago, they are not managing the canvas garbage collector correctly in their SO.