### PR TITLE
Fix rendercomplete for WebGLPoints layer and subclasses

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -943,10 +943,13 @@ class PluggableMap extends BaseObject {
   /**
    * @return {boolean} Layers have sources that are still loading.
    */
-  getLoading() {
+  getLoadingOrNotReady() {
     const layerStatesArray = this.getLayerGroup().getLayerStatesArray();
     for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
       const layer = layerStatesArray[i].layer;
+      if (!layer.getRenderer().ready) {
+        return true;
+      }
       const source = /** @type {import("./layer/Layer.js").default} */ (
         layer
       ).getSource();
@@ -1561,7 +1564,7 @@ class PluggableMap extends BaseObject {
     this.renderComplete_ =
       !this.tileQueue_.getTilesLoading() &&
       !this.tileQueue_.getCount() &&
-      !this.getLoading();
+      !this.getLoadingOrNotReady();
 
     if (!this.postRenderTimeoutHandle_) {
       this.postRenderTimeoutHandle_ = setTimeout(() => {

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -17,6 +17,11 @@ class LayerRenderer extends Observable {
   constructor(layer) {
     super();
 
+    /**
+     * @type {boolean} The renderer is initialized and ready to render.
+     */
+    this.ready = true;
+
     /** @private */
     this.boundHandleImageChange_ = this.handleImageChange_.bind(this);
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -137,6 +137,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       postProcesses: options.postProcesses,
     });
 
+    this.ready = false;
+
     this.sourceRevision_ = -1;
 
     this.verticesBuffer_ = new WebGLArrayBuffer(ARRAY_BUFFER, DYNAMIC_DRAW);
@@ -320,7 +322,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
               event.data.renderInstructions
             );
           }
-
+          this.ready = true;
           this.getLayer().changed();
         }
       }.bind(this)
@@ -610,6 +612,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;
+    this.ready = false;
     this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
     this.renderInstructions_ = null;
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -287,6 +287,13 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
      */
     this.hitRenderTarget_;
 
+    /**
+     * Keep track of latest message sent to worker
+     * @type {number}
+     * @private
+     */
+    this.generateBuffersRun_ = 0;
+
     this.worker_ = createWebGLWorker();
     this.worker_.addEventListener(
       'message',
@@ -321,8 +328,11 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
             this.renderInstructions_ = new Float32Array(
               event.data.renderInstructions
             );
+            if (received.generateBuffersRun === this.generateBuffersRun_) {
+              this.ready = true;
+            }
           }
-          this.ready = true;
+
           this.getLayer().changed();
         }
       }.bind(this)
@@ -612,6 +622,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;
+    message['generateBuffersRun'] = ++this.generateBuffersRun_;
     this.ready = false;
     this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
     this.renderInstructions_ = null;

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -23,6 +23,7 @@ import TileLayerRenderer from '../../../../src/ol/renderer/canvas/TileLayer.js';
 import VectorLayer from '../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
+import WebGLPointsLayer from '../../../../src/ol/layer/WebGLPoints.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 import {LineString, Point, Polygon} from '../../../../src/ol/geom.js';
 import {TRUE} from '../../../../src/ol/functions.js';
@@ -449,6 +450,17 @@ describe('ol/Map', function () {
               },
             }),
           }),
+          new WebGLPointsLayer({
+            source: new VectorSource({
+              features: [new Feature(new Point([0, 0]))],
+            }),
+            style: {
+              symbol: {
+                color: 'red',
+                symbolType: 'circle',
+              },
+            },
+          }),
         ],
       });
     });
@@ -460,13 +472,15 @@ describe('ol/Map', function () {
     });
 
     it('triggers when all tiles and sources are loaded and faded in', function (done) {
+      const layers = map.getLayers().getArray();
+      expect(layers[6].getRenderer().ready).to.be(false);
       map.once('rendercomplete', function () {
-        const layers = map.getLayers().getArray();
         expect(map.tileQueue_.getTilesLoading()).to.be(0);
         expect(layers[1].getSource().image_.getState()).to.be(
           ImageState.LOADED
         );
         expect(layers[2].getSource().getFeatures().length).to.be(1);
+        expect(layers[6].getRenderer().ready).to.be(true);
         done();
       });
       map.setView(

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -747,5 +747,21 @@ describe('ol/renderer/webgl/PointsLayer', function () {
         });
       });
     });
+    it('is not ready until after second rebuildBuffers_ worker calls completed', function (done) {
+      map.renderSync();
+      map.getView().setCenter([10, 10]);
+      map.renderSync();
+      let changed = 0;
+      layer.on('change', function () {
+        try {
+          expect(layer.getRenderer().ready).to.be(++changed > 2);
+          if (changed === 4) {
+            done();
+          }
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
This pull request fixes the problem described in https://github.com/openlayers/openlayers/pull/13294#issuecomment-1026023330.

It introduces a `ready` flag on the layer renderer. For the WebGLPoints layer, this will be set to `false` whenever the renderer is waiting for a message from the worker, in which case it cannot render the latest data.