### PR TITLE
Get data from tiles

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,16 @@
 ## Upgrade notes
 
+### Next
+
+#### New behavior of map.forEachLayerAtPixel() for WebGL tile layers
+
+The `map.forEachLayerAtPixel()` method now returns original pixel values for WebGL-rendered tile layers.  Previously,
+the value returned was based on the RGBA composite pixel based on rendering all layers.  Additional data types have been added to the signature of the callback passed to this method.  In addition to being called with a `Uint8ClampedArray` or `Uint8Array`, the method may now be called with a `Float32Array` or `DataView` depending on the underlying data type of the tiles used.
+
+For example, when rendering a GeoTIFF source that loads floating point values (with `normalize: false`), the `map.forEachLayerAtPixel()` callback will be called with a `Float32Array` representing pixel values.
+
+Previously, when rendering data tile sources with zero pixel values in the fourth band, the `map.forEachLayerAtPixel()` callback would be called with `null`.  Now, the full pixel array will be provided (even if the fourth band is zero).
+
 ### v6.12.0
 
 No special changes are required when upgrading to the 6.12.0 release.

--- a/examples/cog-math.html
+++ b/examples/cog-math.html
@@ -3,9 +3,12 @@ layout: example.html
 title: NDVI from a Sentinel 2 COG
 shortdesc: Calculating NDVI and applying a custom color map.
 docs: >
-  The GeoTIFF layer in this example draws from two Sentinel 2 sources: a red band and a near infrared band.
+  The GeoTIFF layer in this example draws from two Sentinel 2 sources: a red band and a near-infrared band.
   The layer style includes a `color` expression that calculates the Normalized Difference Vegetation Index (NDVI)
   from values in the two bands.  The `interpolate` expression is used to map NDVI values to colors.
+  The `map.forEachLayerAtPixel()` method can be used to retrieve pixel values from the GeoTIFF.  Move your mouse
+  or tap on the map to see calculated NDVI values based on the red and near-infrared pixel values.
 tags: "cog, ndvi"
 ---
 <div id="map" class="map"></div>
+<div>NDVI: <span id="output"></span></div>

--- a/examples/cog-math.js
+++ b/examples/cog-math.js
@@ -79,3 +79,17 @@ const map = new Map({
   ],
   view: source.getView(),
 });
+
+const output = document.getElementById('output');
+function displayPixelValue(event) {
+  map.forEachLayerAtPixel(event.pixel, (layer, data) => {
+    if (!data) {
+      return;
+    }
+    const red = data[0];
+    const nir = data[1];
+    const ndvi = (nir - red) / (nir + red);
+    output.textContent = ndvi.toFixed(2);
+  });
+}
+map.on(['pointermove', 'click'], displayPixelValue);

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -696,12 +696,13 @@ class PluggableMap extends BaseObject {
    * `className` in its constructor.
    *
    * @param {import("./pixel.js").Pixel} pixel Pixel.
-   * @param {function(this: S, import("./layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback
+   * @param {function(this: S, import("./layer/Layer.js").default, (Uint8ClampedArray|Uint8Array|Float32Array|DataView)): T} callback
    *     Layer callback. This callback will receive two arguments: first is the
    *     {@link module:ol/layer/Layer layer}, second argument is an array representing
-   *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
-   *     that do not currently support this argument. To stop detection, callback
-   *     functions can return a truthy value.
+   *     pixel values and will be `null` for layer types that do not currently support this method.
+   *     The type of pixel data passed to the callback depends on the source data type.  For example,
+   *     the callback will be called with a 5 element Float32Array for a data source with 5 bands of
+   *     floating point data.  To stop detection, callback functions can return a truthy value.
    * @param {AtPixelOptions} [opt_options] Configuration options.
    * @return {T|undefined} Callback result, i.e. the return value of last
    * callback execution, or the first truthy callback return value.

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -155,7 +155,7 @@ class CompositeMapRenderer extends MapRenderer {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array|Float32Array|DataView)): T} callback Layer
    *     callback.
    * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -130,7 +130,7 @@ class LayerRenderer extends Observable {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @return {Uint8ClampedArray|Uint8Array} The result.  If there is no data at the pixel
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView} The result.  If there is no data at the pixel
    *    location, null will be returned.  If there is data, but pixel values cannot be
    *    returned, and empty array will be returned.
    */

--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -175,7 +175,7 @@ class MapRenderer extends Disposable {
    * @param {import("../pixel.js").Pixel} pixel Pixel.
    * @param {import("../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array)): T} callback Layer
+   * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>, (Uint8ClampedArray|Uint8Array|Float32Array|DataView)): T} callback Layer
    *     callback.
    * @param {function(import("../layer/Layer.js").default<import("../source/Source").default>): boolean} layerFilter Layer filter
    *     function, only layers which are visible and for which this function

--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -283,7 +283,7 @@ class WebGLLayerRenderer extends LayerRenderer {
    * @param {import("../../pixel.js").Pixel} pixel Pixel.
    * @param {import("../../PluggableMap.js").FrameState} frameState FrameState.
    * @param {number} hitTolerance Hit tolerance in pixels.
-   * @return {Uint8ClampedArray|Uint8Array} The result.  If there is no data at the pixel
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView} The result.  If there is no data at the pixel
    *    location, null will be returned.  If there is data, but pixel values cannot be
    *    returned, and empty array will be returned.
    */

--- a/test/browser/spec/ol/renderer/webgl/Layer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/Layer.test.js
@@ -436,89 +436,7 @@ describe('ol/renderer/webgl/Layer', function () {
     });
   });
 
-  describe('#getDataAtPixel (preserveDrawingBuffer false)', function () {
-    let map, target, source, layer, getContextOriginal;
-    beforeEach(function (done) {
-      getContextOriginal = HTMLCanvasElement.prototype.getContext;
-      HTMLCanvasElement.prototype.getContext = function (type, attributes) {
-        if (attributes && attributes.preserveDrawingBuffer) {
-          attributes.preserveDrawingBuffer = false;
-        }
-        return getContextOriginal.call(this, type, attributes);
-      };
-
-      const projection = new Projection({
-        code: 'custom-image',
-        units: 'pixels',
-        extent: [0, 0, 200, 200],
-      });
-      target = document.createElement('div');
-      target.style.width = '100px';
-      target.style.height = '100px';
-      document.body.appendChild(target);
-      source = new DataTileSource({
-        loader: function (z, x, y) {
-          return new Uint8Array(x == 0 ? [255, 0, 0, 255] : [0, 0, 0, 0]);
-        },
-        projection: projection,
-        maxZoom: 0,
-        tileSize: 1,
-        maxResolution: 100,
-      });
-      layer = new TileLayer({
-        source: source,
-        extent: [50, 0, 150, 100],
-      });
-      map = new Map({
-        pixelRatio: 1,
-        target: target,
-        layers: [layer],
-        view: new View({
-          projection: projection,
-          center: [100, 100],
-          zoom: 0,
-        }),
-      });
-      map.once('rendercomplete', function () {
-        done();
-      });
-    });
-
-    afterEach(function () {
-      HTMLCanvasElement.prototype.getContext = getContextOriginal;
-      map.setLayers([]);
-      map.setTarget(null);
-      document.body.removeChild(target);
-    });
-
-    it('should not detect pixels outside of the layer extent', function () {
-      const pixel = [10, 10];
-      const frameState = map.frameState_;
-      const hitTolerance = 0;
-      const layerRenderer = layer.getRenderer();
-      const data = layerRenderer.getDataAtPixel(
-        pixel,
-        frameState,
-        hitTolerance
-      );
-      expect(data).to.be(null);
-    });
-
-    it('should handle unreadable pixels in the layer extent', function () {
-      const pixel = [10, 60];
-      const frameState = map.frameState_;
-      const hitTolerance = 0;
-      const layerRenderer = layer.getRenderer();
-      const data = layerRenderer.getDataAtPixel(
-        pixel,
-        frameState,
-        hitTolerance
-      );
-      expect(data.length).to.be(0);
-    });
-  });
-
-  describe('#getDataAtPixel (preserveDrawingBuffer true)', function () {
+  describe('#getDataAtPixel', function () {
     let map, target, source, layer;
     beforeEach(function (done) {
       const projection = new Projection({
@@ -587,14 +505,14 @@ describe('ol/renderer/webgl/Layer', function () {
         frameState,
         hitTolerance
       );
-      expect(data.length > 0).to.be(true);
+      expect(data).length(4);
       expect(data[0]).to.be(255);
       expect(data[1]).to.be(0);
       expect(data[2]).to.be(0);
       expect(data[3]).to.be(255);
     });
 
-    it('should handle no data in the layer extent', function () {
+    it('returns values even if the fourth band has a zero', function () {
       const pixel = [60, 60];
       const frameState = map.frameState_;
       const hitTolerance = 0;
@@ -604,7 +522,11 @@ describe('ol/renderer/webgl/Layer', function () {
         frameState,
         hitTolerance
       );
-      expect(data).to.be(null);
+      expect(data).length(4);
+      expect(data[0]).to.be(0);
+      expect(data[1]).to.be(0);
+      expect(data[2]).to.be(0);
+      expect(data[3]).to.be(0);
     });
   });
 });


### PR DESCRIPTION
This changes the implementation of the `getDataAtPixel` method for the WebGL tile renderer.  The implementation in #13186 returns a Uint8 array representing the color rendered for all layers at the requested pixel.  The implementation in this branch returns the pixel data value from a single layer.  The data type returned depends on the tile type.  For data tiles, the returned value is the same type as the data tile.  For image tiles, a Uint8 array is returned.

I've removed the test that sets the context's `preserveDrawingBuffer: false` because we no longer require this attribute to be set in order to get pixel data.

The other change in behavior (seen in the tests) is that the method works for pixel values where the fourth band is zero.  Previously, the method returned `null` in this case.  We now return the full pixel array.

The [NDVI example](https://deploy-preview-13335--ol-site.netlify.app/examples/cog-math.html) demonstrates how NDVI values (based on original pixel values) can be displayed on `pointermove` or `click`.  This is not possible (in general) with the current implementation (no guarantee that you can invert a color value to retrieve the original data values, and layer composition and alpha handling is "lossy" in terms of original data values).