### PR TITLE
Fix error when accessing ready property of renderer

### DIFF
--- a/test/rendering/cases/stacking/main.js
+++ b/test/rendering/cases/stacking/main.js
@@ -28,6 +28,10 @@ class Element extends Layer {
   render() {
     return this.element;
   }
+
+  createRenderer() {
+    return {};
+  }
 }
 
 // elements for stacked controls


### PR DESCRIPTION
One of the rendering tests silently fails since #13323 because it is accessing a property of a null renderer.
https://github.com/openlayers/openlayers/blob/93c08784af88c3c89367d901de80c3857c233133/src/ol/PluggableMap.js#L950
Alternatively that line above should include a null check?