### PR TITLE
Get pixel data

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,13 @@
 ## Upgrade notes
 
+### Next
+
+#### New `layer.getData()` method
+
+Raster layers (static images, image tiles, data tiles) have a new `layer.getData(pixel)` method that returns the pixel data at the provided location.  The return value depends on the underlying source data type.  For example, a GeoTIFF may return a `Float32Array` with one value per band, while a PNG rendered from a tile layer will return a `Uint8ClampedArray` of RGBA values.
+
+If you were previously using the `map.forEachLayerAtPixel()` method, you should use the new `layer.getData()` method instead.  The old method returns composite pixel values from multiple layers and is limited to RGBA values.  The new method doesn't suffer from these shortcomings and is more performant.
+
 ### v6.12.0
 
 No special changes are required when upgrading to the 6.12.0 release.

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -8,6 +8,10 @@ Raster layers (static images, image tiles, data tiles) have a new `layer.getData
 
 If you were previously using the `map.forEachLayerAtPixel()` method, you should use the new `layer.getData()` method instead.  The old method returns composite pixel values from multiple layers and is limited to RGBA values.  The new method doesn't suffer from these shortcomings and is more performant.
 
+#### Deprecated `map.forEachLayerAtPixel()` method
+
+The `map.forEachLayerAtPixel()` method has been deprecated.  It will be removed (or its behavior may change) in the next major release.  Please use the `layer.getData()` method instead.
+
 ### v6.12.0
 
 No special changes are required when upgrading to the 6.12.0 release.

--- a/examples/cog-math.html
+++ b/examples/cog-math.html
@@ -3,9 +3,12 @@ layout: example.html
 title: NDVI from a Sentinel 2 COG
 shortdesc: Calculating NDVI and applying a custom color map.
 docs: >
-  The GeoTIFF layer in this example draws from two Sentinel 2 sources: a red band and a near infrared band.
+  The GeoTIFF layer in this example draws from two Sentinel 2 sources: a red band and a near-infrared band.
   The layer style includes a `color` expression that calculates the Normalized Difference Vegetation Index (NDVI)
   from values in the two bands.  The `interpolate` expression is used to map NDVI values to colors.
+  The `layer.getData()` method can be used to retrieve pixel values from the GeoTIFF.  Move your mouse
+  or tap on the map to see calculated NDVI values based on the red and near-infrared pixel values.
 tags: "cog, ndvi"
 ---
 <div id="map" class="map"></div>
+<div>NDVI: <span id="output"></span></div>

--- a/examples/cog-math.js
+++ b/examples/cog-math.js
@@ -17,65 +17,74 @@ const source = new GeoTIFF({
   ],
 });
 
+const layer = new TileLayer({
+  style: {
+    color: [
+      'interpolate',
+      ['linear'],
+      // calculate NDVI, bands come from the sources below
+      ['/', ['-', ['band', 2], ['band', 1]], ['+', ['band', 2], ['band', 1]]],
+      // color ramp for NDVI values, ranging from -1 to 1
+      -0.2,
+      [191, 191, 191],
+      -0.1,
+      [219, 219, 219],
+      0,
+      [255, 255, 224],
+      0.025,
+      [255, 250, 204],
+      0.05,
+      [237, 232, 181],
+      0.075,
+      [222, 217, 156],
+      0.1,
+      [204, 199, 130],
+      0.125,
+      [189, 184, 107],
+      0.15,
+      [176, 194, 97],
+      0.175,
+      [163, 204, 89],
+      0.2,
+      [145, 191, 82],
+      0.25,
+      [128, 179, 71],
+      0.3,
+      [112, 163, 64],
+      0.35,
+      [97, 150, 54],
+      0.4,
+      [79, 138, 46],
+      0.45,
+      [64, 125, 36],
+      0.5,
+      [48, 110, 28],
+      0.55,
+      [33, 97, 18],
+      0.6,
+      [15, 84, 10],
+      0.65,
+      [0, 69, 0],
+    ],
+  },
+  source: source,
+});
+
 const map = new Map({
   target: 'map',
-  layers: [
-    new TileLayer({
-      style: {
-        color: [
-          'interpolate',
-          ['linear'],
-          // calculate NDVI, bands come from the sources below
-          [
-            '/',
-            ['-', ['band', 2], ['band', 1]],
-            ['+', ['band', 2], ['band', 1]],
-          ],
-          // color ramp for NDVI values, ranging from -1 to 1
-          -0.2,
-          [191, 191, 191],
-          -0.1,
-          [219, 219, 219],
-          0,
-          [255, 255, 224],
-          0.025,
-          [255, 250, 204],
-          0.05,
-          [237, 232, 181],
-          0.075,
-          [222, 217, 156],
-          0.1,
-          [204, 199, 130],
-          0.125,
-          [189, 184, 107],
-          0.15,
-          [176, 194, 97],
-          0.175,
-          [163, 204, 89],
-          0.2,
-          [145, 191, 82],
-          0.25,
-          [128, 179, 71],
-          0.3,
-          [112, 163, 64],
-          0.35,
-          [97, 150, 54],
-          0.4,
-          [79, 138, 46],
-          0.45,
-          [64, 125, 36],
-          0.5,
-          [48, 110, 28],
-          0.55,
-          [33, 97, 18],
-          0.6,
-          [15, 84, 10],
-          0.65,
-          [0, 69, 0],
-        ],
-      },
-      source: source,
-    }),
-  ],
+  layers: [layer],
   view: source.getView(),
 });
+
+const output = document.getElementById('output');
+function displayPixelValue(event) {
+  const data = layer.getData(event.pixel);
+  if (!data) {
+    return;
+  }
+  const red = data[0];
+  const nir = data[1];
+  const ndvi = (nir - red) / (nir + red);
+  output.textContent = ndvi.toFixed(2);
+}
+map.on(['pointermove', 'click'], displayPixelValue);

--- a/examples/getfeatureinfo-image.html
+++ b/examples/getfeatureinfo-image.html
@@ -3,8 +3,8 @@ layout: example.html
 title: WMS GetFeatureInfo (Image Layer)
 shortdesc: Using an image WMS source with GetFeatureInfo requests
 docs: >
-  This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS image layer.  Additionally <code>map.forEachLayerAtPixel</code> is used to change the mouse pointer when hovering a non-transparent pixel on the map.
-tags: "getfeatureinfo, forEachLayerAtPixel"
+  This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS image layer.  Additionally `layer.getData(pixel)` is used to change the mouse pointer when hovering a non-transparent pixel on the map.
+tags: "getfeatureinfo, getData"
 ---
 <div id="map" class="map"></div>
 <div id="info">&nbsp;</div>

--- a/examples/getfeatureinfo-image.js
+++ b/examples/getfeatureinfo-image.js
@@ -47,9 +47,7 @@ map.on('pointermove', function (evt) {
   if (evt.dragging) {
     return;
   }
-  const pixel = map.getEventPixel(evt.originalEvent);
-  const hit = map.forEachLayerAtPixel(pixel, function () {
-    return true;
-  });
+  const data = wmsLayer.getData(evt.pixel);
+  const hit = data && data[3] > 0; // transparent pixels have zero for data[3]
   map.getTargetElement().style.cursor = hit ? 'pointer' : '';
 });

--- a/examples/getfeatureinfo-tile.html
+++ b/examples/getfeatureinfo-tile.html
@@ -3,8 +3,8 @@ layout: example.html
 title: WMS GetFeatureInfo (Tile Layer)
 shortdesc: Issuing GetFeatureInfo requests with a WMS tiled source
 docs: >
-  This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS tile layer.  Additionally <code>map.forEachLayerAtPixel</code> is used to change the mouse pointer when hovering a non-transparent pixel on the map.
-tags: "getfeatureinfo, forEachLayerAtPixel"
+  This example shows how to trigger WMS GetFeatureInfo requests on click for a WMS tile layer.  Additionally `layer.getData(pixel)` is used to change the mouse pointer when hovering a non-transparent pixel on the map.
+tags: "getfeatureinfo, getData"
 ---
 <div id="map" class="map"></div>
 <div id="info">&nbsp;</div>

--- a/examples/getfeatureinfo-tile.js
+++ b/examples/getfeatureinfo-tile.js
@@ -47,9 +47,7 @@ map.on('pointermove', function (evt) {
   if (evt.dragging) {
     return;
   }
-  const pixel = map.getEventPixel(evt.originalEvent);
-  const hit = map.forEachLayerAtPixel(pixel, function () {
-    return true;
-  });
+  const data = wmsLayer.getData(evt.pixel);
+  const hit = data && data[3] > 0; // transparent pixels have zero for data[3]
   map.getTargetElement().style.cursor = hit ? 'pointer' : '';
 });

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -685,6 +685,9 @@ class PluggableMap extends BaseObject {
   }
 
   /**
+   * Please the `layer.getData()` method for {@link module:ol/layer/Tile~TileLayer#getData tile layers} or
+   * {@link module:ol/layer/Image~ImageLayer#getData image layers} instead of using this method.
+   *
    * Detect layers that have a color value at a pixel on the viewport, and
    * execute a callback with each matching layer. Layers included in the
    * detection can be configured through `opt_layerFilter`.

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -710,6 +710,7 @@ class PluggableMap extends BaseObject {
    * callback execution, or the first truthy callback return value.
    * @template S,T
    * @api
+   * @deprecated
    */
   forEachLayerAtPixel(pixel, callback, opt_options) {
     if (!this.frameState_) {

--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -136,6 +136,26 @@ class BaseTileLayer extends Layer {
   setUseInterimTilesOnError(useInterimTilesOnError) {
     this.set(TileProperty.USE_INTERIM_TILES_ON_ERROR, useInterimTilesOnError);
   }
+
+  /**
+   * Get data for a pixel location.  The return type depends on the source data.  For image tiles,
+   * a four element RGBA array will be returned.  For data tiles, the array length will match the
+   * number of bands in the dataset.  For requests outside the layer extent, `null` will be returned.
+   * Data for a image tiles can only be retrieved if the source's `crossOrigin` property is set.
+   *
+   * ```js
+   * // display layer data on every pointer move
+   * map.on('pointermove', (event) => {
+   *   console.log(layer.getData(event.pixel));
+   * });
+   * ```
+   * @param {import("../pixel").Pixel} pixel Pixel.
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView|null} Pixel data.
+   * @api
+   */
+  getData(pixel) {
+    return super.getData(pixel);
+  }
 }
 
 export default BaseTileLayer;

--- a/src/ol/layer/Image.js
+++ b/src/ol/layer/Image.js
@@ -27,6 +27,25 @@ class ImageLayer extends BaseImageLayer {
   createRenderer() {
     return new CanvasImageLayerRenderer(this);
   }
+
+  /**
+   * Get data for a pixel location.  A four element RGBA array will be returned.  For requests outside the
+   * layer extent, `null` will be returned.  Data for an image can only be retrieved if the
+   * source's `crossOrigin` property is set.
+   *
+   * ```js
+   * // display layer data on every pointer move
+   * map.on('pointermove', (event) => {
+   *   console.log(layer.getData(event.pixel));
+   * });
+   * ```
+   * @param {import("../pixel").Pixel} pixel Pixel.
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView|null} Pixel data.
+   * @api
+   */
+  getData(pixel) {
+    return super.getData(pixel);
+  }
 }
 
 export default ImageLayer;

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -251,6 +251,17 @@ class Layer extends BaseLayer {
   }
 
   /**
+   * @param {import("../pixel").Pixel} pixel Pixel.
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView|null} Pixel data.
+   */
+  getData(pixel) {
+    if (!this.renderer_) {
+      return null;
+    }
+    return this.renderer_.getData(pixel);
+  }
+
+  /**
    * In charge to manage the rendering of the layer. One layer type is
    * bounded with one layer renderer.
    * @param {?import("../PluggableMap.js").FrameState} frameState Frame state.

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -146,6 +146,12 @@ class Layer extends BaseLayer {
      */
     this.renderer_ = null;
 
+    /**
+     * @protected
+     * @type {boolean}
+     */
+    this.rendered = false;
+
     // Overwrite default render method with a custom one
     if (options.render) {
       this.render = options.render;
@@ -255,7 +261,7 @@ class Layer extends BaseLayer {
    * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView|null} Pixel data.
    */
   getData(pixel) {
-    if (!this.renderer_) {
+    if (!this.renderer_ || !this.rendered) {
       return null;
     }
     return this.renderer_.getData(pixel);
@@ -273,8 +279,16 @@ class Layer extends BaseLayer {
     const layerRenderer = this.getRenderer();
 
     if (layerRenderer.prepareFrame(frameState)) {
+      this.rendered = true;
       return layerRenderer.renderFrame(frameState, target);
     }
+  }
+
+  /**
+   * Called when a layer is not visible during a map render.
+   */
+  unrender() {
+    this.rendered = false;
   }
 
   /**
@@ -282,6 +296,9 @@ class Layer extends BaseLayer {
    * @param {import("../PluggableMap.js").default|null} map Map.
    */
   setMapInternal(map) {
+    if (!map) {
+      this.unrender();
+    }
     this.set(LayerProperty.MAP, map);
   }
 

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -440,6 +440,7 @@ class WebGLTileLayer extends BaseTileLayer {
    * @return {HTMLElement} The rendered element.
    */
   render(frameState, target) {
+    this.rendered = true;
     const viewState = frameState.viewState;
     const sources = this.getSources(frameState.extent, viewState.resolution);
     let ready = true;

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -118,6 +118,7 @@ class CompositeMapRenderer extends MapRenderer {
         (sourceState != SourceState.READY &&
           sourceState != SourceState.UNDEFINED)
       ) {
+        layer.unrender();
         continue;
       }
 

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -48,6 +48,14 @@ class LayerRenderer extends Observable {
   }
 
   /**
+   * @param {import("../pixel.js").Pixel} pixel Pixel.
+   * @return {Uint8ClampedArray|Uint8Array|Float32Array|DataView|null} Pixel data.
+   */
+  getData(pixel) {
+    return null;
+  }
+
+  /**
    * Determine whether render should be called.
    * @abstract
    * @param {import("../PluggableMap.js").FrameState} frameState Frame state.
@@ -190,6 +198,14 @@ class LayerRenderer extends Observable {
     if (layer.getVisible() && layer.getSourceState() == SourceState.READY) {
       layer.changed();
     }
+  }
+
+  /**
+   * Clean up.
+   */
+  disposeInternal() {
+    delete this.layer_;
+    super.disposeInternal();
   }
 }
 

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -5,15 +5,19 @@ import CanvasLayerRenderer from './Layer.js';
 import ViewHint from '../../ViewHint.js';
 import {ENABLE_RASTER_REPROJECTION} from '../../reproj/common.js';
 import {IMAGE_SMOOTHING_DISABLED, IMAGE_SMOOTHING_ENABLED} from './common.js';
-import {assign} from '../../obj.js';
 import {
+  apply as applyTransform,
   compose as composeTransform,
   makeInverse,
   toString as toTransformString,
 } from '../../transform.js';
+import {assign} from '../../obj.js';
 import {
+  containsCoordinate,
   containsExtent,
+  getHeight,
   getIntersection,
+  getWidth,
   intersects as intersectsExtent,
   isEmpty,
 } from '../../extent.js';
@@ -96,6 +100,51 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     }
 
     return !!this.image_;
+  }
+
+  /**
+   * @param {import("../../pixel.js").Pixel} pixel Pixel.
+   * @return {Uint8ClampedArray} Data at the pixel location.
+   */
+  getData(pixel) {
+    const frameState = this.frameState;
+    if (!frameState) {
+      return null;
+    }
+
+    const layer = this.getLayer();
+    const coordinate = applyTransform(
+      frameState.pixelToCoordinateTransform,
+      pixel.slice()
+    );
+
+    const layerExtent = layer.getExtent();
+    if (layerExtent) {
+      if (!containsCoordinate(layerExtent, coordinate)) {
+        return null;
+      }
+    }
+
+    const imageExtent = this.image_.getExtent();
+    const img = this.image_.getImage();
+
+    const imageMapWidth = getWidth(imageExtent);
+    const col = Math.floor(
+      img.width * ((coordinate[0] - imageExtent[0]) / imageMapWidth)
+    );
+    if (col < 0 || col >= img.width) {
+      return null;
+    }
+
+    const imageMapHeight = getHeight(imageExtent);
+    const row = Math.floor(
+      img.height * ((imageExtent[3] - coordinate[1]) / imageMapHeight)
+    );
+    if (row < 0 || row >= img.height) {
+      return null;
+    }
+
+    return this.getImageData(img, col, row);
   }
 
   /**

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -108,7 +108,6 @@ class DataTileSource extends TileSource {
   }
 
   /**
-   * @abstract
    * @param {number} z Tile coordinate z.
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.

--- a/test/browser/spec/ol/layer/Image.test.js
+++ b/test/browser/spec/ol/layer/Image.test.js
@@ -1,0 +1,75 @@
+import ImageLayer from '../../../../../src/ol/layer/Image.js';
+import Map from '../../../../../src/ol/Map.js';
+import Static from '../../../../../src/ol/source/ImageStatic.js';
+import View from '../../../../../src/ol/View.js';
+import {Projection} from '../../../../../src/ol/proj.js';
+
+describe('ol/layer/Image', () => {
+  describe('getData()', () => {
+    let map, target, layer;
+
+    beforeEach((done) => {
+      const projection = new Projection({
+        code: 'custom-image',
+        units: 'pixels',
+        extent: [0, 0, 200, 200],
+      });
+
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+
+      const imageExtent = [0, 0, 20, 20];
+      const source = new Static({
+        url: 'spec/ol/data/dot.png',
+        projection: projection,
+        imageExtent: imageExtent,
+      });
+
+      layer = new ImageLayer({
+        source: source,
+        extent: imageExtent,
+      });
+
+      map = new Map({
+        pixelRatio: 1,
+        target: target,
+        layers: [layer],
+        view: new View({
+          projection: projection,
+          center: [10, 10],
+          zoom: 1,
+          maxZoom: 8,
+        }),
+      });
+      map.once('rendercomplete', () => {
+        done();
+      });
+    });
+
+    afterEach(() => {
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+
+    it('should not detect pixels outside of the layer extent', () => {
+      map.renderSync();
+      const pixel = [10, 10];
+      const data = layer.getData(pixel);
+      expect(data).to.be(null);
+    });
+
+    it('should detect pixels in the layer extent', () => {
+      map.renderSync();
+      const pixel = [50, 50];
+      const data = layer.getData(pixel);
+      expect(data).to.be.a(Uint8ClampedArray);
+      expect(data.length).to.be(4);
+      expect(data[0]).to.be(255);
+      expect(data[1]).to.be(255);
+      expect(data[2]).to.be(255);
+      expect(data[3]).to.be(255);
+    });
+  });
+});

--- a/test/browser/spec/ol/layer/Layer.test.js
+++ b/test/browser/spec/ol/layer/Layer.test.js
@@ -4,6 +4,9 @@ import Map from '../../../../../src/ol/Map.js';
 import Property from '../../../../../src/ol/layer/Property.js';
 import RenderEvent from '../../../../../src/ol/render/Event.js';
 import Source from '../../../../../src/ol/source/Source.js';
+import TileLayer from '../../../../../src/ol/layer/Tile.js';
+import View from '../../../../../src/ol/View.js';
+import XYZ from '../../../../../src/ol/source/XYZ.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
 
 describe('ol/layer/Layer', function () {
@@ -616,6 +619,77 @@ describe('ol/layer/Layer', function () {
 
       layer.setVisible(true);
       expect(listener.callCount).to.be(2);
+    });
+  });
+
+  describe('unrender()', () => {
+    /** @type {Map} */
+    let map;
+
+    /** @type {TileLayer} */
+    let layer;
+
+    /** HTMLDivElement */
+    let target;
+
+    beforeEach((done) => {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+
+      layer = new TileLayer({
+        source: new XYZ({
+          url: 'spec/ol/data/osm-0-0-0.png',
+        }),
+      });
+
+      map = new Map({
+        target: target,
+        layers: [layer],
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+
+      map.once('rendercomplete', () => done());
+    });
+
+    afterEach(() => {
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+
+    it('is called when a layer goes from visible to not visible', () => {
+      const spy = sinon.spy(layer, 'unrender');
+      map.renderSync();
+      expect(spy.callCount).to.be(0);
+
+      layer.setVisible(false);
+      map.renderSync();
+      expect(spy.callCount).to.be(1);
+    });
+
+    it('is called when a layer is removed from the map', () => {
+      const spy = sinon.spy(layer, 'unrender');
+      map.renderSync();
+      expect(spy.callCount).to.be(0);
+
+      map.removeLayer(layer);
+      map.renderSync();
+      expect(spy.callCount).to.be(1);
+    });
+
+    it('is called when a layer goes out of range', () => {
+      const spy = sinon.spy(layer, 'unrender');
+      map.renderSync();
+      expect(spy.callCount).to.be(0);
+
+      layer.setMaxZoom(3);
+      map.getView().setZoom(4);
+      map.renderSync();
+      expect(spy.callCount).to.be(1);
     });
   });
 

--- a/test/browser/spec/ol/layer/Tile.test.js
+++ b/test/browser/spec/ol/layer/Tile.test.js
@@ -2,7 +2,7 @@ import TileLayer from '../../../../../src/ol/layer/Tile.js';
 import {Map, View} from '../../../../../src/ol/index.js';
 import {OSM, XYZ} from '../../../../../src/ol/source.js';
 
-describe('ol.layer.Tile', function () {
+describe('ol/layer/Tile', function () {
   describe('constructor (defaults)', function () {
     let layer;
 
@@ -26,6 +26,48 @@ describe('ol.layer.Tile', function () {
 
     it('provides default useInterimTilesOnError', function () {
       expect(layer.getUseInterimTilesOnError()).to.be(true);
+    });
+  });
+
+  describe('getData()', () => {
+    let map, target, layer;
+    beforeEach((done) => {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+
+      layer = new TileLayer({
+        source: new XYZ({
+          url: 'spec/ol/data/osm-0-0-0.png',
+        }),
+      });
+
+      map = new Map({
+        target: target,
+        layers: [layer],
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+
+      map.once('rendercomplete', () => done());
+    });
+
+    afterEach(() => {
+      map.setTarget(null);
+      document.body.removeChild(target);
+    });
+
+    it('gets pixel data', () => {
+      const data = layer.getData([50, 50]);
+      expect(data).to.be.a(Uint8ClampedArray);
+      expect(data.length).to.be(4);
+      expect(data[0]).to.be(181);
+      expect(data[1]).to.be(208);
+      expect(data[2]).to.be(208);
+      expect(data[3]).to.be(255);
     });
   });
 

--- a/test/browser/spec/ol/layer/Tile.test.js
+++ b/test/browser/spec/ol/layer/Tile.test.js
@@ -69,6 +69,13 @@ describe('ol/layer/Tile', function () {
       expect(data[2]).to.be(208);
       expect(data[3]).to.be(255);
     });
+
+    it('gets pixel data', () => {
+      layer.setVisible(false);
+      map.renderSync();
+      const data = layer.getData([50, 50]);
+      expect(data).to.be(null);
+    });
   });
 
   describe('frameState.animate after tile transition with layer opacity', function () {

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -1,5 +1,4 @@
 import DataTileSource from '../../../../../src/ol/source/DataTile.js';
-import GeoTIFF from '../../../../../src/ol/source/GeoTIFF.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';
 import WebGLHelper from '../../../../../src/ol/webgl/Helper.js';
@@ -66,6 +65,10 @@ describe('ol/layer/WebGLTile', function () {
       document.body.appendChild(target);
       map = new Map({
         target: target,
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
       });
     });
 
@@ -75,23 +78,26 @@ describe('ol/layer/WebGLTile', function () {
     });
 
     it('retrieves pixel data', (done) => {
-      const source = new GeoTIFF({
-        sources: [{url: 'spec/ol/source/images/0-0-0.tif'}],
+      const layer = new WebGLTileLayer({
+        source: new DataTileSource({
+          tilePixelRatio: 1 / 256,
+          loader(z, x, y) {
+            return new Uint8Array([5, 4, 3, 2, 1]);
+          },
+        }),
       });
 
-      const layer = new WebGLTileLayer({source: source});
-
       map.addLayer(layer);
-      map.setView(source.getView());
 
       map.once('rendercomplete', () => {
         const data = layer.getData([50, 25]);
         expect(data).to.be.a(Uint8Array);
-        expect(data.length).to.be(4);
-        expect(data[0]).to.be(255);
-        expect(data[1]).to.be(189);
-        expect(data[2]).to.be(103);
-        expect(data[3]).to.be(255);
+        expect(data.length).to.be(5);
+        expect(data[0]).to.be(5);
+        expect(data[1]).to.be(4);
+        expect(data[2]).to.be(3);
+        expect(data[3]).to.be(2);
+        expect(data[4]).to.be(1);
         done();
       });
     });
@@ -107,12 +113,6 @@ describe('ol/layer/WebGLTile', function () {
       });
 
       map.addLayer(layer);
-      map.setView(
-        new View({
-          center: [0, 0],
-          zoom: 0,
-        })
-      );
 
       map.once('rendercomplete', () => {
         const data = layer.getData([50, 25]);

--- a/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
@@ -10,7 +10,7 @@ import VectorSource from '../../../../../../src/ol/source/Vector.js';
 import View from '../../../../../../src/ol/View.js';
 import {get as getProj} from '../../../../../../src/ol/proj.js';
 
-describe('ol.renderer.canvas.ImageLayer', function () {
+describe('ol/renderer/canvas/ImageLayer', function () {
   describe('#forEachLayerAtCoordinate', function () {
     let map, target, source;
     beforeEach(function (done) {

--- a/test/browser/spec/ol/webgl/TileTexture.test.js
+++ b/test/browser/spec/ol/webgl/TileTexture.test.js
@@ -42,11 +42,11 @@ describe('ol/webgl/TileTexture', function () {
       mapId: 'map-1',
     });
 
-    tileTexture = new TileTexture(
-      layer.getSource().getTile(3, 2, 1),
-      layer.getSource().getTileGrid(),
-      renderer.helper
-    );
+    tileTexture = new TileTexture({
+      tile: layer.getSource().getTile(3, 2, 1),
+      grid: layer.getSource().getTileGrid(),
+      helper: renderer.helper,
+    });
   });
 
   afterEach(() => {


### PR DESCRIPTION
This branch adds a `layer.getData()` method for getting pixel data.  This is an alternative to making use of the existing `map.forEachLayerAtPixel()` as proposed in #13335.

In addition to returning actual pixel data for just a single layer (as opposed to a rendered composite of multiple layers), the new `layer.getData()` method is quite a bit faster than the old `map.forEachLayerAtPixel()` method.

I've updated the [`getfeatureinfo-tile.html` example](https://deploy-preview-13338--ol-site.netlify.app/examples/getfeatureinfo-tile.html) to demonstrate the use of the method for changing the cursor style when hovering over non-transparent pixels (for an individual layer).  Benchmarking `layer.getData()` vs `map.forEachLayerAtPixel()` shows the new method is ~90X faster.

<details>
  <summary>Benchmark functions for those that are interested</summary>

<pre>
<code>
// add to getfeatureinfo-tile.js
const size = 200;

function bench0() {
  function callback() {
    return true;
  }
  let elapsed = 0;
  let count = 0;
  let hits = 0;
  const start = performance.now();
  for (let i = 0; i < size; ++i) {
    for (let j = 0; j < size; ++j) {
      const hit = map.forEachLayerAtPixel([i, j], callback);
      if (hit) {
        ++hits;
      }
      ++count;
    }
  }
  elapsed = performance.now() - start;
  console.table({hits, count, elapsed, average: elapsed / count});
}

function bench1() {
  let elapsed = 0;
  let count = 0;
  let hits = 0;
  const start = performance.now();
  for (let i = 0; i < size; ++i) {
    for (let j = 0; j < size; ++j) {
      const data = wmsLayer.getData([i, j]);
      if (data && data[3] > 0) {
        ++hits;
      }
      ++count;
    }
  }
  elapsed = performance.now() - start;
  console.table({hits, count, elapsed, average: elapsed / count});
}

window.bench0 = bench0;
window.bench1 = bench1;
</code>
</pre>
</details>
