### PR TITLE
Remove warning for `@type` annotation by jsdoc

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -18,7 +18,8 @@ class LayerRenderer extends Observable {
     super();
 
     /**
-     * @type {boolean} The renderer is initialized and ready to render.
+     * The renderer is initialized and ready to render.
+     * @type {boolean}
      */
     this.ready = true;
 


### PR DESCRIPTION
> WARNING: The `@type` tag does not permit a description; the description will be ignored. File: Layer.js, line: 20
> WARNING: The `@type` tag does not permit a description; the description will be ignored. File: Layer.js, line: 23