### PR TITLE
Reset globalAlpha back to its initial after mutating it for drawing layers

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -98,6 +98,7 @@ document.getElementById('export-png').addEventListener('click', function () {
         }
       }
     );
+    mapContext.globalAlpha = 1;
     if (navigator.msSaveBlob) {
       // link download attribute does not work on MS browsers
       navigator.msSaveBlob(mapCanvas.msToBlob(), 'map.png');

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -83,6 +83,7 @@ exportButton.addEventListener(
           }
         }
       );
+      mapContext.globalAlpha = 1;
       const pdf = new jspdf.jsPDF('landscape', undefined, format);
       pdf.addImage(
         mapCanvas.toDataURL('image/jpeg'),


### PR DESCRIPTION
The `mapContext` ends up having the opacity of the last layer iterated over.
Since some users might like to pass this `context` around to add their own stuff on top of it (scale, branding, copyright, etc.), I believe it's better to reset it back to its initial `1` value after we're done with the drawings.