### PR TITLE
Avoid event creation when there are no listeners

### DIFF
--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -172,9 +172,13 @@ class BaseObject extends Observable {
   notify(key, oldValue) {
     let eventType;
     eventType = `change:${key}`;
-    this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
+    if (this.hasListener(eventType)) {
+      this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
+    }
     eventType = ObjectEventType.PROPERTYCHANGE;
-    this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
+    if (this.hasListener(eventType)) {
+      this.dispatchEvent(new ObjectEvent(eventType, key, oldValue));
+    }
   }
 
   /**

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -240,27 +240,25 @@ class ImageSource extends Source {
    */
   handleImageChange(event) {
     const image = /** @type {import("../Image.js").default} */ (event.target);
+    let type;
     switch (image.getState()) {
       case ImageState.LOADING:
         this.loading = true;
-        this.dispatchEvent(
-          new ImageSourceEvent(ImageSourceEventType.IMAGELOADSTART, image)
-        );
+        type = ImageSourceEventType.IMAGELOADSTART;
         break;
       case ImageState.LOADED:
         this.loading = false;
-        this.dispatchEvent(
-          new ImageSourceEvent(ImageSourceEventType.IMAGELOADEND, image)
-        );
+        type = ImageSourceEventType.IMAGELOADEND;
         break;
       case ImageState.ERROR:
         this.loading = false;
-        this.dispatchEvent(
-          new ImageSourceEvent(ImageSourceEventType.IMAGELOADERROR, image)
-        );
+        type = ImageSourceEventType.IMAGELOADERROR;
         break;
       default:
-      // pass
+        return;
+    }
+    if (this.hasListener(type)) {
+      this.dispatchEvent(new ImageSourceEvent(type, image));
     }
   }
 }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -457,10 +457,12 @@ class VectorSource extends Source {
       this.featuresRtree_.load(extents, geometryFeatures);
     }
 
-    for (let i = 0, length = newFeatures.length; i < length; i++) {
-      this.dispatchEvent(
-        new VectorSourceEvent(VectorEventType.ADDFEATURE, newFeatures[i])
-      );
+    if (this.hasListener(VectorEventType.ADDFEATURE)) {
+      for (let i = 0, length = newFeatures.length; i < length; i++) {
+        this.dispatchEvent(
+          new VectorSourceEvent(VectorEventType.ADDFEATURE, newFeatures[i])
+        );
+      }
     }
   }
 


### PR DESCRIPTION
This skips the creation of some event objects when there are no listeners.

- when calling `dispatchEvent` with a string instead of an `Event` object
- all `propertychange` and `change:propery` events, e. g. when constructing a feature with a properties object or when changing properties where nobody is listening
- when calling `addFeatures` on a vectorsource that is not added to a layer like in https://openlayers.org/en/latest/examples/icon-sprite-webgl.html (should load noticably faster with this PR)

These have some noticable performance gains when you are working with lots of features.

Might add hasListener checks for other dispatchEvent calls if you like.
