### PR TITLE
Add floor, round and ceil to style expressions

### DIFF
--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -38,6 +38,9 @@ import {log2} from '../math.js';
  *   * `['%', value1, value2]` returns the result of `value1 % value2` (modulo)
  *   * `['^', value1, value2]` returns the value of `value1` raised to the `value2` power
  *   * `['abs', value1]` returns the absolute value of `value1`
+ *   * `['floor', value1]` returns the nearest integer less than or equal to `value1`
+ *   * `['round', value1]` returns the nearest integer to `value1`
+ *   * `['ceil', value1]` returns the nearest integer greater than or equal to `value1`
  *   * `['sin', value1]` returns the sine of `value1`
  *   * `['cos', value1]` returns the cosine of `value1`
  *   * `['atan', value1, value2]` returns `atan2(value1, value2)`. If `value2` is not provided, returns `atan(value1)`
@@ -664,6 +667,39 @@ Operators['abs'] = {
     assertArgsCount(args, 1);
     assertNumbers(args);
     return `abs(${expressionToGlsl(context, args[0])})`;
+  },
+};
+
+Operators['floor'] = {
+  getReturnType: function (args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function (context, args) {
+    assertArgsCount(args, 1);
+    assertNumbers(args);
+    return `floor(${expressionToGlsl(context, args[0])})`;
+  },
+};
+
+Operators['round'] = {
+  getReturnType: function (args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function (context, args) {
+    assertArgsCount(args, 1);
+    assertNumbers(args);
+    return `floor(${expressionToGlsl(context, args[0])} + 0.5)`;
+  },
+};
+
+Operators['ceil'] = {
+  getReturnType: function (args) {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function (context, args) {
+    assertArgsCount(args, 1);
+    assertNumbers(args);
+    return `ceil(${expressionToGlsl(context, args[0])})`;
   },
 };
 

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -243,6 +243,11 @@ describe('ol/style/expressions', function () {
           ['-', ['get', 'attr3'], ['get', 'attr2']],
         ])
       ).to.eql('abs((a_attr3 - a_attr2))');
+      expect(expressionToGlsl(context, ['floor', 1])).to.eql('floor(1.0)');
+      expect(expressionToGlsl(context, ['round', 1])).to.eql(
+        'floor(1.0 + 0.5)'
+      );
+      expect(expressionToGlsl(context, ['ceil', 1])).to.eql('ceil(1.0)');
       expect(expressionToGlsl(context, ['sin', 1])).to.eql('sin(1.0)');
       expect(expressionToGlsl(context, ['cos', 1])).to.eql('cos(1.0)');
       expect(expressionToGlsl(context, ['atan', 1])).to.eql('atan(1.0)');


### PR DESCRIPTION
This includes the `floor` operator extracted from #13232 and, for completeness, corresponding `round` and `ceil` operators. As `round` is not fully supported in WebGL it is implemented as `floor(value1 + 0.5)`.
