### PR TITLE
Fix JsDoc references

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -9,9 +9,9 @@ import {getHeight} from './extent.js';
 import {listenOnce, unlistenByKey} from './events.js';
 
 /**
- * A function that takes an {@link module:ol/Image~Image} for the image and a
+ * A function that takes an {@link module:ol/Image~ImageWrapper} for the image and a
  * `{string}` for the src as arguments. It is supposed to make it so the
- * underlying image {@link module:ol/Image~Image#getImage} is assigned the
+ * underlying image {@link module:ol/Image~ImageWrapper#getImage} is assigned the
  * content specified by the src. If not specified, the default is
  *
  *     function(image, src) {

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -30,7 +30,7 @@ import {defaults as defaultInteractions} from './interaction.js';
  *       target: 'map'
  *     });
  *
- * The above snippet creates a map using a {@link module:ol/layer/Tile} to
+ * The above snippet creates a map using a {@link module:ol/layer/Tile~TileLayer} to
  * display {@link module:ol/source/OSM~OSM} OSM data and render it to a DOM
  * element with the id `map`.
  *
@@ -47,8 +47,8 @@ import {defaults as defaultInteractions} from './interaction.js';
  * accessed by `getLayerGroup` and `setLayerGroup`. Layers entered in the
  * options are added to this group, and `addLayer` and `removeLayer` change the
  * layer collection in the group. `getLayers` is a convenience function for
- * `getLayerGroup().getLayers()`. Note that {@link module:ol/layer/Group~Group}
- * is a subclass of {@link module:ol/layer/Base}, so layers entered in the
+ * `getLayerGroup().getLayers()`. Note that {@link module:ol/layer/Group~LayerGroup}
+ * is a subclass of {@link module:ol/layer/Base~BaseLayer}, so layers entered in the
  * options or added with `addLayer` can be groups, which can contain further
  * groups, and so on.
  *

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -4,7 +4,7 @@
 import {clear} from './obj.js';
 
 /**
- * Key to use with {@link module:ol/Observable~Observable#unByKey}.
+ * Key to use with {@link module:ol/Observable.unByKey}.
  * @typedef {Object} EventsKey
  * @property {ListenerFunction} listener Listener.
  * @property {import("./events/Target.js").EventTargetLike} target Target.

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -7,7 +7,7 @@ import {MAC, WEBKIT} from '../has.js';
 import {assert} from '../asserts.js';
 
 /**
- * A function that takes an {@link module:ol/MapBrowserEvent} and returns a
+ * A function that takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * `{boolean}`. If the condition is met, true should be returned.
  *
  * @typedef {function(this: ?, import("../MapBrowserEvent.js").default): boolean} Condition

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -17,11 +17,11 @@ let withCredentials = false;
  *
  * This function takes up to 5 arguments. These are an {@link module:ol/extent~Extent} representing
  * the area to be loaded, a `{number}` representing the resolution (map units per pixel), an
- * {@link module:ol/proj/Projection} for the projection, an optional success callback that should get
+ * {@link module:ol/proj/Projection~Projection} for the projection, an optional success callback that should get
  * the loaded features passed as an argument and an optional failure callback with no arguments. If
  * the callbacks are not used, the corresponding vector source will not fire `'featuresloadend'` and
  * `'featuresloaderror'` events. `this` within the function is bound to the
- * {@link module:ol/source/Vector} it's called from.
+ * {@link module:ol/source/Vector~VectorSource} it's called from.
  *
  * The function is responsible for loading the features and adding them to the
  * source.
@@ -40,7 +40,7 @@ let withCredentials = false;
  *
  * This function takes an {@link module:ol/extent~Extent} representing the area
  * to be loaded, a `{number}` representing the resolution (map units per pixel)
- * and an {@link module:ol/proj/Projection} for the projection  as
+ * and an {@link module:ol/proj/Projection~Projection} for the projection  as
  * arguments and returns a `{string}` representing the URL.
  * @typedef {function(import("./extent.js").Extent, number, import("./proj/Projection.js").default): string} FeatureUrlFunction
  * @api

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -148,9 +148,9 @@ const TRANSACTION_SERIALIZERS = {
  * @property {import("../extent.js").Extent} [bbox] Extent to use for the BBOX filter. The `geometryName`
  * option must be set.
  * @property {import("./filter/Filter.js").default} [filter] Filter condition. See
- * {@link module:ol/format/Filter} for more information.
+ * {@link module:ol/format/filter} for more information.
  * @property {string} [resultType] Indicates what response should be returned,
- * E.g. `hits` only includes the `numberOfFeatures` attribute in the response and no features.
+ * e.g. `hits` only includes the `numberOfFeatures` attribute in the response and no features.
  */
 
 /**

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -8,7 +8,7 @@ import RenderBox from '../render/Box.js';
 import {mouseActionButton} from '../events/condition.js';
 
 /**
- * A function that takes a {@link module:ol/MapBrowserEvent} and two
+ * A function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and two
  * {@link module:ol/pixel~Pixel}s and returns a `{boolean}`. If the condition is met,
  * true should be returned.
  * @typedef {function(this: ?, import("../MapBrowserEvent.js").default, import("../pixel.js").Pixel, import("../pixel.js").Pixel):boolean} EndCondition

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -1165,7 +1165,7 @@ function getDefaultStyleFunction() {
 /**
  * Create a `geometryFunction` for `type: 'Circle'` that will create a regular
  * polygon with a user specified number of sides and start angle instead of a
- * `import("../geom/Circle.js").Circle` geometry.
+ * {@link import("../geom/Circle.js").Circle} geometry.
  * @param {number} [opt_sides] Number of sides of the regular polygon.
  *     Default is 32.
  * @param {number} [opt_angle] Angle of the first point in counter-clockwise

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -121,7 +121,7 @@ class PointerInteraction extends Interaction {
   handleDragEvent(mapBrowserEvent) {}
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} and may call into
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may call into
    * other functions, if event sequences like e.g. 'drag' or 'down-up' etc. are
    * detected.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -27,9 +27,9 @@ const SelectEventType = {
 };
 
 /**
- * A function that takes an {@link module:ol/Feature} or
- * {@link module:ol/render/Feature} and an
- * {@link module:ol/layer/Layer} and returns `true` if the feature may be
+ * A function that takes an {@link module:ol/Feature~Feature} or
+ * {@link module:ol/render/Feature~RenderFeature} and an
+ * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
  * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>):boolean} FilterFunction
  */
@@ -83,8 +83,8 @@ const SelectEventType = {
  * used by the interaction is returned by
  * {@link module:ol/interaction/Select~Select#getFeatures}.
  * @property {FilterFunction} [filter] A function
- * that takes an {@link module:ol/Feature} and an
- * {@link module:ol/layer/Layer} and returns `true` if the feature may be
+ * that takes an {@link module:ol/Feature~Feature} and an
+ * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
  * selected or `false` otherwise.
  * @property {number} [hitTolerance=0] Hit-detection tolerance. Pixels inside
  * the radius around the given position will be checked for features.
@@ -309,7 +309,7 @@ class Select extends Interaction {
   }
 
   /**
-   * Returns the associated {@link module:ol/layer/Vector~Vector vector layer} of
+   * Returns the associated {@link module:ol/layer/Vector~VectorLayer vector layer} of
    * a selected feature.
    * @param {import("../Feature.js").FeatureLike} feature Feature
    * @return {import('../layer/Vector.js').default} Layer.

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -34,9 +34,9 @@ const TranslateEventType = {
 };
 
 /**
- * A function that takes an {@link module:ol/Feature} or
- * {@link module:ol/render/Feature} and an
- * {@link module:ol/layer/Layer} and returns `true` if the feature may be
+ * A function that takes an {@link module:ol/Feature~Feature} or
+ * {@link module:ol/render/Feature~RenderFeature} and an
+ * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
  * translated or `false` otherwise.
  * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>):boolean} FilterFunction
  */
@@ -55,8 +55,8 @@ const TranslateEventType = {
  * absent, all visible layers will be considered translatable.
  * Not used if `features` is provided.
  * @property {FilterFunction} [filter] A function
- * that takes an {@link module:ol/Feature} and an
- * {@link module:ol/layer/Layer} and returns `true` if the feature may be
+ * that takes an {@link module:ol/Feature~Feature} and an
+ * {@link module:ol/layer/Layer~Layer} and returns `true` if the feature may be
  * translated or `false` otherwise. Not used if `features` is provided.
  * @property {number} [hitTolerance=0] Hit-detection tolerance. Pixels inside the radius around the given position
  * will be checked for features.

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -73,7 +73,7 @@ import {assign} from '../obj.js';
  * @property {import("../PluggableMap.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
- * use {@link module:ol/Map#addLayer}.
+ * use {@link module:ol/Map~Map#addLayer}.
  * @property {boolean} [useInterimTilesOnError=true] Use interim tiles on error.
  * @property {number} [cacheSize=512] The internal texture cache size.  This needs to be large enough to render
  * two zoom levels worth of tiles.

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -171,7 +171,7 @@ export function get(projectionLike) {
  * Get the resolution of the point in degrees or distance units.
  * For projections with degrees as the unit this will simply return the
  * provided resolution. For other projections the point resolution is
- * by default estimated by transforming the 'point' pixel to EPSG:4326,
+ * by default estimated by transforming the `point` pixel to EPSG:4326,
  * measuring its width and height on the normal sphere,
  * and taking the average of the width and height.
  * A custom function can be provided for a specific projection, either

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -25,8 +25,8 @@ import {getTransformFromProjections, getUserProjection} from './proj.js';
 
 /**
  * A function to be used when sorting features before rendering.
- * It takes two instances of {@link module:ol/Feature} or
- * {@link module:ol/render/Feature} and returns a `{number}`.
+ * It takes two instances of {@link module:ol/Feature~Feature} or
+ * {@link module:ol/render/Feature~RenderFeature} and returns a `{number}`.
  *
  * @typedef {function(import("./Feature.js").FeatureLike, import("./Feature.js").FeatureLike):number} OrderFunction
  */

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -671,7 +671,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    * @param {import("../../proj/Projection.js").default} projection Projection.
    * @param {import("../../extent.js").Extent} extent Extent.
    * @param {number} currentZ Current Z.
-   * @param {number} preload Load low resolution tiles up to 'preload' levels.
+   * @param {number} preload Load low resolution tiles up to `preload` levels.
    * @param {function(import("../../Tile.js").default):void} [opt_tileCallback] Tile callback.
    * @protected
    */

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -479,7 +479,7 @@ class Triangulation {
   }
 
   /**
-   * Calculates extent of the 'source' coordinates from all the triangles.
+   * Calculates extent of the `source` coordinates from all the triangles.
    *
    * @return {import("../extent.js").Extent} Calculated extent.
    */

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -28,8 +28,8 @@ import {getUid} from '../util.js';
  * overlapping icons. As a tradoff, the cluster feature's position will no longer be
  * the center of all its features.
  * @property {function(Feature):Point} [geometryFunction]
- * Function that takes an {@link module:ol/Feature} as argument and returns an
- * {@link module:ol/geom/Point} as cluster calculation point for the feature. When a
+ * Function that takes an {@link module:ol/Feature~Feature} as argument and returns an
+ * {@link module:ol/geom/Point~Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return
  * `null`. The default, which works when the underlying source contains point
  * features only, is
@@ -41,9 +41,9 @@ import {getUid} from '../util.js';
  * See {@link module:ol/geom/Polygon~Polygon#getInteriorPoint} for a way to get a cluster
  * calculation point for polygons.
  * @property {function(Point, Array<Feature>):Feature} [createCluster]
- * Function that takes the cluster's center {@link module:ol/geom/Point} and an array
- * of {@link module:ol/Feature} included in this cluster. Must return a
- * {@link module:ol/Feature} that will be used to render. Default implementation is:
+ * Function that takes the cluster's center {@link module:ol/geom/Point~Point} and an array
+ * of {@link module:ol/Feature~Feature} included in this cluster. Must return a
+ * {@link module:ol/Feature~Feature} that will be used to render. Default implementation is:
  * ```js
  * function(point, features) {
  *   return new Feature({
@@ -143,7 +143,7 @@ class Cluster extends VectorSource {
 
   /**
    * Remove all features from the source.
-   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/Vector.VectorSourceEvent#removefeature} events.
+   * @param {boolean} [opt_fast] Skip dispatching of {@link module:ol/source/VectorEventType~VectorEventType#removefeature} events.
    * @api
    */
   clear(opt_fast) {

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -29,9 +29,9 @@ import {
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {FunctionType} [canvasFunction] Canvas function.
  * The function returning the canvas element used by the source
- * as an image. The arguments passed to the function are: `{import("../extent.js").Extent}` the
+ * as an image. The arguments passed to the function are: {@link import("../extent.js").Extent} the
  * image extent, `{number}` the image resolution, `{number}` the pixel ratio of the map,
- * `{import("../size.js").Size}` the image size, and `{import("../proj/Projection.js").Projection}` the image
+ * {@link import("../size.js").Size} the image size, and {@link import("../proj/Projection.js").default} the image
  * projection. The canvas returned by this function is cached by the source. If
  * the value returned by the function is later changed then
  * `changed` should be called on the source for the source to

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -327,7 +327,7 @@ class VectorSource extends Source {
    * instead. A feature will not be added to the source if feature with
    * the same id is already there. The reason for this behavior is to avoid
    * feature duplication when using bbox or tile loading strategies.
-   * Note: this also applies if an {@link module:ol/Collection} is used for features,
+   * Note: this also applies if an {@link module:ol/Collection~Collection} is used for features,
    * meaning that if a feature with a duplicate id is added in the collection, it will
    * be removed from it right away.
    * @param {import("../Feature.js").default<Geometry>} feature Feature to add.
@@ -684,7 +684,7 @@ class VectorSource extends Source {
   /**
    * Get the features collection associated with this source. Will be `null`
    * unless the source was configured with `useSpatialIndex` set to `false`, or
-   * with an {@link module:ol/Collection} as `features`.
+   * with an {@link module:ol/Collection~Collection} as `features`.
    * @return {Collection<import("../Feature.js").default<Geometry>>|null} The collection of features.
    * @api
    */

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -91,11 +91,11 @@ import {toSize} from '../size.js';
 /**
  * @classdesc
  * Class for layer sources providing vector data divided into a tile grid, to be
- * used with {@link module:ol/layer/VectorTile~VectorTile}. Although this source receives tiles
+ * used with {@link module:ol/layer/VectorTile~VectorTileLayer}. Although this source receives tiles
  * with vector features from the server, it is not meant for feature editing.
  * Features are optimized for rendering, their geometries are clipped at or near
  * tile boundaries and simplified for a view resolution. See
- * {@link module:ol/source/Vector} for vector sources that are suitable for feature
+ * {@link module:ol/source/Vector~VectorSource} for vector sources that are suitable for feature
  * editing.
  *
  * @fires import("./Tile.js").TileSourceEvent

--- a/src/ol/style/IconImageCache.js
+++ b/src/ol/style/IconImageCache.js
@@ -5,7 +5,7 @@ import {asString} from '../color.js';
 
 /**
  * @classdesc
- * Singleton class. Available through {@link module:ol/style/IconImageCache~shared}.
+ * Singleton class. Available through {@link module:ol/style/IconImageCache.shared}.
  */
 class IconImageCache {
   constructor() {

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -9,7 +9,7 @@ import Stroke from './Stroke.js';
 import {assert} from '../asserts.js';
 
 /**
- * A function that takes an {@link module:ol/Feature} and a `{number}`
+ * A function that takes an {@link module:ol/Feature~Feature} and a `{number}`
  * representing the view's resolution. The function should return a
  * {@link module:ol/style/Style~Style} or an array of them. This way e.g. a
  * vector layer can be styled. If the function returns `undefined`, the
@@ -24,8 +24,8 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * A function that takes an {@link module:ol/Feature} as argument and returns an
- * {@link module:ol/geom/Geometry} that will be rendered and styled for the feature.
+ * A function that takes an {@link module:ol/Feature~Feature} as argument and returns an
+ * {@link module:ol/geom/Geometry~Geometry} that will be rendered and styled for the feature.
  *
  * @typedef {function(import("../Feature.js").FeatureLike):
  *     (import("../geom/Geometry.js").default|import("../render/Feature.js").default|undefined)} GeometryFunction

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -603,7 +603,7 @@ class TileGrid {
   /**
    * Get the tile size for a zoom level. The type of the return value matches the
    * `tileSize` or `tileSizes` that the tile grid was configured with. To always
-   * get an `import("../size.js").Size`, run the result through `import("../size.js").Size.toSize()`.
+   * get an {@link import("../size.js").Size}, run the result through {@link module:ol/size.toSize}.
    * @param {number} z Z.
    * @return {number|import("../size.js").Size} Tile size.
    * @api

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -264,8 +264,8 @@ function releaseCanvas(key) {
  * ### Specifying attributes
  *
  *   The GPU only receives the data as arrays of numbers. These numbers must be handled differently depending on what it describes (position, texture coordinate...).
- *   Attributes are used to specify these uses. Use {@link module:ol/webgl/Helper~WebGLHelper#enableAttributes endableAttributes} and either
- *   the default attribute names in {@link module:ol/webgl/Helper.DefaultAttrib} or custom ones.
+ *   Attributes are used to specify these uses. Specify the attribute names with
+ *   {@link module:ol/webgl/Helper~WebGLHelper#enableAttributes enableAttributes()} (see code snippet below).
  *
  *   Please note that you will have to specify the type and offset of the attributes in the data array. You can refer to the documentation of [WebGLRenderingContext.vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer) for more explanation.
  *   ```js

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -264,7 +264,7 @@ function releaseCanvas(key) {
  * ### Specifying attributes
  *
  *   The GPU only receives the data as arrays of numbers. These numbers must be handled differently depending on what it describes (position, texture coordinate...).
- *   Attributes are used to specify these uses. Use {@link enableAttributeArray_} and either
+ *   Attributes are used to specify these uses. Use {@link module:ol/webgl/Helper~WebGLHelper#enableAttributes endableAttributes} and either
  *   the default attribute names in {@link module:ol/webgl/Helper.DefaultAttrib} or custom ones.
  *
  *   Please note that you will have to specify the type and offset of the attributes in the data array. You can refer to the documentation of [WebGLRenderingContext.vertexAttribPointer](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/vertexAttribPointer) for more explanation.
@@ -302,7 +302,6 @@ function releaseCanvas(key) {
  *   ```
  *
  * For an example usage of this class, refer to {@link module:ol/renderer/webgl/PointsLayer~WebGLPointsLayerRenderer}.
- *
  *
  * @api
  */

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -289,7 +289,7 @@ export function makeChildAppender(nodeWriter, opt_this) {
 /**
  * Create a serializer that calls the provided `nodeWriter` from
  * {@link module:ol/xml.serialize}. This can be used by the parent writer to have the
- * 'nodeWriter' called with an array of values when the `nodeWriter` was
+ * `nodeWriter` called with an array of values when the `nodeWriter` was
  * designed to serialize a single item. An example would be a LineString
  * geometry writer, which could be reused for writing MultiLineString
  * geometries.


### PR DESCRIPTION
This fixes some issues with the apidoc

- some broken links
- some links pointing to the module page instead of the class page
- format some argument names in to description as code