### PR TITLE
Fix wrong types when using `"skipLibCheck": false`

### DIFF
--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -66,6 +66,9 @@ class GeoJSON extends JSONFeature {
     );
 
     if (options.featureProjection) {
+      /**
+       * @type {import("../proj/Projection.js").default}
+       */
       this.defaultFeatureProjection = getProjection(options.featureProjection);
     }
 

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -55,7 +55,7 @@ class SimpleGeometry extends Geometry {
 
   /**
    * @abstract
-   * @return {Array<*>} Coordinates.
+   * @return {Array<*> | null} Coordinates.
    */
   getCoordinates() {
     return abstract();

--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -29,7 +29,7 @@ export const SymbolType = {
 
 /**
  * @typedef {Object} LiteralSymbolStyle
- * @property {ExpressionValue|Array<ExpressionValue, ExpressionValue>} size Size, mandatory.
+ * @property {ExpressionValue|Array<ExpressionValue>} size Size, mandatory.
  * @property {SymbolType} symbolType Symbol type to use, either a regular shape or an image.
  * @property {string} [src] Path to the image to be used for the symbol. Only required with `symbolType: 'image'`.
  * @property {string} [crossOrigin='anonymous'] The `crossOrigin` attribute for loading `src`.


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

Fix wrong types when compile an Angular app with `"skipLibCheck": false'` an `"allowSyntheticDefaultImports": true` on `tsconfig.json`.

Without this fixes build:
![Captura de pantalla 2022-02-14 a las 13 05 28](https://user-images.githubusercontent.com/5394989/153861312-c5b4a7bd-1df8-45c2-a16d-12e798434468.png)

