### PR TITLE
Change remaining links to point to class page instead of module

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -36,7 +36,7 @@ import {listen, unlistenByKey} from './events.js';
  * Features can be styled individually with `setStyle`; otherwise they use the
  * style of their vector layer.
  *
- * Note that attribute properties are set as {@link module:ol/Object} properties on
+ * Note that attribute properties are set as {@link module:ol/Object~BaseObject} properties on
  * the feature object, so they are observable, and have get/set accessors.
  *
  * Typically, a feature has a single geometry property. You can set the

--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -50,7 +50,7 @@ export class ObjectEvent extends Event {
  * instantiated in apps.
  * Most non-trivial classes inherit from this.
  *
- * This extends {@link module:ol/Observable} with observable
+ * This extends {@link module:ol/Observable~Observable} with observable
  * properties, where each property is observable as well as the object as a
  * whole.
  *

--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -73,7 +73,7 @@ import {removeNode} from './dom.js';
  * @typedef {Object} AtPixelOptions
  * @property {undefined|function(import("./layer/Layer.js").default<import("./source/Source").default>): boolean} [layerFilter] Layer filter
  * function. The filter function will receive one argument, the
- * {@link module:ol/layer/Layer layer-candidate} and it should return a boolean value.
+ * {@link module:ol/layer/Layer~Layer layer-candidate} and it should return a boolean value.
  * Only layers which are visible and for which this function returns `true`
  * will be tested for features. By default, all visible layers will be tested.
  * @property {number} [hitTolerance=0] Hit-detection tolerance in css pixels. Pixels
@@ -610,9 +610,9 @@ class PluggableMap extends BaseObject {
    * @param {import("./pixel.js").Pixel} pixel Pixel.
    * @param {function(import("./Feature.js").FeatureLike, import("./layer/Layer.js").default<import("./source/Source").default>, import("./geom/SimpleGeometry.js").default): T} callback Feature callback. The callback will be
    *     called with two arguments. The first argument is one
-   *     {@link module:ol/Feature feature} or
-   *     {@link module:ol/render/Feature render feature} at the pixel, the second is
-   *     the {@link module:ol/layer/Layer layer} of the feature and will be null for
+   *     {@link module:ol/Feature~Feature feature} or
+   *     {@link module:ol/render/Feature~RenderFeature render feature} at the pixel, the second is
+   *     the {@link module:ol/layer/Layer~Layer layer} of the feature and will be null for
    *     unmanaged layers. To stop detection, callback functions can return a
    *     truthy value.
    * @param {AtPixelOptions} [opt_options] Optional options.
@@ -701,7 +701,7 @@ class PluggableMap extends BaseObject {
    * @param {import("./pixel.js").Pixel} pixel Pixel.
    * @param {function(this: S, import("./layer/Layer.js").default, (Uint8ClampedArray|Uint8Array)): T} callback
    *     Layer callback. This callback will receive two arguments: first is the
-   *     {@link module:ol/layer/Layer layer}, second argument is an array representing
+   *     {@link module:ol/layer/Layer~Layer layer}, second argument is an array representing
    *     [R, G, B, A] pixel values (0 - 255) and will be `null` for layer types
    *     that do not currently support this argument. To stop detection, callback
    *     functions can return a truthy value.

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -8,7 +8,7 @@ import {abstract} from './util.js';
 import {easeIn} from './easing.js';
 
 /**
- * A function that takes an {@link module:ol/Tile} for the tile and a
+ * A function that takes an {@link module:ol/Tile~Tile} for the tile and a
  * `{string}` for the url as arguments. The default is
  * ```js
  * source.setTileLoadFunction(function(tile, src) {
@@ -50,7 +50,7 @@ import {easeIn} from './easing.js';
  *
  * This function takes an {@link module:ol/tilecoord~TileCoord} for the tile
  * coordinate, a `{number}` representing the pixel ratio and a
- * {@link module:ol/proj/Projection} for the projection  as arguments
+ * {@link module:ol/proj/Projection~Projection} for the projection  as arguments
  * and returns a `{string}` representing the tile URL, or undefined if no tile
  * should be requested for the passed tile coordinate.
  *

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -45,7 +45,7 @@ import {easeIn} from './easing.js';
  */
 
 /**
- * {@link module:ol/source/Tile~Tile} sources use a function of this type to get
+ * {@link module:ol/source/Tile~TileSource} sources use a function of this type to get
  * the url that provides a tile for a given tile coordinate.
  *
  * This function takes an {@link module:ol/tilecoord~TileCoord} for the tile

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -12,7 +12,7 @@ import {VOID} from './functions.js';
 let withCredentials = false;
 
 /**
- * {@link module:ol/source/Vector} sources use a function of this type to
+ * {@link module:ol/source/Vector~VectorSource} sources use a function of this type to
  * load features.
  *
  * This function takes up to 5 arguments. These are an {@link module:ol/extent~Extent} representing
@@ -35,7 +35,7 @@ let withCredentials = false;
  */
 
 /**
- * {@link module:ol/source/Vector} sources use a function of this type to
+ * {@link module:ol/source/Vector~VectorSource} sources use a function of this type to
  * get the url to load features from.
  *
  * This function takes an {@link module:ol/extent~Extent} representing the area

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -14,7 +14,7 @@ import {listen, unlistenByKey} from '../events.js';
 
 /**
  * @classdesc
- * An array of {@link module:ol/geom/Geometry} objects.
+ * An array of {@link module:ol/geom/Geometry~Geometry} objects.
  *
  * @api
  */

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -301,7 +301,7 @@ class MultiPolygon extends SimpleGeometry {
   }
 
   /**
-   * Return the interior points as {@link module:ol/geom/MultiPoint multipoint}.
+   * Return the interior points as {@link module:ol/geom/MultiPoint~MultiPoint multipoint}.
    * @return {MultiPoint} Interior points as XYM coordinates, where M is
    * the length of the horizontal intersection that the point belongs to.
    * @api

--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -60,8 +60,8 @@ export {default as Translate} from './interaction/Translate.js';
  * excluded by setting the appropriate option to false in the constructor
  * options, but the order of the interactions is fixed.  If you want to specify
  * a different order for interactions, you will need to create your own
- * {@link module:ol/interaction/Interaction} instances and insert
- * them into a {@link module:ol/Collection} in the order you want
+ * {@link module:ol/interaction/Interaction~Interaction} instances and insert
+ * them into a {@link module:ol/Collection~Collection} in the order you want
  * before creating your {@link module:ol/Map~Map} instance. Changing the order can
  * be of interest if the event propagation needs to be stopped at a point.
  * The default set of interactions, in sequence, is:

--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -38,7 +38,7 @@ class DoubleClickZoom extends Interaction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} (if it was a
    * doubleclick) and eventually zooms the map.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -110,7 +110,7 @@ export class DragBoxEvent extends Event {
  * it to when the shift or other key is held down. This is used, for example,
  * for zooming to a specific area of the map
  * (see {@link module:ol/interaction/DragZoom~DragZoom} and
- * {@link module:ol/interaction/DragRotateAndZoom}).
+ * {@link module:ol/interaction/DragRotateAndZoom~DragRotateAndZoom}).
  *
  * @fires DragBoxEvent
  * @api

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -529,7 +529,7 @@ class Draw extends PointerInteraction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} and may actually draw or finish the drawing.
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may actually draw or finish the drawing.
    * @param {import("../MapBrowserEvent.js").default} event Map browser event.
    * @return {boolean} `false` to stop event propagation.
    * @api

--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -93,7 +93,7 @@ class Interaction extends BaseObject {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event}.
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event}.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
    * @api

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -76,7 +76,7 @@ class KeyboardPan extends Interaction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} if it was a
    * `KeyEvent`, and decides the direction to pan to (if an arrow key was
    * pressed).
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -57,7 +57,7 @@ class KeyboardZoom extends Interaction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} if it was a
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} if it was a
    * `KeyEvent`, and decides whether to zoom in or out (depending on whether the
    * key pressed was '+' or '-').
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -142,10 +142,10 @@ export class ModifyEvent extends Event {
    * @param {ModifyEventType} type Type.
    * @param {Collection<import("../Feature").FeatureLike>} features
    * The features modified.
-   * @param {import("../MapBrowserEvent.js").default} MapBrowserEvent
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent
    * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
    */
-  constructor(type, features, MapBrowserEvent) {
+  constructor(type, features, mapBrowserEvent) {
     super(type);
 
     /**
@@ -160,7 +160,7 @@ export class ModifyEvent extends Event {
      * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
-    this.mapBrowserEvent = MapBrowserEvent;
+    this.mapBrowserEvent = mapBrowserEvent;
   }
 }
 

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -121,7 +121,7 @@ const ModifyEventType = {
  * must be provided with the `features` option.
  * @property {boolean|import("../layer/BaseVector").default} [hitDetection] When configured, point
  * features will be considered for modification based on their visual appearance, instead of being within
- * the `pixelTolerance` from the pointer location. When a {@link module:ol/layer/BaseVector} is
+ * the `pixelTolerance` from the pointer location. When a {@link module:ol/layer/BaseVector~BaseVectorLayer} is
  * provided, only the rendered representation of the features on that layer will be considered.
  * @property {Collection<Feature>} [features]
  * The features the interaction works on.  If a feature collection is not
@@ -143,7 +143,7 @@ export class ModifyEvent extends Event {
    * @param {Collection<import("../Feature").FeatureLike>} features
    * The features modified.
    * @param {import("../MapBrowserEvent.js").default} MapBrowserEvent
-   * Associated {@link module:ol/MapBrowserEvent}.
+   * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
    */
   constructor(type, features, MapBrowserEvent) {
     super(type);
@@ -156,7 +156,7 @@ export class ModifyEvent extends Event {
     this.features = features;
 
     /**
-     * Associated {@link module:ol/MapBrowserEvent}.
+     * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
      * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
@@ -834,7 +834,7 @@ class Modify extends PointerInteraction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} and may modify the geometry.
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may modify the geometry.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
    */

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -164,7 +164,7 @@ class MouseWheelZoom extends Interaction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} (if it was a mousewheel-event) and eventually
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} (if it was a mousewheel-event) and eventually
    * zooms the map.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -101,7 +101,7 @@ export class SelectEvent extends Event {
    * @param {Array<import("../Feature.js").default>} selected Selected features.
    * @param {Array<import("../Feature.js").default>} deselected Deselected features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Associated
-   *     {@link module:ol/MapBrowserEvent}.
+   *     {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
    */
   constructor(type, selected, deselected, mapBrowserEvent) {
     super(type);
@@ -121,7 +121,7 @@ export class SelectEvent extends Event {
     this.deselected = deselected;
 
     /**
-     * Associated {@link module:ol/MapBrowserEvent}.
+     * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
      * @type {import("../MapBrowserEvent.js").default}
      * @api
      */
@@ -460,7 +460,7 @@ class Select extends Interaction {
   }
 
   /**
-   * Handles the {@link module:ol/MapBrowserEvent map browser event} and may change the
+   * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may change the
    * selected state of features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -73,7 +73,7 @@ const tempSegment = [];
 /**
  * @classdesc
  * Handles snapping of vector features while modifying or drawing them.  The
- * features can come from a {@link module:ol/source/Vector} or {@link module:ol/Collection~Collection}
+ * features can come from a {@link module:ol/source/Vector~VectorSource} or {@link module:ol/Collection~Collection}
  * Any interaction object that allows the user to interact
  * with the features using the mouse can benefit from the snapping, as long
  * as it is added before.

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -102,7 +102,7 @@ export class TranslateEvent extends Event {
     this.startCoordinate = startCoordinate;
 
     /**
-     * Associated {@link module:ol/MapBrowserEvent}.
+     * Associated {@link module:ol/MapBrowserEvent~MapBrowserEvent}.
      * @type {import("../MapBrowserEvent.js").default}
      * @api
      */

--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -55,8 +55,8 @@ import {clamp} from '../math.js';
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
- * Note that with {@link module:ol/layer/Base} and all its subclasses, any property set in
- * the options is set as a {@link module:ol/Object} property on the layer object, so
+ * Note that with {@link module:ol/layer/Base~BaseLayer} and all its subclasses, any property set in
+ * the options is set as a {@link module:ol/Object~BaseObject} property on the layer object, so
  * is observable, and has get/set accessors.
  *
  * @api

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -243,10 +243,10 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * Returns the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
+   * Returns the {@link module:ol/Collection~Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
    * @return {!import("../Collection.js").default<import("./Base.js").default>} Collection of
-   *   {@link module:ol/layer/Base layers} that are part of this group.
+   *   {@link module:ol/layer/Base~BaseLayer layers} that are part of this group.
    * @observable
    * @api
    */
@@ -257,10 +257,10 @@ class LayerGroup extends BaseLayer {
   }
 
   /**
-   * Set the {@link module:ol/Collection collection} of {@link module:ol/layer/Layer~Layer layers}
+   * Set the {@link module:ol/Collection~Collection collection} of {@link module:ol/layer/Layer~Layer layers}
    * in this group.
    * @param {!import("../Collection.js").default<import("./Base.js").default>} layers Collection of
-   *   {@link module:ol/layer/Base layers} that are part of this group.
+   *   {@link module:ol/layer/Base~BaseLayer layers} that are part of this group.
    * @observable
    * @api
    */

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -4,7 +4,7 @@
 
 /**
  * The ol/proj module stores:
- * * a list of {@link module:ol/proj/Projection}
+ * * a list of {@link module:ol/proj/Projection~Projection}
  * objects, one for each projection supported by the application
  * * a list of transform functions needed to convert coordinates in one projection
  * into another.
@@ -43,13 +43,13 @@
  *
  * In addition to Proj4js support, any transform functions can be added with
  * {@link module:ol/proj.addCoordinateTransforms}. To use this, you must first create
- * a {@link module:ol/proj/Projection} object for the new projection and add it with
+ * a {@link module:ol/proj/Projection~Projection} object for the new projection and add it with
  * {@link module:ol/proj.addProjection}. You can then add the forward and inverse
  * functions with {@link module:ol/proj.addCoordinateTransforms}. See
  * examples/wms-custom-proj for an example of this.
  *
  * Note that if no transforms are needed and you only need to define the
- * projection, just add a {@link module:ol/proj/Projection} with
+ * projection, just add a {@link module:ol/proj/Projection~Projection} with
  * {@link module:ol/proj.addProjection}. See examples/wms-no-proj for an example of
  * this.
  */
@@ -77,7 +77,7 @@ import {getDistance} from './sphere.js';
 import {getWorldsAway} from './coordinate.js';
 
 /**
- * A projection as {@link module:ol/proj/Projection}, SRS identifier
+ * A projection as {@link module:ol/proj/Projection~Projection}, SRS identifier
  * string or undefined.
  * @typedef {Projection|string|undefined} ProjectionLike
  * @api

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -32,7 +32,7 @@ import {transformGeom2D} from '../../geom/SimpleGeometry.js';
 
 /**
  * @classdesc
- * A concrete subclass of {@link module:ol/render/VectorContext VectorContext} that implements
+ * A concrete subclass of {@link module:ol/render/VectorContext~VectorContext VectorContext} that implements
  * direct rendering of features and geometries to an HTML5 Canvas context.
  * Instances of this class are created internally by the library and
  * provided to application code as vectorContext member of the

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -8,9 +8,9 @@ import {getUid} from '../util.js';
 
 /**
  * Feature callback. The callback will be called with three arguments. The first
- * argument is one {@link module:ol/Feature feature} or {@link module:ol/render/Feature render feature}
- * at the pixel, the second is the {@link module:ol/layer/Layer layer} of the feature and will be null for
- * unmanaged layers. The third is the {@link module:ol/geom/SimpleGeometry} of the feature. For features
+ * argument is one {@link module:ol/Feature~Feature feature} or {@link module:ol/render/Feature~RenderFeature render feature}
+ * at the pixel, the second is the {@link module:ol/layer/Layer~Layer layer} of the feature and will be null for
+ * unmanaged layers. The third is the {@link module:ol/geom/SimpleGeometry~SimpleGeometry} of the feature. For features
  * with a GeometryCollection geometry, it will be the first detected geometry from the collection.
  * @template T
  * @typedef {function(import("../Feature.js").FeatureLike, import("../layer/Layer.js").default<import("../source/Source").default>, import("../geom/SimpleGeometry.js").default): T} FeatureCallback

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -66,7 +66,7 @@ import {listen, unlistenByKey} from '../../events.js';
  * every time the vector source changes.
  *
  * You need to provide vertex and fragment shaders for rendering. This can be done using
- * {@link module:ol/webgl/ShaderBuilder} utilities. These shaders shall expect a `a_position` attribute
+ * {@link module:ol/webgl/ShaderBuilder~ShaderBuilder} utilities. These shaders shall expect a `a_position` attribute
  * containing the screen-space projected center of the quad, as well as a `a_index` attribute
  * whose value (0, 1, 2 or 3) indicates which quad vertex is currently getting processed (see structure below).
  *

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -47,7 +47,7 @@ import {containsExtent, getHeight, getWidth} from '../extent.js';
  *
  * If underlying map service is not using labels,
  * take advantage of ol image caching and use
- * {@link module:ol/source/TileArcGISRest} data source.
+ * {@link module:ol/source/TileArcGISRest~TileArcGISRest} data source.
  *
  * @fires module:ol/source/Image.ImageSourceEvent
  * @api

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -16,9 +16,9 @@ import {
  * used by the source as an image. The arguments passed to the function are:
  * {@link module:ol/extent~Extent} the image extent, `{number}` the image resolution,
  * `{number}` the pixel ratio of the map, {@link module:ol/size~Size} the image size,
- * and {@link module:ol/proj/Projection} the image projection. The canvas returned by
+ * and {@link module:ol/proj/Projection~Projection} the image projection. The canvas returned by
  * this function is cached by the source. The this keyword inside the function
- * references the {@link module:ol/source/ImageCanvas}.
+ * references the {@link module:ol/source/ImageCanvas~ImageCanvasSource}.
  *
  * @typedef {function(this:import("../ImageCanvas.js").default, import("../extent.js").Extent, number,
  *     number, import("../size.js").Size, import("../proj/Projection.js").default): HTMLCanvasElement} FunctionType

--- a/src/ol/source/OGCVectorTile.js
+++ b/src/ol/source/OGCVectorTile.js
@@ -23,7 +23,7 @@ import {getTileSetInfo} from './ogcTileUtil.js';
  * stroke operations.
  * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Projection of the tile grid.
  * @property {typeof import("../VectorTile.js").default} [tileClass] Class used to instantiate image tiles.
- * Default is {@link module:ol/VectorTile}.
+ * Default is {@link module:ol/VectorTile~VectorTile}.
  * @property {number} [transition] A duration for tile opacity
  * transitions in milliseconds. A duration of 0 disables the opacity transition.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -466,7 +466,7 @@ const RasterOperationType = {
 
 /**
  * @classdesc
- * Events emitted by {@link module:ol/source/Raster} instances are instances of this
+ * Events emitted by {@link module:ol/source/Raster~RasterSource} instances are instances of this
  * type.
  */
 export class RasterSourceEvent extends Event {

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -32,7 +32,7 @@ import {xhr} from '../featureloader.js';
 
 /**
  * @classdesc
- * Events emitted by {@link module:ol/source/Vector} instances are instances of this
+ * Events emitted by {@link module:ol/source/Vector~VectorSource} instances are instances of this
  * type.
  * @template {import("../geom/Geometry.js").default} [Geometry=import("../geom/Geometry.js").default]
  */
@@ -74,7 +74,7 @@ export class VectorSourceEvent extends Event {
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {Array<import("../Feature.js").default>|Collection<import("../Feature.js").default>} [features]
- * Features. If provided as {@link module:ol/Collection}, the features in the source
+ * Features. If provided as {@link module:ol/Collection~Collection}, the features in the source
  * and the collection will stay in sync.
  * @property {import("../format/Feature.js").default} [format] The feature format used by the XHR
  * feature loader when `url` is set. Required if `url` is set, otherwise ignored.
@@ -155,7 +155,7 @@ export class VectorSourceEvent extends Event {
  * through all features.
  *
  * When set to `false`, the features will be maintained in an
- * {@link module:ol/Collection}, which can be retrieved through
+ * {@link module:ol/Collection~Collection}, which can be retrieved through
  * {@link module:ol/source/Vector~VectorSource#getFeaturesCollection}.
  * @property {boolean} [wrapX=true] Wrap the world horizontally. For vector editing across the
  * -180° and 180° meridians to work properly, this should be set to `false`. The
@@ -756,7 +756,7 @@ class VectorSource extends Source {
    * `useSpatialIndex` set to `false`.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
    * @param {function(import("../Feature.js").default<Geometry>):boolean} [opt_filter] Feature filter function.
-   *     The filter function will receive one argument, the {@link module:ol/Feature feature}
+   *     The filter function will receive one argument, the {@link module:ol/Feature~Feature feature}
    *     and it should return a boolean value. By default, no filtering is made.
    * @return {import("../Feature.js").default<Geometry>} Closest feature.
    * @api

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -37,7 +37,7 @@ import {toSize} from '../size.js';
  * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Projection of the tile grid.
  * @property {import("./State.js").default} [state] Source state.
  * @property {typeof import("../VectorTile.js").default} [tileClass] Class used to instantiate image tiles.
- * Default is {@link module:ol/VectorTile}.
+ * Default is {@link module:ol/VectorTile~VectorTile}.
  * @property {number} [maxZoom=22] Optional max zoom level. Not used if `tileGrid` is provided.
  * @property {number} [minZoom] Optional min zoom level. Not used if `tileGrid` is provided.
  * @property {number|import("../size.js").Size} [tileSize=512] Optional tile size. Not used if `tileGrid` is provided.

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -27,7 +27,7 @@ const DECIMALS = 5;
 /**
  * @typedef {Object} Options
  * @property {import("../extent.js").Extent} [extent] Extent for the tile grid. No tiles outside this
- * extent will be requested by {@link module:ol/source/Tile} sources. When no `origin` or
+ * extent will be requested by {@link module:ol/source/Tile~TileSource} sources. When no `origin` or
  * `origins` are configured, the `origin` will be set to the top-left corner of the extent.
  * @property {number} [minZoom=0] Minimum zoom.
  * @property {import("../coordinate.js").Coordinate} [origin] The tile grid origin, i.e. where the `x`

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -9,7 +9,7 @@ import {get as getProjection} from '../proj.js';
 /**
  * @typedef {Object} Options
  * @property {import("../extent.js").Extent} [extent] Extent for the tile grid. No tiles
- * outside this extent will be requested by {@link module:ol/source/Tile} sources.
+ * outside this extent will be requested by {@link module:ol/source/Tile~TileSource} sources.
  * When no `origin` or `origins` are configured, the `origin` will be set to the
  * top-left corner of the extent.
  * @property {import("../coordinate.js").Coordinate} [origin] The tile grid origin, i.e.


### PR DESCRIPTION
Change the remaining links to point to the class instead of the module page and fix one more link to `ol/source/Tile~TileSource`.