### PR TITLE
Fix setting View resolution or center to undefined

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1636,7 +1636,9 @@ class View extends BaseObject {
    * @api
    */
   setCenter(center) {
-    this.setCenterInternal(fromUserCoordinate(center, this.getProjection()));
+    this.setCenterInternal(
+      center ? fromUserCoordinate(center, this.getProjection()) : center
+    );
   }
 
   /**

--- a/src/ol/centerconstraint.js
+++ b/src/ol/centerconstraint.js
@@ -18,52 +18,54 @@ export function createExtent(extent, onlyCenter, smooth) {
   return (
     /**
      * @param {import("./coordinate.js").Coordinate|undefined} center Center.
-     * @param {number} resolution Resolution.
+     * @param {number|undefined} resolution Resolution.
      * @param {import("./size.js").Size} size Viewport size; unused if `onlyCenter` was specified.
      * @param {boolean} [opt_isMoving] True if an interaction or animation is in progress.
      * @param {Array<number>} [opt_centerShift] Shift between map center and viewport center.
      * @return {import("./coordinate.js").Coordinate|undefined} Center.
      */
     function (center, resolution, size, opt_isMoving, opt_centerShift) {
-      if (center) {
-        const viewWidth = onlyCenter ? 0 : size[0] * resolution;
-        const viewHeight = onlyCenter ? 0 : size[1] * resolution;
-        const shiftX = opt_centerShift ? opt_centerShift[0] : 0;
-        const shiftY = opt_centerShift ? opt_centerShift[1] : 0;
-        let minX = extent[0] + viewWidth / 2 + shiftX;
-        let maxX = extent[2] - viewWidth / 2 + shiftX;
-        let minY = extent[1] + viewHeight / 2 + shiftY;
-        let maxY = extent[3] - viewHeight / 2 + shiftY;
-
-        // note: when zooming out of bounds, min and max values for x and y may
-        // end up inverted (min > max); this has to be accounted for
-        if (minX > maxX) {
-          minX = (maxX + minX) / 2;
-          maxX = minX;
-        }
-        if (minY > maxY) {
-          minY = (maxY + minY) / 2;
-          maxY = minY;
-        }
-
-        let x = clamp(center[0], minX, maxX);
-        let y = clamp(center[1], minY, maxY);
-        const ratio = 30 * resolution;
-
-        // during an interaction, allow some overscroll
-        if (opt_isMoving && smooth) {
-          x +=
-            -ratio * Math.log(1 + Math.max(0, minX - center[0]) / ratio) +
-            ratio * Math.log(1 + Math.max(0, center[0] - maxX) / ratio);
-          y +=
-            -ratio * Math.log(1 + Math.max(0, minY - center[1]) / ratio) +
-            ratio * Math.log(1 + Math.max(0, center[1] - maxY) / ratio);
-        }
-
-        return [x, y];
-      } else {
+      if (!center) {
         return undefined;
       }
+      if (!resolution && !onlyCenter) {
+        return center;
+      }
+      const viewWidth = onlyCenter ? 0 : size[0] * resolution;
+      const viewHeight = onlyCenter ? 0 : size[1] * resolution;
+      const shiftX = opt_centerShift ? opt_centerShift[0] : 0;
+      const shiftY = opt_centerShift ? opt_centerShift[1] : 0;
+      let minX = extent[0] + viewWidth / 2 + shiftX;
+      let maxX = extent[2] - viewWidth / 2 + shiftX;
+      let minY = extent[1] + viewHeight / 2 + shiftY;
+      let maxY = extent[3] - viewHeight / 2 + shiftY;
+
+      // note: when zooming out of bounds, min and max values for x and y may
+      // end up inverted (min > max); this has to be accounted for
+      if (minX > maxX) {
+        minX = (maxX + minX) / 2;
+        maxX = minX;
+      }
+      if (minY > maxY) {
+        minY = (maxY + minY) / 2;
+        maxY = minY;
+      }
+
+      let x = clamp(center[0], minX, maxX);
+      let y = clamp(center[1], minY, maxY);
+
+      // during an interaction, allow some overscroll
+      if (opt_isMoving && smooth && resolution) {
+        const ratio = 30 * resolution;
+        x +=
+          -ratio * Math.log(1 + Math.max(0, minX - center[0]) / ratio) +
+          ratio * Math.log(1 + Math.max(0, center[0] - maxX) / ratio);
+        y +=
+          -ratio * Math.log(1 + Math.max(0, minY - center[1]) / ratio) +
+          ratio * Math.log(1 + Math.max(0, center[1] - maxY) / ratio);
+      }
+
+      return [x, y];
     }
   );
 }

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -562,6 +562,18 @@ describe('ol/View', function () {
     });
   });
 
+  describe('#setResolution()', function () {
+    it('does not change center when set to undefined', function () {
+      const center = [1, 1];
+      const view = new View({
+        center: center.slice(),
+        resolution: 1,
+      });
+      view.setResolution(undefined);
+      expect(view.getCenter()).to.eql(center);
+    });
+  });
+
   describe('#setCenter()', function () {
     it('allows setting undefined center', function () {
       const view = new View({


### PR DESCRIPTION
Setting the resolution to undefined resulted in an invalid center `[NaN, NaN]`.

The check for the warning from #13383 broke setting `ol/View` center to `undefined`, though it arguably never should have called that function with `undefined`. It worked once `showCoordinateWarning` was `false`.
https://github.com/openlayers/openlayers/blob/63fc00902faff8c017c600fbd8c1f04791add5d4/src/ol/proj.js#L610-L614