### PR TITLE
Clear image when source's image is not ready

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -82,6 +82,8 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
         );
         if (image && this.loadImage(image)) {
           this.image_ = image;
+        } else {
+          this.image_ = null;
         }
       } else {
         this.image_ = null;


### PR DESCRIPTION
In some cases, Static Image should disappear is not cleared.

Set renderer image_ to null when source's image is not ready, for example, the status is empty.

close https://github.com/openlayers/openlayers/issues/13397