### PR TITLE
Increase GeoTIFF resolutions tolerance

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -525,7 +525,7 @@ class GeoTIFFSource extends DataTile {
         assertEqual(
           resolutions.slice(minZoom, resolutions.length),
           scaledSourceResolutions,
-          0.005,
+          0.02,
           message,
           this.viewRejector
         );


### PR DESCRIPTION
This pull request increases the tolerance of resolution difference between two GeoTIFFs that are used to combine bands in a data tile to 2 percent. This makes it easier to combine GeoTIFFs in a single GeoTIFF for pixel operations.

I also thought about making this tolerance configurable, but decided against it to keep the API simple.