### PR TITLE
Update ol-mapbox-style for rich text labels support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^2.0.2",
-        "ol-mapbox-style": "^6.8.2",
+        "ol-mapbox-style": "^7.0.0",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -7436,9 +7436,9 @@
       "dev": true
     },
     "node_modules/ol-mapbox-style": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
-      "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.0.0.tgz",
+      "integrity": "sha512-y0OrKfx/TBcbGUf0UefDuYPSfMCCjPz0aUttm/kG461CNwzJpGavvf/lJ7nyNfeHSJFr0iEEdAbB98UUUQQkww==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.1",
@@ -16040,9 +16040,9 @@
       "dev": true
     },
     "ol-mapbox-style": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-6.9.0.tgz",
-      "integrity": "sha512-Isxk+IPB6pCBD2Pubz9cpQcZjEeuPhxyk/QsLZjb2+KwvyGaIFltdlxnxx/QXJ7rOxUiLvS/XhsOyiK0c7prEw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.0.0.tgz",
+      "integrity": "sha512-y0OrKfx/TBcbGUf0UefDuYPSfMCCjPz0aUttm/kG461CNwzJpGavvf/lJ7nyNfeHSJFr0iEEdAbB98UUUQQkww==",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.20.1",
         "mapbox-to-css-font": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "geotiff": "^2.0.2",
-    "ol-mapbox-style": "^6.8.2",
+    "ol-mapbox-style": "^7.0.0",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
   },


### PR DESCRIPTION
This pull request updates ol-mapbox-style to a (beta) version that passes text/style tupels to `ol/style/Text`, for support of the new rich text labels.