### PR TITLE
Handle layers without renderer properly

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -951,7 +951,8 @@ class PluggableMap extends BaseObject {
     const layerStatesArray = this.getLayerGroup().getLayerStatesArray();
     for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
       const layer = layerStatesArray[i].layer;
-      if (!layer.getRenderer().ready) {
+      const renderer = layer.getRenderer();
+      if (renderer && !renderer.ready) {
         return true;
       }
       const source = /** @type {import("./layer/Layer.js").default} */ (

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -371,7 +371,7 @@ class Layer extends BaseLayer {
 
   /**
    * Get the renderer for this layer.
-   * @return {RendererType} The layer renderer.
+   * @return {RendererType|null} The layer renderer.
    */
   getRenderer() {
     if (!this.renderer_) {


### PR DESCRIPTION
Since layers can have just a `render()` function instead of a separate renderer, we need to handle the case where `layer.getRenderer()` returns `null`.

Fixes #13423 