### PR TITLE
Fix rendercomplete with invisible WebGLPoints layer

### DIFF
--- a/src/ol/PluggableMap.js
+++ b/src/ol/PluggableMap.js
@@ -950,13 +950,16 @@ class PluggableMap extends BaseObject {
   getLoadingOrNotReady() {
     const layerStatesArray = this.getLayerGroup().getLayerStatesArray();
     for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-      const layer = layerStatesArray[i].layer;
-      const renderer = layer.getRenderer();
+      const state = layerStatesArray[i];
+      if (!state.visible) {
+        continue;
+      }
+      const renderer = state.layer.getRenderer();
       if (renderer && !renderer.ready) {
         return true;
       }
       const source = /** @type {import("./layer/Layer.js").default} */ (
-        layer
+        state.layer
       ).getSource();
       if (source && source.loading) {
         return true;

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -491,6 +491,18 @@ describe('ol/Map', function () {
         })
       );
     });
+    it('ignores invisible layers', function (done) {
+      map.getLayers().forEach(function (layer, i) {
+        layer.setVisible(i === 4);
+      });
+      map.setView(
+        new View({
+          center: [0, 0],
+          zoom: 0,
+        })
+      );
+      map.once('rendercomplete', () => done());
+    });
   });
 
   describe('#getFeaturesAtPixel', function () {


### PR DESCRIPTION
When a WebGLPoints layer is not yet visible no rendercomplete event fires.

I already included the commit from #13424 to avoid a merge conflict.
Replaces #13424
Fixes #13423