### PR TITLE
Clarify docs on color values

### DIFF
--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -78,8 +78,8 @@ import {log2} from '../math.js';
  * * Conversion operators:
  *   * `['array', value1, ...valueN]` creates a numerical array from `number` values; please note that the amount of
  *     values can currently only be 2, 3 or 4.
- *   * `['color', red, green, blue, alpha]` creates a `color` value from `number` values; the `alpha` parameter is
- *     optional; if not specified, it will be set to 1.
+ *   * `['color', red, green, blue, alpha]` creates a `color` value from `number` values;  the red, green, and blue
+ *     values range between 0 and 255; the alpha ranges between 0 and 1; if not specified, alpha will be set to 1.
  *     Note: `red`, `green` and `blue` components must be values between 0 and 255; `alpha` between 0 and 1.
  *   * `['palette', index, colors]` picks a `color` value from an array of colors using the given index; the `index`
  *     expression must evaluate to a number; the items in the `colors` array must be strings with hex colors


### PR DESCRIPTION
This adds to the documentation for the `color` expression, clarifying that rgb values are 0-255 and alpha is 0-1.