### PR TITLE
Ensure FullScreen button has classname set on render.

### DIFF
--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -165,6 +165,7 @@ class FullScreen extends Control {
 
     const tipLabel = options.tipLabel ? options.tipLabel : 'Toggle full-screen';
     this.button_.setAttribute('type', 'button');
+    this.setClassName_(this.button_, this.isInFullscreen_);
     this.button_.title = tipLabel;
     this.button_.appendChild(this.labelNode_);
 

--- a/test/browser/spec/ol/control/fullscreen.test.js
+++ b/test/browser/spec/ol/control/fullscreen.test.js
@@ -7,4 +7,23 @@ describe('ol.control.FullScreen', function () {
       expect(instance).to.be.an(FullScreen);
     });
   });
+
+  describe('the fullscreen button', function () {
+    describe('when inactiveClassName is not set', function () {
+      it('is created with the default inactive classname set on the button', function () {
+        const instance = new FullScreen();
+        const button = instance.button_;
+        expect(button.className).to.equal('ol-full-screen-false');
+      });
+    });
+    describe('when inactiveClassName is set', function () {
+      it('is created with the desired inactive classnames set on the button', function () {
+        const instance = new FullScreen({
+          inactiveClassName: 'foo bar',
+        });
+        const button = instance.button_;
+        expect(button.className).to.equal('foo bar');
+      });
+    });
+  });
 });


### PR DESCRIPTION
When the FullScreen icon is first rendered, the button within it is not having the inactive classname set. The class name is set on toggling fullscreen on/off - just not being set on render.

**After render (classname not set)**

![after render](https://user-images.githubusercontent.com/14044806/156753043-8e462d16-2ff0-4b21-a307-a4a615c14eb0.png)

**After entering full screen (classname correctly set)**

![after full screen click](https://user-images.githubusercontent.com/14044806/156753042-8748a3eb-cf6f-40ad-8695-c19c2cea24d2.png)

**After existing fullscreen (classname correctly set)**

![after exiting fullscreen](https://user-images.githubusercontent.com/14044806/156753039-353e6427-2798-40c7-8107-42a519ced5cd.png)




