### PR TITLE
Initialize variable before use in FullScreen control

### DIFF
--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -107,6 +107,29 @@ class FullScreen extends Control {
 
     /**
      * @private
+     * @type {boolean}
+     */
+    this.keys_ = options.keys !== undefined ? options.keys : false;
+
+    /**
+     * @private
+     * @type {HTMLElement|string|undefined}
+     */
+    this.source_ = options.source;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.isInFullscreen_ = false;
+
+    /**
+     * @private
+     */
+    this.boundHandleMapTargetChange_ = this.handleMapTargetChange_.bind(this);
+
+    /**
+     * @private
      * @type {string}
      */
     this.cssClassName_ =
@@ -157,49 +180,25 @@ class FullScreen extends Control {
         ? document.createTextNode(labelActive)
         : labelActive;
 
+    const tipLabel = options.tipLabel ? options.tipLabel : 'Toggle full-screen';
+
     /**
      * @private
      * @type {HTMLElement}
      */
     this.button_ = document.createElement('button');
-
-    const tipLabel = options.tipLabel ? options.tipLabel : 'Toggle full-screen';
-    this.button_.setAttribute('type', 'button');
-    this.setClassName_(this.button_, this.isInFullscreen_);
     this.button_.title = tipLabel;
+    this.button_.setAttribute('type', 'button');
     this.button_.appendChild(this.labelNode_);
-
     this.button_.addEventListener(
       EventType.CLICK,
       this.handleClick_.bind(this),
       false
     );
+    this.setClassName_(this.button_, this.isInFullscreen_);
 
     this.element.className = `${this.cssClassName_} ${CLASS_UNSELECTABLE} ${CLASS_CONTROL}`;
     this.element.appendChild(this.button_);
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this.keys_ = options.keys !== undefined ? options.keys : false;
-
-    /**
-     * @private
-     * @type {HTMLElement|string|undefined}
-     */
-    this.source_ = options.source;
-
-    /**
-     * @type {boolean}
-     * @private
-     */
-    this.isInFullscreen_ = false;
-
-    /**
-     * @private
-     */
-    this.boundHandleMapTargetChange_ = this.handleMapTargetChange_.bind(this);
   }
 
   /**
@@ -272,12 +271,13 @@ class FullScreen extends Control {
    * @private
    */
   setClassName_(element, fullscreen) {
-    const activeClassName = this.activeClassName_;
-    const inactiveClassName = this.inactiveClassName_;
-    const nextClassName = fullscreen ? activeClassName : inactiveClassName;
-    element.classList.remove(...activeClassName);
-    element.classList.remove(...inactiveClassName);
-    element.classList.add(...nextClassName);
+    if (fullscreen) {
+      element.classList.remove(...this.inactiveClassName_);
+      element.classList.add(...this.activeClassName_);
+    } else {
+      element.classList.remove(...this.activeClassName_);
+      element.classList.add(...this.inactiveClassName_);
+    }
   }
 
   /**


### PR DESCRIPTION
isInFullscreen_ was not yet initialized in the constructor when setClassName_is being called.
It worked fine because undefined is also a falsy value.

Only remove the unnecessary classes when state changes instead of removing all and then adding the necessary classes again
