### PR TITLE
Add loadstart and loadend map events

### DIFF
--- a/examples/image-load-events.html
+++ b/examples/image-load-events.html
@@ -3,11 +3,13 @@ layout: example.html
 title: Image Load Events
 shortdesc: Example using image load events.
 docs: >
-  <p>Image sources fire events related to image loading.  You can
+  Image sources fire events related to image loading.  You can
   listen for <code>imageloadstart</code>, <code>imageloadend</code>,
   and <code>imageloaderror</code> type events to monitor image loading
   progress.  This example registers listeners for these events and
-  renders an image loading progress bar at the bottom of the map.</p>
+  renders an image loading progress bar at the bottom of the map. The
+  progress bar is shown and hidden according to the map's <code>loadstart</code>
+  and <code>loadend</code> events.
 tags: "image, events, loading"
 ---
 <div class="wrapper">

--- a/examples/image-load-events.js
+++ b/examples/image-load-events.js
@@ -18,9 +18,6 @@ function Progress(el) {
  * Increment the count of loading tiles.
  */
 Progress.prototype.addLoading = function () {
-  if (this.loading === 0) {
-    this.show();
-  }
   ++this.loading;
   this.update();
 };
@@ -29,11 +26,8 @@ Progress.prototype.addLoading = function () {
  * Increment the count of loaded tiles.
  */
 Progress.prototype.addLoaded = function () {
-  const this_ = this;
-  setTimeout(function () {
-    ++this_.loaded;
-    this_.update();
-  }, 100);
+  ++this.loaded;
+  this.update();
 };
 
 /**
@@ -42,14 +36,6 @@ Progress.prototype.addLoaded = function () {
 Progress.prototype.update = function () {
   const width = ((this.loaded / this.loading) * 100).toFixed(1) + '%';
   this.el.style.width = width;
-  if (this.loading === this.loaded) {
-    this.loading = 0;
-    this.loaded = 0;
-    const this_ = this;
-    setTimeout(function () {
-      this_.hide();
-    }, 500);
-  }
 };
 
 /**
@@ -63,10 +49,11 @@ Progress.prototype.show = function () {
  * Hide the progress bar.
  */
 Progress.prototype.hide = function () {
-  if (this.loading === this.loaded) {
-    this.el.style.visibility = 'hidden';
-    this.el.style.width = 0;
-  }
+  const style = this.el.style;
+  setTimeout(function () {
+    style.visibility = 'hidden';
+    style.width = 0;
+  }, 250);
 };
 
 const progress = new Progress(document.getElementById('progress'));
@@ -80,11 +67,7 @@ const source = new ImageWMS({
 source.on('imageloadstart', function () {
   progress.addLoading();
 });
-
-source.on('imageloadend', function () {
-  progress.addLoaded();
-});
-source.on('imageloaderror', function () {
+source.on(['imageloadend', 'imageloaderror'], function () {
   progress.addLoaded();
 });
 
@@ -95,4 +78,11 @@ const map = new Map({
     center: [-10997148, 4569099],
     zoom: 4,
   }),
+});
+
+map.on('loadstart', function () {
+  progress.show();
+});
+map.on('loadend', function () {
+  progress.hide();
 });

--- a/examples/load-events.css
+++ b/examples/load-events.css
@@ -1,0 +1,30 @@
+.map {
+  background: #85ccf9;
+  position: relative;
+}
+#map {
+  height: 400px;
+  position: relative;
+}
+
+@keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner:after {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  margin-left: -20px;
+  border-radius: 50%;
+  border: 5px solid rgba(180, 180, 180, 0.6);
+  border-top-color: rgba(0, 0, 0, 0.6);
+  animation: spinner 0.6s linear infinite;
+}

--- a/examples/load-events.html
+++ b/examples/load-events.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: Loading Spinner
+shortdesc: Example using load events to show a loading spinner.
+docs: >
+  You can listen for the map's <code>loadstart</code> and <code>loadend</code> events
+  to show a loading spinner on top of the map.
+tags: "events, loading, spinner"
+cloak:
+  - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ
+    value: Your Mapbox access token from https://mapbox.com/ here
+---
+<div id="map" class="map"></div>

--- a/examples/load-events.js
+++ b/examples/load-events.js
@@ -1,0 +1,31 @@
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import View from '../src/ol/View.js';
+import XYZ from '../src/ol/source/XYZ.js';
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const attributions =
+  '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> ' +
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+
+const source = new XYZ({
+  attributions: attributions,
+  url: 'https://api.maptiler.com/maps/streets/{z}/{x}/{y}.png?key=' + key,
+  tileSize: 512,
+});
+
+const map = new Map({
+  layers: [new TileLayer({source: source})],
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 2,
+  }),
+});
+
+map.on('loadstart', function () {
+  map.getTargetElement().classList.add('spinner');
+});
+map.on('loadend', function () {
+  map.getTargetElement().classList.remove('spinner');
+});

--- a/examples/tile-load-events.html
+++ b/examples/tile-load-events.html
@@ -7,7 +7,9 @@ docs: >
   listen for <code>tileloadstart</code>, <code>tileloadend</code>,
   and <code>tileloaderror</code> type events to monitor tile loading
   progress.  This example registers listeners for these events and
-  renders a tile loading progress bar at the bottom of the map.</p>
+  renders a tile loading progress bar at the bottom of the map. The
+  progress bar is shown and hidden according to the map's <code>loadstart</code>
+  and <code>loadend</code> events.
 tags: "tile, events, loading"
 cloak:
   - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ

--- a/examples/tile-load-events.js
+++ b/examples/tile-load-events.js
@@ -18,9 +18,6 @@ function Progress(el) {
  * Increment the count of loading tiles.
  */
 Progress.prototype.addLoading = function () {
-  if (this.loading === 0) {
-    this.show();
-  }
   ++this.loading;
   this.update();
 };
@@ -29,11 +26,8 @@ Progress.prototype.addLoading = function () {
  * Increment the count of loaded tiles.
  */
 Progress.prototype.addLoaded = function () {
-  const this_ = this;
-  setTimeout(function () {
-    ++this_.loaded;
-    this_.update();
-  }, 100);
+  ++this.loaded;
+  this.update();
 };
 
 /**
@@ -42,14 +36,6 @@ Progress.prototype.addLoaded = function () {
 Progress.prototype.update = function () {
   const width = ((this.loaded / this.loading) * 100).toFixed(1) + '%';
   this.el.style.width = width;
-  if (this.loading === this.loaded) {
-    this.loading = 0;
-    this.loaded = 0;
-    const this_ = this;
-    setTimeout(function () {
-      this_.hide();
-    }, 500);
-  }
 };
 
 /**
@@ -63,10 +49,11 @@ Progress.prototype.show = function () {
  * Hide the progress bar.
  */
 Progress.prototype.hide = function () {
-  if (this.loading === this.loaded) {
-    this.el.style.visibility = 'hidden';
-    this.el.style.width = 0;
-  }
+  const style = this.el.style;
+  setTimeout(function () {
+    style.visibility = 'hidden';
+    style.width = 0;
+  }, 250);
 };
 
 const progress = new Progress(document.getElementById('progress'));
@@ -85,11 +72,7 @@ const source = new XYZ({
 source.on('tileloadstart', function () {
   progress.addLoading();
 });
-
-source.on('tileloadend', function () {
-  progress.addLoaded();
-});
-source.on('tileloaderror', function () {
+source.on(['tileloadend', 'tileloaderror'], function () {
   progress.addLoaded();
 });
 
@@ -100,4 +83,11 @@ const map = new Map({
     center: [0, 0],
     zoom: 2,
   }),
+});
+
+map.on('loadstart', function () {
+  progress.show();
+});
+map.on('loadend', function () {
+  progress.hide();
 });

--- a/src/ol/MapEventType.js
+++ b/src/ol/MapEventType.js
@@ -26,8 +26,22 @@ export default {
    * @api
    */
   MOVEEND: 'moveend',
+
+  /**
+   * Triggered when loading of additional map data (tiles, images, features) starts.
+   * @event module:ol/render/Event~RenderEvent#loadstart
+   * @api
+   */
+  LOADSTART: 'loadstart',
+
+  /**
+   * Triggered when loading of additional map data has completed.
+   * @event module:ol/render/Event~RenderEvent#loadend
+   * @api
+   */
+  LOADEND: 'loadend',
 };
 
 /***
- * @typedef {'postrender'|'movestart'|'moveend'} Types
+ * @typedef {'postrender'|'movestart'|'moveend'|'loadstart'|'loadend'} Types
  */


### PR DESCRIPTION
This pull request adds `loadstart` and `loadend` events to the map. For implementing loading indicators, these events are more straightforward than the `rendercomplete` event.

With this pull request, loading indicators become as simple as
```js
map.on('loadstart', () => console.log('Loading map data...'));
map.on('loadend', () => console.log('Map data loaded.'));
```

See https://deploy-preview-13491--ol-site.netlify.app/examples/load-events.html for the simplest way to add a loading spinner.

Fixes #13489.