### PR TITLE
Workaround for Safari WebGL issue

### DIFF
--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -20,6 +20,17 @@ export const FIREFOX = ua.indexOf('firefox') !== -1;
 export const SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') == -1;
 
 /**
+ * https://bugs.webkit.org/show_bug.cgi?id=237906
+ * @type {boolean}
+ */
+export const SAFARI_BUG_237906 =
+  SAFARI &&
+  !!(
+    ua.indexOf('version/15.4') >= 0 ||
+    ua.match(/cpu (os|iphone os) 15_4 like mac os x/)
+  );
+
+/**
  * User agent string says we are dealing with a WebKit engine.
  * @type {boolean}
  */

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -2,6 +2,7 @@
  * @module ol/webgl
  */
 
+import {SAFARI_BUG_237906} from './has.js';
 import {assign} from './obj.js';
 
 /**
@@ -91,7 +92,13 @@ const CONTEXT_IDS = ['experimental-webgl', 'webgl', 'webkit-3d', 'moz-webgl'];
  * @return {WebGLRenderingContext} WebGL rendering context.
  */
 export function getContext(canvas, opt_attributes) {
-  const attributes = assign({preserveDrawingBuffer: true}, opt_attributes);
+  const attributes = assign(
+    {
+      preserveDrawingBuffer: true,
+      antialias: SAFARI_BUG_237906 ? false : true, // https://bugs.webkit.org/show_bug.cgi?id=237906
+    },
+    opt_attributes
+  );
   const ii = CONTEXT_IDS.length;
   for (let i = 0; i < ii; ++i) {
     try {


### PR DESCRIPTION
This is a workaround for a WebGL rendering issue in Safari (https://bugs.webkit.org/show_bug.cgi?id=237906).

Fixes #13486.
