### PR TITLE
Improve Projection and Scale example calculations

### DIFF
--- a/examples/projection-and-scale.js
+++ b/examples/projection-and-scale.js
@@ -43,18 +43,13 @@ function onChangeProjection() {
   const currentCenter = currentView.getCenter();
   const currentRotation = currentView.getRotation();
   const newCenter = transform(currentCenter, currentProjection, newProjection);
-  const currentPointResolution = getPointResolution(
-    currentProjection,
-    1,
-    currentCenter,
-    'm'
-  );
-  const newPointResolution = getPointResolution(
-    newProjection,
-    1,
-    newCenter,
-    'm'
-  );
+  const currentMPU = currentProjection.getMetersPerUnit();
+  const newMPU = newProjection.getMetersPerUnit();
+  const currentPointResolution =
+    getPointResolution(currentProjection, 1 / currentMPU, currentCenter, 'm') *
+    currentMPU;
+  const newPointResolution =
+    getPointResolution(newProjection, 1 / newMPU, newCenter, 'm') * newMPU;
   const newResolution =
     (currentResolution * currentPointResolution) / newPointResolution;
   const newView = new View({


### PR DESCRIPTION
Replaces #13173

Changes to `getPointResolution` can be avoided by ensuring that the Projection and Scale example does not use very large resolutions (1 degree) across which calculating an accurate point resolution would be affected by the curvature of the earth.  By using meters per unit all calculations can be done more accurately at a resolution of approximately 1 meter.  Differences in scale which appeared at the 6th digit are gone, only very small differences at the 8th digit can now be seen. 

https://deploy-preview-13496--ol-site.netlify.app/examples/projection-and-scale.html
