### PR TITLE
Updates for the 6.14.1 release

### DIFF
--- a/changelog/v6.14.1.md
+++ b/changelog/v6.14.1.md
@@ -1,0 +1,4 @@
+# 6.14.1
+
+The 6.14.1 release is a patch to correct a version discrepancy in the `package-lock.json` file.  See the [changelog for 6.14.0](https://github.com/openlayers/openlayers/releases/tag/v6.14.0) for new features and fixes since 6.13.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ol",
-  "version": "6.14.1",
+  "version": "6.14.2-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ol",
-      "version": "6.14.1",
+      "version": "6.14.2-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ol",
-  "version": "6.14.1-dev",
+  "version": "6.14.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ol",
-      "version": "6.14.1-dev",
+      "version": "6.14.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol",
-  "version": "6.14.1-dev",
+  "version": "6.14.1",
   "description": "OpenLayers mapping library",
   "keywords": [
     "map",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol",
-  "version": "6.14.1",
+  "version": "6.14.2-dev",
   "description": "OpenLayers mapping library",
   "keywords": [
     "map",


### PR DESCRIPTION
The 6.14.0 release didn't have the correct version number in the `package-lock.json` file.  This patch release corrects that.