### PR TITLE
Add featureType property to features

### DIFF
--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -98,6 +98,13 @@ class Feature extends BaseObject {
     this.un;
 
     /**
+     * Name of type of feature (e.g. GML Feature element name)
+     * @type {string|undefined}
+     * @api
+     */
+    this.featureType = undefined;
+
+    /**
      * @private
      * @type {number|string|undefined}
      */
@@ -156,6 +163,7 @@ class Feature extends BaseObject {
     const clone = /** @type {Feature<Geometry>} */ (
       new Feature(this.hasProperties() ? this.getProperties() : null)
     );
+    clone.featureType = this.featureType;
     clone.setGeometryName(this.getGeometryName());
     const geometry = this.getGeometry();
     if (geometry) {

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -354,6 +354,7 @@ class GMLBase extends XMLFeature {
       if (fid) {
         feature.setId(fid);
       }
+      feature.featureType = node.localName;
       return feature;
     }
   }

--- a/test/browser/spec/ol/format/gml.test.js
+++ b/test/browser/spec/ol/format/gml.test.js
@@ -43,6 +43,10 @@ describe('ol.format.GML2', function () {
     it('reads all features', function () {
       expect(features.length).to.be(3);
     });
+
+    it('reads the names of feature types', function () {
+      expect(features[0].featureType).to.be('water_areas');
+    });
   });
 
   describe('#readGeometry', function () {
@@ -1442,6 +1446,10 @@ describe('ol.format.GML3', function () {
       expect(features[0].getId()).to.equal('states.1');
     });
 
+    it('reads the names of feature types', function () {
+      expect(features[0].featureType).to.be('states');
+    });
+
     it('can reuse the parser for a different featureNS', function () {
       const text =
         '<gml:featureMembers xmlns:gml="http://www.opengis.net/gml">' +
@@ -1504,6 +1512,10 @@ describe('ol.format.GML3', function () {
 
     it('creates the right id for the feature', function () {
       expect(features[0].getId()).to.equal('states.1');
+    });
+
+    it('reads the names of feature types', function () {
+      expect(features[0].featureType).to.be('states');
     });
 
     it('writes back features as GML', function () {
@@ -1682,6 +1694,11 @@ describe('ol.format.GML3', function () {
     it('reads all features', function () {
       expect(features.length).to.be(12);
     });
+
+    it('reads the names of feature types', function () {
+      expect(features[0].featureType).to.be('planet_osm_line');
+      expect(features[11].featureType).to.be('planet_osm_polygon');
+    });
   });
 
   describe('when parsing multiple feature types', function () {
@@ -1727,6 +1744,11 @@ describe('ol.format.GML3', function () {
 
     it('reads all features', function () {
       expect(features.length).to.be(2);
+    });
+
+    it('reads the names of feature types', function () {
+      expect(features[0].featureType).to.be('states');
+      expect(features[1].featureType).to.be('roads');
     });
   });
 

--- a/test/node/ol/Feature.test.js
+++ b/test/node/ol/Feature.test.js
@@ -358,12 +358,21 @@ describe('ol/Feature.js', function () {
     });
   });
 
+  describe('featureType', function () {
+    it('is initially undefined', function () {
+      const feature = new Feature();
+
+      expect(feature.featureType).to.be(undefined);
+    });
+  });
+
   describe('#clone', function () {
     it('correctly clones features', function () {
       const feature = new Feature();
       feature.setProperties({'fookey': 'fooval'});
       feature.setId(1);
       feature.setGeometryName('geom');
+      feature.featureType = 'Foo';
       const geometry = new Point([1, 2]);
       feature.setGeometry(geometry);
       const style = new Style({});
@@ -374,6 +383,7 @@ describe('ol/Feature.js', function () {
       expect(clone.get('fookey')).to.be('fooval');
       expect(clone.getId()).to.be(undefined);
       expect(clone.getGeometryName()).to.be('geom');
+      expect(clone.featureType).to.be('Foo');
       const geometryClone = clone.getGeometry();
       expect(geometryClone).not.to.be(geometry);
       const coordinates = geometryClone.getFlatCoordinates();
@@ -383,13 +393,14 @@ describe('ol/Feature.js', function () {
       expect(clone.get('barkey')).to.be('barval');
     });
 
-    it('correctly clones features with no geometry and no style', function () {
+    it('correctly clones features with no geometry, no featureType and no style', function () {
       const feature = new Feature();
       feature.set('fookey', 'fooval');
 
       const clone = feature.clone();
       expect(clone.get('fookey')).to.be('fooval');
       expect(clone.getGeometry()).to.be(undefined);
+      expect(clone.featureType).to.be(undefined);
       expect(clone.getStyle()).to.be(null);
     });
   });


### PR DESCRIPTION
This PR implements (most of) the functionality described in #12937:
 - adds a non-observable feature type property to features (comparable to feature ID), with getters/setters `getFeatureType()`/`setFeatureType()`
 - when reading GML, the (local) element name will be parsed to this property

Not (yet?) implemented is the use of the defined individual feature type when writing features, which is somewhat more complicated.

Motivation for this change are service query results (e.g. [this GetFeatureInfo request](https://www.geodaten-mv.de/dienste/alkis_wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&FORMAT=image%2Fpng&TRANSPARENT=true&QUERY_LAYERS=adv_alkis_gesetzl_festlegungen%2Cadv_alkis_weiteres%2Cadv_alkis_gebaeude%2Cadv_alkis_flurstuecke&LAYERS=adv_alkis_gesetzl_festlegungen%2Cadv_alkis_weiteres%2Cadv_alkis_gebaeude%2Cadv_alkis_flurstuecke&INFO_FORMAT=text%2Fxml%3Bsubtype%3Dgml%2F3.2.1&I=50&J=50&CRS=EPSG%3A25833&STYLES=&WIDTH=101&HEIGHT=101&BBOX=293849.5404071358%2C6004185.0609577745%2C293918.4150123862%2C6004253.935563024)) containing multiple feature types where a differentiation (not just based on the contained properties) between them is required.