### PR TITLE
Update backgrounds when function returns a different color

### DIFF
--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -155,7 +155,8 @@ class CanvasLayerRenderer extends LayerRenderer {
       target.style.opacity === '' &&
       opacity === 1 &&
       (!opt_backgroundColor ||
-        (target.style.backgroundColor &&
+        (target &&
+          target.style.backgroundColor &&
           equals(
             asArray(target.style.backgroundColor),
             asArray(opt_backgroundColor)
@@ -184,9 +185,6 @@ class CanvasLayerRenderer extends LayerRenderer {
       style.position = 'absolute';
       style.width = '100%';
       style.height = '100%';
-      if (opt_backgroundColor) {
-        style.backgroundColor = opt_backgroundColor;
-      }
       context = createCanvasContext2D();
       const canvas = context.canvas;
       container.appendChild(canvas);
@@ -196,6 +194,13 @@ class CanvasLayerRenderer extends LayerRenderer {
       style.transformOrigin = 'top left';
       this.container = container;
       this.context = context;
+    }
+    if (
+      !this.containerReused &&
+      opt_backgroundColor &&
+      !this.container.style.backgroundColor
+    ) {
+      this.container.style.backgroundColor = opt_backgroundColor;
     }
   }
 

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -318,6 +318,24 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
         done();
       });
     });
+
+    it('changes background when function returns a different color', function (done) {
+      let first = true;
+      layer.setBackground(function (resolution) {
+        expect(resolution).to.be(map.getView().getResolution());
+        const background = first === true ? undefined : 'rgba(255, 0, 0, 0.5)';
+        first = false;
+        return background;
+      });
+      map.once('rendercomplete', function () {
+        expect(layer.getRenderer().container.style.backgroundColor).to.be('');
+        map.renderSync();
+        expect(layer.getRenderer().container.style.backgroundColor).to.be(
+          'rgba(255, 0, 0, 0.5)'
+        );
+        done();
+      });
+    });
   });
 
   describe('#prepareFrame', function () {


### PR DESCRIPTION
This pull request fixes a problem with background functions: when the map has only one layer and a background function returns different values on subsequent calls, the background of the container was not updated. This pull request fixes that.

The test case is a good explanation. Previously, the second assertion failed, because the background was still `''`.