### PR TITLE
Do not add second interaction in Pinch Zoom example

### DIFF
--- a/examples/pinch-zoom.js
+++ b/examples/pinch-zoom.js
@@ -2,13 +2,8 @@ import Map from '../src/ol/Map.js';
 import OSM from '../src/ol/source/OSM.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
-import {
-  PinchZoom,
-  defaults as defaultInteractions,
-} from '../src/ol/interaction.js';
 
 const map = new Map({
-  interactions: defaultInteractions().extend([new PinchZoom()]),
   layers: [
     new TileLayer({
       source: new OSM(),


### PR DESCRIPTION
Before version 6 the Pinch Zoom example replaced the default interaction with one specifying `constrainResolution`.  In version 6 the constraint is moved to the view, but the example has gained an unnecessary second default interaction https://github.com/openlayers/openlayers/pull/9137/files#diff-c42b5ce0fa11ec19b452214fbb1845c75c0934c8961225d186bb020b0a23c4ed
