### PR TITLE
Updates for ol-mapbox-style v8

### DIFF
--- a/examples/offscreen-canvas.worker.js
+++ b/examples/offscreen-canvas.worker.js
@@ -5,9 +5,9 @@ import TileQueue, {
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
 import stringify from 'json-stringify-safe';
-import styleFunction from 'ol-mapbox-style/dist/stylefunction.js';
 import {get} from '../src/ol/proj.js';
 import {inView} from '../src/ol/layer/Layer.js';
+import {stylefunction} from 'ol-mapbox-style';
 
 /** @type {any} */
 const worker = self;
@@ -95,7 +95,7 @@ function loadStyles() {
               };
               rendererTransform = transform;
             };
-            styleFunction(
+            stylefunction(
               layer,
               styleJson,
               bucket.layers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "serve-static": "^1.14.0",
         "shx": "^0.3.2",
         "sinon": "^13.0.0",
+        "source-map-loader": "^3.0.1",
         "threads": "^1.6.5",
         "typescript": "4.6.3",
         "walk": "^2.3.9",
@@ -2473,6 +2474,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "node_modules/abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -9066,6 +9073,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.1.tgz",
+      "integrity": "sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -12427,6 +12476,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "dev": true
+    },
+    "abab": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "accepts": {
@@ -17428,6 +17483,34 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
+    "source-map-loader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-3.0.1.tgz",
+      "integrity": "sha512-Vp1UsfyPvgujKQzi4pyDiTOnE3E4H+yHvkVRN3c/9PJmQS4CQJExvcDvaX/D+RV+xQben9HJ56jMJS3CgUeWyA==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.5",
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.1"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
     },
     "source-map-support": {
       "version": "0.5.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^2.0.2",
-        "ol-mapbox-style": "^7.1.1",
+        "ol-mapbox-style": "^8.0.4",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-style-spec": {
-      "version": "13.20.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.1.tgz",
-      "integrity": "sha512-xVCJ3IbKoPwcPrxxtGAxUqHEVxXi1hnJtLIFqgkuZfnzj0KeRbk3dZlDr/KNo1/doJjIoFgPFUO/HMOT+wXGPA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.24.0.tgz",
+      "integrity": "sha512-9yhRSqnKX+59MrG647x2pACfR2Ewk8Ii5X75Ag8oToEKZU+PSY0+r10EirIVCTDwuHPzp/VuuN3j6n+Hv/gGpQ==",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -1799,10 +1799,10 @@
         "sort-object": "^0.3.2"
       },
       "bin": {
-        "gl-style-composite": "bin/gl-style-composite",
-        "gl-style-format": "bin/gl-style-format",
-        "gl-style-migrate": "bin/gl-style-migrate",
-        "gl-style-validate": "bin/gl-style-validate"
+        "gl-style-composite": "bin/gl-style-composite.js",
+        "gl-style-format": "bin/gl-style-format.js",
+        "gl-style-migrate": "bin/gl-style-migrate.js",
+        "gl-style-validate": "bin/gl-style-validate.js"
       }
     },
     "node_modules/@mapbox/point-geometry": {
@@ -7451,11 +7451,11 @@
       "dev": true
     },
     "node_modules/ol-mapbox-style": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
-      "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.4.tgz",
+      "integrity": "sha512-Tvjy3reugxZ1CO+PzngdbCwBgEBfHJI7gBTk0RUhj6o01OZKbjr+9obqPav22TLhQB4f/8w+RPUF/M8+bnqtiQ==",
       "dependencies": {
-        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
         "webfont-matcher": "^1.1.0"
       }
@@ -11802,9 +11802,9 @@
       "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
     },
     "@mapbox/mapbox-gl-style-spec": {
-      "version": "13.20.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.20.1.tgz",
-      "integrity": "sha512-xVCJ3IbKoPwcPrxxtGAxUqHEVxXi1hnJtLIFqgkuZfnzj0KeRbk3dZlDr/KNo1/doJjIoFgPFUO/HMOT+wXGPA==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.24.0.tgz",
+      "integrity": "sha512-9yhRSqnKX+59MrG647x2pACfR2Ewk8Ii5X75Ag8oToEKZU+PSY0+r10EirIVCTDwuHPzp/VuuN3j6n+Hv/gGpQ==",
       "requires": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/point-geometry": "^0.1.0",
@@ -16194,11 +16194,11 @@
       "dev": true
     },
     "ol-mapbox-style": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-7.1.1.tgz",
-      "integrity": "sha512-GLTEYiH/Ec9Zn1eS4S/zXyR2sierVrUc+OLVP8Ra0FRyqRhoYbXdko0b7OIeSHWdtJfHssWYefDOGxfTRUUZ/A==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.4.tgz",
+      "integrity": "sha512-Tvjy3reugxZ1CO+PzngdbCwBgEBfHJI7gBTk0RUhj6o01OZKbjr+9obqPav22TLhQB4f/8w+RPUF/M8+bnqtiQ==",
       "requires": {
-        "@mapbox/mapbox-gl-style-spec": "^13.20.1",
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
         "webfont-matcher": "^1.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "geotiff": "^2.0.2",
-        "ol-mapbox-style": "^8.0.4",
+        "ol-mapbox-style": "^8.0.5",
         "pbf": "3.2.1",
         "rbush": "^3.0.1"
       },
@@ -7458,9 +7458,9 @@
       "dev": true
     },
     "node_modules/ol-mapbox-style": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.4.tgz",
-      "integrity": "sha512-Tvjy3reugxZ1CO+PzngdbCwBgEBfHJI7gBTk0RUhj6o01OZKbjr+9obqPav22TLhQB4f/8w+RPUF/M8+bnqtiQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.5.tgz",
+      "integrity": "sha512-krDZv3pBVuU52Hmk6b2oXS6z8TVTAteR6S5JmZNyNTVG+ghl8tVeNILr57BRn0ACiC0T5hF6ZPcK/Cn94XaMqg==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",
@@ -16249,9 +16249,9 @@
       "dev": true
     },
     "ol-mapbox-style": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.4.tgz",
-      "integrity": "sha512-Tvjy3reugxZ1CO+PzngdbCwBgEBfHJI7gBTk0RUhj6o01OZKbjr+9obqPav22TLhQB4f/8w+RPUF/M8+bnqtiQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-8.0.5.tgz",
+      "integrity": "sha512-krDZv3pBVuU52Hmk6b2oXS6z8TVTAteR6S5JmZNyNTVG+ghl8tVeNILr57BRn0ACiC0T5hF6ZPcK/Cn94XaMqg==",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
         "mapbox-to-css-font": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "geotiff": "^2.0.2",
-    "ol-mapbox-style": "^7.1.1",
+    "ol-mapbox-style": "^8.0.4",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "geotiff": "^2.0.2",
-    "ol-mapbox-style": "^8.0.4",
+    "ol-mapbox-style": "^8.0.5",
     "pbf": "3.2.1",
     "rbush": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "serve-static": "^1.14.0",
     "shx": "^0.3.2",
     "sinon": "^13.0.0",
+    "source-map-loader": "^3.0.1",
     "threads": "^1.6.5",
     "typescript": "4.6.3",
     "walk": "^2.3.9",

--- a/src/ol/layer/MapboxVector.js
+++ b/src/ol/layer/MapboxVector.js
@@ -7,110 +7,7 @@ import MVT from '../format/MVT.js';
 import SourceState from '../source/State.js';
 import VectorTileLayer from '../layer/VectorTile.js';
 import VectorTileSource from '../source/VectorTile.js';
-import {applyBackground, applyStyle, setupVectorSource} from 'ol-mapbox-style';
-
-const mapboxBaseUrl = 'https://api.mapbox.com';
-
-/**
- * Gets the path from a mapbox:// URL.
- * @param {string} url The Mapbox URL.
- * @return {string} The path.
- * @private
- */
-export function getMapboxPath(url) {
-  const startsWith = 'mapbox://';
-  if (url.indexOf(startsWith) !== 0) {
-    return '';
-  }
-  return url.slice(startsWith.length);
-}
-
-/**
- * Turns mapbox:// sprite URLs into resolvable URLs.
- * @param {string} url The sprite URL.
- * @param {string} token The access token.
- * @param {string} styleUrl The style URL.
- * @return {string} A resolvable URL.
- * @private
- */
-export function normalizeSpriteUrl(url, token, styleUrl) {
-  const mapboxPath = getMapboxPath(url);
-  if (!mapboxPath) {
-    return decodeURI(new URL(url, styleUrl).href);
-  }
-  const startsWith = 'sprites/';
-  if (mapboxPath.indexOf(startsWith) !== 0) {
-    throw new Error(`unexpected sprites url: ${url}`);
-  }
-  const sprite = mapboxPath.slice(startsWith.length);
-
-  return `${mapboxBaseUrl}/styles/v1/${sprite}/sprite?access_token=${token}`;
-}
-
-/**
- * Turns mapbox:// glyphs URLs into resolvable URLs.
- * @param {string} url The glyphs URL.
- * @param {string} token The access token.
- * @param {string} styleUrl The style URL.
- * @return {string} A resolvable URL.
- * @private
- */
-export function normalizeGlyphsUrl(url, token, styleUrl) {
-  const mapboxPath = getMapboxPath(url);
-  if (!mapboxPath) {
-    return decodeURI(new URL(url, styleUrl).href);
-  }
-  const startsWith = 'fonts/';
-  if (mapboxPath.indexOf(startsWith) !== 0) {
-    throw new Error(`unexpected fonts url: ${url}`);
-  }
-  const font = mapboxPath.slice(startsWith.length);
-
-  return `${mapboxBaseUrl}/fonts/v1/${font}/0-255.pbf?access_token=${token}`;
-}
-
-/**
- * Turns mapbox:// style URLs into resolvable URLs.
- * @param {string} url The style URL.
- * @param {string} token The access token.
- * @return {string} A resolvable URL.
- * @private
- */
-export function normalizeStyleUrl(url, token) {
-  const mapboxPath = getMapboxPath(url);
-  if (!mapboxPath) {
-    return decodeURI(new URL(url, location.href).href);
-  }
-  const startsWith = 'styles/';
-  if (mapboxPath.indexOf(startsWith) !== 0) {
-    throw new Error(`unexpected style url: ${url}`);
-  }
-  const style = mapboxPath.slice(startsWith.length);
-
-  return `${mapboxBaseUrl}/styles/v1/${style}?&access_token=${token}`;
-}
-
-/**
- * Turns mapbox:// source URLs into vector tile URL templates.
- * @param {string} url The source URL.
- * @param {string} token The access token.
- * @param {string} tokenParam The access token key.
- * @param {string} styleUrl The style URL.
- * @return {string} A vector tile template.
- * @private
- */
-export function normalizeSourceUrl(url, token, tokenParam, styleUrl) {
-  const urlObject = new URL(url, styleUrl);
-  const mapboxPath = getMapboxPath(url);
-  if (!mapboxPath) {
-    if (!token) {
-      return decodeURI(urlObject.href);
-    }
-    urlObject.searchParams.set(tokenParam, token);
-    return decodeURI(urlObject.href);
-  }
-  return `https://{a-d}.tiles.mapbox.com/v4/${mapboxPath}/{z}/{x}/{y}.vector.pbf?access_token=${token}`;
-}
+import {applyBackground, applyStyle} from 'ol-mapbox-style';
 
 /**
  * @classdesc
@@ -129,38 +26,6 @@ class ErrorEvent extends BaseEvent {
     this.error = error;
   }
 }
-
-/**
- * @typedef {Object} StyleObject
- * @property {Object<string, SourceObject>} sources The style sources.
- * @property {string} sprite The sprite URL.
- * @property {string} glyphs The glyphs URL.
- * @property {Array<LayerObject>} layers The style layers.
- */
-
-/**
- * @typedef {Object} SourceObject
- * @property {string} url The source URL.
- * @property {SourceType} type The source type.
- * @property {Array<string>} [tiles] TileJSON tiles.
- */
-
-/**
- * The Mapbox source type.
- * @enum {string}
- */
-const SourceType = {
-  VECTOR: 'vector',
-};
-
-/**
- * @typedef {Object} LayerObject
- * @property {string} id The layer id.
- * @property {string} type The layer type.
- * @property {string} source The source id.
- * @property {Object} layout The layout.
- * @property {Object} paint The paint.
- */
 
 /**
  * @typedef {Object} Options
@@ -306,211 +171,26 @@ class MapboxVectorLayer extends VectorTileLayer {
       properties: options.properties,
     });
 
-    this.setMaxResolutionFromTileGrid_ =
-      options.maxResolution === undefined && options.minZoom === undefined;
-
-    this.sourceId = options.source;
-    this.layers = options.layers;
-
     if (options.accessToken) {
       this.accessToken = options.accessToken;
-    } else {
-      const url = new URL(options.styleUrl, location.href);
-      // The last search parameter is the access token
-      url.searchParams.forEach((value, key) => {
-        this.accessToken = value;
-        this.accessTokenParam_ = key;
-      });
     }
-    this.fetchStyle(options.styleUrl);
-  }
-
-  /**
-   * Fetch the style object.
-   * @param {string} styleUrl The URL of the style to load.
-   * @protected
-   */
-  fetchStyle(styleUrl) {
-    const url = normalizeStyleUrl(styleUrl, this.accessToken);
-    fetch(url)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(
-            `unexpected response when fetching style: ${response.status}`
-          );
-        }
-        return response.json();
-      })
-      .then((style) => {
-        this.onStyleLoad(style, url.startsWith('data:') ? location.href : url);
+    const url = options.styleUrl;
+    applyStyle(this, url, options.layers || options.source, {
+      accessToken: this.accessToken,
+    })
+      .then(() => {
+        source.setState(SourceState.READY);
       })
       .catch((error) => {
-        this.handleError(error);
+        this.dispatchEvent(new ErrorEvent(error));
+        const source = this.getSource();
+        source.setState(SourceState.ERROR);
       });
-  }
-
-  /**
-   * Handle the loaded style object.
-   * @param {StyleObject} style The loaded style.
-   * @param {string} styleUrl The URL of the style.
-   * @protected
-   */
-  onStyleLoad(style, styleUrl) {
-    let sourceId;
-    let sourceIdOrLayersList;
-    if (this.layers) {
-      // confirm all layers share the same source
-      const lookup = {};
-      for (let i = 0; i < style.layers.length; ++i) {
-        const layer = style.layers[i];
-        if (layer.source) {
-          lookup[layer.id] = layer.source;
-        }
-      }
-      let firstSource;
-      for (let i = 0; i < this.layers.length; ++i) {
-        const candidate = lookup[this.layers[i]];
-        if (!candidate) {
-          this.handleError(
-            new Error(`could not find source for ${this.layers[i]}`)
-          );
-          return;
-        }
-        if (!firstSource) {
-          firstSource = candidate;
-        } else if (firstSource !== candidate) {
-          this.handleError(
-            new Error(
-              `layers can only use a single source, found ${firstSource} and ${candidate}`
-            )
-          );
-          return;
-        }
-      }
-      sourceId = firstSource;
-      sourceIdOrLayersList = this.layers;
-    } else {
-      sourceId = this.sourceId;
-      sourceIdOrLayersList = sourceId;
-    }
-
-    if (!sourceIdOrLayersList) {
-      // default to the first source in the style
-      sourceId = Object.keys(style.sources)[0];
-      sourceIdOrLayersList = sourceId;
-    }
-
-    if (style.sprite) {
-      style.sprite = normalizeSpriteUrl(
-        style.sprite,
-        this.accessToken,
-        styleUrl
-      );
-    }
-
-    if (style.glyphs) {
-      style.glyphs = normalizeGlyphsUrl(
-        style.glyphs,
-        this.accessToken,
-        styleUrl
-      );
-    }
-
-    const styleSource = style.sources[sourceId];
-    if (styleSource.type !== SourceType.VECTOR) {
-      this.handleError(
-        new Error(`only works for vector sources, found ${styleSource.type}`)
-      );
-      return;
-    }
-
-    const source = this.getSource();
-    if (styleSource.url && styleSource.url.indexOf('mapbox://') === 0) {
-      // Tile source url, handle it directly
-      source.setUrl(
-        normalizeSourceUrl(
-          styleSource.url,
-          this.accessToken,
-          this.accessTokenParam_,
-          styleUrl
-        )
-      );
-      applyStyle(this, style, sourceIdOrLayersList)
-        .then(() => {
-          this.configureSource(source, style);
-        })
-        .catch((error) => {
-          this.handleError(error);
-        });
-    } else {
-      // TileJSON url, let ol-mapbox-style handle it
-      if (styleSource.tiles) {
-        styleSource.tiles = styleSource.tiles.map((url) =>
-          normalizeSourceUrl(
-            url,
-            this.accessToken,
-            this.accessTokenParam_,
-            styleUrl
-          )
-        );
-      }
-      setupVectorSource(
-        styleSource,
-        styleSource.url
-          ? normalizeSourceUrl(
-              styleSource.url,
-              this.accessToken,
-              this.accessTokenParam_,
-              styleUrl
-            )
-          : undefined
-      ).then((source) => {
-        applyStyle(this, style, sourceIdOrLayersList)
-          .then(() => {
-            this.configureSource(source, style);
-          })
-          .catch((error) => {
-            this.configureSource(source, style);
-            this.handleError(error);
-          });
-      });
-    }
-  }
-
-  /**
-   * Applies configuration from the provided source to this layer's source,
-   * and reconfigures the loader to add a feature that renders the background,
-   * if the style is configured with a background.
-   * @param {import("../source/VectorTile.js").default} source The source to configure from.
-   * @param {StyleObject} style The style to configure the background from.
-   */
-  configureSource(source, style) {
-    const targetSource = this.getSource();
-    if (source !== targetSource) {
-      targetSource.setAttributions(source.getAttributions());
-      targetSource.setTileUrlFunction(source.getTileUrlFunction());
-      targetSource.setTileLoadFunction(source.getTileLoadFunction());
-      targetSource.tileGrid = source.tileGrid;
-    }
     if (this.getBackground() === undefined) {
-      applyBackground(this, style);
+      applyBackground(this, options.styleUrl, {
+        accessToken: this.accessToken,
+      });
     }
-    if (this.setMaxResolutionFromTileGrid_) {
-      const tileGrid = targetSource.getTileGrid();
-      this.setMaxResolution(tileGrid.getResolution(tileGrid.getMinZoom()));
-    }
-    targetSource.setState(SourceState.READY);
-  }
-
-  /**
-   * Handle configuration or loading error.
-   * @param {Error} error The error.
-   * @protected
-   */
-  handleError(error) {
-    this.dispatchEvent(new ErrorEvent(error));
-    const source = this.getSource();
-    source.setState(SourceState.ERROR);
   }
 }
 

--- a/test/browser/karma.config.cjs
+++ b/test/browser/karma.config.cjs
@@ -76,6 +76,11 @@ module.exports = function (karma) {
         rules: [
           {
             test: /\.js$/,
+            enforce: 'pre',
+            use: ['source-map-loader'],
+          },
+          {
+            test: /\.js$/,
             use: {
               loader: 'babel-loader',
               options: {

--- a/test/browser/spec/ol/layer/MapboxVector.test.js
+++ b/test/browser/spec/ol/layer/MapboxVector.test.js
@@ -1,6 +1,5 @@
 import MapboxVectorLayer from '../../../../../src/ol/layer/MapboxVector.js';
 import {asString} from '../../../../../src/ol/color.js';
-import {strokeInstruction} from '../../../../../src/ol/render/canvas/Instruction.js';
 import {unByKey} from '../../../../../src/ol/Observable.js';
 
 describe('ol/layer/MapboxVector', () => {


### PR DESCRIPTION
This pull request makes the necessary changes for the breaking changes in ol-mapbox-style v8, and updates the [vector-tiles-4326.js](https://github.com/openlayers/openlayers/compare/main...ahocevar:ol-mapbox-style-8?expand=1#diff-97d89635db79fdc975294642548a387103c0246be1b93eb029d54015361b379c) example to make use of the improved API.

`ol/layer/MapboxVector` can now be simplified. In part, this is achieved by moving the Mapbox url utilities to `ol-mapbox-style`. This also avoids some circular dependencies between `ol` and `ol-mapbox-style`. The tests related to these utilities are now also in `ol-mapbox-style`.