### PR TITLE
Do not assert null projection

### DIFF
--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -54,7 +54,7 @@ class Source extends BaseObject {
 
     /**
      * @protected
-     * @type {import("../proj/Projection.js").default}
+     * @type {import("../proj/Projection.js").default|null}
      */
     this.projection = getProjection(options.projection);
 
@@ -141,7 +141,7 @@ class Source extends BaseObject {
 
   /**
    * Get the projection of the source.
-   * @return {import("../proj/Projection.js").default} Projection.
+   * @return {import("../proj/Projection.js").default|null} Projection.
    * @api
    */
   getProjection() {

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -281,8 +281,9 @@ class TileSource extends Source {
    * @protected
    */
   getTileCacheForProjection(projection) {
+    const sourceProjection = this.getProjection();
     assert(
-      equivalent(this.getProjection(), projection),
+      sourceProjection === null || equivalent(sourceProjection, projection),
       68 // A VectorTile source can only be rendered if it has a projection compatible with the view projection.
     );
     return this.tileCache;


### PR DESCRIPTION
Fixes #13564

Source and view projections must be equivalent, but for GeoTIFF null is valid and equivalent to view projection.
