### PR TITLE
Update OSM Vector Tiles attribution

### DIFF
--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -62,7 +62,7 @@ const map = new Map({
       source: new VectorTileSource({
         attributions:
           '&copy; OpenStreetMap contributors, Who’s On First, ' +
-          'Natural Earth, and openstreetmapdata.com',
+          'Natural Earth, and osmdata.openstreetmap.de',
         format: new TopoJSON({
           layerName: 'layer',
           layers: ['water', 'roads', 'buildings'],


### PR DESCRIPTION
`openstreetmapdata.com` is merely a holding page.  `osmdata.openstreetmap.de` as mentioned in https://tilezen.readthedocs.io/en/latest/attribution/ is a valid site.
