### PR TITLE
Do not reload data tiles if already loaded or loading

### DIFF
--- a/src/ol/DataTile.js
+++ b/src/ol/DataTile.js
@@ -75,21 +75,26 @@ class DataTile extends Tile {
    * @api
    */
   load() {
-    this.state = TileState.LOADING;
-    this.changed();
+    if (this.state == TileState.ERROR) {
+      this.state = TileState.IDLE;
+    }
+    if (this.state == TileState.IDLE) {
+      this.state = TileState.LOADING;
+      this.changed();
 
-    const self = this;
-    this.loader_()
-      .then(function (data) {
-        self.data_ = data;
-        self.state = TileState.LOADED;
-        self.changed();
-      })
-      .catch(function (error) {
-        self.error_ = error;
-        self.state = TileState.ERROR;
-        self.changed();
-      });
+      const self = this;
+      this.loader_()
+        .then(function (data) {
+          self.data_ = data;
+          self.state = TileState.LOADED;
+          self.changed();
+        })
+        .catch(function (error) {
+          self.error_ = error;
+          self.state = TileState.ERROR;
+          self.changed();
+        });
+    }
   }
 }
 

--- a/src/ol/DataTile.js
+++ b/src/ol/DataTile.js
@@ -75,26 +75,24 @@ class DataTile extends Tile {
    * @api
    */
   load() {
-    if (this.state == TileState.ERROR) {
-      this.state = TileState.IDLE;
+    if (this.state !== TileState.IDLE && this.state !== TileState.ERROR) {
+      return;
     }
-    if (this.state == TileState.IDLE) {
-      this.state = TileState.LOADING;
-      this.changed();
+    this.state = TileState.LOADING;
+    this.changed();
 
-      const self = this;
-      this.loader_()
-        .then(function (data) {
-          self.data_ = data;
-          self.state = TileState.LOADED;
-          self.changed();
-        })
-        .catch(function (error) {
-          self.error_ = error;
-          self.state = TileState.ERROR;
-          self.changed();
-        });
-    }
+    const self = this;
+    this.loader_()
+      .then(function (data) {
+        self.data_ = data;
+        self.state = TileState.LOADED;
+        self.changed();
+      })
+      .catch(function (error) {
+        self.error_ = error;
+        self.state = TileState.ERROR;
+        self.changed();
+      });
   }
 }
 

--- a/test/browser/spec/ol/DataTile.test.js
+++ b/test/browser/spec/ol/DataTile.test.js
@@ -1,7 +1,8 @@
 import DataTile from '../../../../src/ol/DataTile.js';
 import TileState from '../../../../src/ol/TileState.js';
+import {listenOnce} from '../../../../src/ol/events.js';
 
-describe('ol.DataTile', function () {
+describe('ol/DataTile', function () {
   /** @type {Promise<import('../../../../src/ol/DataTile.js').Data} */
   let loader;
   beforeEach(function () {
@@ -42,10 +43,26 @@ describe('ol.DataTile', function () {
       expect(tile.getState()).to.be(TileState.IDLE);
       tile.load();
       expect(tile.getState()).to.be(TileState.LOADING);
-      setTimeout(() => {
+      listenOnce(tile, 'change', () => {
         expect(tile.getState()).to.be(TileState.LOADED);
         done();
-      }, 16);
+      });
+    });
+
+    it('reloads tiles in an error state', function (done) {
+      const tileCoord = [0, 0, 0];
+      const tile = new DataTile({
+        tileCoord: tileCoord,
+        loader: loader,
+      });
+      tile.state = TileState.ERROR;
+
+      tile.load();
+      expect(tile.getState()).to.be(TileState.LOADING);
+      listenOnce(tile, 'change', () => {
+        expect(tile.getState()).to.be(TileState.LOADED);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
The API states "Load not yet loaded URI." but the `load()` method for data tiles does reload already loaded or loading tiles unless the application uses the non-API `getState()` method to prevent it.  Code which works for Image tiles results in continuously loading data tiles hanging the application.
