### PR TITLE
Fix dynamic import paths for legacy build

### DIFF
--- a/config/webpack-config-legacy-build.mjs
+++ b/config/webpack-config-legacy-build.mjs
@@ -48,7 +48,7 @@ export default {
   },
   output: {
     path: path.resolve('./build/legacy'),
-    publicPath: 'auto',
+    publicPath: '',
     filename: 'ol.js',
     library: 'ol',
     libraryTarget: 'umd',


### PR DESCRIPTION
I know I went a bit back and forth on this, but the correct configuration was introduced with #12870, and #13469 broke it again. The real fix for  #13468, which #13606 is a duplicate of, is https://github.com/openlayers/openlayers.github.io/pull/125.