### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,5 +10,3 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary


### PR DESCRIPTION
It looks like the change in #13611 included configuration outside of the allowed schema for the `package-ecosystem: github-actions`.  I haven't found that schema, so I'm removing all properties not mentioned specifically [in the docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

See https://github.com/openlayers/openlayers/runs/6203836160 for detail.
