### PR TITLE
Wait for icons to be loaded before firing rendercomplete event

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -196,7 +196,11 @@ class LayerRenderer extends Observable {
    */
   renderIfReadyAndVisible() {
     const layer = this.getLayer();
-    if (layer.getVisible() && layer.getSourceState() == SourceState.READY) {
+    if (
+      layer &&
+      layer.getVisible() &&
+      layer.getSourceState() == SourceState.READY
+    ) {
       layer.changed();
     }
   }

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -63,12 +63,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     this.animatingOrInteracting_;
 
     /**
-     * @private
-     * @type {boolean}
-     */
-    this.dirty_ = false;
-
-    /**
      * @type {ImageData}
      */
     this.hitDetectionImageData_ = null;
@@ -523,7 +517,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const updateWhileInteracting = vectorLayer.getUpdateWhileInteracting();
 
     if (
-      (!this.dirty_ && !updateWhileAnimating && animating) ||
+      (this.ready && !updateWhileAnimating && animating) ||
       (!updateWhileInteracting && interacting)
     ) {
       this.animatingOrInteracting_ = true;
@@ -594,7 +588,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     }
 
     if (
-      !this.dirty_ &&
+      this.ready &&
       this.renderedResolution_ == resolution &&
       this.renderedRevision_ == vectorLayerRevision &&
       this.renderedRenderOrder_ == vectorLayerRenderOrder &&
@@ -610,8 +604,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     }
 
     this.replayGroup_ = null;
-
-    this.dirty_ = false;
 
     const replayGroup = new CanvasBuilderGroup(
       getRenderTolerance(resolution, pixelRatio),
@@ -650,7 +642,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     }
 
     const squaredTolerance = getSquaredRenderTolerance(resolution, pixelRatio);
-
+    let ready = true;
     const render =
       /**
        * @param {import("../../Feature.js").default} feature Feature.
@@ -672,7 +664,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
             userTransform,
             declutterBuilderGroup
           );
-          this.dirty_ = this.dirty_ || dirty;
+          ready = ready && !dirty;
         }
       }.bind(this);
 
@@ -686,6 +678,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       render(features[i]);
     }
     this.renderedFeatures_ = features;
+    this.ready = ready;
 
     const replayGroupInstructions = replayGroup.finish();
     const executorGroup = new ExecutorGroup(

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -87,12 +87,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
 
     /**
      * @private
-     * @type {boolean}
-     */
-    this.dirty_ = false;
-
-    /**
-     * @private
      * @type {number}
      */
     this.renderedLayerRevision_;
@@ -289,7 +283,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
             builderGroup,
             declutterBuilderGroup
           );
-          this.dirty_ = this.dirty_ || dirty;
           builderState.dirty = builderState.dirty || dirty;
         }
       };
@@ -339,6 +332,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     builderState.renderedRevision = revision;
     builderState.renderedRenderOrder = renderOrder;
     builderState.renderedResolution = resolution;
+    this.ready = !builderState.dirty;
   }
 
   /**

--- a/src/ol/renderer/vector.js
+++ b/src/ol/renderer/vector.js
@@ -124,14 +124,13 @@ export function renderFeature(
   let loading = false;
   const imageStyle = style.getImage();
   if (imageStyle) {
-    let imageState = imageStyle.getImageState();
+    const imageState = imageStyle.getImageState();
     if (imageState == ImageState.LOADED || imageState == ImageState.ERROR) {
       imageStyle.unlistenImageChange(listener);
     } else {
       if (imageState == ImageState.IDLE) {
         imageStyle.load();
       }
-      imageState = imageStyle.getImageState();
       imageStyle.listenImageChange(listener);
       loading = true;
     }

--- a/test/browser/spec/ol/layer/vectortile.test.js
+++ b/test/browser/spec/ol/layer/vectortile.test.js
@@ -1,9 +1,17 @@
+import Feature from '../../../../../src/ol/Feature.js';
 import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
+import ImageState from '../../../../../src/ol/ImageState.js';
 import Map from '../../../../../src/ol/Map.js';
 import VectorTileLayer from '../../../../../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../../../../../src/ol/source/VectorTile.js';
 import View from '../../../../../src/ol/View.js';
-import {fromLonLat} from '../../../../../src/ol/proj.js';
+import {Icon, Style} from '../../../../../src/ol/style.js';
+import {Point} from '../../../../../src/ol/geom.js';
+import {create as createTransform} from '../../../../../src/ol/transform.js';
+import {createXYZ} from '../../../../../src/ol/tilegrid.js';
+import {fromLonLat, get as getProjection} from '../../../../../src/ol/proj.js';
+import {getUid} from '../../../../../src/ol/util.js';
+import {isEmpty} from '../../../../../src/ol/obj.js';
 
 describe('ol.layer.VectorTile', function () {
   describe('constructor (defaults)', function () {
@@ -148,6 +156,96 @@ describe('ol.layer.VectorTile', function () {
           })
           .catch(done);
       });
+    });
+  });
+
+  describe('#renderFrame', function () {
+    /** @type {VectorTileLayer} */ let layer;
+
+    afterEach(function () {
+      layer.dispose();
+    });
+
+    it('sets ready property to false when icons are loading', function (done) {
+      const zoom = 1;
+      const tileSize = 32;
+      const projection = getProjection('EPSG:3857');
+      const tileGrid = createXYZ({tileSize: tileSize});
+      const resolution = tileGrid.getResolution(zoom);
+      layer = new VectorTileLayer({
+        renderBuffer: 0,
+        source: new VectorTileSource({
+          tileSize: tileSize,
+          tileUrlFunction: (tileCoord) => tileCoord.join('/'),
+          tileLoadFunction: function (tile, url) {
+            const coordinate = tileGrid.getTileCoordCenter(tile.getTileCoord());
+            tile.setFeatures([new Feature(new Point(coordinate))]);
+          },
+        }),
+        style: new Style({
+          image: new Icon({
+            src:
+              'data:image/svg+xml;base64,' +
+              window.btoa(`<svg width="10" height="10" viewBox="0 0 1 1" xmlns="http://www.w3.org/2000/svg">
+              <rect x="0" y="0" width="1" height="1"/>
+              </svg>`),
+          }),
+        }),
+      });
+      const renderer = layer.getRenderer();
+      const frameState =
+        /** @type {import("../../../../../src/ol/PluggableMap.js").FrameState} */ ({
+          pixelRatio: 1,
+          viewState: {
+            zoom: zoom,
+            resolution: resolution,
+            center: [0, 0],
+            rotation: 0,
+            projection: projection,
+          },
+          size: [2 * tileSize, 2 * tileSize],
+          extent: [-tileSize, -tileSize, tileSize, tileSize].map(
+            (n) => n * resolution
+          ),
+          viewHints: [0, 0],
+          layerStatesArray: layer.getLayerStatesArray(),
+          layerIndex: 0,
+          wantedTiles: {},
+          usedTiles: {},
+          tileQueue: {isKeyQueued: () => true},
+          pixelToCoordinateTransform: createTransform(),
+        });
+
+      renderer.renderFrame(frameState);
+      // Tiles not yet loaded, no icon queued
+      expect(renderer.ready).to.be(true);
+      const source = layer.getSource();
+      const wantedTiles = frameState.wantedTiles[getUid(source)];
+      expect(isEmpty(wantedTiles)).to.be(false);
+
+      // Tiles are loaded synchronously
+      source.tileCache.forEach((tile) => tile.load());
+
+      renderer.renderFrame(frameState);
+      // Tiles loaded, waiting for icon
+      expect(renderer.ready).to.be(false);
+
+      layer
+        .getStyle()
+        .getImage()
+        .listenImageChange(function (evt) {
+          if (evt.target.getImageState() !== ImageState.LOADED) {
+            return;
+          }
+          try {
+            renderer.renderFrame(frameState);
+            // Tiles and icon loaded
+            expect(renderer.ready).to.be(true);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
     });
   });
 });


### PR DESCRIPTION
The rendercomplete event should wait for icons to load before it is being fired.
As there is already similar behavior for the webgl renderers with the `ready` property, this uses the same property.

This also fixes an error when an icon is loaded after the renderer has been disposed.