### PR TITLE
Support non-uniform tile pixel ratios

### DIFF
--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -318,7 +318,6 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     const tileLayer = this.getLayer();
     const tileSource = tileLayer.getRenderSource();
     const tileGrid = tileSource.getTileGridForProjection(viewState.projection);
-    const tilePixelRatio = tileSource.getTilePixelRatio(frameState.pixelRatio);
     const gutter = tileSource.getGutterForProjection(viewState.projection);
 
     const tileSourceKey = getUid(tileSource);
@@ -341,6 +340,10 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
         this.tempTileRange_
       );
 
+      const tilePixelRatio = tileSource.getTilePixelRatio(
+        frameState.pixelRatio,
+        z
+      );
       const tileResolution = tileGrid.getResolution(z);
 
       for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -189,7 +189,7 @@ export function calculateSourceExtentResolution(
  *
  * @param {number} width Width of the canvas.
  * @param {number} height Height of the canvas.
- * @param {number} pixelRatio Pixel ratio.
+ * @param {Array<number>} pixelRatio Pixel ratio.
  * @param {number} sourceResolution Source resolution.
  * @param {import("./extent.js").Extent} sourceExtent Extent of the data source.
  * @param {number} targetResolution Target resolution.
@@ -216,8 +216,8 @@ export function render(
   opt_interpolate
 ) {
   const context = createCanvasContext2D(
-    Math.round(pixelRatio * width),
-    Math.round(pixelRatio * height)
+    Math.round(pixelRatio[0] * width),
+    Math.round(pixelRatio[1] * height)
   );
 
   if (!opt_interpolate) {
@@ -228,10 +228,14 @@ export function render(
     return context.canvas;
   }
 
-  context.scale(pixelRatio, pixelRatio);
+  context.scale(pixelRatio[0], pixelRatio[1]);
 
-  function pixelRound(value) {
-    return Math.round(value * pixelRatio) / pixelRatio;
+  function pixelRoundX(value) {
+    return Math.round(value * pixelRatio[0]) / pixelRatio[0];
+  }
+
+  function pixelRoundY(value) {
+    return Math.round(value * pixelRatio[1]) / pixelRatio[1];
   }
 
   context.globalCompositeOperation = 'lighter';
@@ -244,15 +248,16 @@ export function render(
   const canvasWidthInUnits = getWidth(sourceDataExtent);
   const canvasHeightInUnits = getHeight(sourceDataExtent);
   const stitchContext = createCanvasContext2D(
-    Math.round((pixelRatio * canvasWidthInUnits) / sourceResolution),
-    Math.round((pixelRatio * canvasHeightInUnits) / sourceResolution)
+    Math.round((pixelRatio[0] * canvasWidthInUnits) / sourceResolution),
+    Math.round((pixelRatio[1] * canvasHeightInUnits) / sourceResolution)
   );
 
   if (!opt_interpolate) {
     assign(stitchContext, IMAGE_SMOOTHING_DISABLED);
   }
 
-  const stitchScale = pixelRatio / sourceResolution;
+  const stitchScaleX = pixelRatio[0] / sourceResolution;
+  const stitchScaleY = pixelRatio[1] / sourceResolution;
 
   sources.forEach(function (src, i, arr) {
     const xPos = src.extent[0] - sourceDataExtent[0];
@@ -268,10 +273,10 @@ export function render(
         gutter,
         src.image.width - 2 * gutter,
         src.image.height - 2 * gutter,
-        xPos * stitchScale,
-        yPos * stitchScale,
-        srcWidth * stitchScale,
-        srcHeight * stitchScale
+        xPos * stitchScaleX,
+        yPos * stitchScaleY,
+        srcWidth * stitchScaleX,
+        srcHeight * stitchScaleY
       );
     }
   });
@@ -308,16 +313,22 @@ export function render(
     let x2 = source[2][0],
       y2 = source[2][1];
     // Make sure that everything is on pixel boundaries
-    const u0 = pixelRound((target[0][0] - targetTopLeft[0]) / targetResolution);
-    const v0 = pixelRound(
+    const u0 = pixelRoundX(
+      (target[0][0] - targetTopLeft[0]) / targetResolution
+    );
+    const v0 = pixelRoundY(
       -(target[0][1] - targetTopLeft[1]) / targetResolution
     );
-    const u1 = pixelRound((target[1][0] - targetTopLeft[0]) / targetResolution);
-    const v1 = pixelRound(
+    const u1 = pixelRoundX(
+      (target[1][0] - targetTopLeft[0]) / targetResolution
+    );
+    const v1 = pixelRoundY(
       -(target[1][1] - targetTopLeft[1]) / targetResolution
     );
-    const u2 = pixelRound((target[2][0] - targetTopLeft[0]) / targetResolution);
-    const v2 = pixelRound(
+    const u2 = pixelRoundX(
+      (target[2][0] - targetTopLeft[0]) / targetResolution
+    );
+    const v2 = pixelRoundY(
       -(target[2][1] - targetTopLeft[1]) / targetResolution
     );
 
@@ -357,14 +368,14 @@ export function render(
       for (let step = 0; step < steps; step++) {
         // Go horizontally
         context.lineTo(
-          u1 + pixelRound(((step + 1) * ud) / steps),
-          v1 + pixelRound((step * vd) / (steps - 1))
+          u1 + pixelRoundX(((step + 1) * ud) / steps),
+          v1 + pixelRoundY((step * vd) / (steps - 1))
         );
         // Go vertically
         if (step != steps - 1) {
           context.lineTo(
-            u1 + pixelRound(((step + 1) * ud) / steps),
-            v1 + pixelRound(((step + 1) * vd) / (steps - 1))
+            u1 + pixelRoundX(((step + 1) * ud) / steps),
+            v1 + pixelRoundY(((step + 1) * vd) / (steps - 1))
           );
         }
       }
@@ -393,8 +404,8 @@ export function render(
     );
 
     context.scale(
-      sourceResolution / pixelRatio,
-      -sourceResolution / pixelRatio
+      sourceResolution / pixelRatio[0],
+      -sourceResolution / pixelRatio[1]
     );
 
     context.drawImage(stitchContext.canvas, 0, 0);

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -16,7 +16,7 @@ import {getArea, getIntersection} from '../extent.js';
 import {listen, unlistenByKey} from '../events.js';
 
 /**
- * @typedef {function(number, number, number, number) : import("../Tile.js").default} FunctionType
+ * @typedef {function(number, number, number, Array<number>) : import("../Tile.js").default} FunctionType
  */
 
 /**
@@ -33,7 +33,7 @@ class ReprojTile extends Tile {
    * @param {import("../tilegrid/TileGrid.js").default} targetTileGrid Target tile grid.
    * @param {import("../tilecoord.js").TileCoord} tileCoord Coordinate of the tile.
    * @param {import("../tilecoord.js").TileCoord} wrappedTileCoord Coordinate of the tile wrapped in X.
-   * @param {number} pixelRatio Pixel ratio.
+   * @param {Array<number>} pixelRatio Pixel ratio.
    * @param {number} gutter Gutter of the source tiles.
    * @param {FunctionType} getTileFunction
    *     Function returning source tiles (z, x, y, pixelRatio).
@@ -65,7 +65,7 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {number}
+     * @type {Array<number>}
      */
     this.pixelRatio_ = pixelRatio;
 

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -36,7 +36,7 @@ export function hasArea(size) {
 /**
  * Returns a size scaled by a ratio. The result will be an array of integers.
  * @param {Size} size Size.
- * @param {number} ratio Ratio.
+ * @param {Array<number>} ratio The x and y scale.
  * @param {Size} [opt_size] Optional reusable size array.
  * @return {Size} The scaled size.
  */
@@ -44,8 +44,8 @@ export function scale(size, ratio, opt_size) {
   if (opt_size === undefined) {
     opt_size = [0, 0];
   }
-  opt_size[0] = (size[0] * ratio + 0.5) | 0;
-  opt_size[1] = (size[1] * ratio + 0.5) | 0;
+  opt_size[0] = (size[0] * ratio[0] + 0.5) | 0;
+  opt_size[1] = (size[1] * ratio[1] + 0.5) | 0;
   return opt_size;
 }
 

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -35,7 +35,9 @@ import {toPromise} from '../functions.js';
  * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
  * @property {boolean} [opaque=false] Whether the layer is opaque.
  * @property {import("./State.js").default} [state] The source state.
- * @property {number} [tilePixelRatio] Tile pixel ratio.
+ * @property {number|Array<Array<number>>} [tilePixelRatio] The ratio of source pixels to rendered pixels.
+ * If the source pixel resolutions differ in the x and y direction or if pixel ratios differ per zoom level,
+ * an array of [sx, sy] elements (one two element array per zoom level) can be provided.
  * @property {boolean} [wrapX=false] Render tiles beyond the antimeridian.
  * @property {number} [transition] Transition time when fading in new tiles (in miliseconds).
  * @property {number} [bandCount=4] Number of bands represented in the data.

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -10,6 +10,8 @@ import {modulo} from '../math.js';
 import {scale as scaleSize, toSize} from '../size.js';
 import {hash as tileCoordHash} from '../tilecoord.js';
 
+const defaultTilePixelRatio = [1, 1];
+
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
@@ -196,10 +198,11 @@ class TileArcGISRest extends TileImage {
   /**
    * Get the tile pixel ratio for this source.
    * @param {number} pixelRatio Pixel ratio.
-   * @return {number} Tile pixel ratio.
+   * @param {number} z The zoom level (for the tile grid being used for rendering).
+   * @return {Array<number>} Tile pixel ratio in the x and y direction.
    */
-  getTilePixelRatio(pixelRatio) {
-    return this.hidpi_ ? pixelRatio : 1;
+  getTilePixelRatio(pixelRatio, z) {
+    return this.hidpi_ ? [pixelRatio, pixelRatio] : defaultTilePixelRatio;
   }
 
   /**
@@ -237,7 +240,7 @@ class TileArcGISRest extends TileImage {
     let tileSize = toSize(tileGrid.getTileSize(tileCoord[0]), this.tmpSize);
 
     if (pixelRatio != 1) {
-      tileSize = scaleSize(tileSize, pixelRatio, this.tmpSize);
+      tileSize = scaleSize(tileSize, [pixelRatio, pixelRatio], this.tmpSize);
     }
 
     // Apply default params and override with user specified values.

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -353,7 +353,7 @@ class TileImage extends UrlTile {
           targetTileGrid,
           tileCoord,
           wrappedTileCoord,
-          this.getTilePixelRatio(pixelRatio),
+          this.getTilePixelRatio(pixelRatio, z),
           this.getGutter(),
           function (z, x, y, pixelRatio) {
             return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -17,6 +17,8 @@ import {get as getProjection, transform, transformExtent} from '../proj.js';
 import {modulo} from '../math.js';
 import {hash as tileCoordHash} from '../tilecoord.js';
 
+const defaultTilePixelRatio = [1, 1];
+
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
@@ -387,10 +389,13 @@ class TileWMS extends TileImage {
   /**
    * Get the tile pixel ratio for this source.
    * @param {number} pixelRatio Pixel ratio.
-   * @return {number} Tile pixel ratio.
+   * @param {number} z The zoom level (for the tile grid being used for rendering).
+   * @return {Array<number>} Tile pixel ratio in the x and y direction.
    */
-  getTilePixelRatio(pixelRatio) {
-    return !this.hidpi_ || this.serverType_ === undefined ? 1 : pixelRatio;
+  getTilePixelRatio(pixelRatio, z) {
+    return !this.hidpi_ || this.serverType_ === undefined
+      ? defaultTilePixelRatio
+      : [pixelRatio, pixelRatio];
   }
 
   /**
@@ -457,7 +462,7 @@ class TileWMS extends TileImage {
     }
 
     if (pixelRatio != 1) {
-      tileSize = scaleSize(tileSize, pixelRatio, this.tmpSize);
+      tileSize = scaleSize(tileSize, [pixelRatio, pixelRatio], this.tmpSize);
     }
 
     const baseParams = {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -442,10 +442,11 @@ class VectorTile extends UrlTile {
   /**
    * Get the tile pixel ratio for this source.
    * @param {number} pixelRatio Pixel ratio.
-   * @return {number} Tile pixel ratio.
+   * @param {number} z The zoom level (for the tile grid being used for rendering).
+   * @return {Array<number>} Tile pixel ratio in the x and y direction.
    */
-  getTilePixelRatio(pixelRatio) {
-    return pixelRatio;
+  getTilePixelRatio(pixelRatio, z) {
+    return [pixelRatio, pixelRatio];
   }
 
   /**

--- a/src/ol/webgl/TileTexture.js
+++ b/src/ol/webgl/TileTexture.js
@@ -138,7 +138,7 @@ function createPixelContext() {
  * @property {TileType} tile The tile.
  * @property {import("../tilegrid/TileGrid.js").default} grid Tile grid.
  * @property {import("../webgl/Helper.js").default} helper WebGL helper.
- * @property {number} [tilePixelRatio=1] Tile pixel ratio.
+ * @property {Array<number>} [tilePixelRatio] Tile pixel ratio in the x and y direction.
  * @property {number} [gutter=0] The size in pixels of the gutter around image tiles to ignore.
  */
 
@@ -166,10 +166,10 @@ class TileTexture extends EventTarget {
     this.size = toSize(options.grid.getTileSize(options.tile.tileCoord[0]));
 
     /**
-     * @type {number}
+     * @type {Array<number>}
      * @private
      */
-    this.tilePixelRatio_ = options.tilePixelRatio || 1;
+    this.tilePixelRatio_ = options.tilePixelRatio || [1, 1];
 
     /**
      * @type {number}
@@ -248,8 +248,8 @@ class TileTexture extends EventTarget {
     }
 
     const pixelSize = [
-      (this.size[0] + 2 * this.gutter_) * this.tilePixelRatio_,
-      (this.size[1] + 2 * this.gutter_) * this.tilePixelRatio_,
+      this.size[0] * this.tilePixelRatio_[0] + 2 * this.gutter_,
+      this.size[1] * this.tilePixelRatio_[1] + 2 * this.gutter_,
     ];
     const data = tile.getData();
     const isFloat = data instanceof Float32Array;
@@ -348,17 +348,16 @@ class TileTexture extends EventTarget {
       return null;
     }
 
-    const gutter = Math.round(this.tilePixelRatio_ * this.gutter_);
-    col = Math.floor(this.tilePixelRatio_ * col) + gutter;
-    row = Math.floor(this.tilePixelRatio_ * row) + gutter;
+    col = Math.floor(this.tilePixelRatio_[0] * col) + this.gutter_;
+    row = Math.floor(this.tilePixelRatio_[1] * row) + this.gutter_;
 
     if (this.tile instanceof DataTile) {
       const data = this.tile.getData();
       let size = this.size;
-      if (gutter > 0) {
+      if (this.gutter_ > 0) {
         size = [size[0] + 2 * this.gutter_, size[1] + 2 * this.gutter_];
       }
-      const pixelsPerRow = Math.floor(this.tilePixelRatio_ * size[0]);
+      const pixelsPerRow = Math.floor(this.tilePixelRatio_[0] * size[0]);
       if (data instanceof DataView) {
         const bytesPerPixel = data.byteLength / (size[0] * size[1]);
         const offset = row * pixelsPerRow * bytesPerPixel + col * bytesPerPixel;

--- a/test/browser/spec/ol/size.test.js
+++ b/test/browser/spec/ol/size.test.js
@@ -36,15 +36,21 @@ describe('ol.size', function () {
   describe('scale()', function () {
     it('scales a size and rounds the result', function () {
       const size = [50, 75];
-      const scaledSize = scaleSize(size, 1.75);
+      const scaledSize = scaleSize(size, [1.75, 1.75]);
       expect(scaledSize).to.eql([88, 131]);
     });
 
     it('reuses an existing array', function () {
       const reuse = [0, 0];
       const size = [50, 50];
-      const scaledSize = scaleSize(size, 1.75, reuse);
+      const scaledSize = scaleSize(size, [1.75, 1.75], reuse);
       expect(scaledSize).to.equal(reuse);
+    });
+
+    it('allows non-uniform scaling', function () {
+      const size = [50, 50];
+      const scaledSize = scaleSize(size, [2, 3]);
+      expect(scaledSize).to.equal([100, 150]);
     });
   });
 

--- a/test/browser/spec/ol/source/Tile.test.js
+++ b/test/browser/spec/ol/source/Tile.test.js
@@ -98,6 +98,52 @@ describe('ol/source/Tile', function () {
     });
   });
 
+  describe('getTilePixelRatio()', function () {
+    it('works with scalar in the constructor', function () {
+      const source = new TileSource({
+        tilePixelRatio: 2,
+      });
+      expect(source.getTilePixelRatio(-1, -1)).to.eql([2, 2]);
+    });
+
+    it('works with array of arrays in the constructor', function () {
+      const ratios = [
+        [1, 2],
+        [1, 3],
+        [1, 4],
+      ];
+      const source = new TileSource({
+        tilePixelRatio: ratios,
+      });
+      expect(source.getTilePixelRatio(-1, 1)).to.eql([1, 3]);
+    });
+
+    it('works with scalar updated after construction', function () {
+      const source = new TileSource({
+        tilePixelRatio: [
+          [1, 2],
+          [1, 3],
+          [1, 4],
+        ],
+      });
+      source.setTilePixelRatio(2);
+      expect(source.getTilePixelRatio(-1, 2)).to.eql([2, 2]);
+    });
+
+    it('works with an array of arrays updated after construction', function () {
+      const ratios = [
+        [1, 2],
+        [1, 3],
+        [1, 4],
+      ];
+      const source = new TileSource({
+        tilePixelRatio: 2,
+      });
+      source.setTilePixelRatio(ratios);
+      expect(source.getTilePixelRatio(-1, 2)).to.eql([1, 4]);
+    });
+  });
+
   describe('#setKey()', function () {
     it('sets the source key', function () {
       const source = new TileSource({});


### PR DESCRIPTION
This is an alternative to #13593 for supporting non-uniform pixel resolutions.

In #13593, the tile grid is updated to know about non-uniform resolutions.  In this branch, the source and tile textures are updated to support non-uniform pixel ratios, modifying the tile sizes returned by the tile grid.