### PR TITLE
Output GeoTIFF tile load errors to console

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -770,6 +770,11 @@ class GeoTIFFSource extends DataTile {
       }
 
       return data;
+    })
+    .catch(function (error) {
+      // output then rethrow
+      console.error(error); // eslint-disable-line no-console
+      throw error;
     });
   }
 }


### PR DESCRIPTION
#13639 highlighted that while GeoTIFF source load errors are output for debugging tile load errors are handled silently by the parent class.  This catches and outputs the error before rethrowing for handling by the parent.
