### PR TITLE
Add  null return type

### DIFF
--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -287,7 +287,7 @@ class ExecutorGroup {
 
   /**
    * @param {import("../../transform.js").Transform} transform Transform.
-   * @return {Array<number>} Clip coordinates.
+   * @return {Array<number>|null} Clip coordinates.
    */
   getClipCoords(transform) {
     const maxExtent = this.maxExtent_;


### PR DESCRIPTION
Follow up on #13672: add `null` as return type for `getClipCoords()`, in preparation for the `strictNullChecks: true` TypeScript configuration.