### PR TITLE
Flip extent coordinates for projections with ne* axis order

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -461,7 +461,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   }
 
   let wrapX = false;
-  const switchOriginXY = projection.getAxisOrientation().substr(0, 2) == 'ne';
+  const switchXY = projection.getAxisOrientation().substr(0, 2) == 'ne';
 
   let matrix = matrixSetObj.TileMatrix[0];
 
@@ -491,12 +491,20 @@ export function optionsFromCapabilities(wmtsCap, config) {
 
   const resolution =
     (matrix.ScaleDenominator * 0.00028) / projection.getMetersPerUnit(); // WMTS 1.0.0: standardized rendering pixel size
-  const origin = switchOriginXY
+  const origin = switchXY
     ? [matrix.TopLeftCorner[1], matrix.TopLeftCorner[0]]
     : matrix.TopLeftCorner;
   const tileSpanX = matrix.TileWidth * resolution;
   const tileSpanY = matrix.TileHeight * resolution;
-  const matrixSetExtent = matrixSetObj['BoundingBox'];
+  let matrixSetExtent = matrixSetObj['BoundingBox'];
+  if (matrixSetExtent && switchXY) {
+    matrixSetExtent = [
+      matrixSetExtent[1],
+      matrixSetExtent[0],
+      matrixSetExtent[3],
+      matrixSetExtent[2],
+    ];
+  }
   let extent = [
     origin[0] + tileSpanX * selectedMatrixLimit.MinTileCol,
     // add one to get proper bottom/right coordinate

--- a/test/browser/spec/ol/format/wmts/capabilities_epsg4326_with_boundingbox.xml
+++ b/test/browser/spec/ol/format/wmts/capabilities_epsg4326_with_boundingbox.xml
@@ -1,0 +1,1259 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0"
+  xmlns:ows="http://www.opengis.net/ows/1.1"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gml="http://www.opengis.net/gml"
+  xmlns:inspire_common="http://inspire.ec.europa.eu/schemas/common/1.0"
+  xmlns:inspire_vs="http://inspire.ec.europa.eu/schemas/inspire_vs_ows11/1.0" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd http://inspire.ec.europa.eu/schemas/inspire_vs_ows11/1.0 http://inspire.ec.europa.eu/schemas/inspire_vs_ows11/1.0/inspire_vs_ows_11.xsd" version="1.0.0">
+  <ows:ServiceIdentification>
+    <ows:Title>EOX::Maps</ows:Title>
+    <ows:Abstract>EOX::Maps are background and overlay maps made of Open Data and designed and provided by EOX.</ows:Abstract>
+    <ows:Keywords>
+      <ows:Keyword>maps</ows:Keyword>
+    </ows:Keywords>
+    <ows:ServiceType>OGC WMTS</ows:ServiceType>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    <ows:AccessConstraints>Proper attribution is required for any usage. The attribution shall follow the example of the demo map at https://maps.eox.at in the lower right corner including the respective links e.g. "Terrain { Data © OpenStreetMap contributers and others, Rendering © EOX }" with links to http://www.openstreetmap.org/copyright, https://maps.eox.at/#data, and https://eox.at. Additional restrictions may apply for individual layers as indicated in the respective abstract.</ows:AccessConstraints>
+  </ows:ServiceIdentification>
+  <ows:ServiceProvider>
+    <ows:ProviderName>EOX</ows:ProviderName>
+    <ows:ProviderSite xlink:href="https://maps.eox.at"></ows:ProviderSite>
+    <ows:ServiceContact>
+      <ows:IndividualName>Stephan Meissl</ows:IndividualName>
+      <ows:ContactInfo>
+        <ows:Phone>
+          <ows:Voice>+43 664 9688701</ows:Voice>
+        </ows:Phone>
+        <ows:Address>
+          <ows:DeliveryPoint>EOX IT Services GmbH</ows:DeliveryPoint>
+          <ows:City>Vienna</ows:City>
+          <ows:PostalCode>1090</ows:PostalCode>
+          <ows:Country>Austria</ows:Country>
+          <ows:ElectronicMailAddress>stephan.meissl@eox.at</ows:ElectronicMailAddress>
+        </ows:Address>
+      </ows:ContactInfo>
+    </ows:ServiceContact>
+  </ows:ServiceProvider>
+  <ows:OperationsMetadata>
+    <ows:Operation name="GetCapabilities">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://s2maps-tiles.eu/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetTile">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://s2maps-tiles.eu/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <ows:Operation name="GetFeatureInfo">
+      <ows:DCP>
+        <ows:HTTP>
+          <ows:Get xlink:href="http://s2maps-tiles.eu/wmts?">
+            <ows:Constraint name="GetEncoding">
+              <ows:AllowedValues>
+                <ows:Value>KVP</ows:Value>
+              </ows:AllowedValues>
+            </ows:Constraint>
+          </ows:Get>
+        </ows:HTTP>
+      </ows:DCP>
+    </ows:Operation>
+    <inspire_vs:ExtendedCapabilities>
+      <inspire_common:MetadataUrl xsi:type="inspire_common:resourceLocatorType">
+        <inspire_common:URL>TBD</inspire_common:URL>
+        <inspire_common:MediaType>application/vnd.iso.19139+xml</inspire_common:MediaType>
+      </inspire_common:MetadataUrl>
+      <inspire_common:SupportedLanguages>
+        <inspire_common:DefaultLanguage>
+          <inspire_common:Language>eng</inspire_common:Language>
+        </inspire_common:DefaultLanguage>
+      </inspire_common:SupportedLanguages>
+      <inspire_common:ResponseLanguage>
+        <inspire_common:Language>eng</inspire_common:Language>
+      </inspire_common:ResponseLanguage>
+    </inspire_vs:ExtendedCapabilities>
+  </ows:OperationsMetadata>
+  <Contents>
+    <Layer>
+      <ows:Title>Blue marble background layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Blue Marble&lt;/a&gt; { &amp;copy; &lt;a href="http://nasa.gov"&gt;NASA&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>bluemarble</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/bluemarble/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2021 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2021) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:Identifier>s2cloudless-2021_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2021_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Black coastline overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Black coastline overlay&lt;/a&gt; { Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>coastline_black</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/coastline_black/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2017 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2017) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by/4.0/"&gt;Creative Commons Attribution 4.0 International License&lt;/a&gt;.</ows:Abstract>
+      <ows:Identifier>s2cloudless-2017_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2017_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Streets overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Streets overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>streets_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/streets_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Bright overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay bright&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>overlay_bright</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_bright/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2019 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2019) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:Identifier>s2cloudless-2019_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2019_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>overlay</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Black marble background layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Black Marble&lt;/a&gt; { &amp;copy; &lt;a href="http://nasa.gov"&gt;NASA&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>blackmarble_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/blackmarble_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Hydrography overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Hydrography overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>hydrography_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/hydrography_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2017 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2017) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by/4.0/"&gt;Creative Commons Attribution 4.0 International License&lt;/a&gt;.</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless-2017</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2017/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Streets overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Streets overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>streets</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/streets/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2018 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2017 &amp;amp; 2018) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless-2018</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2018/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2019 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2019) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless-2019</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2019/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>OpenStreetMap background layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;OpenStreetMap&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>osm</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/osm/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Black marble background layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Black Marble&lt;/a&gt; { &amp;copy; &lt;a href="http://nasa.gov"&gt;NASA&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>blackmarble</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/blackmarble/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Terrain Light background layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Terrain Light&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors and &lt;a href="https://maps.eox.at/#data"&gt;others&lt;/a&gt;, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>terrain-light_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Blue marble background layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Blue Marble&lt;/a&gt; { &amp;copy; &lt;a href="http://nasa.gov"&gt;NASA&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>bluemarble_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/bluemarble_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>overlay_base_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_base_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2016 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2016 &amp;amp; 2017) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by/4.0/"&gt;Creative Commons Attribution 4.0 International License&lt;/a&gt;.</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Terrain background layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Terrain&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors and &lt;a href="https://maps.eox.at/#data"&gt;others&lt;/a&gt;, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>terrain</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/terrain/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Bright overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay bright&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>overlay_bright_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_bright_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Coastline overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Coastline overlay&lt;/a&gt; { Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>coastline_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/coastline_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2020 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2020) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:Identifier>s2cloudless-2020_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2020_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Magnetic Graticules overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Magnetic Graticules&lt;/a&gt; { Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>magnetic_graticules</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/magnetic_graticules/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Terrain Light background layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Terrain Light&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors and &lt;a href="https://maps.eox.at/#data"&gt;others&lt;/a&gt;, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>terrain-light</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/terrain-light/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Bright overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay bright&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>overlay_base_bright</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_base_bright/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>overlay_base</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_base/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2018 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2017 &amp;amp; 2018) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:Identifier>s2cloudless-2018_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2018_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Coastline overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Coastline overlay&lt;/a&gt; { Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>coastline</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/coastline/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2020 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2020) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless-2020</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2020/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2021 by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2021) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"&gt;Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License&lt;/a&gt;. For commercial usage please see &lt;a href="https://cloudless.eox.at"&gt;https://cloudless.eox.at&lt;/a&gt;</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>s2cloudless-2021</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless-2021/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>OpenStreetMap background layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;OpenStreetMap&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>osm_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Sentinel-2 cloudless layer for 2016 by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a xmlns:dct="http://purl.org/dc/terms/" href="https://s2maps.eu" property="dct:title"&gt;Sentinel-2 cloudless - https://s2maps.eu&lt;/a&gt; by &lt;a xmlns:cc="http://creativecommons.org/ns#" href="https://eox.at" property="cc:attributionName" rel="cc:attributionURL"&gt;EOX IT Services GmbH&lt;/a&gt; (Contains modified Copernicus Sentinel data 2016 &amp;amp; 2017) released under &lt;a rel="license" href="https://creativecommons.org/licenses/by/4.0/"&gt;Creative Commons Attribution 4.0 International License&lt;/a&gt;.</ows:Abstract>
+      <ows:Identifier>s2cloudless_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/s2cloudless_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Terrain background layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Terrain&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors and &lt;a href="https://maps.eox.at/#data"&gt;others&lt;/a&gt;, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>terrain_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/jpeg</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/jpeg" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/terrain_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.jpg"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Bright overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay bright&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>overlay_base_bright_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_base_bright_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Hydrography overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Hydrography overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>hydrography</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/hydrography/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Graticules overlay layer by EOX - 4326</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Graticules&lt;/a&gt; { Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; }</ows:Abstract>
+      <ows:WGS84BoundingBox>
+        <ows:LowerCorner>-180.000000 -90.000000</ows:LowerCorner>
+        <ows:UpperCorner>180.000000 90.000000</ows:UpperCorner>
+      </ows:WGS84BoundingBox>
+      <ows:Identifier>graticules</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>WGS84</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/graticules/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <Layer>
+      <ows:Title>Overlay layer by EOX - 3857</ows:Title>
+      <ows:Abstract>&lt;a href="https://maps.eox.at"&gt;Overlay&lt;/a&gt; { Data &amp;copy; &lt;a href="http://www.openstreetmap.org/copyright"&gt;OpenStreetMap&lt;/a&gt; contributors, Rendering &amp;copy; &lt;a href="https://eox.at"&gt;EOX&lt;/a&gt; and &lt;a href="https://github.com/mapserver/basemaps"&gt;MapServer&lt;/a&gt; }</ows:Abstract>
+      <ows:Identifier>overlay_3857</ows:Identifier>
+      <Style isDefault="true">
+        <ows:Identifier>default</ows:Identifier>
+      </Style>
+      <Format>image/png</Format>
+      <TileMatrixSetLink>
+        <TileMatrixSet>g</TileMatrixSet>
+      </TileMatrixSetLink>
+      <TileMatrixSetLink>
+        <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>
+      </TileMatrixSetLink>
+      <ResourceURL format="image/png" resourceType="tile" template="http://s2maps-tiles.eu/wmts/1.0.0/overlay_3857/default/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"></ResourceURL>
+    </Layer>
+    <TileMatrixSet>
+      <ows:Identifier>WGS84</ows:Identifier>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:4326">
+        <ows:LowerCorner>-90.000000 -180.000000</ows:LowerCorner>
+        <ows:UpperCorner>90.000000 180.000000</ows:UpperCorner>
+      </ows:BoundingBox>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:4326</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleCRS84Quad</WellKnownScaleSet>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>279541132.01435887813568115234</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>139770566.00717943906784057617</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>69885283.00358971953392028809</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>34942641.50179485976696014404</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>17471320.75089742988348007202</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32</MatrixWidth>
+        <MatrixHeight>16</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>5</ows:Identifier>
+        <ScaleDenominator>8735660.37544871494174003601</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>64</MatrixWidth>
+        <MatrixHeight>32</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>6</ows:Identifier>
+        <ScaleDenominator>4367830.18772435747087001801</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>128</MatrixWidth>
+        <MatrixHeight>64</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>7</ows:Identifier>
+        <ScaleDenominator>2183915.09386217873543500900</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>256</MatrixWidth>
+        <MatrixHeight>128</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>8</ows:Identifier>
+        <ScaleDenominator>1091957.54693108936771750450</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>512</MatrixWidth>
+        <MatrixHeight>256</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>9</ows:Identifier>
+        <ScaleDenominator>545978.77346554468385875225</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1024</MatrixWidth>
+        <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>10</ows:Identifier>
+        <ScaleDenominator>272989.38673277234192937613</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2048</MatrixWidth>
+        <MatrixHeight>1024</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>11</ows:Identifier>
+        <ScaleDenominator>136494.69336638617096468806</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4096</MatrixWidth>
+        <MatrixHeight>2048</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>12</ows:Identifier>
+        <ScaleDenominator>68247.34668319308548234403</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>13</ows:Identifier>
+        <ScaleDenominator>34123.67334159654274117202</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16384</MatrixWidth>
+        <MatrixHeight>8192</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>14</ows:Identifier>
+        <ScaleDenominator>17061.83667079825318069197</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32768</MatrixWidth>
+        <MatrixHeight>16384</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>15</ows:Identifier>
+        <ScaleDenominator>8530.91833539912659034599</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>65536</MatrixWidth>
+        <MatrixHeight>32768</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>16</ows:Identifier>
+        <ScaleDenominator>4265.45916769956329517299</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>131072</MatrixWidth>
+        <MatrixHeight>65536</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>17</ows:Identifier>
+        <ScaleDenominator>2132.72958384978574031265</ScaleDenominator>
+        <TopLeftCorner>90.000000 -180.000000</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>262144</MatrixWidth>
+        <MatrixHeight>131072</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+    <TileMatrixSet>
+      <ows:Identifier>GoogleMapsCompatible</ows:Identifier>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:3857">
+        <ows:LowerCorner>-20037508.342789 -20037508.342789</ows:LowerCorner>
+        <ows:UpperCorner>20037508.342789 20037508.342789</ows:UpperCorner>
+      </ows:BoundingBox>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:3857</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.02871787548065185547</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.01435887813568115234</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.00717940926551818848</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>69885283.00358971953392028809</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>34942641.50179485976696014404</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16</MatrixWidth>
+        <MatrixHeight>16</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>5</ows:Identifier>
+        <ScaleDenominator>17471320.75089742988348007202</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32</MatrixWidth>
+        <MatrixHeight>32</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>6</ows:Identifier>
+        <ScaleDenominator>8735660.37544871494174003601</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>64</MatrixWidth>
+        <MatrixHeight>64</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>7</ows:Identifier>
+        <ScaleDenominator>4367830.18772435747087001801</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>128</MatrixWidth>
+        <MatrixHeight>128</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>8</ows:Identifier>
+        <ScaleDenominator>2183915.09386217873543500900</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>256</MatrixWidth>
+        <MatrixHeight>256</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>9</ows:Identifier>
+        <ScaleDenominator>1091957.54693108866922557354</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>512</MatrixWidth>
+        <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>10</ows:Identifier>
+        <ScaleDenominator>545978.77346554468385875225</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1024</MatrixWidth>
+        <MatrixHeight>1024</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>11</ows:Identifier>
+        <ScaleDenominator>272989.38673277228372171521</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2048</MatrixWidth>
+        <MatrixHeight>2048</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>12</ows:Identifier>
+        <ScaleDenominator>136494.69336638617096468806</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4096</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>13</ows:Identifier>
+        <ScaleDenominator>68247.34668319307093042880</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>8192</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>14</ows:Identifier>
+        <ScaleDenominator>34123.67334159654274117202</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16384</MatrixWidth>
+        <MatrixHeight>16384</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>15</ows:Identifier>
+        <ScaleDenominator>17061.83667079827137058601</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32768</MatrixWidth>
+        <MatrixHeight>32768</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>16</ows:Identifier>
+        <ScaleDenominator>8530.91833539913568529300</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>65536</MatrixWidth>
+        <MatrixHeight>65536</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>17</ows:Identifier>
+        <ScaleDenominator>4265.45916769956784264650</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>131072</MatrixWidth>
+        <MatrixHeight>131072</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>18</ows:Identifier>
+        <ScaleDenominator>2132.72958384978392132325</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>262144</MatrixWidth>
+        <MatrixHeight>262144</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+    <TileMatrixSet>
+      <ows:Identifier>g</ows:Identifier>
+      <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.3:900913">
+        <ows:LowerCorner>-20037508.342789 -20037508.342789</ows:LowerCorner>
+        <ows:UpperCorner>20037508.342789 20037508.342789</ows:UpperCorner>
+      </ows:BoundingBox>
+      <ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.3:900913</ows:SupportedCRS>
+      <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>
+      <TileMatrix>
+        <ows:Identifier>0</ows:Identifier>
+        <ScaleDenominator>559082264.02871787548065185547</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1</MatrixWidth>
+        <MatrixHeight>1</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>1</ows:Identifier>
+        <ScaleDenominator>279541132.01435887813568115234</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2</MatrixWidth>
+        <MatrixHeight>2</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>2</ows:Identifier>
+        <ScaleDenominator>139770566.00717940926551818848</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4</MatrixWidth>
+        <MatrixHeight>4</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>3</ows:Identifier>
+        <ScaleDenominator>69885283.00358971953392028809</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8</MatrixWidth>
+        <MatrixHeight>8</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>4</ows:Identifier>
+        <ScaleDenominator>34942641.50179485976696014404</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16</MatrixWidth>
+        <MatrixHeight>16</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>5</ows:Identifier>
+        <ScaleDenominator>17471320.75089742988348007202</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32</MatrixWidth>
+        <MatrixHeight>32</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>6</ows:Identifier>
+        <ScaleDenominator>8735660.37544871494174003601</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>64</MatrixWidth>
+        <MatrixHeight>64</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>7</ows:Identifier>
+        <ScaleDenominator>4367830.18772435747087001801</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>128</MatrixWidth>
+        <MatrixHeight>128</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>8</ows:Identifier>
+        <ScaleDenominator>2183915.09386217873543500900</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>256</MatrixWidth>
+        <MatrixHeight>256</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>9</ows:Identifier>
+        <ScaleDenominator>1091957.54693108866922557354</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>512</MatrixWidth>
+        <MatrixHeight>512</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>10</ows:Identifier>
+        <ScaleDenominator>545978.77346554468385875225</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>1024</MatrixWidth>
+        <MatrixHeight>1024</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>11</ows:Identifier>
+        <ScaleDenominator>272989.38673277228372171521</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>2048</MatrixWidth>
+        <MatrixHeight>2048</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>12</ows:Identifier>
+        <ScaleDenominator>136494.69336638617096468806</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>4096</MatrixWidth>
+        <MatrixHeight>4096</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>13</ows:Identifier>
+        <ScaleDenominator>68247.34668319307093042880</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>8192</MatrixWidth>
+        <MatrixHeight>8192</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>14</ows:Identifier>
+        <ScaleDenominator>34123.67334159654274117202</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>16384</MatrixWidth>
+        <MatrixHeight>16384</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>15</ows:Identifier>
+        <ScaleDenominator>17061.83667079827137058601</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>32768</MatrixWidth>
+        <MatrixHeight>32768</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>16</ows:Identifier>
+        <ScaleDenominator>8530.91833539913568529300</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>65536</MatrixWidth>
+        <MatrixHeight>65536</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>17</ows:Identifier>
+        <ScaleDenominator>4265.45916769956784264650</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>131072</MatrixWidth>
+        <MatrixHeight>131072</MatrixHeight>
+      </TileMatrix>
+      <TileMatrix>
+        <ows:Identifier>18</ows:Identifier>
+        <ScaleDenominator>2132.72958384978392132325</ScaleDenominator>
+        <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+        <TileWidth>256</TileWidth>
+        <TileHeight>256</TileHeight>
+        <MatrixWidth>262144</MatrixWidth>
+        <MatrixHeight>262144</MatrixHeight>
+      </TileMatrix>
+    </TileMatrixSet>
+  </Contents>
+</Capabilities>

--- a/test/browser/spec/ol/source/WMTS.test.js
+++ b/test/browser/spec/ol/source/WMTS.test.js
@@ -475,6 +475,34 @@ describe('ol/source/WMTS', function () {
       expectDelta(extent[3], expectedMatrixSetExtend[3]);
     });
   });
+
+  describe('when creating options from epsg:4326 capabilities with BoundingBox', function () {
+    const parser = new WMTSCapabilities();
+    let capabilities;
+    before(function (done) {
+      afterLoadText(
+        'spec/ol/format/wmts/capabilities_epsg4326_with_boundingbox.xml',
+        function (xml) {
+          try {
+            capabilities = parser.read(xml);
+          } catch (e) {
+            done(e);
+          }
+          done();
+        }
+      );
+    });
+
+    it('returns correct bounding box when the layer has BoundingBox', function () {
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 's2cloudless-2020',
+      });
+
+      const extent = options.tileGrid.getExtent();
+      expect(extent).to.eql([-180, -90, 180, 90]);
+    });
+  });
+
   describe('set wrap x by bounding box if available', function () {
     const parser = new WMTSCapabilities();
     let capabilities;


### PR DESCRIPTION
This pull request fixes a problem with extents defined in WMTS Capabilities Tile Matrix Sets, when a projection with inverted axis order is used.

To solve this, the same technique we use for flipping origin coordinates already is used.