### PR TITLE
Change typedef to boolean

### DIFF
--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -198,7 +198,7 @@ export function calculateSourceExtentResolution(
  * @param {Array<ImageExtent>} sources Array of sources.
  * @param {number} gutter Gutter of the sources.
  * @param {boolean} [opt_renderEdges] Render reprojection edges.
- * @param {Object} [opt_interpolate] Use linear interpolation when resampling.
+ * @param {boolean} [opt_interpolate] Use linear interpolation when resampling.
  * @return {HTMLCanvasElement} Canvas with reprojected data.
  */
 export function render(


### PR DESCRIPTION
`opt_interpolate` receives the `boolean` tile or source interpolate setting.  The typedef seems to be a leftover from the `contextOptions` object which it replaced.
