### PR TITLE
PointerInteraction: handle pointer cancel events when tracking

### DIFF
--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -193,7 +193,10 @@ class PointerInteraction extends Interaction {
       const event = mapBrowserEvent.originalEvent;
 
       const id = event.pointerId.toString();
-      if (mapBrowserEvent.type == MapBrowserEventType.POINTERUP) {
+      if (
+        mapBrowserEvent.type == MapBrowserEventType.POINTERUP ||
+        mapBrowserEvent.type == MapBrowserEventType.POINTERCANCEL
+      ) {
         delete this.trackedPointers_[id];
       } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERDOWN) {
         this.trackedPointers_[id] = event;


### PR DESCRIPTION
As explained by @bjoernboldt in #13238:

"updateTrackedPointers_ does not listen to pointercancel-Event. Sometimes pointer events stay in trackedPointers_ list.
This happens, when the browser does not fire a pointerup event for an associated pointerdown event.
In updateActivePointers_ (File: MapBrowserEventHandler.js Line: 140) you do so."

This PR updates `updateTrackedPointers_()` to also listen to `MapBrowserEventType.POINTERCANCEL`

Fixes #13238