### PR TITLE
Fix modifying polygons with overlapping vertices

### DIFF
--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -419,6 +419,52 @@ describe('ol.interaction.Modify', function () {
       expect(lineFeature.getGeometry().getCoordinates()[2][2]).to.equal(30);
       expect(lineFeature.getGeometry().getCoordinates()[4][2]).to.equal(50);
     });
+
+    it('keeps polygon geometries valid', function () {
+      const overlappingVertexFeature = new Feature({
+        geometry: new Polygon([
+          [
+            [10, 20],
+            [0, 20],
+            [0, 0],
+            [20, 0],
+            [20, 20],
+            [10, 20],
+            [15, 15],
+            [5, 15],
+            [10, 20],
+          ],
+        ]),
+      });
+      features.length = 0;
+      features.push(overlappingVertexFeature);
+
+      const modify = new Modify({
+        features: new Collection(features),
+      });
+      map.addInteraction(modify);
+
+      let coords, exteriorRing;
+      coords = overlappingVertexFeature.getGeometry().getCoordinates();
+      exteriorRing = coords[0];
+
+      expect(exteriorRing.length).to.equal(9);
+      expect(exteriorRing[0]).to.eql(exteriorRing[exteriorRing.length - 1]);
+
+      // move the overlapping vertice
+      simulateEvent('pointermove', 10, -20, null, 0);
+      simulateEvent('pointerdown', 10, -20, null, 0);
+      simulateEvent('pointermove', 10, -25, null, 0);
+      simulateEvent('pointerdrag', 10, -25, null, 0);
+      simulateEvent('pointerup', 10, -25, null, 0);
+
+      coords = overlappingVertexFeature.getGeometry().getCoordinates();
+      exteriorRing = coords[0];
+
+      expect(exteriorRing.length).to.equal(9);
+      expect(exteriorRing[0]).to.eql([10, 25]);
+      expect(exteriorRing[0]).to.eql(exteriorRing[exteriorRing.length - 1]);
+    });
   });
 
   describe('vertex insertion', function () {


### PR DESCRIPTION
This PR fixes #13736. It adds a check to make sure that when you are modifying the first vertex of a polygon, the other segment selected contains the closing vertex. I thought about allowing more than two segments to be dragged for overlapping vertices, but that would change the current behaviour (for overlapping vertices that don't include the first vertex, modifying them only allows one vertex to be dragged at a time). I tried to follow the style in `removeVertex_` for this.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
