### PR TITLE
Fix single selection bug when holding modifier keys

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -478,7 +478,7 @@ class Select extends Interaction {
     const features = this.getFeatures();
     const deselected = [];
     const selected = [];
-    if (set) {
+    if (set || !this.multi_) {
       // Replace the currently selected feature(s) with the feature(s) at the
       // pixel, or clear the selected feature(s) if there is no feature at
       // the pixel.


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

## The problem

- A Layer has two features A and B.
- A Select interaction is active on the layer with `multi` **disabled**
- **You select A** (A is now selected)
- **You hold SHIFT and select B** (B is now selected)
- **You hold SHIFT and select A** (Nothing is selected)

## Result

The current SelectEvent holds no features

## Expected behavior

In single selection mode (with multi disabled), the last clicked feature should always be in the SelectEvent
