### PR TITLE
Allow DblClickZoom interaction to zoom out with 2 fingers

### DIFF
--- a/src/ol/interaction/DoubleClickZoom.js
+++ b/src/ol/interaction/DoubleClickZoom.js
@@ -3,6 +3,7 @@
  */
 import Interaction, {zoomByDelta} from './Interaction.js';
 import MapBrowserEventType from '../MapBrowserEventType.js';
+import {getValues} from '../obj.js';
 
 /**
  * @typedef {Object} Options
@@ -20,9 +21,11 @@ class DoubleClickZoom extends Interaction {
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
-    super();
-
     const options = opt_options ? opt_options : {};
+
+    super(
+      /** @type {import("./Interaction.js").InteractionOptions} */ (options)
+    );
 
     /**
      * @private
@@ -35,6 +38,24 @@ class DoubleClickZoom extends Interaction {
      * @type {number}
      */
     this.duration_ = options.duration !== undefined ? options.duration : 250;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.handlingDownUpSequence_ = false;
+
+    /**
+     * @type {!Object<string, PointerEvent>}
+     * @private
+     */
+    this.trackedPointers_ = {};
+
+    /**
+     * @type {Array<PointerEvent>}
+     * @protected
+     */
+    this.targetPointers = [];
   }
 
   /**
@@ -45,6 +66,8 @@ class DoubleClickZoom extends Interaction {
    */
   handleEvent(mapBrowserEvent) {
     let stopEvent = false;
+    this.updateTrackedPointers_(mapBrowserEvent);
+
     if (mapBrowserEvent.type == MapBrowserEventType.DBLCLICK) {
       const browserEvent = /** @type {MouseEvent} */ (
         mapBrowserEvent.originalEvent
@@ -56,8 +79,87 @@ class DoubleClickZoom extends Interaction {
       zoomByDelta(view, delta, anchor, this.duration_);
       browserEvent.preventDefault();
       stopEvent = true;
+      return !stopEvent;
+    }
+
+    if (
+      mapBrowserEvent.type === MapBrowserEventType.POINTERDRAG ||
+      mapBrowserEvent.type === MapBrowserEventType.POINTERMOVE
+    ) {
+      // If the user drag the map we abort this interaction.
+      this.handlingDownUpSequence_ = false;
+      stopEvent = false;
+      return !stopEvent;
+    }
+
+    if (
+      this.targetPointers.length === 2 &&
+      mapBrowserEvent.type === MapBrowserEventType.POINTERDOWN
+    ) {
+      this.handlingDownUpSequence_ = true;
+      stopEvent = this.stopDown(true);
+    } else if (
+      this.handlingDownUpSequence_ &&
+      mapBrowserEvent.type === MapBrowserEventType.POINTERUP
+    ) {
+      const handledUp = this.handleUpEvent(mapBrowserEvent);
+      this.handlingDownUpSequence_ = false;
+      stopEvent = handledUp;
     }
     return !stopEvent;
+  }
+
+  /**
+   * Handle pointer up events zooming out.
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
+   * @return {boolean} If the event was consumed.
+   */
+  handleUpEvent(mapBrowserEvent) {
+    const browserEvent = /** @type {MouseEvent} */ (
+      mapBrowserEvent.originalEvent
+    );
+    const {map} = mapBrowserEvent;
+    const anchor = mapBrowserEvent.coordinate;
+    const delta = browserEvent.shiftKey ? this.delta_ : -this.delta_;
+    const view = map.getView();
+    zoomByDelta(view, delta, anchor, this.duration_);
+    browserEvent.preventDefault();
+    return true;
+  }
+
+  /**
+   * This function is used to determine if "down" events should be propagated
+   * to other interactions or should be stopped.
+   * @param {boolean} handled Was the event handled by the interaction?
+   * @return {boolean} Should the `down` event be stopped?
+   */
+  stopDown(handled) {
+    return handled;
+  }
+
+  /**
+   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
+   * @private
+   */
+  updateTrackedPointers_(mapBrowserEvent) {
+    const event = mapBrowserEvent.originalEvent;
+
+    // On some other event, pointerId can be empty.
+    if (
+      mapBrowserEvent.type === MapBrowserEventType.POINTERUP ||
+      mapBrowserEvent.type === MapBrowserEventType.POINTERDOWN
+    ) {
+      const id = event.pointerId.toString();
+      if (mapBrowserEvent.type === MapBrowserEventType.POINTERUP) {
+        delete this.trackedPointers_[id];
+      } else if (mapBrowserEvent.type === MapBrowserEventType.POINTERDOWN) {
+        this.trackedPointers_[id] = event;
+      } else if (id in this.trackedPointers_) {
+        // update only when there was a pointerdown event for this pointer
+        this.trackedPointers_[id] = event;
+      }
+      this.targetPointers = getValues(this.trackedPointers_);
+    }
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
New proposal  for https://github.com/openlayers/openlayers/issues/13753

The "2 finger tap " is handled in DoubleClickZoom interaction as suggested by @ahocevar 

You can test the behavior in the [drag-rotate-and-zoom.html example](https://deploy-preview-13752--ol-site.netlify.app/examples/drag-rotate-and-zoom.html)
