### PR TITLE
Clean up tracked pointers when the event target has changed

### DIFF
--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -195,6 +195,16 @@ class PointerInteraction extends Interaction {
       const id = event.pointerId.toString();
       if (mapBrowserEvent.type == MapBrowserEventType.POINTERUP) {
         delete this.trackedPointers_[id];
+        for (const pointerId in this.trackedPointers_) {
+          if (this.trackedPointers_[pointerId].target !== event.target) {
+            // Some platforms assign a new pointerId when the target changes.
+            // If this happens, delete one tracked pointer. If there is more
+            // than one tracked pointer for the old target, it will be cleared
+            // by subsequent POINTERUP events from other pointers.
+            delete this.trackedPointers_[pointerId];
+            break;
+          }
+        }
       } else if (mapBrowserEvent.type == MapBrowserEventType.POINTERDOWN) {
         this.trackedPointers_[id] = event;
       } else if (id in this.trackedPointers_) {


### PR DESCRIPTION
Fixes #11465
Fixes #13746

The reason for the failing interactions is that on affected devices, a new `pointerId` is used when the event target changes. To fix this, we clean up tracked pointers for abandoned `pointerId`s one by one on `pointerup`.