### PR TITLE
Do not refresh use time for tiles when collecting used source tiles

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -240,8 +240,9 @@ class VectorTile extends UrlTile {
     const tileCache = this.getTileCacheForProjection(projection);
     const usedSourceTiles = Object.keys(usedTiles).reduce((acc, key) => {
       const cacheKey = getCacheKeyForTileKey(key);
-      if (tileCache.containsKey(cacheKey)) {
-        const sourceTiles = tileCache.get(cacheKey).sourceTiles;
+      const tile = tileCache.peek(cacheKey);
+      if (tile) {
+        const sourceTiles = tile.sourceTiles;
         for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
           acc[sourceTiles[i].getKey()] = true;
         }

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -215,6 +215,18 @@ class LRUCache {
   }
 
   /**
+   * Return an entry without updating least recently used time.
+   * @param {string} key Key.
+   * @return {T} Value.
+   */
+  peek(key) {
+    if (!this.containsKey(key)) {
+      return undefined;
+    }
+    return this.entries_[key].value_;
+  }
+
+  /**
    * @return {T} value Value.
    */
   pop() {


### PR DESCRIPTION
Fixes #13797

`tileCache.get(cacheKey)` changes the least recently used state. That's bad when done just for tile expiration.

~Iterating the entire cache may be slower when the cache size is large, but there is currently no way to access an entry by key without updating the used time.~