### PR TITLE
Change WKB readFeature(s) return type to Feature

### DIFF
--- a/src/ol/format/WKB.js
+++ b/src/ol/format/WKB.js
@@ -700,7 +700,7 @@ class WKB extends FeatureFormat {
    *
    * @param {string|ArrayBuffer|ArrayBufferView} source Source.
    * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
-   * @return {import("../Feature.js").FeatureLike} Feature.
+   * @return {import("../Feature.js").default} Feature.
    * @api
    */
   readFeature(source, opt_options) {
@@ -714,7 +714,7 @@ class WKB extends FeatureFormat {
    *
    * @param {string|ArrayBuffer|ArrayBufferView} source Source.
    * @param {import("./Feature.js").ReadOptions} [opt_options] Read options.
-   * @return {Array<import("../Feature.js").FeatureLike>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   readFeatures(source, opt_options) {


### PR DESCRIPTION
WKB `readFeature()`/`readFeatures()` has no option to return `RenderFeature` so the return type could be more precisely defined as `Feature`.  See https://stackoverflow.com/q/72798555/10118270