### PR TITLE
Base vector tile render tile grid on the source grid 

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -510,7 +510,9 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
         let hitDetectionImageData = tile.hitDetectionImageData[layerUid];
         if (!hitDetectionImageData && !this.animatingOrInteracting_) {
           const tileSize = toSize(
-            tileGrid.getTileSize(tileGrid.getZForResolution(resolution))
+            tileGrid.getTileSize(
+              tileGrid.getZForResolution(resolution, source.zDirection)
+            )
           );
           const rotation = this.renderedRotation_;
           const transforms = [

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -50,7 +50,7 @@ const DECIMALS = 5;
  * negative because OpenLayers tile coordinates use the top left as the origin.
  * @property {number|import("../size.js").Size} [tileSize] Tile size.
  * Default is `[256, 256]`.
- * @property {Array<import("../size.js").Size>} [tileSizes] Tile sizes. If given, the array length
+ * @property {Array<number|import("../size.js").Size>} [tileSizes] Tile sizes. If given, the array length
  * should match the length of the `resolutions` array, i.e. each resolution can have a different
  * tile size.
  */

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -34,7 +34,7 @@ import {get as getProjection} from '../proj.js';
  * an extent is used as `origin` or `origins`, then the `y` value must be
  * negative because OpenLayers tile coordinates use the top left as the origin.
  * @property {number|import("../size.js").Size} [tileSize] Tile size.
- * @property {Array<import("../size.js").Size>} [tileSizes] Tile sizes. The length of
+ * @property {Array<number|import("../size.js").Size>} [tileSizes] Tile sizes. The length of
  * this array needs to match the length of the `resolutions` array.
  */
 
@@ -108,7 +108,7 @@ export function createFromCapabilitiesMatrixSet(
   const matrixIds = [];
   /** @type {!Array<import("../coordinate.js").Coordinate>} */
   const origins = [];
-  /** @type {!Array<import("../size.js").Size>} */
+  /** @type {!Array<number|import("../size.js").Size>} */
   const tileSizes = [];
   /** @type {!Array<import("../size.js").Size>} */
   const sizes = [];

--- a/test/browser/spec/ol/source/vectortile.test.js
+++ b/test/browser/spec/ol/source/vectortile.test.js
@@ -228,17 +228,13 @@ describe('ol.source.VectorTile', function () {
   });
 
   describe('different source and render tile grids', function () {
-    let source, map, loaded, requested, target;
+    let source, map, loaded, target;
 
     beforeEach(function () {
       loaded = [];
-      requested = 0;
 
       function tileUrlFunction(tileCoord) {
-        ++requested;
-        if (tileCoord.toString() == '5,13,-29') {
-          return tileCoord.join('/');
-        }
+        return tileCoord.join('/');
       }
 
       function tileLoadFunction(tile, src) {
@@ -286,11 +282,10 @@ describe('ol.source.VectorTile', function () {
       document.body.removeChild(target);
     });
 
-    it('loads available tiles', function (done) {
+    it('loads only required tiles', function (done) {
       map.renderSync();
       setTimeout(function () {
-        expect(requested).to.be.greaterThan(1);
-        expect(loaded).to.eql(['5/13/-29']);
+        expect(loaded).to.eql(['5/13/-28']);
         done();
       }, 0);
     });

--- a/test/browser/spec/ol/vectorrendertile.test.js
+++ b/test/browser/spec/ol/vectorrendertile.test.js
@@ -63,6 +63,7 @@ describe('ol.VectorRenderTile', function () {
   });
 
   it("only loads tiles within the source tileGrid's extent", function (done) {
+    let tile;
     const url = 'spec/ol/data/point.json';
     const source = new VectorTileSource({
       projection: 'EPSG:4326',
@@ -77,8 +78,12 @@ describe('ol.VectorRenderTile', function () {
       },
       url: url,
     });
-    const tile = source.getTile(0, 0, 0, 1, source.getProjection());
 
+    tile = source.getTile(0, 0, 0, 1, source.getProjection());
+    expect(tile.getState()).to.be(TileState.EMPTY);
+
+    tile = source.getTile(0, 16, 9, 1, source.getProjection());
+    expect(tile.getState()).to.be(TileState.IDLE);
     tile.load();
     const key = listen(tile, EventType.CHANGE, function () {
       if (tile.getState() === TileState.LOADED) {


### PR DESCRIPTION
Fixes #13187

Base the vector tile render tile grid on the source grid, with a factor 2 pyramid below that for overzooming.

Ensure the specified `zDirection` is used throughout.  This is especially important for grids with irregular tile sizes such as those in https://github.com/openlayers/openlayers/issues/13187#issuecomment-1005434098

This includes a fix to the `tileSizes` typedef for tile grids.  Numbers are clearly valid in the array (`createFromCapabilitiesMatrixSet` passes them where possible) but the typedef only permitted `ol/size` arrays.