### PR TITLE
No string enums and type safety for observable properties and event types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "handlebars": "4.7.7",
         "jquery": "3.6.0",
         "jsdoc": "3.6.10",
-        "jsdoc-plugin-typescript": "^2.0.5",
+        "jsdoc-plugin-typescript": "^2.1.0",
         "json-stringify-safe": "^5.0.1",
         "karma": "^6.3.8",
         "karma-chrome-launcher": "^3.1.0",
@@ -6291,9 +6291,9 @@
       }
     },
     "node_modules/jsdoc-plugin-typescript": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.0.7.tgz",
-      "integrity": "sha512-xIZW+c+W5BUEeSWFphXcf5Pppvs/MxZDrDAcQod/vYh3BLZNPSqJjCJihjK061x1YRLU7fQjJw/GZ4KGb2fmTw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.0.tgz",
+      "integrity": "sha512-GYNBCW20YyoFGz8ZYjZS0Prt/arfaCm8yku/yN/d4NXNnF25Ghq9gVpxVdN+8sK5fnA8YRNh8am4kGA8amL99Q==",
       "dev": true,
       "dependencies": {
         "string.prototype.matchall": "^4.0.0"
@@ -15018,9 +15018,9 @@
       }
     },
     "jsdoc-plugin-typescript": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.0.7.tgz",
-      "integrity": "sha512-xIZW+c+W5BUEeSWFphXcf5Pppvs/MxZDrDAcQod/vYh3BLZNPSqJjCJihjK061x1YRLU7fQjJw/GZ4KGb2fmTw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.0.tgz",
+      "integrity": "sha512-GYNBCW20YyoFGz8ZYjZS0Prt/arfaCm8yku/yN/d4NXNnF25Ghq9gVpxVdN+8sK5fnA8YRNh8am4kGA8amL99Q==",
       "dev": true,
       "requires": {
         "string.prototype.matchall": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "handlebars": "4.7.7",
     "jquery": "3.6.0",
     "jsdoc": "3.6.10",
-    "jsdoc-plugin-typescript": "^2.0.5",
+    "jsdoc-plugin-typescript": "^2.1.0",
     "json-stringify-safe": "^5.0.1",
     "karma": "^6.3.8",
     "karma-chrome-launcher": "^3.1.0",

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -2,7 +2,6 @@
  * @module ol/Observable
  */
 import EventTarget from './events/Target.js';
-import EventType from './events/EventType.js';
 import {listen, listenOnce, unlistenByKey} from './events.js';
 
 /***
@@ -36,6 +35,8 @@ import {listen, listenOnce, unlistenByKey} from './events.js';
  * {@link module:ol/Observable~Observable#changed}.
  *
  * @fires import("./events/Event.js").default
+ * @template {string} ObservableEventTypes
+ * @extends EventTarget<ObservableEventTypes|EventTypes>
  * @api
  */
 class Observable extends EventTarget {
@@ -67,7 +68,7 @@ class Observable extends EventTarget {
    */
   changed() {
     ++this.revision_;
-    this.dispatchEvent(EventType.CHANGE);
+    this.dispatchEvent('change');
   }
 
   /**
@@ -81,7 +82,7 @@ class Observable extends EventTarget {
   }
 
   /**
-   * @param {string|Array<string>} type Type.
+   * @param {EventTypes|Array<EventTypes>} type Type.
    * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Event key.
    * @protected
@@ -100,7 +101,7 @@ class Observable extends EventTarget {
   }
 
   /**
-   * @param {string|Array<string>} type Type.
+   * @param {EventTypes|Array<EventTypes>} type Type.
    * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @return {import("./events.js").EventsKey|Array<import("./events.js").EventsKey>} Event key.
    * @protected
@@ -122,7 +123,7 @@ class Observable extends EventTarget {
 
   /**
    * Unlisten for a certain type of event.
-   * @param {string|Array<string>} type Type.
+   * @param {EventTypes|Array<EventTypes>} type Type.
    * @param {function((Event|import("./events/Event").default)): ?} listener Listener.
    * @protected
    */

--- a/src/ol/events/Event.js
+++ b/src/ol/events/Event.js
@@ -11,10 +11,12 @@
  * `stopPropagation` and `preventDefault` methods. It is meant as base class
  * for higher level events defined in the library, and works with
  * {@link module:ol/events/Target~Target}.
+ *
+ * @template {string} EventTypes
  */
 class BaseEvent {
   /**
-   * @param {string} type Type.
+   * @param {EventTypes} type Type.
    */
   constructor(type) {
     /**
@@ -29,7 +31,7 @@ class BaseEvent {
 
     /**
      * The event type.
-     * @type {string}
+     * @type {EventTypes}
      * @api
      */
     this.type = type;
@@ -61,14 +63,14 @@ class BaseEvent {
 }
 
 /**
- * @param {Event|import("./Event.js").default} evt Event
+ * @param {Event|BaseEvent} evt Event
  */
 export function stopPropagation(evt) {
   evt.stopPropagation();
 }
 
 /**
- * @param {Event|import("./Event.js").default} evt Event
+ * @param {Event|BaseEvent} evt Event
  */
 export function preventDefault(evt) {
   evt.preventDefault();

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -24,6 +24,8 @@ import {clear} from '../obj.js';
  *    `stopPropagation` or `preventDefault` on an event object, it means that no
  *    more listeners after this one will be called. Same as when the listener
  *    returns false.
+ *
+ * @template {string} EventTypes
  */
 class Target extends Disposable {
   /**
@@ -52,13 +54,13 @@ class Target extends Disposable {
 
     /**
      * @private
-     * @type {Object<string, Array<import("../events.js").Listener>>}
+     * @type {Object<EventTypes, Array<import("../events.js").Listener>>}
      */
     this.listeners_ = null;
   }
 
   /**
-   * @param {string} type Type.
+   * @param {EventTypes} type Type.
    * @param {import("../events.js").Listener} listener Listener.
    */
   addEventListener(type, listener) {
@@ -77,7 +79,7 @@ class Target extends Disposable {
    * of this type. The event parameter can either be a string or an
    * Object with a `type` property.
    *
-   * @param {import("./Event.js").default|string} event Event object.
+   * @param {import("./Event.js").default<EventTypes>|EventTypes} event Event object.
    * @return {boolean|undefined} `false` if anyone called preventDefault on the
    *     event object or if any of the listeners returned false.
    * @api
@@ -140,7 +142,7 @@ class Target extends Disposable {
    * Get the listeners for a specified event type. Listeners are returned in the
    * order that they will be called in.
    *
-   * @param {string} type Type.
+   * @param {EventTypes} type Type.
    * @return {Array<import("../events.js").Listener>|undefined} Listeners.
    */
   getListeners(type) {
@@ -148,7 +150,7 @@ class Target extends Disposable {
   }
 
   /**
-   * @param {string} [opt_type] Type. If not provided,
+   * @param {EventTypes} [opt_type] Type. If not provided,
    *     `true` will be returned if this event target has any listeners.
    * @return {boolean} Has listeners.
    */
@@ -162,7 +164,7 @@ class Target extends Disposable {
   }
 
   /**
-   * @param {string} type Type.
+   * @param {EventTypes} type Type.
    * @param {import("../events.js").Listener} listener Listener.
    */
   removeEventListener(type, listener) {


### PR DESCRIPTION
This pull request aims to remove string enums for event types, and add type safety for observable properties and event types by adding union type generics (defaulting to `string`) to Event, Observable and Object.