### PR TITLE
Propagate style changes to features and layers

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next version
 
+#### Style changes propagate to layers and features
+
+It is no longer necessary to call `layer.changed()` or `feature.changed()` if you modify the layer or feature's style with one of the setter methods.  Vector layers with a style or features with a style will now automatically dispatch change events when those styles are modified (resulting in a map render).
+
 ### 6.15.0
 
 #### Deprecated `tilePixelRatio` option for data tile sources.

--- a/examples/regularshape.js
+++ b/examples/regularshape.js
@@ -137,6 +137,5 @@ document.getElementById('color-changer').addEventListener('click', function () {
   styles.square
     .getImage()
     .setFill(new Fill({color: colors[currentColor % colors.length]}));
-  vectorLayer.changed();
   currentColor++;
 });

--- a/src/ol/style/Circle.js
+++ b/src/ol/style/Circle.js
@@ -76,6 +76,7 @@ class CircleStyle extends RegularShape {
   setRadius(radius) {
     this.radius_ = radius;
     this.render();
+    this.changed();
   }
 }
 

--- a/src/ol/style/Fill.js
+++ b/src/ol/style/Fill.js
@@ -2,6 +2,8 @@
  * @module ol/style/Fill
  */
 
+import Observable from '../Observable.js';
+
 /**
  * @typedef {Object} Options
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike|null} [color=null] A color, gradient or pattern.
@@ -14,11 +16,13 @@
  * Set fill style for vector features.
  * @api
  */
-class Fill {
+class Fill extends Observable {
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
+    super();
+
     const options = opt_options || {};
 
     /**
@@ -57,6 +61,7 @@ class Fill {
    */
   setColor(color) {
     this.color_ = color;
+    this.changed();
   }
 }
 

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -306,6 +306,7 @@ class Icon extends ImageStyle {
   setAnchor(anchor) {
     this.anchor_ = anchor;
     this.normalizedAnchor_ = null;
+    this.changed();
   }
 
   /**

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/style/Image
  */
+import Observable from '../Observable.js';
 import {abstract} from '../util.js';
 import {toSize} from '../size.js';
 
@@ -21,11 +22,13 @@ import {toSize} from '../size.js';
  * @abstract
  * @api
  */
-class ImageStyle {
+class ImageStyle extends Observable {
   /**
    * @param {Options} options Options.
    */
   constructor(options) {
+    super();
+
     /**
      * @private
      * @type {number}
@@ -227,6 +230,7 @@ class ImageStyle {
    */
   setDisplacement(displacement) {
     this.displacement_ = displacement;
+    this.changed();
   }
 
   /**
@@ -237,6 +241,7 @@ class ImageStyle {
    */
   setOpacity(opacity) {
     this.opacity_ = opacity;
+    this.changed();
   }
 
   /**
@@ -247,6 +252,7 @@ class ImageStyle {
    */
   setRotateWithView(rotateWithView) {
     this.rotateWithView_ = rotateWithView;
+    this.changed();
   }
 
   /**
@@ -257,7 +263,9 @@ class ImageStyle {
    */
   setRotation(rotation) {
     this.rotation_ = rotation;
+    this.changed();
   }
+
   /**
    * Set the scale.
    *
@@ -267,6 +275,7 @@ class ImageStyle {
   setScale(scale) {
     this.scale_ = scale;
     this.scaleArray_ = toSize(scale);
+    this.changed();
   }
 
   /**

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -45,6 +45,8 @@ import {
  * @property {number} miterLimit MiterLimit.
  */
 
+const change = 'change';
+
 /**
  * @classdesc
  * Set regular shape style for vector features. The resulting shape will be
@@ -73,6 +75,8 @@ class RegularShape extends ImageStyle {
       declutterMode: options.declutterMode,
     });
 
+    this.handleChange_ = this.handleChange_.bind(this);
+
     /**
      * @private
      * @type {Object<number, HTMLCanvasElement>}
@@ -84,12 +88,6 @@ class RegularShape extends ImageStyle {
      * @type {HTMLCanvasElement}
      */
     this.hitDetectionCanvas_ = null;
-
-    /**
-     * @private
-     * @type {import("./Fill.js").default}
-     */
-    this.fill_ = options.fill !== undefined ? options.fill : null;
 
     /**
      * @private
@@ -124,12 +122,6 @@ class RegularShape extends ImageStyle {
 
     /**
      * @private
-     * @type {import("./Stroke.js").default}
-     */
-    this.stroke_ = options.stroke !== undefined ? options.stroke : null;
-
-    /**
-     * @private
      * @type {import("../size.js").Size}
      */
     this.size_ = null;
@@ -140,7 +132,32 @@ class RegularShape extends ImageStyle {
      */
     this.renderOptions_ = null;
 
+    /**
+     * @private
+     * @type {import("./Fill.js").default}
+     */
+    this.fill_ = null;
+    if (options.fill) {
+      this.setFill(options.fill);
+    }
+
+    /**
+     * @private
+     * @type {import("./Stroke.js").default}
+     */
+    this.stroke_ = null;
+    if (options.stroke) {
+      this.setStroke(options.stroke);
+    }
+
     this.render();
+  }
+
+  /**
+   * @private
+   */
+  handleChange_() {
+    this.changed();
   }
 
   /**
@@ -206,8 +223,15 @@ class RegularShape extends ImageStyle {
    * @api
    */
   setFill(fill) {
+    if (this.fill_) {
+      this.fill_.removeEventListener(change, this.handleChange_);
+    }
     this.fill_ = fill;
+    if (fill) {
+      fill.addEventListener(change, this.handleChange_);
+    }
     this.render();
+    this.changed();
   }
 
   /**
@@ -325,8 +349,15 @@ class RegularShape extends ImageStyle {
    * @api
    */
   setStroke(stroke) {
+    if (this.stroke_) {
+      this.stroke_.removeEventListener(change, this.handleChange_);
+    }
     this.stroke_ = stroke;
+    if (stroke) {
+      stroke.addEventListener(change, this.handleChange_);
+    }
     this.render();
+    this.changed();
   }
 
   /**

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -2,6 +2,8 @@
  * @module ol/style/Stroke
  */
 
+import Observable from '../Observable.js';
+
 /**
  * @typedef {Object} Options
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [color] A color, gradient or pattern.
@@ -25,11 +27,13 @@
  * the options; they will not return the default.
  * @api
  */
-class Stroke {
+class Stroke extends Observable {
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
+    super();
+
     const options = opt_options || {};
 
     /**
@@ -164,6 +168,7 @@ class Stroke {
    */
   setColor(color) {
     this.color_ = color;
+    this.changed();
   }
 
   /**
@@ -174,6 +179,7 @@ class Stroke {
    */
   setLineCap(lineCap) {
     this.lineCap_ = lineCap;
+    this.changed();
   }
 
   /**
@@ -190,6 +196,7 @@ class Stroke {
    */
   setLineDash(lineDash) {
     this.lineDash_ = lineDash;
+    this.changed();
   }
 
   /**
@@ -200,6 +207,7 @@ class Stroke {
    */
   setLineDashOffset(lineDashOffset) {
     this.lineDashOffset_ = lineDashOffset;
+    this.changed();
   }
 
   /**
@@ -210,6 +218,7 @@ class Stroke {
    */
   setLineJoin(lineJoin) {
     this.lineJoin_ = lineJoin;
+    this.changed();
   }
 
   /**
@@ -220,6 +229,7 @@ class Stroke {
    */
   setMiterLimit(miterLimit) {
     this.miterLimit_ = miterLimit;
+    this.changed();
   }
 
   /**
@@ -230,6 +240,7 @@ class Stroke {
    */
   setWidth(width) {
     this.width_ = width;
+    this.changed();
   }
 }
 

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -4,6 +4,7 @@
 
 import CircleStyle from './Circle.js';
 import Fill from './Fill.js';
+import Observable from '../Observable.js';
 import Stroke from './Stroke.js';
 import {assert} from '../asserts.js';
 
@@ -53,6 +54,8 @@ import {assert} from '../asserts.js';
  * @property {import("./Text.js").default} [text] Text style.
  * @property {number} [zIndex] Z index.
  */
+
+const change = 'change';
 
 /**
  * @classdesc
@@ -149,11 +152,15 @@ import {assert} from '../asserts.js';
  *
  * @api
  */
-class Style {
+class Style extends Observable {
   /**
    * @param {Options} [opt_options] Style options.
    */
   constructor(opt_options) {
+    super();
+
+    this.handleChange_ = this.handleChange_.bind(this);
+
     const options = opt_options || {};
 
     /**
@@ -176,13 +183,19 @@ class Style {
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.fill_ = options.fill !== undefined ? options.fill : null;
+    this.fill_ = null;
+    if (options.fill) {
+      this.setFill(options.fill);
+    }
 
     /**
      * @private
      * @type {import("./Image.js").default}
      */
-    this.image_ = options.image !== undefined ? options.image : null;
+    this.image_ = null;
+    if (options.image) {
+      this.setImage(options.image);
+    }
 
     /**
      * @private
@@ -203,19 +216,32 @@ class Style {
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.stroke_ = options.stroke !== undefined ? options.stroke : null;
+    this.stroke_ = null;
+    if (options.stroke) {
+      this.setStroke(options.stroke);
+    }
 
     /**
      * @private
      * @type {import("./Text.js").default}
      */
-    this.text_ = options.text !== undefined ? options.text : null;
+    this.text_ = null;
+    if (options.text) {
+      this.setText(options.text);
+    }
 
     /**
      * @private
      * @type {number|undefined}
      */
     this.zIndex_ = options.zIndex;
+  }
+
+  /**
+   * @private
+   */
+  handleChange_() {
+    this.changed();
   }
 
   /**
@@ -259,6 +285,7 @@ class Style {
    */
   setRenderer(renderer) {
     this.renderer_ = renderer;
+    this.changed();
   }
 
   /**
@@ -317,7 +344,14 @@ class Style {
    * @api
    */
   setFill(fill) {
+    if (this.fill_) {
+      this.fill_.removeEventListener(change, this.handleChange_);
+    }
     this.fill_ = fill;
+    if (fill) {
+      fill.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -335,7 +369,14 @@ class Style {
    * @api
    */
   setImage(image) {
+    if (this.image_) {
+      this.image_.removeEventListener(change, this.handleChange_);
+    }
     this.image_ = image;
+    if (image) {
+      image.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -353,7 +394,14 @@ class Style {
    * @api
    */
   setStroke(stroke) {
+    if (this.stroke_) {
+      this.stroke_.removeEventListener(change, this.handleChange_);
+    }
     this.stroke_ = stroke;
+    if (stroke) {
+      stroke.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -371,7 +419,14 @@ class Style {
    * @api
    */
   setText(text) {
+    if (this.text_) {
+      this.text_.removeEventListener(change, this.handleChange_);
+    }
     this.text_ = text;
+    if (text) {
+      text.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -408,6 +463,7 @@ class Style {
       };
     }
     this.geometry_ = geometry;
+    this.changed();
   }
 
   /**
@@ -418,6 +474,7 @@ class Style {
    */
   setZIndex(zIndex) {
     this.zIndex_ = zIndex;
+    this.changed();
   }
 }
 

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -2,6 +2,7 @@
  * @module ol/style/Text
  */
 import Fill from './Fill.js';
+import Observable from '../Observable.js';
 import {toSize} from '../size.js';
 
 /**
@@ -58,16 +59,22 @@ const DEFAULT_FILL_COLOR = '#333';
  * values in the array is `[top, right, bottom, left]`.
  */
 
+const change = 'change';
+
 /**
  * @classdesc
  * Set text style for vector features.
  * @api
  */
-class Text {
+class Text extends Observable {
   /**
    * @param {Options} [opt_options] Options.
    */
   constructor(opt_options) {
+    super();
+
+    this.handleChange_ = this.handleChange_.bind(this);
+
     const options = opt_options || {};
 
     /**
@@ -128,10 +135,8 @@ class Text {
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.fill_ =
-      options.fill !== undefined
-        ? options.fill
-        : new Fill({color: DEFAULT_FILL_COLOR});
+    this.fill_ = null;
+    this.setFill(options.fill || new Fill({color: DEFAULT_FILL_COLOR}));
 
     /**
      * @private
@@ -157,7 +162,10 @@ class Text {
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.stroke_ = options.stroke !== undefined ? options.stroke : null;
+    this.stroke_ = null;
+    if (options.stroke) {
+      this.setStroke(options.stroke);
+    }
 
     /**
      * @private
@@ -175,23 +183,32 @@ class Text {
      * @private
      * @type {import("./Fill.js").default}
      */
-    this.backgroundFill_ = options.backgroundFill
-      ? options.backgroundFill
-      : null;
+    this.backgroundFill_ = null;
+    if (options.backgroundFill) {
+      this.setBackgroundFill(options.backgroundFill);
+    }
 
     /**
      * @private
      * @type {import("./Stroke.js").default}
      */
-    this.backgroundStroke_ = options.backgroundStroke
-      ? options.backgroundStroke
-      : null;
+    this.backgroundStroke_ = null;
+    if (options.backgroundStroke) {
+      this.setBackgroundStroke(options.backgroundStroke);
+    }
 
     /**
      * @private
      * @type {Array<number>|null}
      */
     this.padding_ = options.padding === undefined ? null : options.padding;
+  }
+
+  /**
+   * @private
+   */
+  handleChange_() {
+    this.changed();
   }
 
   /**
@@ -405,6 +422,7 @@ class Text {
    */
   setOverflow(overflow) {
     this.overflow_ = overflow;
+    this.changed();
   }
 
   /**
@@ -415,6 +433,7 @@ class Text {
    */
   setFont(font) {
     this.font_ = font;
+    this.changed();
   }
 
   /**
@@ -425,6 +444,7 @@ class Text {
    */
   setMaxAngle(maxAngle) {
     this.maxAngle_ = maxAngle;
+    this.changed();
   }
 
   /**
@@ -435,6 +455,7 @@ class Text {
    */
   setOffsetX(offsetX) {
     this.offsetX_ = offsetX;
+    this.changed();
   }
 
   /**
@@ -445,6 +466,7 @@ class Text {
    */
   setOffsetY(offsetY) {
     this.offsetY_ = offsetY;
+    this.changed();
   }
 
   /**
@@ -455,6 +477,7 @@ class Text {
    */
   setPlacement(placement) {
     this.placement_ = placement;
+    this.changed();
   }
 
   /**
@@ -465,6 +488,7 @@ class Text {
    */
   setRotateWithView(rotateWithView) {
     this.rotateWithView_ = rotateWithView;
+    this.changed();
   }
 
   /**
@@ -474,7 +498,14 @@ class Text {
    * @api
    */
   setFill(fill) {
+    if (this.fill_) {
+      this.fill_.removeEventListener(change, this.handleChange_);
+    }
     this.fill_ = fill;
+    if (fill) {
+      fill.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -485,6 +516,7 @@ class Text {
    */
   setRotation(rotation) {
     this.rotation_ = rotation;
+    this.changed();
   }
 
   /**
@@ -496,6 +528,7 @@ class Text {
   setScale(scale) {
     this.scale_ = scale;
     this.scaleArray_ = toSize(scale !== undefined ? scale : 1);
+    this.changed();
   }
 
   /**
@@ -505,7 +538,14 @@ class Text {
    * @api
    */
   setStroke(stroke) {
+    if (this.stroke_) {
+      this.stroke_.removeEventListener(change, this.handleChange_);
+    }
     this.stroke_ = stroke;
+    if (stroke) {
+      stroke.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -516,6 +556,7 @@ class Text {
    */
   setText(text) {
     this.text_ = text;
+    this.changed();
   }
 
   /**
@@ -526,6 +567,7 @@ class Text {
    */
   setTextAlign(textAlign) {
     this.textAlign_ = textAlign;
+    this.changed();
   }
 
   /**
@@ -536,6 +578,7 @@ class Text {
    */
   setJustify(justify) {
     this.justify_ = justify;
+    this.changed();
   }
 
   /**
@@ -546,6 +589,7 @@ class Text {
    */
   setTextBaseline(textBaseline) {
     this.textBaseline_ = textBaseline;
+    this.changed();
   }
 
   /**
@@ -555,7 +599,14 @@ class Text {
    * @api
    */
   setBackgroundFill(fill) {
+    if (this.backgroundFill_) {
+      this.backgroundFill_.removeEventListener(change, this.handleChange_);
+    }
     this.backgroundFill_ = fill;
+    if (fill) {
+      fill.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -565,7 +616,14 @@ class Text {
    * @api
    */
   setBackgroundStroke(stroke) {
+    if (this.backgroundStroke_) {
+      this.backgroundStroke_.removeEventListener(change, this.handleChange_);
+    }
     this.backgroundStroke_ = stroke;
+    if (stroke) {
+      stroke.addEventListener(change, this.handleChange_);
+    }
+    this.changed();
   }
 
   /**
@@ -576,6 +634,7 @@ class Text {
    */
   setPadding(padding) {
     this.padding_ = padding;
+    this.changed();
   }
 }
 

--- a/test/browser/spec/ol/graticule.test.js
+++ b/test/browser/spec/ol/graticule.test.js
@@ -187,8 +187,6 @@ describe('ol.layer.Graticule', function () {
       graticule.createGraticule_(extent, [0, 0], resolution, squaredTolerance);
       expect(graticule.meridiansLabels_[0].text).to.be('lon: 0');
       expect(graticule.parallelsLabels_[0].text).to.be('lat: 0');
-      expect(graticule.lonLabelStyle_(feature).getText()).to.eql(lonLabelStyle);
-      expect(graticule.latLabelStyle_(feature).getText()).to.eql(latLabelStyle);
       feature.set('graticule_label', graticule.meridiansLabels_[0].text);
       expect(graticule.lonLabelStyle_(feature).getText().getText()).to.be(
         'lon: 0'

--- a/test/node/ol/Feature.test.js
+++ b/test/node/ol/Feature.test.js
@@ -3,6 +3,7 @@ import Point from '../../../src/ol/geom/Point.js';
 import Style from '../../../src/ol/style/Style.js';
 import expect from '../expect.js';
 import sinon from 'sinon';
+import {Stroke} from '../../../src/ol/style.js';
 import {isEmpty} from '../../../src/ol/obj.js';
 
 describe('ol/Feature.js', function () {
@@ -33,6 +34,17 @@ describe('ol/Feature.js', function () {
       const geometry = feature.getGeometry();
       expect(geometry).to.be.a(Point);
       expect(feature.get('geometry')).to.be(geometry);
+    });
+  });
+
+  describe('change event', () => {
+    it('is fired if the style is modified', (done) => {
+      const feature = new Feature();
+      const style = new Style({stroke: new Stroke({width: 10})});
+      feature.setStyle(style);
+      feature.on('change', () => done());
+
+      style.getStroke().setWidth(42);
     });
   });
 
@@ -379,7 +391,8 @@ describe('ol/Feature.js', function () {
       const coordinates = geometryClone.getFlatCoordinates();
       expect(coordinates[0]).to.be(1);
       expect(coordinates[1]).to.be(2);
-      expect(clone.getStyle()).to.be(style);
+      expect(clone.getStyle()).to.be.a(Style);
+      expect(clone.getStyle()).not.to.be(style);
       expect(clone.get('barkey')).to.be('barval');
     });
 

--- a/test/node/ol/layer/Vector.test.js
+++ b/test/node/ol/layer/Vector.test.js
@@ -1,0 +1,15 @@
+import Fill from '../../../../src/ol/style/Fill.js';
+import Style from '../../../../src/ol/style/Style.js';
+import Vector from '../../../../src/ol/layer/Vector.js';
+
+describe('ol/layer/Vector.js', () => {
+  describe('change event', () => {
+    it('is fired if the style is modified', (done) => {
+      const style = new Style({fill: new Fill({color: 'yellow'})});
+      const layer = new Vector({style});
+      layer.on('change', () => done());
+
+      style.getFill().setColor('black');
+    });
+  });
+});

--- a/test/node/ol/style/Style.test.js
+++ b/test/node/ol/style/Style.test.js
@@ -1,0 +1,108 @@
+import Fill from '../../../../src/ol/style/Fill.js';
+import Stroke from '../../../../src/ol/style/Stroke.js';
+import Style from '../../../../src/ol/style/Style.js';
+import Text from '../../../../src/ol/style/Text.js';
+import {Circle} from '../../../../src/ol/style.js';
+
+describe('ol/Style.js', () => {
+  describe('change event', () => {
+    it('is fired if the stroke changes', (done) => {
+      const style = new Style({
+        stroke: new Stroke({width: 10}),
+      });
+      style.on('change', () => done());
+
+      style.setStroke(new Stroke({width: 20}));
+    });
+
+    it('is fired if the stroke width changes', (done) => {
+      const style = new Style({
+        stroke: new Stroke({width: 10}),
+      });
+      style.on('change', () => done());
+
+      style.getStroke().setWidth(20);
+    });
+
+    it('is fired if the stroke color changes', (done) => {
+      const style = new Style({
+        stroke: new Stroke({width: 10}),
+      });
+      style.on('change', () => done());
+
+      style.getStroke().setColor('green');
+    });
+
+    it('is fired if the fill changes', (done) => {
+      const style = new Style({
+        stroke: new Fill({color: 'red'}),
+      });
+      style.on('change', () => done());
+
+      style.setFill(new Fill({color: 'blue'}));
+    });
+
+    it('is fired if the fill color changes', (done) => {
+      const style = new Style({
+        fill: new Fill({color: 'red'}),
+      });
+      style.on('change', () => done());
+
+      style.getFill().setColor('blue');
+    });
+
+    it('is fired if the text changes', (done) => {
+      const style = new Style({
+        text: new Text({text: 'chicken'}),
+      });
+      style.on('change', () => done());
+
+      style.setText(new Text({text: 'soup'}));
+    });
+
+    it('is fired if the text stroke changes', (done) => {
+      const style = new Style({
+        text: new Text({text: 'chicken', stroke: new Stroke({color: 'blue'})}),
+      });
+      style.on('change', () => done());
+
+      style.getText().setStroke(new Stroke({color: 'red'}));
+    });
+
+    it('is fired if the text stroke width changes', (done) => {
+      const style = new Style({
+        text: new Text({text: 'chicken', stroke: new Stroke({color: 'blue'})}),
+      });
+      style.on('change', () => done());
+
+      style.getText().getStroke().setWidth(10);
+    });
+
+    it('is fired if the image changes', (done) => {
+      const style = new Style({
+        image: new Circle({fill: new Fill({color: 'gray'})}),
+      });
+      style.on('change', () => done());
+
+      style.setImage(new Circle({fill: new Fill({color: 'purple'})}));
+    });
+
+    it('is fired if the image fill changes', (done) => {
+      const style = new Style({
+        image: new Circle({fill: new Fill({color: 'gray'})}),
+      });
+      style.on('change', () => done());
+
+      style.getImage().setFill(new Fill({color: 'purple'}));
+    });
+
+    it('is fired if the image fill color changes', (done) => {
+      const style = new Style({
+        image: new Circle({fill: new Fill({color: 'gray'})}),
+      });
+      style.on('change', () => done());
+
+      style.getImage().getFill().setColor('purple');
+    });
+  });
+});


### PR DESCRIPTION
Although we have methods to modify styles, we also require that application developers manually call `layer.changed()` to get the map to render after a style is modified.  Instead, changes to styles should propagate to their parent layer or feature.