### PR TITLE
Remove workaround for Array.prototype.includes

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next version
 
+#### Internet Explorer is no longer supported
+
+Please see https://docs.microsoft.com/en-us/lifecycle/announcements/internet-explorer-11-end-of-support.
+
 ### 6.15.0
 
 #### Deprecated `tilePixelRatio` option for data tile sources.

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -22,7 +22,6 @@ import {
   pushSerializeAndPop,
 } from '../xml.js';
 import {get as getProjection} from '../proj.js';
-import {includes} from '../array.js';
 import {
   readDateTime,
   readDecimal,
@@ -172,7 +171,7 @@ class GPX extends XMLFeature {
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
-    if (!includes(NAMESPACE_URIS, node.namespaceURI)) {
+    if (!NAMESPACE_URIS.includes(node.namespaceURI)) {
       return null;
     }
     const featureReader = FEATURE_READER[node.localName];
@@ -195,7 +194,7 @@ class GPX extends XMLFeature {
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {
-    if (!includes(NAMESPACE_URIS, node.namespaceURI)) {
+    if (!NAMESPACE_URIS.includes(node.namespaceURI)) {
       return [];
     }
     if (node.localName == 'gpx') {

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -3,7 +3,6 @@
  */
 
 import {assert} from '../asserts.js';
-import {includes} from '../array.js';
 
 /**
  * @typedef {Object} PreferredOptions
@@ -249,10 +248,10 @@ function generateVersion3Options(iiifInfo) {
       iiifInfo.imageInfo.preferredFormats.length > 0
         ? iiifInfo.imageInfo.preferredFormats
             .filter(function (format) {
-              return includes(['jpg', 'png', 'gif'], format);
+              return ['jpg', 'png', 'gif'].includes(format);
             })
             .reduce(function (acc, format) {
-              return acc === undefined && includes(formats, format)
+              return acc === undefined && formats.includes(format)
                 ? format
                 : acc;
             }, undefined)
@@ -460,16 +459,16 @@ class IIIFInfo {
       sizes: imageOptions.sizes,
       format:
         options.format !== undefined &&
-        includes(imageOptions.formats, options.format)
+        imageOptions.formats.includes(options.format)
           ? options.format
           : imageOptions.preferredFormat !== undefined
           ? imageOptions.preferredFormat
           : 'jpg',
       supports: imageOptions.supports,
       quality:
-        options.quality && includes(imageOptions.qualities, options.quality)
+        options.quality && imageOptions.qualities.includes(options.quality)
           ? options.quality
-          : includes(imageOptions.qualities, 'native')
+          : imageOptions.qualities.includes('native')
           ? 'native'
           : 'default',
       resolutions: Array.isArray(imageOptions.resolutions)

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -37,7 +37,7 @@ import {
 } from '../xml.js';
 import {asArray} from '../color.js';
 import {assert} from '../asserts.js';
-import {extend, includes} from '../array.js';
+import {extend} from '../array.js';
 import {get as getProjection} from '../proj.js';
 import {
   readBoolean,
@@ -631,7 +631,7 @@ class KML extends XMLFeature {
    * @return {import("../Feature.js").default} Feature.
    */
   readFeatureFromNode(node, opt_options) {
-    if (!includes(NAMESPACE_URIS, node.namespaceURI)) {
+    if (!NAMESPACE_URIS.includes(node.namespaceURI)) {
       return null;
     }
     const feature = this.readPlacemark_(node, [
@@ -651,7 +651,7 @@ class KML extends XMLFeature {
    * @return {Array<import("../Feature.js").default>} Features.
    */
   readFeaturesFromNode(node, opt_options) {
-    if (!includes(NAMESPACE_URIS, node.namespaceURI)) {
+    if (!NAMESPACE_URIS.includes(node.namespaceURI)) {
       return [];
     }
     let features;
@@ -730,14 +730,14 @@ class KML extends XMLFeature {
    */
   readNameFromNode(node) {
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
-      if (includes(NAMESPACE_URIS, n.namespaceURI) && n.localName == 'name') {
+      if (NAMESPACE_URIS.includes(n.namespaceURI) && n.localName == 'name') {
         return readString(n);
       }
     }
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
       const localName = n.localName;
       if (
-        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        NAMESPACE_URIS.includes(n.namespaceURI) &&
         (localName == 'Document' ||
           localName == 'Folder' ||
           localName == 'Placemark' ||
@@ -803,7 +803,7 @@ class KML extends XMLFeature {
     const networkLinks = [];
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
       if (
-        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        NAMESPACE_URIS.includes(n.namespaceURI) &&
         n.localName == 'NetworkLink'
       ) {
         const obj = pushParseAndPop({}, NETWORK_LINK_PARSERS, n, []);
@@ -813,7 +813,7 @@ class KML extends XMLFeature {
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
       const localName = n.localName;
       if (
-        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        NAMESPACE_URIS.includes(n.namespaceURI) &&
         (localName == 'Document' || localName == 'Folder' || localName == 'kml')
       ) {
         extend(networkLinks, this.readNetworkLinksFromNode(n));
@@ -867,7 +867,7 @@ class KML extends XMLFeature {
   readRegionFromNode(node) {
     const regions = [];
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
-      if (includes(NAMESPACE_URIS, n.namespaceURI) && n.localName == 'Region') {
+      if (NAMESPACE_URIS.includes(n.namespaceURI) && n.localName == 'Region') {
         const obj = pushParseAndPop({}, REGION_PARSERS, n, []);
         regions.push(obj);
       }
@@ -875,7 +875,7 @@ class KML extends XMLFeature {
     for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
       const localName = n.localName;
       if (
-        includes(NAMESPACE_URIS, n.namespaceURI) &&
+        NAMESPACE_URIS.includes(n.namespaceURI) &&
         (localName == 'Document' || localName == 'Folder' || localName == 'kml')
       ) {
         extend(regions, this.readRegionFromNode(n));

--- a/src/ol/format/WMSGetFeatureInfo.js
+++ b/src/ol/format/WMSGetFeatureInfo.js
@@ -4,7 +4,7 @@
 import GML2 from './GML2.js';
 import XMLFeature from './XMLFeature.js';
 import {assign} from '../obj.js';
-import {extend, includes} from '../array.js';
+import {extend} from '../array.js';
 import {makeArrayPusher, makeStructureNS, pushParseAndPop} from '../xml.js';
 
 /**
@@ -100,7 +100,7 @@ class WMSGetFeatureInfo extends XMLFeature {
         const toRemove = layerIdentifier;
         const layerName = layerElement.localName.replace(toRemove, '');
 
-        if (this.layers_ && !includes(this.layers_, layerName)) {
+        if (this.layers_ && !this.layers_.includes(layerName)) {
           continue;
         }
 

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -32,7 +32,7 @@ import {
   squaredDistanceToSegment,
 } from '../coordinate.js';
 import {createEditingStyle} from '../style/Style.js';
-import {equals, includes} from '../array.js';
+import {equals} from '../array.js';
 import {fromCircle} from '../geom/Polygon.js';
 import {
   fromUserCoordinate,
@@ -1190,7 +1190,7 @@ class Modify extends PointerInteraction {
             );
           if (
             geometry.getType() === 'Point' &&
-            includes(this.features_.getArray(), feature)
+            this.features_.getArray().includes(feature)
           ) {
             hitPointGeometry = geometry;
             const coordinate = geometry.getFlatCoordinates().slice(0, 2);

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -7,7 +7,6 @@ import InteractionProperty from './Property.js';
 import PointerInteraction from './Pointer.js';
 import {TRUE} from '../functions.js';
 import {always} from '../events/condition.js';
-import {includes} from '../array.js';
 
 /**
  * @enum {string}
@@ -182,7 +181,7 @@ class Translate extends PointerInteraction {
       } else {
         const layers = options.layers;
         layerFilter = function (layer) {
-          return includes(layers, layer);
+          return layers.includes(layer);
         };
       }
     } else {
@@ -347,7 +346,7 @@ class Translate extends PointerInteraction {
       pixel,
       function (feature, layer) {
         if (this.filter_(feature, layer)) {
-          if (!this.features_ || includes(this.features_.getArray(), feature)) {
+          if (!this.features_ || this.features_.getArray().includes(feature)) {
             return feature;
           }
         }

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -9,7 +9,6 @@ import {DEFAULT_TILE_SIZE} from '../tilegrid/common.js';
 import {Versions} from '../format/IIIFInfo.js';
 import {assert} from '../asserts.js';
 import {getTopLeft} from '../extent.js';
-import {includes} from '../array.js';
 import {toSize} from '../size.js';
 
 /**
@@ -119,11 +118,11 @@ class IIIF extends TileImage {
     const supportsArbitraryTiling =
       supports != undefined &&
       Array.isArray(supports) &&
-      (includes(supports, 'regionByPx') || includes(supports, 'regionByPct')) &&
-      (includes(supports, 'sizeByWh') ||
-        includes(supports, 'sizeByH') ||
-        includes(supports, 'sizeByW') ||
-        includes(supports, 'sizeByPct'));
+      (supports.includes('regionByPx') || supports.includes('regionByPct')) &&
+      (supports.includes('sizeByWh') ||
+        supports.includes('sizeByH') ||
+        supports.includes('sizeByW') ||
+        supports.includes('sizeByPct'));
 
     let tileWidth, tileHeight, maxZoom;
 
@@ -278,10 +277,10 @@ class IIIF extends TileImage {
           regionParam = 'full';
         } else if (
           !supportsArbitraryTiling ||
-          includes(supports, 'regionByPx')
+          supports.includes('regionByPx')
         ) {
           regionParam = regionX + ',' + regionY + ',' + regionW + ',' + regionH;
-        } else if (includes(supports, 'regionByPct')) {
+        } else if (supports.includes('regionByPct')) {
           const pctX = formatPercentage((regionX / width) * 100),
             pctY = formatPercentage((regionY / height) * 100),
             pctW = formatPercentage((regionW / width) * 100),
@@ -290,16 +289,16 @@ class IIIF extends TileImage {
         }
         if (
           version == Versions.VERSION3 &&
-          (!supportsArbitraryTiling || includes(supports, 'sizeByWh'))
+          (!supportsArbitraryTiling || supports.includes('sizeByWh'))
         ) {
           sizeParam = sizeW + ',' + sizeH;
-        } else if (!supportsArbitraryTiling || includes(supports, 'sizeByW')) {
+        } else if (!supportsArbitraryTiling || supports.includes('sizeByW')) {
           sizeParam = sizeW + ',';
-        } else if (includes(supports, 'sizeByH')) {
+        } else if (supports.includes('sizeByH')) {
           sizeParam = ',' + sizeH;
-        } else if (includes(supports, 'sizeByWh')) {
+        } else if (supports.includes('sizeByWh')) {
           sizeParam = sizeW + ',' + sizeH;
-        } else if (includes(supports, 'sizeByPct')) {
+        } else if (supports.includes('sizeByPct')) {
           sizeParam = 'pct:' + formatPercentage(100 / scale);
         }
       } else {

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -9,7 +9,7 @@ import {containsExtent} from '../extent.js';
 import {createFromCapabilitiesMatrixSet} from '../tilegrid/WMTS.js';
 import {createFromTileUrlFunctions, expandUrl} from '../tileurlfunction.js';
 import {equivalent, get as getProjection, transformExtent} from '../proj.js';
-import {find, findIndex, includes} from '../array.js';
+import {find, findIndex} from '../array.js';
 
 /**
  * Request encoding. One of 'KVP', 'REST'.
@@ -566,7 +566,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
           requestEncoding = encodings[0];
         }
         if (requestEncoding === 'KVP') {
-          if (includes(encodings, 'KVP')) {
+          if (encodings.includes('KVP')) {
             urls.push(/** @type {string} */ (gets[i]['href']));
           }
         } else {


### PR DESCRIPTION
This removes the `includes` function from `ol/array.js` in favor of Array.prototype.includes.

See #13883.