### PR TITLE
Remove find and findIndex from array module

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -209,20 +209,6 @@ export function stableSort(arr, compareFnc) {
 }
 
 /**
- * @param {Array<*>} arr The array to search in.
- * @param {Function} func Comparison function.
- * @return {number} Return index.
- */
-export function findIndex(arr, func) {
-  let index;
-  const found = !arr.every(function (el, idx) {
-    index = idx;
-    return !func(el, idx, arr);
-  });
-  return found ? index : -1;
-}
-
-/**
  * @param {Array<*>} arr The array to test.
  * @param {Function} [opt_func] Comparison function.
  * @param {boolean} [opt_strict] Strictly sorted (default false).

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -169,25 +169,6 @@ export function remove(arr, obj) {
 }
 
 /**
- * @param {Array<VALUE>} arr The array to search in.
- * @param {function(VALUE, number, ?) : boolean} func The function to compare.
- * @template VALUE
- * @return {VALUE|null} The element found or null.
- */
-export function find(arr, func) {
-  const length = arr.length >>> 0;
-  let value;
-
-  for (let i = 0; i < length; i++) {
-    value = arr[i];
-    if (func(value, i, arr)) {
-      return value;
-    }
-  }
-  return null;
-}
-
-/**
  * @param {Array|Uint8ClampedArray} arr1 The first array to compare.
  * @param {Array|Uint8ClampedArray} arr2 The second array to compare.
  * @return {boolean} Whether the two arrays are equal.

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -9,7 +9,7 @@ import {containsExtent} from '../extent.js';
 import {createFromCapabilitiesMatrixSet} from '../tilegrid/WMTS.js';
 import {createFromTileUrlFunctions, expandUrl} from '../tileurlfunction.js';
 import {equivalent, get as getProjection, transformExtent} from '../proj.js';
-import {find, findIndex} from '../array.js';
+import {findIndex} from '../array.js';
 
 /**
  * Request encoding. One of 'KVP', 'REST'.
@@ -372,10 +372,10 @@ export default WMTS;
  */
 export function optionsFromCapabilities(wmtsCap, config) {
   const layers = wmtsCap['Contents']['Layer'];
-  const l = find(layers, function (elt, index, array) {
+  const l = layers.find(function (elt) {
     return elt['Identifier'] == config['layer'];
   });
-  if (l === null) {
+  if (!l) {
     return null;
   }
   const tileMatrixSets = wmtsCap['Contents']['TileMatrixSet'];
@@ -383,7 +383,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   if (l['TileMatrixSetLink'].length > 1) {
     if ('projection' in config) {
       idx = findIndex(l['TileMatrixSetLink'], function (elt, index, array) {
-        const tileMatrixSet = find(tileMatrixSets, function (el) {
+        const tileMatrixSet = tileMatrixSets.find(function (el) {
           return el['Identifier'] == elt['TileMatrixSet'];
         });
         const supportedCRS = tileMatrixSet['SupportedCRS'];
@@ -442,7 +442,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   }
 
   const matrixSets = wmtsCap['Contents']['TileMatrixSet'];
-  const matrixSetObj = find(matrixSets, function (elt, index, array) {
+  const matrixSetObj = matrixSets.find(function (elt) {
     return elt['Identifier'] == matrixSet;
   });
 
@@ -477,8 +477,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   //in case of matrix limits, use matrix limits to calculate extent
   if (matrixLimits) {
     selectedMatrixLimit = matrixLimits[matrixLimits.length - 1];
-    const m = find(
-      matrixSetObj.TileMatrix,
+    const m = matrixSetObj.TileMatrix.find(
       (tileMatrixValue) =>
         tileMatrixValue.Identifier === selectedMatrixLimit.TileMatrix ||
         matrixSetObj.Identifier + ':' + tileMatrixValue.Identifier ===
@@ -556,7 +555,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
 
     for (let i = 0, ii = gets.length; i < ii; ++i) {
       if (gets[i]['Constraint']) {
-        const constraint = find(gets[i]['Constraint'], function (element) {
+        const constraint = gets[i]['Constraint'].find(function (element) {
           return element['name'] == 'GetEncoding';
         });
         const encodings = constraint['AllowedValues']['Value'];

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -9,7 +9,6 @@ import {containsExtent} from '../extent.js';
 import {createFromCapabilitiesMatrixSet} from '../tilegrid/WMTS.js';
 import {createFromTileUrlFunctions, expandUrl} from '../tileurlfunction.js';
 import {equivalent, get as getProjection, transformExtent} from '../proj.js';
-import {findIndex} from '../array.js';
 
 /**
  * Request encoding. One of 'KVP', 'REST'.
@@ -382,7 +381,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   let idx;
   if (l['TileMatrixSetLink'].length > 1) {
     if ('projection' in config) {
-      idx = findIndex(l['TileMatrixSetLink'], function (elt, index, array) {
+      idx = l['TileMatrixSetLink'].findIndex(function (elt) {
         const tileMatrixSet = tileMatrixSets.find(function (el) {
           return el['Identifier'] == elt['TileMatrixSet'];
         });
@@ -396,7 +395,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
         }
       });
     } else {
-      idx = findIndex(l['TileMatrixSetLink'], function (elt, index, array) {
+      idx = l['TileMatrixSetLink'].findIndex(function (elt) {
         return elt['TileMatrixSet'] == config['matrixSet'];
       });
     }
@@ -417,7 +416,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   if ('format' in config) {
     format = config['format'];
   }
-  idx = findIndex(l['Style'], function (elt, index, array) {
+  idx = l['Style'].findIndex(function (elt) {
     if ('style' in config) {
       return elt['Title'] == config['style'];
     } else {

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -3,7 +3,6 @@
  */
 
 import TileGrid from './TileGrid.js';
-import {find} from '../array.js';
 import {get as getProjection} from '../proj.js';
 
 /**
@@ -138,7 +137,7 @@ export function createFromCapabilitiesMatrixSet(
     // use of matrixLimits to filter TileMatrices from GetCapabilities
     // TileMatrixSet from unavailable matrix levels.
     if (matrixLimits.length > 0) {
-      matrixAvailable = find(matrixLimits, function (elt_ml) {
+      matrixAvailable = matrixLimits.find(function (elt_ml) {
         if (elt[identifierPropName] == elt_ml[matrixIdsPropName]) {
           return true;
         }

--- a/test/browser/spec/ol/format/kml.test.js
+++ b/test/browser/spec/ol/format/kml.test.js
@@ -31,7 +31,6 @@ import {
   get as getProjection,
   transform,
 } from '../../../../../src/ol/proj.js';
-import {find} from '../../../../../src/ol/array.js';
 import {parse} from '../../../../../src/ol/xml.js';
 import {remove as removeTransform} from '../../../../../src/ol/proj/transforms.js';
 
@@ -4256,7 +4255,7 @@ describe('ol.format.KML', function () {
       });
 
       it('creates a Point and a MultiPolygon for Alaska', function () {
-        const alaska = find(features, function (feature) {
+        const alaska = features.find(function (feature) {
           return feature.get('name') === 'Alaska';
         });
         expect(alaska).to.be.an(Feature);

--- a/test/node/ol/array.test.js
+++ b/test/node/ol/array.test.js
@@ -3,7 +3,6 @@ import {
   binarySearch,
   equals,
   extend,
-  findIndex,
   isSorted,
   linearFindNearest,
   numberSafeCompareFunction,
@@ -379,26 +378,6 @@ describe('ol/array.js', function () {
       }
       extend(a, bigArray);
       expect(a).to.eql(bigArray);
-    });
-  });
-
-  describe('findIndex', function () {
-    it('finds index of numbers in an array', function () {
-      const a = [0, 1, 2, 3];
-      const b = findIndex(a, function (val, index, a2) {
-        expect(a).to.equal(a2);
-        expect(typeof index).to.be('number');
-        return val > 1;
-      });
-      expect(b).to.be(2);
-    });
-
-    it('returns -1 when an item in an array is not found', function () {
-      const a = [0, 1, 2, 3];
-      const b = findIndex(a, function (val, index, a2) {
-        return val > 100;
-      });
-      expect(b).to.be(-1);
     });
   });
 

--- a/test/node/ol/array.test.js
+++ b/test/node/ol/array.test.js
@@ -3,7 +3,6 @@ import {
   binarySearch,
   equals,
   extend,
-  find,
   findIndex,
   isSorted,
   linearFindNearest,
@@ -380,44 +379,6 @@ describe('ol/array.js', function () {
       }
       extend(a, bigArray);
       expect(a).to.eql(bigArray);
-    });
-  });
-
-  describe('find', function () {
-    it('finds numbers in an array', function () {
-      const a = [0, 1, 2, 3];
-      const b = find(a, function (val, index, a2) {
-        expect(a).to.equal(a2);
-        expect(typeof index).to.be('number');
-        return val > 1;
-      });
-      expect(b).to.be(2);
-    });
-
-    it('returns null when an item in an array is not found', function () {
-      const a = [0, 1, 2, 3];
-      const b = find(a, function (val, index, a2) {
-        return val > 100;
-      });
-      expect(b).to.be(null);
-    });
-
-    it('finds items in an array-like', function () {
-      const a = 'abCD';
-      const b = find(a, function (val, index, a2) {
-        expect(a).to.equal(a2);
-        expect(typeof index).to.be('number');
-        return val >= 'A' && val <= 'Z';
-      });
-      expect(b).to.be('C');
-    });
-
-    it('returns null when nothing in an array-like is found', function () {
-      const a = 'abcd';
-      const b = find(a, function (val, index, a2) {
-        return val >= 'A' && val <= 'Z';
-      });
-      expect(b).to.be(null);
     });
   });
 


### PR DESCRIPTION
This removes the `find` and `findIndex` functions from `ol/array.js` in favor of Array.prototype.find and Array.prototype.findIndex.

See #13883.