### PR TITLE
Use Object.values

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -9,7 +9,6 @@ import PointerEventType from './pointer/EventType.js';
 import Target from './events/Target.js';
 import {PASSIVE_EVENT_LISTENERS} from './has.js';
 import {VOID} from './functions.js';
-import {getValues} from './obj.js';
 import {listen, unlistenByKey} from './events.js';
 
 class MapBrowserEventHandler extends Target {
@@ -193,7 +192,7 @@ class MapBrowserEventHandler extends Target {
     ) {
       this.trackedTouches_[id] = event;
     }
-    this.activePointers_ = getValues(this.trackedTouches_);
+    this.activePointers_ = Object.values(this.trackedTouches_);
   }
 
   /**

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -20,7 +20,6 @@ import {
   toUserCoordinate,
 } from '../proj.js';
 import {getUid} from '../util.js';
-import {getValues} from '../obj.js';
 import {listen, unlistenByKey} from '../events.js';
 
 /**
@@ -324,7 +323,7 @@ class Snap extends PointerInteraction {
    * @return {boolean} If the event was consumed.
    */
   handleUpEvent(evt) {
-    const featuresToUpdate = getValues(this.pendingFeatures_);
+    const featuresToUpdate = Object.values(this.pendingFeatures_);
     if (featuresToUpdate.length) {
       featuresToUpdate.forEach(this.updateFeature_.bind(this));
       this.pendingFeatures_ = {};

--- a/src/ol/obj.js
+++ b/src/ol/obj.js
@@ -44,25 +44,6 @@ export function clear(object) {
 }
 
 /**
- * Polyfill for Object.values().  Get an array of property values from an object.
- * See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values
- *
- * @param {!Object<K,V>} object The object from which to get the values.
- * @return {!Array<V>} The property values.
- * @template K,V
- */
-export const getValues =
-  typeof Object.values === 'function'
-    ? Object.values
-    : function (object) {
-        const values = [];
-        for (const property in object) {
-          values.push(object[property]);
-        }
-        return values;
-      };
-
-/**
  * Determine if an object has any properties.
  * @param {Object} object The object to check.
  * @return {boolean} The object is empty.

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -16,7 +16,7 @@ import {assert} from '../asserts.js';
 import {containsExtent, equals, wrapAndSliceX} from '../extent.js';
 import {extend} from '../array.js';
 import {getUid} from '../util.js';
-import {getValues, isEmpty} from '../obj.js';
+import {isEmpty} from '../obj.js';
 import {listen, unlistenByKey} from '../events.js';
 import {xhr} from '../featureloader.js';
 
@@ -704,7 +704,7 @@ class VectorSource extends Source {
     } else if (this.featuresRtree_) {
       features = this.featuresRtree_.getAll();
       if (!isEmpty(this.nullGeometryFeatures_)) {
-        extend(features, getValues(this.nullGeometryFeatures_));
+        extend(features, Object.values(this.nullGeometryFeatures_));
       }
     }
     return /** @type {Array<import("../Feature.js").default<Geometry>>} */ (

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -25,7 +25,6 @@ import {
   doubleClick,
   never,
 } from '../../../../../src/ol/events/condition.js';
-import {getValues} from '../../../../../src/ol/obj.js';
 
 describe('ol.interaction.Modify', function () {
   let target, map, layer, source, features;
@@ -965,7 +964,7 @@ describe('ol.interaction.Modify', function () {
     beforeEach(function () {
       getModifyListeners = function (feature, modify) {
         const listeners = feature.listeners_['change'];
-        const candidates = getValues(modify);
+        const candidates = Object.values(modify);
         return listeners.filter(function (listener) {
           return candidates.indexOf(listener) !== -1;
         });

--- a/test/node/ol/obj.test.js
+++ b/test/node/ol/obj.test.js
@@ -1,5 +1,5 @@
 import expect from '../expect.js';
-import {assign, clear, getValues, isEmpty} from '../../../src/ol/obj.js';
+import {assign, clear, isEmpty} from '../../../src/ol/obj.js';
 
 describe('ol/obj.js', () => {
   describe('assign()', function () {
@@ -46,13 +46,6 @@ describe('ol/obj.js', () => {
       expect(isEmpty(clear({foo: 'bar', num: 42}))).to.be(true);
       expect(isEmpty(clear({}))).to.be(true);
       expect(isEmpty(clear(null))).to.be(true);
-    });
-  });
-
-  describe('getValues()', function () {
-    it('gets a list of property values from an object', function () {
-      expect(getValues({foo: 'bar', num: 42}).sort()).to.eql([42, 'bar']);
-      expect(getValues([])).to.eql([]);
     });
   });
 


### PR DESCRIPTION
This removes the `getValues` function from `ol/obj.js` in favor of `Object.values()`.

See #13883.