### PR TITLE
Use Math.cosh and Math.log2

### DIFF
--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -15,31 +15,6 @@ export function clamp(value, min, max) {
 }
 
 /**
- * Return the base 2 logarithm of a given number. The method will use the
- * native `Math.log2` function if it is available, otherwise the base 2
- * logarithm will be calculated via the reference implementation of the
- * Mozilla developer network.
- *
- * @param {number} x X.
- * @return {number} Base 2 logarithm of x.
- */
-export const log2 = (function () {
-  // Wrapped in a iife, to save the overhead of checking for the native
-  // implementation on every invocation.
-  let log2;
-  if ('log2' in Math) {
-    // The environment supports the native Math.log2 function, use it…
-    log2 = Math.log2;
-  } else {
-    // … else, use the reference implementation of MDN:
-    log2 = function (x) {
-      return Math.log(x) * Math.LOG2E;
-    };
-  }
-  return log2;
-})();
-
-/**
  * Returns the square of the closest distance between the point (x, y) and the
  * line segment (x1, y1) to (x2, y2).
  * @param {number} x X.

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -15,32 +15,6 @@ export function clamp(value, min, max) {
 }
 
 /**
- * Return the hyperbolic cosine of a given number. The method will use the
- * native `Math.cosh` function if it is available, otherwise the hyperbolic
- * cosine will be calculated via the reference implementation of the Mozilla
- * developer network.
- *
- * @param {number} x X.
- * @return {number} Hyperbolic cosine of x.
- */
-export const cosh = (function () {
-  // Wrapped in a iife, to save the overhead of checking for the native
-  // implementation on every invocation.
-  let cosh;
-  if ('cosh' in Math) {
-    // The environment supports the native Math.cosh function, use it…
-    cosh = Math.cosh;
-  } else {
-    // … else, use the reference implementation of MDN:
-    cosh = function (x) {
-      const y = /** @type {Math} */ (Math).exp(x);
-      return (y + 1 / y) / 2;
-    };
-  }
-  return cosh;
-})();
-
-/**
  * Return the base 2 logarithm of a given number. The method will use the
  * native `Math.log2` function if it is available, otherwise the base 2
  * logarithm will be calculated via the reference implementation of the

--- a/src/ol/proj/epsg3857.js
+++ b/src/ol/proj/epsg3857.js
@@ -3,7 +3,6 @@
  */
 import Projection from './Projection.js';
 import Units from './Units.js';
-import {cosh} from '../math.js';
 
 /**
  * Radius of WGS84 sphere
@@ -54,7 +53,7 @@ class EPSG3857Projection extends Projection {
       global: true,
       worldExtent: WORLD_EXTENT,
       getPointResolution: function (resolution, point) {
-        return resolution / cosh(point[1] / RADIUS);
+        return resolution / Math.cosh(point[1] / RADIUS);
       },
     });
   }

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -14,7 +14,7 @@ import {
   intersects,
 } from '../extent.js';
 import {getTransform} from '../proj.js';
-import {log2, modulo} from '../math.js';
+import {modulo} from '../math.js';
 
 /**
  * Single triangle; consists of 3 source points and 3 target points.
@@ -169,7 +169,7 @@ class Triangulation {
         ? Math.max(
             0,
             Math.ceil(
-              log2(
+              Math.log2(
                 getArea(targetExtent) /
                   (opt_destinationResolution *
                     opt_destinationResolution *

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -6,7 +6,6 @@
 import PaletteTexture from '../webgl/PaletteTexture.js';
 import {Uniforms} from '../renderer/webgl/TileLayer.js';
 import {asArray, fromString, isStringColor} from '../color.js';
-import {log2} from '../math.js';
 
 /**
  * Base type used for literal style parameters; can be a number literal or the output of an operator,
@@ -183,7 +182,7 @@ export function getValueType(value) {
  * @return {boolean} True if only one type flag is enabled, false if zero or multiple
  */
 export function isTypeUnique(valueType) {
-  return log2(valueType) % 1 === 0;
+  return Math.log2(valueType) % 1 === 0;
 }
 
 /**

--- a/test/node/ol/math.test.js
+++ b/test/node/ol/math.test.js
@@ -4,7 +4,6 @@ import {
   clamp,
   floor,
   lerp,
-  log2,
   modulo,
   round,
   solveLinearSystem,
@@ -33,32 +32,6 @@ describe('ol/math.js', () => {
 
     it('returns the correct value at Infinity', function () {
       expect(clamp(Infinity, 10, 20)).to.eql(20);
-    });
-  });
-
-  describe('log2', function () {
-    it('returns the correct value at Infinity', function () {
-      expect(log2(Infinity)).to.eql(Infinity);
-    });
-
-    it('returns the correct value at 3', function () {
-      expect(log2(3)).to.roughlyEqual(1.584962500721156, 1e-9);
-    });
-
-    it('returns the correct value at 2', function () {
-      expect(log2(2)).to.eql(1);
-    });
-
-    it('returns the correct value at 1', function () {
-      expect(log2(1)).to.eql(0);
-    });
-
-    it('returns the correct value at 0', function () {
-      expect(log2(0)).to.eql(-Infinity);
-    });
-
-    it('returns the correct value at -1', function () {
-      expect(log2(-1).toString()).to.eql('NaN');
     });
   });
 

--- a/test/node/ol/math.test.js
+++ b/test/node/ol/math.test.js
@@ -2,7 +2,6 @@ import expect from '../expect.js';
 import {
   ceil,
   clamp,
-  cosh,
   floor,
   lerp,
   log2,
@@ -34,28 +33,6 @@ describe('ol/math.js', () => {
 
     it('returns the correct value at Infinity', function () {
       expect(clamp(Infinity, 10, 20)).to.eql(20);
-    });
-  });
-
-  describe('cosh', function () {
-    it('returns the correct value at -Infinity', function () {
-      expect(cosh(-Infinity)).to.eql(Infinity);
-    });
-
-    it('returns the correct value at -1', function () {
-      expect(cosh(-1)).to.roughlyEqual(1.5430806348152437, 1e-9);
-    });
-
-    it('returns the correct value at 0', function () {
-      expect(cosh(0)).to.eql(1);
-    });
-
-    it('returns the correct value at 1', function () {
-      expect(cosh(1)).to.roughlyEqual(1.5430806348152437, 1e-9);
-    });
-
-    it('returns the correct value at Infinity', function () {
-      expect(cosh(Infinity)).to.eql(Infinity);
     });
   });
 


### PR DESCRIPTION
This removes the `cosh` and `log2` functions from the `ol/math.js` module.

See #13883.