### PR TITLE
Align graticule default intervals to minutes and seconds

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -10,6 +10,10 @@ Please see https://docs.microsoft.com/en-us/lifecycle/announcements/internet-exp
 
 The `toStringHDMS` function from the `ol/coordinate.js` module now formats longitude, latitude pairs so that the minutes and seconds are omitted if they are zero.  This changes the values displayed on graticules.
 
+#### ol/later/Graticule
+
+The default intervals now align with integer minutes and seconds better suited to the default label formatter.  If formatting in decimal degrees you may wish to specify custom intervals suited to that format.
+
 ### 6.15.0
 
 #### Deprecated `tilePixelRatio` option for data tile sources.

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -49,7 +49,26 @@ const DEFAULT_STROKE_STYLE = new Stroke({
  * @private
  */
 const INTERVALS = [
-  90, 45, 30, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.01, 0.005, 0.002, 0.001,
+  90,
+  45,
+  30,
+  20,
+  10,
+  5,
+  2,
+  1,
+  30 / 60,
+  20 / 60,
+  10 / 60,
+  5 / 60,
+  2 / 60,
+  1 / 60,
+  30 / 3600,
+  20 / 3600,
+  10 / 3600,
+  5 / 3600,
+  2 / 3600,
+  1 / 3600,
 ];
 
 /**
@@ -144,7 +163,7 @@ const INTERVALS = [
  * Note that the default's `textAlign` configuration will not work well for
  * `latLabelPosition` configurations that position labels close to the left of
  * the viewport.
- * @property {Array<number>} [intervals=[90, 45, 30, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.01, 0.005, 0.002, 0.001]]
+ * @property {Array<number>} [intervals=[90, 45, 30, 20, 10, 5, 2, 1, 30/60, 20/60, 10/60, 5/60, 2/60, 1/60, 30/3600, 20/3600, 10/3600, 5/3600, 2/3600, 1/3600]]
  * Intervals (in degrees) for the graticule. Example to limit graticules to 30 and 10 degrees intervals:
  * ```js
  * [30, 10]


### PR DESCRIPTION
A follow on from #13886 and #13893   If formatting whole minutes it makes little sense to use intervals such as 36 seconds but not 1 minute, or to use fractional values such as 7.2 seconds.  Instead use the same 30, 20, 10, 5, 2, 1 interval range for degrees, minutes and seconds.
