### PR TITLE
Update jsdoc-plugin-typescript to fix markdown in type annotations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "handlebars": "4.7.7",
         "jquery": "3.6.0",
         "jsdoc": "3.6.11",
-        "jsdoc-plugin-typescript": "^2.0.5",
+        "jsdoc-plugin-typescript": "^2.1.1",
         "json-stringify-safe": "^5.0.1",
         "karma": "^6.3.8",
         "karma-chrome-launcher": "^3.1.0",
@@ -6307,9 +6307,9 @@
       }
     },
     "node_modules/jsdoc-plugin-typescript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.0.tgz",
-      "integrity": "sha512-GYNBCW20YyoFGz8ZYjZS0Prt/arfaCm8yku/yN/d4NXNnF25Ghq9gVpxVdN+8sK5fnA8YRNh8am4kGA8amL99Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.1.tgz",
+      "integrity": "sha512-zbGdmQ6uxe2yR9vG04hEA+wrYFxOxjQ3P1fRXDTTIttozMIWwUuljSgcR+lOZ5O7jb9P7a/GCtftJzQN22qEsg==",
       "dev": true,
       "dependencies": {
         "string.prototype.matchall": "^4.0.0"
@@ -15041,9 +15041,9 @@
       }
     },
     "jsdoc-plugin-typescript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.0.tgz",
-      "integrity": "sha512-GYNBCW20YyoFGz8ZYjZS0Prt/arfaCm8yku/yN/d4NXNnF25Ghq9gVpxVdN+8sK5fnA8YRNh8am4kGA8amL99Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.1.1.tgz",
+      "integrity": "sha512-zbGdmQ6uxe2yR9vG04hEA+wrYFxOxjQ3P1fRXDTTIttozMIWwUuljSgcR+lOZ5O7jb9P7a/GCtftJzQN22qEsg==",
       "dev": true,
       "requires": {
         "string.prototype.matchall": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "handlebars": "4.7.7",
     "jquery": "3.6.0",
     "jsdoc": "3.6.11",
-    "jsdoc-plugin-typescript": "^2.0.5",
+    "jsdoc-plugin-typescript": "^2.1.1",
     "json-stringify-safe": "^5.0.1",
     "karma": "^6.3.8",
     "karma-chrome-launcher": "^3.1.0",


### PR DESCRIPTION
This pull request fixes Markdown formatting in type annotations in JSDoc, which were broken with the previous update of jsdoc-plugin-typescript.

See https://github.com/openlayers/jsdoc-plugin-typescript/pull/17#issuecomment-1198546346