### PR TITLE
Re-export the link interaction from the interactions module

### DIFF
--- a/src/ol/interaction.js
+++ b/src/ol/interaction.js
@@ -25,6 +25,7 @@ export {default as Extent} from './interaction/Extent.js';
 export {default as Interaction} from './interaction/Interaction.js';
 export {default as KeyboardPan} from './interaction/KeyboardPan.js';
 export {default as KeyboardZoom} from './interaction/KeyboardZoom.js';
+export {default as Link} from './interaction/Link.js';
 export {default as Modify} from './interaction/Modify.js';
 export {default as MouseWheelZoom} from './interaction/MouseWheelZoom.js';
 export {default as PinchRotate} from './interaction/PinchRotate.js';


### PR DESCRIPTION
This makes it possible to `import {Link} from 'ol/interactions.js';`.
