### PR TITLE
Remove MousePosition's deprecated undefinedHTML option

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -18,6 +18,10 @@ The default intervals now align with integer minutes and seconds better suited t
 
 Inserting with `setAt` or `insertAt` beyond the current length used to create a sparse Collection with `undefined` inserted for any missing indexes.  This will now throw an error instead.
 
+#### ol/control/MousePosition
+
+The control will now by default keep displaying the last mouse position when the mouse leaves the viewport.  With `placeholder: '&#160;'` you can keep the old behaviour.  The `placeholder` option no longer accepts `false` as a valid value, instead simply omit the option.  The `undefinedHTML` option has been removed. You should use `placeholder` instead.
+
 ### 6.15.0
 
 #### Deprecated `tilePixelRatio` option for data tile sources.

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -41,13 +41,11 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * callback.
  * @property {HTMLElement|string} [target] Specify a target if you want the
  * control to be rendered outside of the map's viewport.
- * @property {string|boolean} [placeholder] Markup to show when the mouse position is not
- * available (e.g. when the pointer leaves the map viewport).  By default, a non-breaking space
- * is rendered when the mouse leaves the viewport.  To render something else, provide a string
- * to be used as the text content (e.g. 'no position' or '' for an empty string).  Set the placeholder
- * to `false` to retain the last position when the mouse leaves the viewport.  In a future release, this
- * will be the default behavior.
- * @property {string} [undefinedHTML='&#160;'] This option is deprecated.  Use the `placeholder` option instead.
+ * @property {string} [placeholder] Markup to show when the mouse position is not
+ * available (e.g. when the pointer leaves the map viewport).  By default, a non-breaking space is rendered
+ * initially and the last position is retained when the mouse leaves the viewport.
+ * When a string is provided (e.g. `'no position'` or `''` for an empty string) it is used as a
+ * placeholder.
  */
 
 /**
@@ -104,41 +102,16 @@ class MousePosition extends Control {
     }
 
     /**
-     * Change this to `false` when removing the deprecated `undefinedHTML` option.
+     * @private
      * @type {boolean}
      */
-    let renderOnMouseOut = true;
-
-    /**
-     * @type {string}
-     */
-    let placeholder = '&#160;';
-
-    if ('undefinedHTML' in options) {
-      // deprecated behavior
-      if (options.undefinedHTML !== undefined) {
-        placeholder = options.undefinedHTML;
-      }
-      renderOnMouseOut = !!placeholder;
-    } else if ('placeholder' in options) {
-      if (options.placeholder === false) {
-        renderOnMouseOut = false;
-      } else {
-        placeholder = String(options.placeholder);
-      }
-    }
+    this.renderOnMouseOut_ = options.placeholder !== undefined;
 
     /**
      * @private
      * @type {string}
      */
-    this.placeholder_ = placeholder;
-
-    /**
-     * @private
-     * @type {boolean}
-     */
-    this.renderOnMouseOut_ = renderOnMouseOut;
+    this.placeholder_ = this.renderOnMouseOut_ ? options.placeholder : '&#160;';
 
     /**
      * @private

--- a/test/browser/spec/ol/control/mouseposition.test.js
+++ b/test/browser/spec/ol/control/mouseposition.test.js
@@ -84,8 +84,8 @@ describe('ol/control/MousePosition', function () {
         expect(element.innerHTML).to.be('some text');
       });
 
-      it('renders the last posisition if placeholder is false and mouse moves outside the viewport', function () {
-        const ctrl = new MousePosition({placeholder: false});
+      it('renders the last posisition if placeholder is not set and mouse moves outside the viewport', function () {
+        const ctrl = new MousePosition();
         ctrl.setMap(map);
         map.renderSync();
 
@@ -105,7 +105,7 @@ describe('ol/control/MousePosition', function () {
         expect(element.innerHTML).to.be('20,-30');
       });
 
-      it('renders an empty space if placehodler is set to the same and mouse moves outside the viewport', function () {
+      it('renders an empty space if placeholder is set to the same and mouse moves outside the viewport', function () {
         const ctrl = new MousePosition({
           placeholder: '',
         });
@@ -126,74 +126,6 @@ describe('ol/control/MousePosition', function () {
 
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
         expect(element.innerHTML).to.be('');
-      });
-    });
-
-    describe('undefinedHTML (deprecated)', function () {
-      it('renders undefinedHTML when mouse moves out', function () {
-        const ctrl = new MousePosition({
-          undefinedHTML: 'some text',
-        });
-        ctrl.setMap(map);
-        map.renderSync();
-
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('some text');
-
-        simulateEvent(EventType.POINTERMOVE, 20, 30);
-        expect(element.innerHTML).to.be('20,-30');
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('some text');
-      });
-
-      it('clears the mouse position by default when the mouse moves outside the viewport', function () {
-        const ctrl = new MousePosition();
-        ctrl.setMap(map);
-        map.renderSync();
-
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('&nbsp;');
-
-        target.dispatchEvent(new PointerEvent('pointermove'));
-        simulateEvent(EventType.POINTERMOVE, 20, 30);
-        expect(element.innerHTML).to.be('20,-30');
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('&nbsp;');
-      });
-
-      it('retains the mouse position when undefinedHTML is falsey and mouse moves outside the viewport', function () {
-        const ctrl = new MousePosition({
-          undefinedHTML: '',
-        });
-        ctrl.setMap(map);
-        map.renderSync();
-
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('');
-
-        target.dispatchEvent(new PointerEvent('pointermove'));
-        simulateEvent(EventType.POINTERMOVE, 20, 30);
-        expect(element.innerHTML).to.be('20,-30');
-
-        simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
-        expect(element.innerHTML).to.be('20,-30');
       });
     });
   });

--- a/test/browser/spec/ol/control/mouseposition.test.js
+++ b/test/browser/spec/ol/control/mouseposition.test.js
@@ -69,10 +69,7 @@ describe('ol/control/MousePosition', function () {
         ctrl.setMap(map);
         map.renderSync();
 
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
+        const element = document.querySelector('.ol-mouse-position');
 
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
         expect(element.innerHTML).to.be('some text');
@@ -89,10 +86,7 @@ describe('ol/control/MousePosition', function () {
         ctrl.setMap(map);
         map.renderSync();
 
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
+        const element = document.querySelector('.ol-mouse-position');
 
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
         expect(element.innerHTML).to.be('&nbsp;');
@@ -112,10 +106,7 @@ describe('ol/control/MousePosition', function () {
         ctrl.setMap(map);
         map.renderSync();
 
-        const element = document.querySelector(
-          '.ol-mouse-position',
-          map.getTarget()
-        );
+        const element = document.querySelector('.ol-mouse-position');
 
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
         expect(element.innerHTML).to.be('');

--- a/test/browser/spec/ol/control/scaleline.test.js
+++ b/test/browser/spec/ol/control/scaleline.test.js
@@ -37,10 +37,7 @@ describe('ol.control.ScaleLine', function () {
       it('defaults to "ol-scale-line"', function () {
         const ctrl = new ScaleLine();
         ctrl.setMap(map);
-        const element = document.querySelector(
-          '.ol-scale-line',
-          map.getTarget()
-        );
+        const element = document.querySelector('.ol-scale-line');
         expect(element).to.not.be(null);
         expect(element).to.be.a(HTMLDivElement);
       });
@@ -51,16 +48,10 @@ describe('ol.control.ScaleLine', function () {
         ctrl.setMap(map);
 
         // check that the default was not chosen
-        const element1 = document.querySelector(
-          '.ol-scale-line',
-          map.getTarget()
-        );
+        const element1 = document.querySelector('.ol-scale-line');
         expect(element1).to.be(null);
         // check if the configured classname was chosen
-        const element2 = document.querySelector(
-          '.humpty-dumpty',
-          map.getTarget()
-        );
+        const element2 = document.querySelector('.humpty-dumpty');
         expect(element2).to.not.be(null);
         expect(element2).to.be.a(HTMLDivElement);
       });
@@ -640,7 +631,7 @@ describe('ol.control.ScaleLine', function () {
         })
       );
       map.renderSync();
-      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      const element = document.querySelector('.ol-scale-text');
       expect(element).to.not.be(null);
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
@@ -661,7 +652,7 @@ describe('ol.control.ScaleLine', function () {
         })
       );
       map.renderSync();
-      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      const element = document.querySelector('.ol-scale-text');
       expect(element).to.not.be(null);
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
@@ -683,7 +674,7 @@ describe('ol.control.ScaleLine', function () {
         })
       );
       map.renderSync();
-      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      const element = document.querySelector('.ol-scale-text');
       expect(element).to.not.be(null);
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;
@@ -705,7 +696,7 @@ describe('ol.control.ScaleLine', function () {
         })
       );
       map.renderSync();
-      const element = document.querySelector('.ol-scale-text', map.getTarget());
+      const element = document.querySelector('.ol-scale-text');
       expect(element).to.not.be(null);
       expect(element).to.be.a(HTMLDivElement);
       const text = element.innerText;


### PR DESCRIPTION
Only allow strings for `placeholder`. `true` never made sense and `undefined` `false` were the same.
Hopefully this is how it was intended to change, the comments were kind of misleading.

See #12491