### PR TITLE
Include babel for CodeSandbox

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -144,7 +144,7 @@
     &lt;style&gt;
       .map {
         width: 100%;
-        height:400px;
+        height: 400px;
       }
 {{#if css.source}}{{ indent css.source spaces=6 }}{{/if}}    &lt;/style&gt;
   &lt;/head&gt;

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -346,6 +346,7 @@ export default class ExampleBuilder {
         dependencies: getDependencies(jsSources, pkg),
         devDependencies: {
           vite: '^3.0.3',
+          '@babel/core': 'latest',
         },
         scripts: {
           start: 'vite',


### PR DESCRIPTION
It looks like CodeSandbox requires `@babel/core` installed when bundling with Vite.  I'm guessing this has to do with additional code that CodeSandbox wraps application code in.  It is not necessary to use `@babel/core` when bundling with Vite outside of CodeSandbox.

Fixes #13921.