### PR TITLE
Remove deprecated DataTile source `tilePixelRatio`

### DIFF
--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -36,8 +36,6 @@ import {toSize} from '../size.js';
  * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
  * @property {boolean} [opaque=false] Whether the layer is opaque.
  * @property {import("./Source.js").State} [state] The source state.
- * @property {number} [tilePixelRatio] Deprecated.  To have tiles scaled, pass a `tileSize` representing
- * the source tile size and a `tileGrid` with the desired rendered tile size.
  * @property {boolean} [wrapX=false] Render tiles beyond the antimeridian.
  * @property {number} [transition] Transition time when fading in new tiles (in miliseconds).
  * @property {number} [bandCount=4] Number of bands represented in the data.
@@ -79,7 +77,6 @@ class DataTileSource extends TileSource {
       tileGrid: tileGrid,
       opaque: options.opaque,
       state: options.state,
-      tilePixelRatio: options.tilePixelRatio,
       wrapX: options.wrapX,
       transition: options.transition,
       interpolate: options.interpolate,
@@ -96,13 +93,6 @@ class DataTileSource extends TileSource {
      * @type {import('../size.js').Size|null}
      */
     this.tileSize_ = options.tileSize ? toSize(options.tileSize) : null;
-    if (!this.tileSize_ && options.tilePixelRatio && tileGrid) {
-      const renderTileSize = toSize(tileGrid.getTileSize(0));
-      this.tileSize_ = [
-        renderTileSize[0] * options.tilePixelRatio,
-        renderTileSize[1] * options.tilePixelRatio,
-      ];
-    }
 
     /**
      * @private

--- a/test/rendering/cases/webgl-data-tile-tilepixelratio2/main.js
+++ b/test/rendering/cases/webgl-data-tile-tilepixelratio2/main.js
@@ -2,7 +2,7 @@ import DataTile from '../../../../src/ol/source/DataTile.js';
 import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 import View from '../../../../src/ol/View.js';
-// import {createXYZ} from '../../../../src/ol/tilegrid.js';
+import {createXYZ} from '../../../../src/ol/tilegrid.js';
 
 const size = 512;
 
@@ -18,12 +18,8 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
-        // remove this in the next major release
-        tilePixelRatio: 2,
-
-        // instead use an explicit source and render tile size
-        // tileSize: size,
-        // tileGrid: createXYZ({maxZoom: 0}),
+        tileSize: size,
+        tileGrid: createXYZ({maxZoom: 0}),
         maxZoom: 0,
         loader: () => data,
       }),


### PR DESCRIPTION
for next full release
