### PR TITLE
Remove check for context.setLineDash

### DIFF
--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -3,7 +3,6 @@
  */
 import CanvasInstruction from './Instruction.js';
 import {TEXT_ALIGN} from './TextBuilder.js';
-import {WORKER_OFFSCREEN_CANVAS} from '../../has.js';
 import {
   apply as applyTransform,
   compose as composeTransform,
@@ -276,12 +275,8 @@ class Executor {
       contextInstructions.push('lineCap', strokeState.lineCap);
       contextInstructions.push('lineJoin', strokeState.lineJoin);
       contextInstructions.push('miterLimit', strokeState.miterLimit);
-      // eslint-disable-next-line
-      const Context = WORKER_OFFSCREEN_CANVAS ? OffscreenCanvasRenderingContext2D : CanvasRenderingContext2D;
-      if (Context.prototype.setLineDash) {
-        contextInstructions.push('setLineDash', [strokeState.lineDash]);
-        contextInstructions.push('lineDashOffset', strokeState.lineDashOffset);
-      }
+      contextInstructions.push('setLineDash', [strokeState.lineDash]);
+      contextInstructions.push('lineDashOffset', strokeState.lineDashOffset);
     }
     if (fillKey) {
       contextInstructions.push('fillStyle', fillState.fillStyle);
@@ -585,10 +580,8 @@ class Executor {
     context.lineCap = /** @type {CanvasLineCap} */ (instruction[3]);
     context.lineJoin = /** @type {CanvasLineJoin} */ (instruction[4]);
     context.miterLimit = /** @type {number} */ (instruction[5]);
-    if (context.setLineDash) {
-      context.lineDashOffset = /** @type {number} */ (instruction[7]);
-      context.setLineDash(/** @type {Array<number>} */ (instruction[6]));
-    }
+    context.lineDashOffset = /** @type {number} */ (instruction[7]);
+    context.setLineDash(/** @type {Array<number>} */ (instruction[6]));
   }
 
   /**

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -883,10 +883,8 @@ class CanvasImmediateRenderer extends VectorContext {
     const contextStrokeState = this.contextStrokeState_;
     if (!contextStrokeState) {
       context.lineCap = strokeState.lineCap;
-      if (context.setLineDash) {
-        context.setLineDash(strokeState.lineDash);
-        context.lineDashOffset = strokeState.lineDashOffset;
-      }
+      context.setLineDash(strokeState.lineDash);
+      context.lineDashOffset = strokeState.lineDashOffset;
       context.lineJoin = strokeState.lineJoin;
       context.lineWidth = strokeState.lineWidth;
       context.miterLimit = strokeState.miterLimit;
@@ -905,16 +903,14 @@ class CanvasImmediateRenderer extends VectorContext {
         contextStrokeState.lineCap = strokeState.lineCap;
         context.lineCap = strokeState.lineCap;
       }
-      if (context.setLineDash) {
-        if (!equals(contextStrokeState.lineDash, strokeState.lineDash)) {
-          context.setLineDash(
-            (contextStrokeState.lineDash = strokeState.lineDash)
-          );
-        }
-        if (contextStrokeState.lineDashOffset != strokeState.lineDashOffset) {
-          contextStrokeState.lineDashOffset = strokeState.lineDashOffset;
-          context.lineDashOffset = strokeState.lineDashOffset;
-        }
+      if (!equals(contextStrokeState.lineDash, strokeState.lineDash)) {
+        context.setLineDash(
+          (contextStrokeState.lineDash = strokeState.lineDash)
+        );
+      }
+      if (contextStrokeState.lineDashOffset != strokeState.lineDashOffset) {
+        contextStrokeState.lineDashOffset = strokeState.lineDashOffset;
+        context.lineDashOffset = strokeState.lineDashOffset;
       }
       if (contextStrokeState.lineJoin != strokeState.lineJoin) {
         contextStrokeState.lineJoin = strokeState.lineJoin;

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -39,7 +39,7 @@ import {
  * @property {import("../colorlike.js").ColorLike} [strokeStyle] StrokeStyle.
  * @property {number} strokeWidth StrokeWidth.
  * @property {number} size Size.
- * @property {Array<number>} lineDash LineDash.
+ * @property {Array<number>|null} lineDash LineDash.
  * @property {number} lineDashOffset LineDashOffset.
  * @property {CanvasLineJoin} lineJoin LineJoin.
  * @property {number} miterLimit MiterLimit.
@@ -517,7 +517,7 @@ class RegularShape extends ImageStyle {
     if (this.stroke_) {
       context.strokeStyle = renderOptions.strokeStyle;
       context.lineWidth = renderOptions.strokeWidth;
-      if (context.setLineDash && renderOptions.lineDash) {
+      if (renderOptions.lineDash) {
         context.setLineDash(renderOptions.lineDash);
         context.lineDashOffset = renderOptions.lineDashOffset;
       }

--- a/src/ol/style/Stroke.js
+++ b/src/ol/style/Stroke.js
@@ -10,8 +10,6 @@
  * @property {CanvasLineCap} [lineCap='round'] Line cap style: `butt`, `round`, or `square`.
  * @property {CanvasLineJoin} [lineJoin='round'] Line join style: `bevel`, `round`, or `miter`.
  * @property {Array<number>} [lineDash] Line dash pattern. Default is `null` (no dash).
- * Please note that Internet Explorer 10 and lower do not support the `setLineDash` method on
- * the `CanvasRenderingContext2D` and therefore this option will have no visual effect in these browsers.
  * @property {number} [lineDashOffset=0] Line dash offset.
  * @property {number} [miterLimit=10] Miter limit.
  * @property {number} [width] Width.
@@ -46,7 +44,7 @@ class Stroke {
 
     /**
      * @private
-     * @type {Array<number>}
+     * @type {Array<number>|null}
      */
     this.lineDash_ = options.lineDash !== undefined ? options.lineDash : null;
 
@@ -113,7 +111,7 @@ class Stroke {
 
   /**
    * Get the line dash style for the stroke.
-   * @return {Array<number>} Line dash.
+   * @return {Array<number>|null} Line dash.
    * @api
    */
   getLineDash() {
@@ -179,13 +177,7 @@ class Stroke {
   /**
    * Set the line dash.
    *
-   * Please note that Internet Explorer 10 and lower [do not support][mdn] the
-   * `setLineDash` method on the `CanvasRenderingContext2D` and therefore this
-   * property will have no visual effect in these browsers.
-   *
-   * [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash#Browser_compatibility
-   *
-   * @param {Array<number>} lineDash Line dash.
+   * @param {Array<number>|null} lineDash Line dash.
    * @api
    */
   setLineDash(lineDash) {


### PR DESCRIPTION
IE 11 actually already supported this, just not IE 10.

I also added a few null type annotations for line dash.