### PR TITLE
Remove workaround for missing TypedArray.from function

### DIFF
--- a/src/ol/webgl/Buffer.js
+++ b/src/ol/webgl/Buffer.js
@@ -74,14 +74,11 @@ class WebGLArrayBuffer {
   }
 
   /**
-   * Populates the buffer with an array of the given size (all values will be zeroes).
+   * Populates the buffer with an array of the given size.
    * @param {Array<number>} array Numerical array
    */
   fromArray(array) {
-    const arrayClass = getArrayClassForType(this.type);
-    this.array = arrayClass.from
-      ? arrayClass.from(array)
-      : new arrayClass(array);
+    this.array = getArrayClassForType(this.type).from(array);
   }
 
   /**


### PR DESCRIPTION
See #13883, 
https://github.com/openlayers/openlayers/pull/12740/files#diff-c3187a6e0eca06b15039f365e7eaead1a29459e53a9d840b2993d084e609f985