### PR TITLE
Use nicer functions, remove old code

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -364,13 +364,12 @@ exports.publish = function (taffyData, opts, tutorials) {
       doclet.examples = doclet.examples.map(function (example) {
         let caption, code;
 
-        if (
-          example.match(
-            /^\s*<caption>([\s\S]+?)<\/caption>(\s*[\n\r])([\s\S]+)$/i
-          )
-        ) {
-          caption = RegExp.$1;
-          code = RegExp.$3;
+        const match = example.match(
+          /^\s*<caption>([\s\S]+?)<\/caption>(?:\s*[\n\r])([\s\S]+)$/i
+        );
+        if (match) {
+          caption = match[1];
+          code = match[2];
         }
 
         return {

--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -461,7 +461,7 @@ exports.publish = function (taffyData, opts, tutorials) {
   data().each(function (doclet) {
     const url = helper.longnameToUrl[doclet.longname];
 
-    if (url.indexOf('#') > -1) {
+    if (url.includes('#')) {
       doclet.id = helper.longnameToUrl[doclet.longname].split(/#/).pop();
     } else {
       doclet.id = doclet.name;

--- a/config/jsdoc/api/template/tmpl/container.tmpl
+++ b/config/jsdoc/api/template/tmpl/container.tmpl
@@ -79,7 +79,7 @@
 
     <?js if (doc.kind == 'class') {
       var subclasses = self.find(function() {
-        return this.augments && this.augments.indexOf(doc.longname) > -1;
+        return this.augments && this.augments.includes(doc.longname);
       })
       if (subclasses.length) {
     ?>

--- a/config/jsdoc/api/template/tmpl/examples.tmpl
+++ b/config/jsdoc/api/template/tmpl/examples.tmpl
@@ -6,7 +6,7 @@
         <p class="code-caption"><?js= example.caption ?></p>
     <?js } ?>
 
-    <?js if (example.code.toString().indexOf('<pre>') === -1) { ?>
+    <?js if (!example.code.toString().includes('<pre>')) { ?>
     <pre class="prettyprint"><code><?js= example.code ?></code></pre>
     <?js } else { ?>
     <?js= example.code.replace(/<pre>/g, '<pre class="prettyprint">') ?>

--- a/config/jsdoc/api/template/tmpl/members.tmpl
+++ b/config/jsdoc/api/template/tmpl/members.tmpl
@@ -14,7 +14,7 @@ if (data.type && data.type.names) {
         <div class="anchor" id="<?js= id ?>">
         </div>
         <h4 class="name">
-            <?js= data.attribs + (data.scope === 'static' ? longname : name.indexOf('module:') === 0 ? name.split('/').pop() : name)  + typeSignature ?>
+            <?js= data.attribs + (data.scope === 'static' ? longname : name.startsWith('module:') ? name.split('/').pop() : name)  + typeSignature ?>
             <?js= this.partial('stability.tmpl', data) ?>
         </h4>
     </div>

--- a/config/jsdoc/api/template/tmpl/navigation.tmpl
+++ b/config/jsdoc/api/template/tmpl/navigation.tmpl
@@ -2,7 +2,7 @@
 var self = this;
 
 function toShortName(name) {
-    return name.indexOf('module:') === 0 ? name.split('/').pop() : name;
+    return name.startsWith('module:') ? name.split('/').pop() : name;
 }
 
 function getItemCssClass(type) {

--- a/config/jsdoc/api/template/tmpl/params.tmpl
+++ b/config/jsdoc/api/template/tmpl/params.tmpl
@@ -23,7 +23,7 @@
     var colspan = 2;
     params.forEach(function(param) {
         if (!param) { return; }
-        if (param.type && param.type.names && param.type.names.indexOf('undefined') !== -1) {
+        if (param.type && param.type.names && param.type.names.includes('undefined')) {
             param.optional = true;
         }
         if (param.name.indexOf('var_') == 0) {
@@ -70,7 +70,7 @@
             <?js if (!param.subparams) {?>
             <td class="type">
             <?js if (param.type && param.type.names) {?>
-                <?js= self.partial('type.tmpl', param.type.names) + (param.optional && typeof param.defaultvalue === 'undefined' && param.type.names.indexOf('undefined') === -1 ? ' | undefined' : '') ?>
+                <?js= self.partial('type.tmpl', param.type.names) + (param.optional && typeof param.defaultvalue === 'undefined' && !param.type.names.includes('undefined') ? ' | undefined' : '') ?>
                 <?js if (typeof param.defaultvalue !== 'undefined') { ?>
                     (defaults to <?js= self.htmlsafe(param.defaultvalue) ?>)
                 <?js } ?>

--- a/config/jsdoc/api/template/tmpl/params.tmpl
+++ b/config/jsdoc/api/template/tmpl/params.tmpl
@@ -1,11 +1,11 @@
 <?js
     var params = obj;
-    
+
     /* sort subparams under their parent params (like opts.classname) */
     var parentParam = null;
     params.forEach(function(param, i) {
         if (!param) { return; }
-        if ( parentParam && param.name && param.name.indexOf(parentParam.name + '.') === 0 ) {
+        if (parentParam && param.name && param.name.startsWith(parentParam.name + '.')) {
             param.name = param.name.substr(parentParam.name.length+1);
             parentParam.subparams = parentParam.subparams || [];
             parentParam.subparams.push(param);
@@ -15,30 +15,30 @@
             parentParam = param;
         }
     });
-    
+
     /* determine if we need extra "attributes" column */
     params.hasAttributes = false;
     params.hasName = false;
-    
+
     var colspan = 2;
     params.forEach(function(param) {
         if (!param) { return; }
         if (param.type && param.type.names && param.type.names.includes('undefined')) {
             param.optional = true;
         }
-        if (param.name.indexOf('var_') == 0) {
+        if (param.name.startsWith('var_')) {
             params.hasAttributes = true;
             param.variable = true;
         }
-        
+
         if (param.optional || param.nullable) {
             params.hasAttributes = true;
         }
-        
+
         if (param.name) {
             params.hasName = true;
         }
-        
+
     });
 ?>
 
@@ -48,25 +48,25 @@
 		<?js if (params.hasName) {?>
 		<th>Name</th>
 		<?js } ?>
-		
+
 		<th>Type</th>
-		
+
 		<th class="last">Description</th>
 	</tr>
 	</thead>
-	
+
 	<tbody>
 	<?js
         var self = this;
 	    params.forEach(function(param) {
 	        if (!param) { return; }
 	?>
-	
+
         <tr class="<?js= (param.stability && param.stability !== 'stable') ? 'unstable' : '' ?>">
             <?js if (params.hasName) {?>
                 <td class="name"><code><?js= param.name.replace(/^opt_/, "") ?></code></td>
             <?js } ?>
-            
+
             <?js if (!param.subparams) {?>
             <td class="type">
             <?js if (param.type && param.type.names) {?>
@@ -87,7 +87,7 @@
                 <?js= self.partial('params.tmpl', param.subparams) ?>
             <?js } ?></td>
         </tr>
-	
+
 	<?js }); ?>
 	</tbody>
 </table>

--- a/config/jsdoc/api/template/tmpl/properties.tmpl
+++ b/config/jsdoc/api/template/tmpl/properties.tmpl
@@ -1,11 +1,11 @@
 <?js
     var props = obj;
-    
+
     /* sort subprops under their parent props (like opts.classname) */
     var parentProp = null;
     props.forEach(function(prop, i) {
         if (!prop) { return; }
-        if ( parentProp && prop.name && prop.name.indexOf(parentProp.name + '.') === 0 ) {
+        if (parentProp && prop.name && prop.name.startsWith(parentProp.name + '.')) {
             prop.name = prop.name.substr(parentProp.name.length+1);
             parentProp.subprops = parentProp.subprops || [];
             parentProp.subprops.push(prop);
@@ -15,23 +15,23 @@
             parentProp = prop;
         }
     });
-    
+
     /* determine if we need extra columns, "attributes" and "default" */
     props.hasAttributes = false;
     props.hasDefault = false;
     props.hasName = false;
-    
+
     props.forEach(function(prop) {
         if (!prop) { return; }
-        
+
         if (prop.optional || prop.nullable) {
             props.hasAttributes = true;
         }
-        
+
         if (prop.name) {
             props.hasName = true;
         }
-        
+
         if (typeof prop.defaultvalue !== 'undefined') {
             props.hasDefault = true;
         }
@@ -44,51 +44,51 @@
 		<?js if (props.hasName) {?>
 		<th>Name</th>
 		<?js } ?>
-		
+
 		<th>Type</th>
-		
+
 		<?js if (props.hasAttributes) {?>
 		<th>Argument</th>
 		<?js } ?>
-		
+
 		<?js if (props.hasDefault) {?>
 		<th>Default</th>
 		<?js } ?>
-		
+
 		<th class="last">Description</th>
 	</tr>
 	</thead>
-	
+
 	<tbody>
 	<?js
         var self = this;
 	    props.forEach(function(prop) {
 	        if (!prop) { return; }
 	?>
-	
+
         <tr>
             <?js if (props.hasName) {?>
                 <td class="name"><code><?js= prop.name ?></code></td>
             <?js } ?>
-            
+
             <td class="type">
             <?js if (prop.type && prop.type.names) {?>
                 <?js= self.partial('type.tmpl', prop.type.names) ?>
             <?js } ?>
             </td>
-            
+
             <?js if (props.hasAttributes) {?>
                 <td class="attributes">
                 <?js if (prop.optional) { ?>
                     &lt;optional><br>
                 <?js } ?>
-                    
+
                 <?js if (prop.nullable) { ?>
                     &lt;nullable><br>
                 <?js } ?>
                 </td>
             <?js } ?>
-            
+
             <?js if (props.hasDefault) {?>
                 <td class="default">
                 <?js if (typeof prop.defaultvalue !== 'undefined') { ?>
@@ -96,12 +96,12 @@
                 <?js } ?>
                 </td>
             <?js } ?>
-            
+
             <td class="description last"><?js= prop.description ?><?js if (prop.subprops) { ?>
                 <h6>Properties</h6><?js= self.partial('properties.tmpl', prop.subprops) ?>
             <?js } ?></td>
         </tr>
-	
+
 	<?js }); ?>
 	</tbody>
 </table>

--- a/config/jsdoc/api/template/tmpl/returns.tmpl
+++ b/config/jsdoc/api/template/tmpl/returns.tmpl
@@ -10,9 +10,9 @@ returns.forEach(function (ret, i) {
         var name = ret.name || ret.description;
         var startSpacePos = name.indexOf(" ");
 
-        if (parentReturn !== null && name.indexOf(parentReturn.name + '.') === 0) {
+        if (parentReturn !== null && name.startsWith(parentReturn.name + '.')) {
             ret.name = isNamed ? name.substr(parentReturn.name.length + 1) : name.substr(parentReturn.name.length + 1, startSpacePos - (parentReturn.name.length + 1));
-        
+
             parentReturn.subReturns = parentReturn.subReturns || [];
             parentReturn.subReturns.push(ret);
             returns[i] = null;
@@ -20,7 +20,7 @@ returns.forEach(function (ret, i) {
             if (!isNamed) {
                 ret.name = ret.description.substr(0, startSpacePos !== -1 ? startSpacePos : ret.description.length);
             }
-            
+
             parentReturn = ret;
         }
     }
@@ -54,7 +54,7 @@ if (returns.length > 1) {
                     ret.type.names.forEach(function(name, i) { ?>
                         <?js= self.linkto(name, self.htmlsafe(name)) ?>
                         <?js if (i < ret.type.names.length-1) { ?> | <?js } ?>
-                    <?js }); 
+                    <?js });
                 }
             ?>
             </td>

--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -59,7 +59,7 @@ exports.publish = function (data, opts) {
       if (
         constructor &&
         constructor.substr(-1) === '_' &&
-        constructor.indexOf('module:') === -1
+        !constructor.includes('module:')
       ) {
         assert.strictEqual(
           doc.inherited,

--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -34,7 +34,7 @@ exports.publish = function (data, opts) {
         return (
           this.meta &&
           this.meta.path &&
-          this.longname.indexOf('<anonymous>') !== 0 &&
+          !this.longname.startsWith('<anonymous>') &&
           this.longname !== 'module:ol'
         );
       },

--- a/config/jsdoc/plugins/api.cjs
+++ b/config/jsdoc/plugins/api.cjs
@@ -37,7 +37,7 @@ function includeAugments(doclet) {
   if (doclet.fires && cls.fires) {
     for (let i = 0, ii = cls.fires.length; i < ii; ++i) {
       const fires = cls.fires[i];
-      if (doclet.fires.indexOf(fires) == -1) {
+      if (!doclet.fires.includes(fires)) {
         doclet.fires.push(fires);
       }
     }
@@ -58,7 +58,7 @@ function includeAugments(doclet) {
             doclet.fires = [];
           }
           cls.fires.forEach(function (f) {
-            if (doclet.fires.indexOf(f) == -1) {
+            if (!doclet.fires.includes(f)) {
               doclet.fires.push(f);
             }
           });
@@ -68,7 +68,7 @@ function includeAugments(doclet) {
             doclet.observables = [];
           }
           cls.observables.forEach(function (f) {
-            if (doclet.observables.indexOf(f) == -1) {
+            if (!doclet.observables.includes(f)) {
               doclet.observables.push(f);
             }
           });

--- a/config/jsdoc/plugins/api.cjs
+++ b/config/jsdoc/plugins/api.cjs
@@ -81,10 +81,10 @@ function includeAugments(doclet) {
 
 function extractTypes(item) {
   item.type.names.forEach(function (type) {
-    const match = type.match(/^(.*<)?([^>]*)>?$/);
+    const match = type.match(/^(?:.*<)?([^>]*)>?$/);
     if (match) {
-      modules[match[2]] = true;
-      types[match[2]] = true;
+      modules[match[1]] = true;
+      types[match[1]] = true;
     }
   });
 }

--- a/config/jsdoc/plugins/markdown.cjs
+++ b/config/jsdoc/plugins/markdown.cjs
@@ -76,7 +76,7 @@ function shouldProcessString(tagName, text) {
   let shouldProcess = true;
 
   // we only want to process `@author` and `@see` tags that contain Markdown links
-  if ((tagName === 'author' || tagName === 'see') && text.indexOf('[') === -1) {
+  if ((tagName === 'author' || tagName === 'see') && !text.includes('[')) {
     shouldProcess = false;
   }
 

--- a/config/jsdoc/plugins/observable.cjs
+++ b/config/jsdoc/plugins/observable.cjs
@@ -29,10 +29,10 @@ exports.handlers = {
         observable.name = name;
         observable.readonly =
           typeof observable.readonly == 'boolean' ? observable.readonly : true;
-        if (doclet.name.indexOf('get') === 0) {
+        if (doclet.name.startsWith('get')) {
           observable.type = doclet.returns[0].type;
           observable.description = doclet.returns[0].description;
-        } else if (doclet.name.indexOf('set') === 0) {
+        } else if (doclet.name.startsWith('set')) {
           observable.readonly = false;
         }
         if (doclet.stability) {

--- a/config/jsdoc/plugins/observable.cjs
+++ b/config/jsdoc/plugins/observable.cjs
@@ -42,14 +42,14 @@ exports.handlers = {
           cls.observables = [];
         }
         observable = observables[doclet.observable];
-        if (observable.type && cls.observables.indexOf(observable) == -1) {
+        if (observable.type && !cls.observables.includes(observable)) {
           cls.observables.push(observable);
         }
         if (!cls.fires) {
           cls.fires = [];
         }
         event = 'module:ol/Object.ObjectEvent#event:change:' + name;
-        if (cls.fires.indexOf(event) == -1) {
+        if (!cls.fires.includes(event)) {
           cls.fires.push(event);
         }
       }

--- a/examples/drag-and-drop-custom-kmz.js
+++ b/examples/drag-and-drop-custom-kmz.js
@@ -27,7 +27,7 @@ function getKMLImage(href) {
   let url = href;
   let path = window.location.href;
   path = path.slice(0, path.lastIndexOf('/') + 1);
-  if (href.indexOf(path) === 0) {
+  if (href.startsWith(path)) {
     const regexp = new RegExp(href.replace(path, '') + '$', 'i');
     const kmlFile = zip.file(regexp)[0];
     if (kmlFile) {

--- a/examples/modify-test.js
+++ b/examples/modify-test.js
@@ -321,10 +321,7 @@ const modify = new Modify({
       .getFeatures()
       .getArray()
       .every(function (feature) {
-        return feature
-          .getGeometry()
-          .getType()
-          .match(/Polygon/);
+        return /Polygon/.test(feature.getGeometry().getType());
       });
   },
 });

--- a/examples/print-to-scale.js
+++ b/examples/print-to-scale.js
@@ -78,7 +78,7 @@ const exportOptions = {
       className.indexOf('ol-control') === -1 ||
       className.indexOf('ol-scale') > -1 ||
       (className.indexOf('ol-attribution') > -1 &&
-        className.indexOf('ol-uncollapsible'))
+        className.indexOf('ol-uncollapsible') > -1)
     );
   },
 };

--- a/examples/print-to-scale.js
+++ b/examples/print-to-scale.js
@@ -74,11 +74,11 @@ const exportOptions = {
   useCORS: true,
   ignoreElements: function (element) {
     const className = element.className || '';
-    return !(
-      className.indexOf('ol-control') === -1 ||
-      className.indexOf('ol-scale') > -1 ||
-      (className.indexOf('ol-attribution') > -1 &&
-        className.indexOf('ol-uncollapsible') > -1)
+    return (
+      className.includes('ol-control') &&
+      !className.includes('ol-scale') &&
+      (!className.includes('ol-attribution') ||
+        !className.includes('ol-uncollapsible'))
     );
   },
 };

--- a/examples/vector-tile-selection.js
+++ b/examples/vector-tile-selection.js
@@ -86,7 +86,7 @@ map.on(['click', 'pointermove'], function (event) {
     }
     const fid = feature.getId();
 
-    if (selectElement.value.indexOf('singleselect') === 0) {
+    if (selectElement.value.startsWith('singleselect')) {
       selection = {};
     }
     // add selected feature to lookup

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -50,16 +50,6 @@ export function numberSafeCompareFunction(a, b) {
 }
 
 /**
- * Whether the array contains the given object.
- * @param {Array<*>} arr The array to test for the presence of the element.
- * @param {*} obj The object for which to test.
- * @return {boolean} The object is in the array.
- */
-export function includes(arr, obj) {
-  return arr.indexOf(obj) >= 0;
-}
-
-/**
  * {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution} can use a function
  * of this type to determine which nearest resolution to use.
  *

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -168,11 +168,11 @@ function fromStringInternal_(s) {
       }
     }
     color = [r, g, b, a / 255];
-  } else if (s.indexOf('rgba(') == 0) {
+  } else if (s.startsWith('rgba(')) {
     // rgba()
     color = s.slice(5, -1).split(',').map(Number);
     normalize(color);
-  } else if (s.indexOf('rgb(') == 0) {
+  } else if (s.startsWith('rgb(')) {
     // rgb()
     color = s.slice(4, -1).split(',').map(Number);
     color.push(1);
@@ -225,7 +225,5 @@ export function isStringColor(s) {
   if (NAMED_COLOR_RE_.test(s)) {
     s = fromNamed(s);
   }
-  return (
-    HEX_COLOR_RE_.test(s) || s.indexOf('rgba(') === 0 || s.indexOf('rgb(') === 0
-  );
+  return HEX_COLOR_RE_.test(s) || s.startsWith('rgba(') || s.startsWith('rgb(');
 }

--- a/src/ol/events/Target.js
+++ b/src/ol/events/Target.js
@@ -67,7 +67,7 @@ class Target extends Disposable {
     }
     const listeners = this.listeners_ || (this.listeners_ = {});
     const listenersForType = listeners[type] || (listeners[type] = []);
-    if (listenersForType.indexOf(listener) === -1) {
+    if (!listenersForType.includes(listener)) {
       listenersForType.push(listener);
     }
   }

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -167,7 +167,7 @@ class GMLBase extends XMLFeature {
           const child = /** @type {Element} */ (node.childNodes[i]);
           if (child.nodeType === 1) {
             const ft = child.nodeName.split(':').pop();
-            if (featureType.indexOf(ft) === -1) {
+            if (!featureType.includes(ft)) {
               let key = '';
               let count = 0;
               const uri = child.namespaceURI;
@@ -206,10 +206,9 @@ class GMLBase extends XMLFeature {
         /** @type {Object<string, import("../xml.js").Parser>} */
         const parsers = {};
         for (let i = 0, ii = featureTypes.length; i < ii; ++i) {
-          const featurePrefix =
-            featureTypes[i].indexOf(':') === -1
-              ? defaultPrefix
-              : featureTypes[i].split(':')[0];
+          const featurePrefix = featureTypes[i].includes(':')
+            ? featureTypes[i].split(':')[0]
+            : defaultPrefix;
           if (featurePrefix === p) {
             parsers[featureTypes[i].split(':').pop()] =
               localName == 'featureMembers'

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -262,7 +262,7 @@ class MVT extends FeatureFormat {
     const pbfLayers = pbf.readFields(layersPBFReader, {});
     const features = [];
     for (const name in pbfLayers) {
-      if (layers && layers.indexOf(name) == -1) {
+      if (layers && !layers.includes(name)) {
         continue;
       }
       const pbfLayer = pbfLayers[name];

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -110,7 +110,7 @@ class TopoJSON extends JSONFeature {
       const property = this.layerName_;
       let feature;
       for (const objectName in topoJSONFeatures) {
-        if (this.layers_ && this.layers_.indexOf(objectName) == -1) {
+        if (this.layers_ && !this.layers_.includes(objectName)) {
           continue;
         }
         if (topoJSONFeatures[objectName].type === 'GeometryCollection') {

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -822,7 +822,7 @@ function getTypeName(featurePrefix, featureType) {
   featurePrefix = featurePrefix ? featurePrefix : FEATURE_PREFIX;
   const prefix = featurePrefix + ':';
   // The featureType already contains the prefix.
-  if (featureType.indexOf(prefix) === 0) {
+  if (featureType.startsWith(prefix)) {
     return featureType;
   } else {
     return prefix + featureType;

--- a/src/ol/format/WKB.js
+++ b/src/ol/format/WKB.js
@@ -864,7 +864,7 @@ class WKB extends FeatureFormat {
         options.dataProjection && getProjection(options.dataProjection);
       if (dataProjection) {
         const code = dataProjection.getCode();
-        if (code.indexOf('EPSG:') === 0) {
+        if (code.startsWith('EPSG:')) {
           srid = Number(code.substring(5));
         }
       }

--- a/src/ol/format/WKB.js
+++ b/src/ol/format/WKB.js
@@ -498,10 +498,10 @@ class WkbWriter {
    */
   writeWkbHeader(wkbType, srid) {
     wkbType %= 1000; // Assume 1000 is an upper limit for type ID
-    if (this.layout_.indexOf('Z') >= 0) {
+    if (this.layout_.includes('Z')) {
       wkbType += this.isEWKB_ ? 0x80000000 : 1000;
     }
-    if (this.layout_.indexOf('M') >= 0) {
+    if (this.layout_.includes('M')) {
       wkbType += this.isEWKB_ ? 0x40000000 : 2000;
     }
     if (this.isEWKB_ && Number.isInteger(srid)) {

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -11,13 +11,13 @@ const ua =
  * User agent string says we are dealing with Firefox as browser.
  * @type {boolean}
  */
-export const FIREFOX = ua.indexOf('firefox') !== -1;
+export const FIREFOX = ua.includes('firefox');
 
 /**
  * User agent string says we are dealing with Safari as browser.
  * @type {boolean}
  */
-export const SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') == -1;
+export const SAFARI = ua.includes('safari') && !ua.includes('chrom');
 
 /**
  * https://bugs.webkit.org/show_bug.cgi?id=237906
@@ -25,22 +25,20 @@ export const SAFARI = ua.indexOf('safari') !== -1 && ua.indexOf('chrom') == -1;
  */
 export const SAFARI_BUG_237906 =
   SAFARI &&
-  !!(
-    ua.indexOf('version/15.4') >= 0 ||
-    ua.match(/cpu (os|iphone os) 15_4 like mac os x/)
-  );
+  (ua.includes('version/15.4') ||
+    !!ua.match(/cpu (os|iphone os) 15_4 like mac os x/));
 
 /**
  * User agent string says we are dealing with a WebKit engine.
  * @type {boolean}
  */
-export const WEBKIT = ua.indexOf('webkit') !== -1 && ua.indexOf('edge') == -1;
+export const WEBKIT = ua.includes('webkit') && !ua.includes('edge');
 
 /**
  * User agent string says we are dealing with a Mac as platform.
  * @type {boolean}
  */
-export const MAC = ua.indexOf('macintosh') !== -1;
+export const MAC = ua.includes('macintosh');
 
 /**
  * The ratio between physical pixels and device-independent pixels

--- a/src/ol/has.js
+++ b/src/ol/has.js
@@ -26,7 +26,7 @@ export const SAFARI = ua.includes('safari') && !ua.includes('chrom');
 export const SAFARI_BUG_237906 =
   SAFARI &&
   (ua.includes('version/15.4') ||
-    !!ua.match(/cpu (os|iphone os) 15_4 like mac os x/));
+    /cpu (os|iphone os) 15_4 like mac os x/.test(ua));
 
 /**
  * User agent string says we are dealing with a WebKit engine.

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -455,7 +455,7 @@ class Modify extends PointerInteraction {
         const segment = segments[i];
         for (let s = 0, ss = segment.length; s < ss; ++s) {
           const feature = segment[s].feature;
-          if (feature && features.indexOf(feature) === -1) {
+          if (feature && !features.includes(feature)) {
             this.featuresBeingModified_.push(feature);
           }
         }
@@ -887,11 +887,11 @@ class Modify extends PointerInteraction {
       const dragSegment = this.dragSegments_[i];
       const segmentData = dragSegment[0];
       const feature = segmentData.feature;
-      if (features.indexOf(feature) === -1) {
+      if (!features.includes(feature)) {
         features.push(feature);
       }
       const geometry = segmentData.geometry;
-      if (geometries.indexOf(geometry) === -1) {
+      if (!geometries.includes(geometry)) {
         geometries.push(geometry);
       }
       const depth = segmentData.depth;

--- a/src/ol/net.js
+++ b/src/ol/net.js
@@ -24,7 +24,7 @@ export function jsonp(url, callback, opt_errback, opt_callbackParam) {
   script.async = true;
   script.src =
     url +
-    (url.indexOf('?') == -1 ? '?' : '&') +
+    (url.includes('?') ? '&' : '?') +
     (opt_callbackParam || 'callback') +
     '=' +
     key;
@@ -131,7 +131,7 @@ export function getJSON(url) {
  * @return {string} The full URL.
  */
 export function resolveUrl(base, url) {
-  if (url.indexOf('://') >= 0) {
+  if (url.includes('://')) {
     return url;
   }
   return new URL(url, base).href;

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -231,7 +231,7 @@ class ExecutorGroup {
           if (
             !declutteredFeatures ||
             (builderType !== 'Image' && builderType !== 'Text') ||
-            declutteredFeatures.indexOf(feature) !== -1
+            declutteredFeatures.includes(feature)
           ) {
             const idx = (indexes[i] - 3) / 4;
             const x = hitTolerance - (idx % contextSize);

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -330,7 +330,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
             }
             if (
               !this.newTiles_ &&
-              (inTransition || this.renderedTiles.indexOf(tile) === -1)
+              (inTransition || !this.renderedTiles.includes(tile))
             ) {
               this.newTiles_ = true;
             }

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -195,11 +195,7 @@ class Zoomify extends TileImage {
     });
 
     let url = options.url;
-    if (
-      url &&
-      url.indexOf('{TileGroup}') == -1 &&
-      url.indexOf('{tileIndex}') == -1
-    ) {
+    if (url && !url.includes('{TileGroup}') && !url.includes('{tileIndex}')) {
       url += '{TileGroup}/{z}-{x}-{y}.jpg';
     }
     const urls = expandUrl(url);

--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -114,7 +114,7 @@ export function getMapTileUrlTemplate(links, mediaType) {
       }
       if (knownMapMediaTypes[link.type]) {
         fallbackUrlTemplate = link.href;
-      } else if (!fallbackUrlTemplate && link.type.indexOf('image/') === 0) {
+      } else if (!fallbackUrlTemplate && link.type.startsWith('image/')) {
         fallbackUrlTemplate = link.href;
       }
     }

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -204,7 +204,7 @@ export function isTypeUnique(valueType) {
  */
 export function numberToGlsl(v) {
   const s = v.toString();
-  return s.indexOf('.') === -1 ? s + '.0' : s;
+  return s.includes('.') ? s : s + '.0';
 }
 
 /**
@@ -395,7 +395,7 @@ Operators['get'] = {
     assertArgsCount(args, 1);
     assertString(args[0]);
     const value = args[0].toString();
-    if (context.attributes.indexOf(value) === -1) {
+    if (!context.attributes.includes(value)) {
       context.attributes.push(value);
     }
     const prefix = context.inFragmentShader ? 'v_' : 'a_';
@@ -420,7 +420,7 @@ Operators['var'] = {
     assertArgsCount(args, 1);
     assertString(args[0]);
     const value = args[0].toString();
-    if (context.variables.indexOf(value) === -1) {
+    if (!context.variables.includes(value)) {
       context.variables.push(value);
     }
     return uniformNameForVariable(value);

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -143,7 +143,7 @@ export function createFromCapabilitiesMatrixSet(
         }
         // Fallback for tileMatrix identifiers that don't get prefixed
         // by their tileMatrixSet identifiers.
-        if (elt[identifierPropName].indexOf(':') === -1) {
+        if (!elt[identifierPropName].includes(':')) {
           return (
             matrixSet[identifierPropName] + ':' + elt[identifierPropName] ===
             elt_ml[matrixIdsPropName]

--- a/src/ol/uri.js
+++ b/src/ol/uri.js
@@ -22,6 +22,6 @@ export function appendParams(uri, params) {
   // remove any trailing ? or &
   uri = uri.replace(/[?&]$/, '');
   // append ? or & depending on whether uri has existing parameters
-  uri = uri.indexOf('?') === -1 ? uri + '?' : uri + '&';
+  uri += uri.includes('?') ? '&' : '?';
   return uri + qs;
 }

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -562,7 +562,7 @@ export function parseLiteralStyle(style) {
   // for each feature attribute used in the fragment shader, define a varying that will be used to pass data
   // from the vertex to the fragment shader, as well as an attribute in the vertex shader (if not already present)
   fragContext.attributes.forEach(function (attrName) {
-    if (vertContext.attributes.indexOf(attrName) === -1) {
+    if (!vertContext.attributes.includes(attrName)) {
       vertContext.attributes.push(attrName);
     }
     builder.addVarying(`v_${attrName}`, 'float', `a_${attrName}`);

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -30,7 +30,7 @@ function getImport(symbol, member) {
   if (
     member &&
     namedExport.length > 1 &&
-    (defaultExport.length <= 1 || defaultExport[0].indexOf('.') !== -1)
+    (defaultExport.length <= 1 || defaultExport[0].includes('.'))
   ) {
     const from = namedExport[0].replace(/^module\:/, './');
     const importName = from.replace(/[.\/]+/g, '_');
@@ -52,7 +52,7 @@ function formatSymbolExport(symbol, namespaces, imports) {
   const last = nsParts.length - 1;
   const imp = getImport(symbol, nsParts[last]);
   if (imp) {
-    const isNamed = parts[0].indexOf('.') !== -1;
+    const isNamed = parts[0].includes('.');
     const importName = isNamed
       ? '_' + nsParts.slice(0, last).join('_') + '$' + nsParts[last]
       : '$' + nsParts.join('$');
@@ -79,7 +79,7 @@ function generateExports(symbols) {
   const blocks = [];
   symbols.forEach(function (symbol) {
     const name = symbol.name;
-    if (name.indexOf('#') == -1) {
+    if (!name.includes('#')) {
       const imp = getImport(symbol);
       if (imp) {
         imports[imp] = true;

--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -5,7 +5,7 @@ import {fileURLToPath} from 'url';
 import {spawn} from 'child_process';
 import {walk} from 'walk';
 
-const isWindows = process.platform.indexOf('win') === 0;
+const isWindows = process.platform.startsWith('win');
 const baseDir = dirname(fileURLToPath(import.meta.url));
 
 const sourceDir = path.join(baseDir, '..', 'src');

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -966,7 +966,7 @@ describe('ol.interaction.Modify', function () {
         const listeners = feature.listeners_['change'];
         const candidates = Object.values(modify);
         return listeners.filter(function (listener) {
-          return candidates.indexOf(listener) !== -1;
+          return candidates.includes(listener);
         });
       };
     });

--- a/test/rendering/test.js
+++ b/test/rendering/test.js
@@ -48,7 +48,7 @@ function indexHandler(req, res) {
 function notFound(req, res) {
   return () => {
     // first, try the default directory
-    if (req.url.match(/^\/cases\/[^\/]+\/(index.html)?$/)) {
+    if (/^\/cases\/[^\/]+\/(index.html)?$/.test(req.url)) {
       // request for a case index file, and file not found, use default
       req.url = '/index.html';
       return defaultHandler(req, res, () => indexHandler(req, res));


### PR DESCRIPTION
Remove the left-over `array.includes` function  #13884
Use `includes` and `startsWith` and `test` functions where possible
Remove some deprecated access of `RegExp` match via `$1` and `$3` properties.
The print-to-scale example worked fine because the attributions were not collapsible.