### PR TITLE
Improve loading of kmz file in example

### DIFF
--- a/examples/drag-and-drop-custom-kmz.js
+++ b/examples/drag-and-drop-custom-kmz.js
@@ -16,7 +16,7 @@ const zip = new JSZip();
 function getKMLData(buffer) {
   let kmlData;
   zip.load(buffer);
-  const kmlFile = zip.file(/.kml$/i)[0];
+  const kmlFile = zip.file(/\.kml$/i)[0];
   if (kmlFile) {
     kmlData = kmlFile.asText();
   }
@@ -24,17 +24,14 @@ function getKMLData(buffer) {
 }
 
 function getKMLImage(href) {
-  let url = href;
-  let path = window.location.href;
-  path = path.slice(0, path.lastIndexOf('/') + 1);
-  if (href.startsWith(path)) {
-    const regexp = new RegExp(href.replace(path, '') + '$', 'i');
-    const kmlFile = zip.file(regexp)[0];
+  const index = window.location.href.lastIndexOf('/');
+  if (index !== -1) {
+    const kmlFile = zip.file(href.slice(index + 1));
     if (kmlFile) {
-      url = URL.createObjectURL(new Blob([kmlFile.asArrayBuffer()]));
+      return URL.createObjectURL(new Blob([kmlFile.asArrayBuffer()]));
     }
   }
-  return url;
+  return href;
 }
 
 // Define a KMZ format class by subclassing ol/format/KML


### PR DESCRIPTION
- The href will always start with path as it is sliced starting from 0
  Not sure if it is possible that window locatin does not have a slash
  unless its some about:-page.
- Should be possible to query for the file name directly without regex,
  if the filename contains special regex characters it may behave
  unexpectedly