### PR TITLE
Scaleline

### DIFF
--- a/examples/scale-line.css
+++ b/examples/scale-line.css
@@ -1,0 +1,3 @@
+#scaleBarOptions {
+  display: none;
+}

--- a/examples/scale-line.css
+++ b/examples/scale-line.css
@@ -1,3 +1,11 @@
 #scaleBarOptions {
   display: none;
 }
+
+.ol-scale-bar-inverted .ol-scale-singlebar-even {
+  background-color: var(--ol-background-color);
+}
+
+.ol-scale-bar-inverted .ol-scale-singlebar-odd {
+  background-color: var(--ol-subtle-foreground-color);;
+}

--- a/examples/scale-line.css
+++ b/examples/scale-line.css
@@ -2,6 +2,10 @@
   display: none;
 }
 
+input[type=range] {
+  vertical-align: middle;
+}
+
 .ol-scale-bar-inverted .ol-scale-singlebar-even {
   background-color: var(--ol-background-color);
 }

--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -31,4 +31,6 @@ tags: "scale-line, openstreetmap"
   </select>
 
   <label><input type="checkbox" id="showScaleText" checked> Show scale text</label>
+
+  <label><input type="checkbox" id="invertColors"> Invert colors</label>
 </div>

--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -23,12 +23,8 @@ tags: "scale-line, openstreetmap"
 </select>
 
 <div id="scaleBarOptions">
-  <select id="steps">
-    <option value=2>2 steps</option>
-    <option value=4 selected>4 steps</option>
-    <option value=6>6 steps</option>
-    <option value=8>8 steps</option>
-  </select>
+  <label for="steps">Steps:</label>
+  <input id="steps" type="range" value="4" min="1" max="8">
 
   <label><input type="checkbox" id="showScaleText" checked> Show scale text</label>
 

--- a/examples/scale-line.html
+++ b/examples/scale-line.html
@@ -7,6 +7,7 @@ docs: >
 tags: "scale-line, openstreetmap"
 ---
 <div id="map" class="map"></div>
+<label for="units">Units:</label>
 <select id="units">
   <option value="degrees">degrees</option>
   <option value="imperial">imperial inch</option>
@@ -15,18 +16,19 @@ tags: "scale-line, openstreetmap"
   <option value="metric" selected>metric</option>
 </select>
 
+<label for="type">Type:</label>
 <select id="type">
   <option value="scaleline">ScaleLine</option>
   <option value="scalebar">ScaleBar</option>
 </select>
 
-<select id="steps" style="display:none">
-  <option value=2>2 steps</option>
-  <option value=4 selected>4 steps</option>
-  <option value=6>6 steps</option>
-  <option value=8>8 steps</option>
-</select>
+<div id="scaleBarOptions">
+  <select id="steps">
+    <option value=2>2 steps</option>
+    <option value=4 selected>4 steps</option>
+    <option value=6>6 steps</option>
+    <option value=8>8 steps</option>
+  </select>
 
-<div id="showScaleTextDiv" style="display:none">
   <label><input type="checkbox" id="showScaleText" checked> Show scale text</label>
 </div>

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -9,6 +9,7 @@ const unitsSelect = document.getElementById('units');
 const typeSelect = document.getElementById('type');
 const stepsSelect = document.getElementById('steps');
 const scaleTextCheckbox = document.getElementById('showScaleText');
+const invertColorsCheckbox = document.getElementById('invertColors');
 
 let control;
 
@@ -26,6 +27,7 @@ function scaleControl() {
       text: scaleTextCheckbox.checked,
       minWidth: 140,
     });
+    onInvertColorsChange();
     scaleBarOptionsContainer.style.display = 'block';
   }
   return control;
@@ -51,7 +53,14 @@ function reconfigureScaleLine() {
 function onChangeUnit() {
   control.setUnits(unitsSelect.value);
 }
+function onInvertColorsChange() {
+  control.element.classList.toggle(
+    'ol-scale-bar-inverted',
+    invertColorsCheckbox.checked
+  );
+}
 unitsSelect.addEventListener('change', onChangeUnit);
 typeSelect.addEventListener('change', reconfigureScaleLine);
 stepsSelect.addEventListener('change', reconfigureScaleLine);
 scaleTextCheckbox.addEventListener('change', reconfigureScaleLine);
+invertColorsCheckbox.addEventListener('change', onInvertColorsChange);

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -7,7 +7,7 @@ import {ScaleLine, defaults as defaultControls} from '../src/ol/control.js';
 const scaleBarOptionsContainer = document.getElementById('scaleBarOptions');
 const unitsSelect = document.getElementById('units');
 const typeSelect = document.getElementById('type');
-const stepsSelect = document.getElementById('steps');
+const stepsRange = document.getElementById('steps');
 const scaleTextCheckbox = document.getElementById('showScaleText');
 const invertColorsCheckbox = document.getElementById('invertColors');
 
@@ -23,7 +23,7 @@ function scaleControl() {
     control = new ScaleLine({
       units: unitsSelect.value,
       bar: true,
-      steps: parseInt(stepsSelect.value, 10),
+      steps: parseInt(stepsRange.value, 10),
       text: scaleTextCheckbox.checked,
       minWidth: 140,
     });
@@ -61,6 +61,6 @@ function onInvertColorsChange() {
 }
 unitsSelect.addEventListener('change', onChangeUnit);
 typeSelect.addEventListener('change', reconfigureScaleLine);
-stepsSelect.addEventListener('change', reconfigureScaleLine);
+stepsRange.addEventListener('input', reconfigureScaleLine);
 scaleTextCheckbox.addEventListener('change', reconfigureScaleLine);
 invertColorsCheckbox.addEventListener('change', onInvertColorsChange);

--- a/examples/scale-line.js
+++ b/examples/scale-line.js
@@ -4,31 +4,30 @@ import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
 import {ScaleLine, defaults as defaultControls} from '../src/ol/control.js';
 
+const scaleBarOptionsContainer = document.getElementById('scaleBarOptions');
 const unitsSelect = document.getElementById('units');
 const typeSelect = document.getElementById('type');
 const stepsSelect = document.getElementById('steps');
 const scaleTextCheckbox = document.getElementById('showScaleText');
-const showScaleTextDiv = document.getElementById('showScaleTextDiv');
 
-let scaleType = 'scaleline';
-let scaleBarSteps = 4;
-let scaleBarText = true;
 let control;
 
 function scaleControl() {
-  if (scaleType === 'scaleline') {
+  if (typeSelect.value === 'scaleline') {
     control = new ScaleLine({
       units: unitsSelect.value,
     });
-    return control;
+    scaleBarOptionsContainer.style.display = 'none';
+  } else {
+    control = new ScaleLine({
+      units: unitsSelect.value,
+      bar: true,
+      steps: parseInt(stepsSelect.value, 10),
+      text: scaleTextCheckbox.checked,
+      minWidth: 140,
+    });
+    scaleBarOptionsContainer.style.display = 'block';
   }
-  control = new ScaleLine({
-    units: unitsSelect.value,
-    bar: true,
-    steps: scaleBarSteps,
-    text: scaleBarText,
-    minWidth: 140,
-  });
   return control;
 }
 const map = new Map({
@@ -45,34 +44,14 @@ const map = new Map({
   }),
 });
 
-function onChange() {
+function reconfigureScaleLine() {
+  map.removeControl(control);
+  map.addControl(scaleControl());
+}
+function onChangeUnit() {
   control.setUnits(unitsSelect.value);
 }
-function onChangeType() {
-  scaleType = typeSelect.value;
-  if (typeSelect.value === 'scalebar') {
-    stepsSelect.style.display = 'inline';
-    showScaleTextDiv.style.display = 'inline';
-    map.removeControl(control);
-    map.addControl(scaleControl());
-  } else {
-    stepsSelect.style.display = 'none';
-    showScaleTextDiv.style.display = 'none';
-    map.removeControl(control);
-    map.addControl(scaleControl());
-  }
-}
-function onChangeSteps() {
-  scaleBarSteps = parseInt(stepsSelect.value, 10);
-  map.removeControl(control);
-  map.addControl(scaleControl());
-}
-function onChangeScaleText() {
-  scaleBarText = scaleTextCheckbox.checked;
-  map.removeControl(control);
-  map.addControl(scaleControl());
-}
-unitsSelect.addEventListener('change', onChange);
-typeSelect.addEventListener('change', onChangeType);
-stepsSelect.addEventListener('change', onChangeSteps);
-scaleTextCheckbox.addEventListener('change', onChangeScaleText);
+unitsSelect.addEventListener('change', onChangeUnit);
+typeSelect.addEventListener('change', reconfigureScaleLine);
+stepsSelect.addEventListener('change', reconfigureScaleLine);
+scaleTextCheckbox.addEventListener('change', reconfigureScaleLine);

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -334,12 +334,9 @@ class ScaleLine extends Control {
       previousDecimalCount = decimalCount;
       ++i;
     }
-    let html;
-    if (this.scaleBar_) {
-      html = this.createScaleBar(width, count, suffix);
-    } else {
-      html = count.toFixed(decimalCount < 0 ? -decimalCount : 0) + ' ' + suffix;
-    }
+    const html = this.scaleBar_
+      ? this.createScaleBar(width, count, suffix)
+      : count.toFixed(decimalCount < 0 ? -decimalCount : 0) + ' ' + suffix;
 
     if (this.renderedHTML_ != html) {
       this.innerElement_.innerHTML = html;
@@ -367,85 +364,49 @@ class ScaleLine extends Control {
   createScaleBar(width, scale, suffix) {
     const mapScale =
       '1 : ' + Math.round(this.getScaleForResolution()).toLocaleString();
-    const scaleSteps = [];
-    const stepWidth = width / this.scaleBarSteps_;
-    let backgroundColor = 'ol-scale-singlebar-odd';
-    for (let i = 0; i < this.scaleBarSteps_; i++) {
-      if (i === 0) {
-        // create the first marker at position 0
-        scaleSteps.push(this.createMarker('absolute', i));
-      }
+    const steps = this.scaleBarSteps_;
+    const stepWidth = width / steps;
+    const scaleSteps = [this.createMarker('absolute')];
+    for (let i = 0; i < steps; ++i) {
+      const cls =
+        i % 2 === 0 ? 'ol-scale-singlebar-odd' : 'ol-scale-singlebar-even';
       scaleSteps.push(
         '<div>' +
           '<div ' +
-          'class="ol-scale-singlebar ' +
-          backgroundColor +
-          '" ' +
-          'style=' +
-          '"width: ' +
-          stepWidth +
-          'px;"' +
+          `class="ol-scale-singlebar ${cls}" ` +
+          `style="width: ${stepWidth}px;"` +
           '>' +
           '</div>' +
-          this.createMarker('relative', i) +
-          /*render text every second step, except when only 2 steps */
-          (i % 2 === 0 || this.scaleBarSteps_ === 2
+          this.createMarker('relative') +
+          // render text every second step, except when only 2 steps
+          (i % 2 === 0 || steps === 2
             ? this.createStepText(i, width, false, scale, suffix)
             : '') +
           '</div>'
       );
-      if (i === this.scaleBarSteps_ - 1) {
-        {
-          /*render text at the end */
-        }
-        scaleSteps.push(this.createStepText(i + 1, width, true, scale, suffix));
-      }
-      // switch style of steps
-      backgroundColor =
-        backgroundColor === 'ol-scale-singlebar-odd'
-          ? 'ol-scale-singlebar-even'
-          : 'ol-scale-singlebar-odd';
     }
+    // render text at the end
+    scaleSteps.push(this.createStepText(steps, width, true, scale, suffix));
 
-    let scaleBarText;
-    if (this.scaleBarText_) {
-      scaleBarText =
-        '<div ' +
-        'class="ol-scale-text" ' +
-        'style="width: ' +
-        width +
-        'px;">' +
+    const scaleBarText = this.scaleBarText_
+      ? `<div class="ol-scale-text" style="width: ${width}px;">` +
         mapScale +
-        '</div>';
-    } else {
-      scaleBarText = '';
-    }
-    const container =
-      '<div ' +
-      'style="display: flex;">' +
-      scaleBarText +
-      scaleSteps.join('') +
-      '</div>';
-    return container;
+        '</div>'
+      : '';
+    return `<div>${scaleBarText}${scaleSteps.join('')}</div>`;
   }
 
   /**
    * Creates a marker at given position
-   * @param {string} position The position, absolute or relative
-   * @param {number} i The iterator
+   * @param {'absolute'|'relative'} position The position, absolute or relative
    * @return {string} The stringified div containing the marker
    */
-  createMarker(position, i) {
+  createMarker(position) {
     const top = position === 'absolute' ? 3 : -10;
     return (
       '<div ' +
       'class="ol-scale-step-marker" ' +
-      'style="position: ' +
-      position +
-      ';' +
-      'top: ' +
-      top +
-      'px;"' +
+      `style="position: ${position}; top: ${top}px;"` +
       '></div>'
     );
   }
@@ -469,19 +430,11 @@ class ScaleLine extends Control {
       '<div ' +
       'class="ol-scale-step-text" ' +
       'style="' +
-      'margin-left: ' +
-      margin +
-      'px;' +
-      'text-align: ' +
-      (i === 0 ? 'left' : 'center') +
-      '; ' +
-      'min-width: ' +
-      minWidth +
-      'px;' +
-      'left: ' +
-      (isLast ? width + 'px' : 'unset') +
-      ';"' +
-      '>' +
+      `margin-left: ${margin}px;` +
+      `text-align: ${i === 0 ? 'left' : 'center'};` +
+      `min-width: ${minWidth}px;` +
+      `left: ${isLast ? width + 'px' : 'unset'};` +
+      '">' +
       lengthString +
       '</div>'
     );

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -39,7 +39,8 @@ const DEFAULT_DPI = 25.4 / 0.28;
 
 /**
  * @typedef {Object} Options
- * @property {string} [className='ol-scale-line'] CSS Class name.
+ * @property {string} [className] CSS class name. The default is `ol-scale-bar` when configured with
+ * `bar: true`. Otherwise the default is `ol-scale-line`.
  * @property {number} [minWidth=64] Minimum width in pixels at the OGC default dpi. The width will be
  * adjusted to match the dpi used.
  * @property {number} [maxWidth] Maximum width in pixels at the OGC default dpi. The width will be

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -366,8 +366,11 @@ class ScaleLine extends Control {
    * @return {string} The stringified HTML of the scalebar.
    */
   createScaleBar(width, scale, suffix) {
+    const resolutionScale = this.getScaleForResolution();
     const mapScale =
-      '1 : ' + Math.round(this.getScaleForResolution()).toLocaleString();
+      resolutionScale < 1
+        ? Math.round(1 / resolutionScale).toLocaleString() + ' : 1'
+        : '1 : ' + Math.round(resolutionScale).toLocaleString();
     const steps = this.scaleBarSteps_;
     const stepWidth = width / steps;
     const scaleSteps = [this.createMarker('absolute')];

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -80,15 +80,11 @@ class ScaleLine extends Control {
   constructor(opt_options) {
     const options = opt_options ? opt_options : {};
 
-    const className =
-      options.className !== undefined
-        ? options.className
-        : options.bar
-        ? 'ol-scale-bar'
-        : 'ol-scale-line';
+    const element = document.createElement('div');
+    element.style.pointerEvents = 'none';
 
     super({
-      element: document.createElement('div'),
+      element: element,
       render: options.render,
       target: options.target,
     });
@@ -107,6 +103,13 @@ class ScaleLine extends Control {
      * @type {ScaleLineOnSignature<void>}
      */
     this.un;
+
+    const className =
+      options.className !== undefined
+        ? options.className
+        : options.bar
+        ? 'ol-scale-bar'
+        : 'ol-scale-line';
 
     /**
      * @private

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -393,7 +393,7 @@ class ScaleLine extends Control {
         mapScale +
         '</div>'
       : '';
-    return `<div>${scaleBarText}${scaleSteps.join('')}</div>`;
+    return scaleBarText + scaleSteps.join('');
   }
 
   /**
@@ -453,7 +453,7 @@ class ScaleLine extends Control {
     );
     const dpi = this.dpi_ || DEFAULT_DPI;
     const inchesPerMeter = 1000 / 25.4;
-    return parseFloat(resolution.toString()) * inchesPerMeter * dpi;
+    return resolution * inchesPerMeter * dpi;
   }
 
   /**

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -41,18 +41,14 @@
   transition: all 0.25s;
 }
 
-.ol-scale-singlebar-even {
-  background-color: var(--ol-subtle-foreground-color);
-}
-
-.ol-scale-singlebar-odd {
-  background-color: var(--ol-background-color);
-}
-
 .ol-scale-bar {
   position: absolute;
   bottom: 8px;
   left: 8px;
+}
+
+.ol-scale-bar-inner > div {
+  display: flex;
 }
 
 .ol-scale-step-marker {
@@ -87,6 +83,14 @@
   z-index: 9;
   box-sizing: border-box;
   border: 1px solid var(--ol-foreground-color);
+}
+
+.ol-scale-singlebar-even {
+  background-color: var(--ol-subtle-foreground-color);
+}
+
+.ol-scale-singlebar-odd {
+  background-color: var(--ol-background-color);
 }
 
 .ol-unsupported {

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -47,7 +47,7 @@
   left: 8px;
 }
 
-.ol-scale-bar-inner > div {
+.ol-scale-bar-inner {
   display: flex;
 }
 


### PR DESCRIPTION
This add some improvements to the ScaleLine class and its example page.

- ScaleLine is now configured with `pointer-events: none;` so it is now possible to e. g. drag the map at the position of the ScaleLine
- For very high zoom levels the scale bar now displays `step : 1` instead of `1 : step` (step always >= 1)
- The scale bar has unnecessary nesting div containing `scaleBarText` and `scaleSteps` removed
- The example has a new option to allow inverting the bar colors and now uses a range input for the number of steps