### PR TITLE
Fix typo and formatting in upgrade notes

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -10,9 +10,9 @@ Please see https://docs.microsoft.com/en-us/lifecycle/announcements/internet-exp
 
 The `toStringHDMS` function from the `ol/coordinate.js` module now formats longitude, latitude pairs so that the minutes and seconds are omitted if they are zero.  This changes the values displayed on graticules.
 
-#### ol/later/Graticule
+#### ol/layer/Graticule
 
-The default intervals now align with integer minutes and seconds better suited to the default label formatter.  If formatting in decimal degrees you may wish to specify custom intervals suited to that format.
+The default `intervals` now align with integer minutes and seconds better suited to the default label formatter.  If formatting in decimal degrees you may wish to specify custom `intervals` suited to that format.
 
 #### ol/Collection
 


### PR DESCRIPTION
Fixes a typo from #13897 and improves the formatting