### PR TITLE
Fixes to export examples

### DIFF
--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -64,13 +64,6 @@ document.getElementById('export-png').addEventListener('click', function () {
           const opacity =
             canvas.parentNode.style.opacity || canvas.style.opacity;
           mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
-
-          const backgroundColor = canvas.parentNode.style.backgroundColor;
-          if (backgroundColor) {
-            mapContext.fillStyle = backgroundColor;
-            mapContext.fillRect(0, 0, canvas.width, canvas.height);
-          }
-
           let matrix;
           const transform = canvas.style.transform;
           if (transform) {
@@ -94,11 +87,17 @@ document.getElementById('export-png').addEventListener('click', function () {
             mapContext,
             matrix
           );
+          const backgroundColor = canvas.parentNode.style.backgroundColor;
+          if (backgroundColor) {
+            mapContext.fillStyle = backgroundColor;
+            mapContext.fillRect(0, 0, canvas.width, canvas.height);
+          }
           mapContext.drawImage(canvas, 0, 0);
         }
       }
     );
     mapContext.globalAlpha = 1;
+    mapContext.setTransform(1, 0, 0, 1, 0, 0);
     const link = document.getElementById('image-download');
     link.href = mapCanvas.toDataURL();
     link.click();

--- a/examples/export-pdf.js
+++ b/examples/export-pdf.js
@@ -84,6 +84,7 @@ exportButton.addEventListener(
         }
       );
       mapContext.globalAlpha = 1;
+      mapContext.setTransform(1, 0, 0, 1, 0, 0);
       const pdf = new jspdf.jsPDF('landscape', undefined, format);
       pdf.addImage(
         mapCanvas.toDataURL('image/jpeg'),


### PR DESCRIPTION
In the map export example the background should be set after applying the transform.  This would be necessary if the layer had opacity and was above another layer (especially with a rotated view), and if the browser zoom is less than 100%:

![image](https://user-images.githubusercontent.com/49240900/183385668-2f226ccc-b26c-4d7c-9995-6db66b1a8f9d.png)
(transparency appears black)

In both examples if the generated canvas is required elsewhere, in addition to resetting the `globalAlpha` the `transform` should also be reset.