### PR TITLE
Do not apply #12467 change to Icons

### DIFF
--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -1041,19 +1041,24 @@ class CanvasImmediateRenderer extends VectorContext {
       this.image_ = null;
       return;
     }
+    const imagePixelRatio = imageStyle.getPixelRatio(this.pixelRatio_);
     const imageAnchor = imageStyle.getAnchor();
     const imageOrigin = imageStyle.getOrigin();
     this.image_ = imageStyle.getImage(this.pixelRatio_);
-    this.imageAnchorX_ = imageAnchor[0] * this.pixelRatio_;
-    this.imageAnchorY_ = imageAnchor[1] * this.pixelRatio_;
-    this.imageHeight_ = imageSize[1] * this.pixelRatio_;
+    this.imageAnchorX_ = imageAnchor[0] * imagePixelRatio;
+    this.imageAnchorY_ = imageAnchor[1] * imagePixelRatio;
+    this.imageHeight_ = imageSize[1] * imagePixelRatio;
     this.imageOpacity_ = imageStyle.getOpacity();
     this.imageOriginX_ = imageOrigin[0];
     this.imageOriginY_ = imageOrigin[1];
     this.imageRotateWithView_ = imageStyle.getRotateWithView();
     this.imageRotation_ = imageStyle.getRotation();
-    this.imageScale_ = imageStyle.getScaleArray();
-    this.imageWidth_ = imageSize[0] * this.pixelRatio_;
+    const imageScale = imageStyle.getScaleArray();
+    this.imageScale_ = [
+      (imageScale[0] * this.pixelRatio_) / imagePixelRatio,
+      (imageScale[1] * this.pixelRatio_) / imagePixelRatio,
+    ];
+    this.imageWidth_ = imageSize[0] * imagePixelRatio;
   }
 
   /**

--- a/test/rendering/cases/immediate-pixel-ratio/main.js
+++ b/test/rendering/cases/immediate-pixel-ratio/main.js
@@ -69,8 +69,8 @@ new Map({
   view: new View({
     center: [256 / 2, -256 / 2],
     resolution: 1,
-    devicePixelRatio: 2,
   }),
+  pixelRatio: 2,
 });
 
 render();


### PR DESCRIPTION
Fixes #13954

Also fixed the rendering test which might have picked this up, but was not using the correct pixel ratio.

Compare the fixed version https://deploy-preview-13955--ol-site.netlify.app/examples/icon-scale.html
with https://openlayers.org/en/v6.15.1/examples/icon-scale.html
on a mobile device or with browser zoom