### PR TITLE
replace VERSION in un-transpiled source

### DIFF
--- a/tasks/prepare-package.js
+++ b/tasks/prepare-package.js
@@ -11,9 +11,11 @@ async function main() {
 
   // update the version number in util.js
   const utilPath = path.join(buildDir, 'util.js');
-  const versionRegEx = /var VERSION = '(.*)';/g;
   let utilSrc = await fse.readFile(utilPath, 'utf-8');
-  utilSrc = utilSrc.replace(versionRegEx, `var VERSION = '${pkg.version}';`);
+  utilSrc = utilSrc.replace(
+    /const VERSION = '(?:[^']*)';/g,
+    `const VERSION = '${pkg.version}';`
+  );
   await fse.writeFile(utilPath, utilSrc, 'utf-8');
 
   // write out simplified package.json


### PR DESCRIPTION
The regex no longer matched because in the un-transpiled sources the declaration is with `const` instead of `var`.
See #13891