### PR TITLE
Remove polyfills for IE and Android 4

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -11,8 +11,6 @@
     <link rel="stylesheet" href="./css/ol.css" type="text/css">
     <link rel="stylesheet" href="./css/site.css" type="text/css">
     <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
-    <script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,TextDecoder"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.18.3/minified.js"></script>
     {{{ extraHead.local }}}
     {{{ css.tag }}}
     <title>{{ title }}</title>
@@ -135,10 +133,7 @@
     &lt;meta charset="UTF-8"&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
     &lt;!-- Pointer events polyfill for old browsers, see https://caniuse.com/#feat=pointer --&gt;
-    &lt;script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;
-    &lt;!-- The lines below are only needed for old environments like Internet Explorer and Android 4.x --&gt;
-    &lt;script src="https://cdn.polyfill.io/v3/polyfill.min.js?features=fetch,requestAnimationFrame,Element.prototype.classList,TextDecoder"&gt;&lt;/script&gt;
-    &lt;script src="https://cdnjs.cloudflare.com/ajax/libs/core-js/3.18.3/minified.js"&gt;&lt;/script&gt;{{#if extraHead.remote}}
+    &lt;script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;{{#if extraHead.remote}}
 {{ indent extraHead.remote spaces=4 }}{{/if}}
     &lt;link rel="stylesheet" href="node_modules/ol/ol.css"&gt;
     &lt;style&gt;


### PR DESCRIPTION
The core-js polyfill was added for IE in #12891.

Removing polyfills for `fetch`, `requestAnimationFrame`, `Element.prototype.classList`, and `TextDecoder` removes support for Android 4.  With ~0.4% usage, I think this is acceptable.

I'm leaving in the pointer events polyfill.  It looks like [about 2%](https://caniuse.com/?search=pointer%20events) of browsers could use that.  Maybe 1% should be the cut off.

See #13883.