### PR TITLE
Remove workaround and docs for IE 11

### DIFF
--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -31,8 +31,6 @@ rome.setStyle(
     image: new Icon({
       color: '#BADA55',
       crossOrigin: 'anonymous',
-      // For Internet Explorer 11
-      imgSize: [20, 20],
       src: 'data/square.svg',
     }),
   })
@@ -64,8 +62,6 @@ paris.setStyle(
     image: new Icon({
       color: '#8959A8',
       crossOrigin: 'anonymous',
-      // For Internet Explorer 11
-      imgSize: [20, 20],
       src: 'data/dot.svg',
     }),
   })
@@ -75,8 +71,6 @@ berlin.setStyle(
   new Style({
     image: new Icon({
       crossOrigin: 'anonymous',
-      // For Internet Explorer 11
-      imgSize: [20, 20],
       src: 'data/dot.svg',
     }),
   })

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -49,8 +49,8 @@ import {getUid} from '../util.js';
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {import("../size.js").Size} [size] Icon size in pixel. Can be used together with `offset` to define the
  * sub-rectangle to use from the origin (sprite) icon image.
- * @property {import("../size.js").Size} [imgSize] Image size in pixels. Only required if `img` is set and `src` is not, and
- * for SVG images in Internet Explorer 11. The provided `imgSize` needs to match the actual size of the image.
+ * @property {import("../size.js").Size} [imgSize] Image size in pixels. Only required if `img` is set and `src` is not.
+ * The provided `imgSize` needs to match the actual size of the image.
  * @property {string} [src] Image source URI.
  * @property {"declutter"|"obstacle"|"none"|undefined} [declutterMode] Declutter mode
  */


### PR DESCRIPTION
This removes workarounds in the icon-color example for IE 11 and updates docs for the icon `imgSize` property.

See #13883.