### PR TITLE
Fix some errors in examples

### DIFF
--- a/examples/es2015-custom-element.js
+++ b/examples/es2015-custom-element.js
@@ -9,7 +9,7 @@ class OLComponent extends HTMLElement {
     this.shadow = this.attachShadow({mode: 'open'});
     const link = document.createElement('link');
     link.setAttribute('rel', 'stylesheet');
-    link.setAttribute('href', 'css/ol.css');
+    link.setAttribute('href', 'theme/ol.css');
     this.shadow.appendChild(link);
     const style = document.createElement('style');
     style.innerText = `

--- a/examples/index.html
+++ b/examples/index.html
@@ -33,9 +33,6 @@
         background-color: #f8f9fa !important;
       }
     </style>
-    <script type="text/javascript" src="resources/Jugl.js"></script>
-    <script type="text/javascript" src="examples-info.js"></script>
-    <script type="text/javascript" src="index.js"></script>
 
     <title>OpenLayers Examples</title>
   </head>
@@ -103,5 +100,8 @@
     </div>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" src="resources/Jugl.js"></script>
+    <script type="text/javascript" src="examples-info.js"></script>
+    <script type="text/javascript" src="index.js"></script>
   </body>
 </html>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,9 @@
 (function () {
   'use strict';
   /* global info, jugl */
-  let template, target;
+
+  const template = new jugl.Template('template');
+  const target = document.getElementById('examples');
 
   function listExamples(examples) {
     target.innerHTML = '';
@@ -82,14 +84,10 @@
     listExamples(examples);
   }
 
-  window.addEventListener('load', function () {
-    template = new jugl.Template('template');
-    target = document.getElementById('examples');
-    const params = new URLSearchParams(window.location.search);
-    const text = params.get('q') || '';
-    const input = document.getElementById('keywords');
-    input.addEventListener('input', inputChange);
-    input.value = text;
-    filterList(text);
-  });
+  const params = new URLSearchParams(window.location.search);
+  const text = params.get('q') || '';
+  const input = document.getElementById('keywords');
+  input.addEventListener('input', inputChange);
+  input.value = text;
+  filterList(text);
 })();

--- a/examples/index.js
+++ b/examples/index.js
@@ -82,26 +82,11 @@
     listExamples(examples);
   }
 
-  function parseParams() {
-    const params = {};
-    const list = window.location.search
-      .substring(1)
-      .replace(/\+/g, '%20')
-      .split('&');
-    for (let i = 0; i < list.length; ++i) {
-      const pair = list[i].split('=');
-      if (pair.length === 2) {
-        params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
-      }
-    }
-    return params;
-  }
-
   window.addEventListener('load', function () {
     template = new jugl.Template('template');
     target = document.getElementById('examples');
-    const params = parseParams();
-    const text = params['q'] || '';
+    const params = new URLSearchParams(window.location.search);
+    const text = params.get('q') || '';
     const input = document.getElementById('keywords');
     input.addEventListener('input', inputChange);
     input.value = text;

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -13,7 +13,7 @@ cloak:
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
     <title>Mobile full screen example</title>
-    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../theme/ol.css" type="text/css">
     <style type="text/css">
       html, body, .map {
         margin: 0;

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -22,11 +22,11 @@ cloak:
         height: 100%;
       }
     </style>
-    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
   </head>
   <body>
     <div id="map" class="map"></div>
-    <script src="common.js"></script>
+    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
     <script src="mobile-full-screen.js"></script>
+    <script src="common.js"></script>
   </body>
 </html>

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -2,6 +2,20 @@
   "use strict"
   /* global LZString */
 
+  let lzStringPromise;
+  function loadLzString() {
+    if (!lzStringPromise) {
+      lzStringPromise = new Promise(function (resolve, reject) {
+        const script = document.createElement('script')
+        script.src = 'https://unpkg.com/lz-string@1.4.4/libs/lz-string.min.js';
+        document.head.append(script);
+        script.addEventListener('load', resolve);
+        script.addEventListener('error', reject);
+      });
+    }
+    return lzStringPromise;
+  }
+
   function compress(json) {
     return LZString.compressToBase64(JSON.stringify(json))
       .replace(/\+/g, '-')
@@ -56,6 +70,7 @@
       const promises = localResources.map(function (resource) {
         return fetchResource(resource);
       });
+      promises.push(loadLzString());
 
       Promise.all(promises).then(
         function (results) {

--- a/examples/resources/external-map-map.html
+++ b/examples/resources/external-map-map.html
@@ -1,7 +1,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <link rel="stylesheet" href="../css/ol.css" type="text/css">
+    <link rel="stylesheet" href="../theme/ol.css" type="text/css">
     <style>
       body {
         margin: 0;

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -3,21 +3,17 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/toolbar/prism-toolbar.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"></script>
     <link rel="stylesheet"  type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/fontawesome.min.css" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/solid.css" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/brands.css" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="/theme/ol.css">
     <link rel="stylesheet"  type="text/css" href="/theme/site.css">
+{{#each css.local}}
+    <link rel="stylesheet" href="{{{ . }}}" type="text/css">
+{{/each}}
     <link rel="icon" type="image/svg+xml" href="/theme/img/logo-light.svg" media="(prefers-color-scheme: light)" />
     <link rel="icon" type="image/svg+xml" href="/theme/img/logo-dark.svg" media="(prefers-color-scheme: dark)" />
-    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
-    {{{ extraHead.local }}}
-    {{{ css.tag }}}
     <title>{{ title }}</title>
   </head>
   <body>
@@ -134,9 +130,9 @@
   &lt;head&gt;
     &lt;meta charset="UTF-8"&gt;
     &lt;title&gt;{{ title }}&lt;/title&gt;
-    &lt;!-- Pointer events polyfill for old browsers, see https://caniuse.com/#feat=pointer --&gt;
-    &lt;script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;{{#if extraHead.remote}}
-{{ indent extraHead.remote spaces=4 }}{{/if}}
+{{#each css.remote}}
+    &lt;link rel="stylesheet" href="{{ . }}"&gt;
+{{/each}}
     &lt;link rel="stylesheet" href="node_modules/ol/ol.css"&gt;
     &lt;style&gt;
       .map {
@@ -146,7 +142,12 @@
 {{#if css.source}}{{ indent css.source spaces=6 }}{{/if}}    &lt;/style&gt;
   &lt;/head&gt;
   &lt;body&gt;
-{{ indent contents spaces=4 }}    &lt;script type="module" src="main.js"&gt;&lt;/script&gt;
+{{ indent contents spaces=4 }}    &lt;!-- Pointer events polyfill for old browsers, see https://caniuse.com/#feat=pointer --&gt;
+    &lt;script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;
+{{#each js.remote}}
+    &lt;script src="{{ . }}"&gt;&lt;/script&gt;
+{{/each}}
+    &lt;script type="module" src="main.js"&gt;&lt;/script&gt;
   &lt;/body&gt;
 &lt;/html&gt;</code></pre>
       </div>
@@ -163,12 +164,17 @@
       </div>
     </div>
 
+    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
     <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.bundle.min.js"></script>
-    <script src="./resources/common.js"></script>
-{{#each js.scripts}}
+{{#each js.local}}
     <script src="{{{ . }}}"></script>
 {{/each}}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/components/prism-core.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/toolbar/prism-toolbar.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.js"></script>
+    <script src="./resources/common.js"></script>
     <script>
       $('#tag-example-list').on('show.bs.modal', function (event) {
         const button = $(event.relatedTarget); // Button that triggered the modal
@@ -178,7 +184,8 @@
         modal.find('.modal-title').text(title);
         modal.find('.modal-body').html(content);
       });
-
+    </script>
+    <script>
       const packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
       fetch(packageUrl).then(function(response) {
         return response.json();

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
-    <script src="https://unpkg.com/lz-string@1.4.4/libs/lz-string.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/components/prism-core.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/toolbar/prism-toolbar.min.js"></script>

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -7,7 +7,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/components/prism-core.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/toolbar/prism-toolbar.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"></script>
     <link rel="stylesheet"  type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/fontawesome.min.css" crossorigin="anonymous">

--- a/examples/webpack/config.mjs
+++ b/examples/webpack/config.mjs
@@ -70,6 +70,10 @@ export default {
     new CopyPlugin({
       patterns: [
         {from: '../site/src/theme', to: 'theme'},
+        {
+          from: path.join(baseDir, '..', '..', 'src', 'ol', 'ol.css'),
+          to: path.join(baseDir, '..', '..', 'theme', 'ol', 'ol.css'),
+        },
         {from: 'data', to: 'data'},
         {from: 'resources', to: 'resources'},
         {from: 'index.html', to: 'index.html'},

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -8,7 +8,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/components/prism-core.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/autoloader/prism-autoloader.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/toolbar/prism-toolbar.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.28.0/plugins/copy-to-clipboard/prism-copy-to-clipboard.min.js"></script>
     <link rel="stylesheet"  type="text/css" href="https://fonts.googleapis.com/css?family=Quattrocento+Sans:400,400italic,700" crossorigin="anonymous">
     <link rel="stylesheet"  type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" crossorigin="anonymous">

--- a/site/src/download/index.hbs
+++ b/site/src/download/index.hbs
@@ -18,7 +18,7 @@ layout: default.hbs
       <p>
         If you want to try out OpenLayers without downloading anything (<b>not recommended for production</b>), include the following in the head of your html page:
 <pre><code class="language-html">&lt;script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/{{ version }}/build/ol.js"&gt;&lt;/script&gt;
-&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/{{ version }}/css/ol.css"&gt;
+&lt;link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/{{ version }}/theme/ol.css"&gt;
 </code></pre>
       </p>
     </div>

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -1,4 +1,5 @@
-:root {
+:root,
+:host {
   --ol-background-color: white;
   --ol-accent-background-color: #F5F5F5;
   --ol-subtle-background-color: rgba(128, 128, 128, 0.25);


### PR DESCRIPTION
- A few examples still used the old path to `ol.css`.
- Use the non-symlinked `ol.css` when building the examples so webpack watching files will pick up changes
The symlink in `site/src/theme` maybe could be deleted with this change
- The topolis example did not show error messages with `toastr` becaue jquery has to be loaded first
This moves all scripts  at the end of the `body` to load them in the order they were specified for the example (jquery and bootstrap will be loaded first as they  are always included, but should be no problem)
- Remove `clipboad.js` script as `prism` No longer seems to depend on it
- Only load `lz-string` when the user wants to edit an example
- `es2015-custom-component` and `example-map` still don't load `ol.css` correctly when editing on codesandbox, though that never worked. Unless someone has a smart idea on how to handle these I'd keep it that way for now.
