### PR TITLE
Fix copying of non-linked ol.css, clean example build

### DIFF
--- a/examples/webpack/config.mjs
+++ b/examples/webpack/config.mjs
@@ -5,9 +5,8 @@ import fs from 'fs';
 import path, {dirname} from 'path';
 import {fileURLToPath} from 'url';
 
-const baseDir = dirname(fileURLToPath(import.meta.url));
-
-const src = path.join(baseDir, '..');
+const src = path.join(dirname(fileURLToPath(import.meta.url)), '..');
+const root = path.join(src, '..');
 
 export default {
   context: src,
@@ -39,9 +38,9 @@ export default {
       {
         test: /\.js$/,
         use: {
-          loader: path.join(baseDir, 'worker-loader.cjs'),
+          loader: path.join(src, 'webpack', 'worker-loader.cjs'),
         },
-        include: [path.join(baseDir, '..', '..', 'src', 'ol', 'worker')],
+        include: [path.join(root, 'src', 'ol', 'worker')],
       },
     ],
   },
@@ -64,15 +63,18 @@ export default {
   },
   plugins: [
     new ExampleBuilder({
-      templates: path.join(baseDir, '..', 'templates'),
+      templates: path.join(src, 'templates'),
       common: 'common',
     }),
     new CopyPlugin({
       patterns: [
-        {from: '../site/src/theme', to: 'theme'},
         {
-          from: path.join(baseDir, '..', '..', 'src', 'ol', 'ol.css'),
-          to: path.join(baseDir, '..', '..', 'theme', 'ol', 'ol.css'),
+          from: path.join(root, 'site', 'src', 'theme'),
+          to: 'theme',
+        },
+        {
+          from: path.join(root, 'src', 'ol', 'ol.css'),
+          to: path.join('theme', 'ol.css'),
         },
         {from: 'data', to: 'data'},
         {from: 'resources', to: 'resources'},
@@ -84,7 +86,7 @@ export default {
   devtool: 'source-map',
   output: {
     filename: '[name].js',
-    path: path.join(baseDir, '..', '..', 'build', 'examples'),
+    path: path.join(root, 'build', 'examples'),
   },
   resolve: {
     fallback: {
@@ -94,7 +96,7 @@ export default {
     },
     alias: {
       // allow imports from 'ol/module' instead of specifiying the source path
-      ol: path.join(baseDir, '..', '..', 'src', 'ol'),
+      ol: path.join(root, 'src', 'ol'),
     },
   },
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "karma": "karma start test/browser/karma.config.cjs",
     "start": "npm run serve-examples",
     "serve-examples": "webpack serve --config examples/webpack/config.mjs --mode development",
-    "build-examples": "webpack --config examples/webpack/config.mjs --mode production",
+    "build-examples": "shx rm -rf build/examples && webpack --config examples/webpack/config.mjs --mode production",
     "build-package": "npm run transpile && npm run copy-css && npm run generate-types && node tasks/prepare-package.js",
     "build-index": "shx rm -f build/index.js && npm run build-package && node tasks/generate-index.js",
     "build-legacy": "shx rm -rf build/legacy && npm run build-index && webpack --config config/webpack-config-legacy-build.mjs && cleancss --source-map src/ol/ol.css -o build/legacy/ol.css",


### PR DESCRIPTION
Watching `ol.css` worked because it copied the symlinked file when the non-symlinked file changed.
I also added a `rm -rf build/examples` to `build-examples` to have a clean build.
Fixes #13983