### PR TITLE
Remove IE workarounds for legacy build, examples, and workers

### DIFF
--- a/config/webpack-config-legacy-build.mjs
+++ b/config/webpack-config-legacy-build.mjs
@@ -2,30 +2,10 @@ import TerserPlugin from 'terser-webpack-plugin';
 import path from 'path';
 
 export default {
-  entry: ['regenerator-runtime/runtime', './build/index.js'],
+  entry: './build/index.js',
   devtool: 'source-map',
   mode: 'production',
-  target: ['web', 'es5'],
-  module: {
-    rules: [
-      {
-        test: /\.m?js$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              [
-                '@babel/preset-env',
-                {
-                  targets: 'last 2 versions, not dead',
-                },
-              ],
-            ],
-          },
-        },
-      },
-    ],
-  },
+  target: ['browserslist'],
   resolve: {
     fallback: {
       fs: false,

--- a/examples/webpack/config.mjs
+++ b/examples/webpack/config.mjs
@@ -10,31 +10,20 @@ const root = path.join(src, '..');
 
 export default {
   context: src,
-  target: ['web', 'es5'],
+  target: ['browserslist'],
   entry: () => {
     const entry = {};
     fs.readdirSync(src)
       .filter((name) => /^(?!index).*\.html$/.test(name))
       .map((name) => name.replace(/\.html$/, ''))
       .forEach((example) => {
-        entry[example] = ['regenerator-runtime/runtime', `./${example}.js`];
+        entry[example] = `./${example}.js`;
       });
     return entry;
   },
   stats: 'minimal',
   module: {
     rules: [
-      {
-        test: /^((?!es2015-)[\s\S])*\.m?js$/,
-        use: {
-          loader: 'babel-loader',
-          options: {
-            presets: [
-              ['@babel/preset-env', {targets: 'last 2 versions, not dead'}],
-            ],
-          },
-        },
-      },
       {
         test: /\.js$/,
         use: {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "pngjs": "^6.0.0",
     "proj4": "2.8.0",
     "puppeteer": "16.1.0",
-    "regenerator-runtime": "^0.13.9",
     "rollup": "^2.42.3",
     "rollup-plugin-terser": "^7.0.2",
     "serve-static": "^1.14.0",
@@ -133,6 +132,11 @@
       ]
     }
   },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions",
+    "not dead"
+  ],
   "sideEffects": [
     "proj.js",
     "ol.css"

--- a/tasks/serialize-workers.cjs
+++ b/tasks/serialize-workers.cjs
@@ -28,7 +28,7 @@ async function build(input, {minify = true} = {}) {
           '@babel/preset-env',
           {
             'modules': false,
-            'targets': 'last 2 versions, not dead',
+            'targets': '> 1%, last 2 versions, not dead',
           },
         ],
       ],


### PR DESCRIPTION
This removes [regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime) from the legacy build, built examples, and built workers.  We now have an explicit [browserslist](https://browsersl.ist/) config in the `package.json`.  The webpack target for building examples and the legacy build will use this browserslist config.

See #12734.
See #13883.