### PR TITLE
Avoid append only cache in WebGL tile layers

### DIFF
--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -674,6 +674,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
      * @param {import("../../Map.js").FrameState} frameState Frame state.
      */
     const postRenderFunction = function (map, frameState) {
+      tileSource.updateCacheSize(0.1, frameState.viewState.projection);
       tileSource.expireCache(frameState.viewState.projection, empty);
     };
 

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -1,5 +1,6 @@
 import DataTileSource from '../../../../../src/ol/source/DataTile.js';
 import Map from '../../../../../src/ol/Map.js';
+import OSM from '../../../../../src/ol/source/OSM.js';
 import TileWMS from '../../../../../src/ol/source/TileWMS.js';
 import View from '../../../../../src/ol/View.js';
 import WebGLHelper from '../../../../../src/ol/webgl/Helper.js';
@@ -266,6 +267,19 @@ describe('ol/layer/WebGLTile', function () {
       const spy = sinon.spy(renderer, 'dispose');
       layer.dispose();
       expect(spy.called).to.be(true);
+    });
+  });
+
+  describe('caching', () => {
+    it('updates the size of the tile cache on the source ', (done) => {
+      const source = new OSM();
+      const spy = sinon.spy(source, 'updateCacheSize');
+      const layer = new WebGLTileLayer({source: source});
+      map.addLayer(layer);
+      map.once('rendercomplete', () => {
+        expect(spy.called).to.be(true);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
The WebGL tile renderer maintains its own cache of tile textures.  When a layer is configured with an explicit `cacheSize`, this is passed to the renderer's cache.  And the intention is that the source's cache remains near empty.  In #12671, the cache size for the data tile source was set to 0.1 to make sure it stays empty.  But for all other tile sources, the source's tile cache has a size of 0 or unlimited.

The Canvas tile renderer calls `source.updateCacheSize()` to manage the cache on its layers' sources.  This change makes the WebGL tile renderer do the same.  (Having the renderer reach through the layer and the source to manage the tile cache is further support for moving the cache to the renderer instead of the source.)

Fixes #13927.