### PR TITLE
Use the full table for constructor options

### DIFF
--- a/config/jsdoc/api/template/tmpl/params.tmpl
+++ b/config/jsdoc/api/template/tmpl/params.tmpl
@@ -58,13 +58,29 @@
 	<tbody>
 	<?js
         var self = this;
+
+        if (params[0].name === 'options' && params[0].subparams) {
+            var onlyOptions = true;
+            for (var i = 1; i < params.length; ++i) {
+                if (params[i]) {
+                    onlyOptions = false;
+                    break;
+                }
+            }
+            if (onlyOptions) {
+                var hasName = params.hasName;
+                params = params[0].subparams;
+                params.hasName = hasName;
+            }
+        }
+
 	    params.forEach(function(param) {
 	        if (!param) { return; }
 	?>
 
         <tr class="<?js= (param.stability && param.stability !== 'stable') ? 'unstable' : '' ?>">
             <?js if (params.hasName) {?>
-                <td class="name"><code><?js= param.name.replace(/^opt_/, "") ?></code></td>
+                <td class="name"><code><?js= param.name ?></code></td>
             <?js } ?>
 
             <?js if (!param.subparams) {?>


### PR DESCRIPTION
This updates the API docs to use a single table for constructor options instead of two nested tables.

Before (squished descriptions):

<img width="715" alt="image" src="https://user-images.githubusercontent.com/41094/185001510-c5c44fdf-85d2-48c6-bc17-2ea9c7f902ac.png">

After (not as squished):

<img width="712" alt="image" src="https://user-images.githubusercontent.com/41094/185001557-cf3b67ee-0ab3-4aca-b1b5-657eb7acadc7.png">
