### PR TITLE
Force render after update in Icon Scale example

### DIFF
--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -164,8 +164,9 @@ function updateStyle() {
     .setTextBaseline(textBaselines[parseFloat(controls['textBaseline'].value)]);
 
   iconStyle.getText().setOffsetX(parseFloat(controls['textOffsetX'].value));
-
   iconStyle.getText().setOffsetY(parseFloat(controls['textOffsetY'].value));
+
+  iconFeature.changed();
 }
 updateStyle();
 


### PR DESCRIPTION
Removing the vector context removed the need to reset the style array which fired a change, so to remain responsive a change has to be forced.

https://deploy-preview-14012--ol-site.netlify.app/en/latest/examples/icon-scale.html