### PR TITLE
Make the website deploy job succeed even if there are no changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,11 +32,13 @@ jobs:
       - run: |
           cp -r build/site/* openlayers.github.io/dist/
           cd openlayers.github.io
-          git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-          git add .
-          git commit -m "Website updates"
-          git push origin main
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+            git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+            git add .
+            git commit -m "Website updates"
+            git push origin main
+          fi
   deploy-tag:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -60,8 +62,10 @@ jobs:
       - run: |
           cp -r build/site/* openlayers.github.io/dist/
           cd openlayers.github.io
-          git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
-          git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-          git add .
-          git commit -m "Website updates"
-          git push origin main
+          if [ -n "$(git status --porcelain)" ]; then
+            git config user.name "$(git --no-pager log --format=format:'%an' -n 1)"
+            git config user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
+            git add .
+            git commit -m "Website updates"
+            git push origin main
+          fi


### PR DESCRIPTION
This makes it so the website deploy job doesn't fail if there aren't any changes to the website content.

Fixes #14016.