### PR TITLE
Do not display TileJSON attributions if empty string

### DIFF
--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -188,7 +188,7 @@ class TileJSON extends TileImage {
 
     this.tileUrlFunction = createFromTemplates(tileJSON['tiles'], tileGrid);
 
-    if (tileJSON['attribution'] !== undefined && !this.getAttributions()) {
+    if (tileJSON['attribution'] && !this.getAttributions()) {
       const attributionExtent = extent !== undefined ? extent : gridExtent;
       this.setAttributions(function (frameState) {
         if (intersects(attributionExtent, frameState.extent)) {


### PR DESCRIPTION
Generally the attributions control is not displayed if the attributions are specified with a falsey value such as empty string https://github.com/openlayers/openlayers/blob/main/src/ol/source/Source.js#L228
However TileJSON tests for undefined resulting in a an attributions control with no content as in https://openlayers.org/en/latest/examples/tilejson.html
