### PR TITLE
New URL to check for latest release

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -278,11 +278,11 @@ $(function () {
 
   // warn about outdated version
   const currentVersion = document.getElementById('package-version').innerHTML;
-  const packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
-  fetch(packageUrl).then(function(response) {
+  const releaseUrl = 'https://api.github.com/repos/openlayers/openlayers/releases/latest';
+  fetch(releaseUrl).then(function(response) {
     return response.json();
   }).then(function(json) {
-    const latestVersion = json.version;
+    const latestVersion = json.name.replace(/^v/, '');
     document.getElementById('latest-version').innerHTML = latestVersion;
     const url = window.location.href;
     const branchSearch = url.match(/\/([^\/]*)\/apidoc\//);

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -186,11 +186,11 @@
       });
     </script>
     <script>
-      const packageUrl = 'https://raw.githubusercontent.com/openlayers/openlayers.github.io/build/package.json';
-      fetch(packageUrl).then(function(response) {
+      const releaseUrl = 'https://api.github.com/repos/openlayers/openlayers/releases/latest';
+      fetch(releaseUrl).then(function(response) {
         return response.json();
       }).then(function(json) {
-        const latestVersion = json.version;
+        const latestVersion = json.name.replace(/^v/, '');
         document.getElementById('latest-version').innerHTML = latestVersion;
         const url = window.location.href;
         const branchSearch = url.match(/\/([^\/]*)\/examples\//);


### PR DESCRIPTION
This updates how we check for the latest release in the examples and API docs.  After this is in, I'll make changes to the openlayers.github.io content for the releases that are already there.

Fixes #14024.