### PR TITLE
Clone the WMS params option

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -6,6 +6,10 @@
 
 Future versions will no longer throw `ol/AssertionError` with an error `code`. Instead, they will throw `Error` with just the error message.
 
+#### Updating parameters in `ol/source/ImageWMS` and `ol/source/TileWMS`
+
+The `updateParams()` method will be the only way to update parameters. Changes made directly to the `params` object passed as a constructor option will have no effect.
+
 ### 7.0.0
 
 #### Removal of deprecated properties and methods

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -106,7 +106,7 @@ class ImageWMS extends ImageSource {
      * @private
      * @type {!Object}
      */
-    this.params_ = options.params || {};
+    this.params_ = Object.assign({}, options.params);
 
     /**
      * @private

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -84,7 +84,7 @@ class TileWMS extends TileImage {
   constructor(options) {
     options = options ? options : /** @type {Options} */ ({});
 
-    const params = options.params || {};
+    const params = Object.assign({}, options.params);
 
     const transparent = 'TRANSPARENT' in params ? params['TRANSPARENT'] : true;
 

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -206,8 +206,8 @@ describe('ol/source/ImageWMS', function () {
 
     it('extends FORMAT_OPTIONS if it is already present', function () {
       options.serverType = 'geoserver';
-      const source = new ImageWMS(options);
       options.params.FORMAT_OPTIONS = 'param1:value1';
+      const source = new ImageWMS(options);
       pixelRatio = 2;
       const image = source.getImage(extent, resolution, pixelRatio, projection);
       const uri = new URL(image.src_);

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -150,8 +150,8 @@ describe('ol/source/TileWMS', function () {
 
     it('extends FORMAT_OPTIONS if it is already present', function () {
       options.serverType = 'geoserver';
-      const source = new TileWMS(options);
       options.params.FORMAT_OPTIONS = 'param1:value1';
+      const source = new TileWMS(options);
       const tile = source.getTile(3, 2, 2, 2, getProjection('CRS:84'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;


### PR DESCRIPTION
Fixes #14044

Clone the WMS params option instead of using it directly to ensure the object is updateable.

This broke two tests which were setting params by bypassing `updateParams` - does that justify an upgrade note?