### PR TITLE
Avoid rate limits from the GitHub API

### DIFF
--- a/config/jsdoc/api/template/static/scripts/main.js
+++ b/config/jsdoc/api/template/static/scripts/main.js
@@ -278,11 +278,11 @@ $(function () {
 
   // warn about outdated version
   const currentVersion = document.getElementById('package-version').innerHTML;
-  const releaseUrl = 'https://api.github.com/repos/openlayers/openlayers/releases/latest';
+  const releaseUrl = 'https://cdn.jsdelivr.net/npm/ol/package.json';
   fetch(releaseUrl).then(function(response) {
     return response.json();
   }).then(function(json) {
-    const latestVersion = json.name.replace(/^v/, '');
+    const latestVersion = json.version;
     document.getElementById('latest-version').innerHTML = latestVersion;
     const url = window.location.href;
     const branchSearch = url.match(/\/([^\/]*)\/apidoc\//);

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -184,11 +184,11 @@
         });
     </script>
     <script>
-      const releaseUrl = 'https://api.github.com/repos/openlayers/openlayers/releases/latest';
+      const releaseUrl = 'https://cdn.jsdelivr.net/npm/ol/package.json';
       fetch(releaseUrl).then(function(response) {
         return response.json();
       }).then(function(json) {
-        const latestVersion = json.name.replace(/^v/, '');
+        const latestVersion = json.version;
         document.getElementById('latest-version').innerHTML = latestVersion;
         const url = window.location.href;
         const branchSearch = url.match(/\/([^\/]*)\/examples\//);


### PR DESCRIPTION
I'm seeing 403s from the https://api.github.com/repos/openlayers/openlayers/releases/latest.  This branch gets the version from https://cdn.jsdelivr.net/npm/ol/package.json instead.