### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new XYZ({
-        url: 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'
+        url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
       })
     })
   ],

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -37,7 +37,7 @@ export const ATTRIBUTION =
  * ```
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
- * @property {string} [url='https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png'] URL template.
+ * @property {string} [url='https://tile.openstreetmap.org/{z}/{x}/{y}.png'] URL template.
  * Must include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
  * @property {boolean} [wrapX=true] Whether to wrap the world horizontally.
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
@@ -70,7 +70,7 @@ class OSM extends XYZ {
     const url =
       options.url !== undefined
         ? options.url
-        : 'https://{a-c}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+        : 'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
 
     super({
       attributions: attributions,


### PR DESCRIPTION
Use the preferred URL for tile.openstreetmap.org, the old aliases are no longer recommended now that tile supports HTTP/2 + HTTP/3.

Signed-off-by: Grant Slater <git@firefishy.com>
