### PR TITLE
Layer for rendering STAC item assets

### DIFF
--- a/examples/planetary-computer.html
+++ b/examples/planetary-computer.html
@@ -1,0 +1,14 @@
+---
+layout: example.html
+title: Planetary Computer
+shortdesc: Rendering a STAC Item from Planetary Computer.
+docs: >
+  This example uses the STAC layer to render an item from Planetary Computer.
+  Planetary Computer requres that asset URLs are signed with a token.  The example
+  uses the `getSourceOptions` callback to sign the asset URL.
+tags: "stac, geotiff, cog"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: <Your API key from https://www.maptiler.com/cloud/>
+---
+<div id="map" class="map"></div>

--- a/examples/planetary-computer.js
+++ b/examples/planetary-computer.js
@@ -1,0 +1,61 @@
+import Map from '../src/ol/Map.js';
+import STAC from '../src/ol/layer/STAC.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+import XYZ from '../src/ol/source/XYZ.js';
+import proj4 from 'proj4';
+import {register} from '../src/ol/proj/proj4.js';
+import {transformExtent} from '../src/ol/proj.js';
+
+register(proj4); // required to support source reprojection
+
+/**
+ * Get a Shared Access Signature Token to authorize asset requests.
+ * See https://planetarycomputer.microsoft.com/docs/concepts/sas/
+ * @param {string} href The unsigned URL.
+ * @return {Promise<string>} A promise for the signed URL.
+ */
+async function sign(href) {
+  const params = new URLSearchParams({href});
+  const response = await fetch(
+    `https://planetarycomputer.microsoft.com/api/sas/v1/sign?${params}`
+  );
+  const body = await response.json();
+  return body.href;
+}
+
+const layer = new STAC({
+  url: 'https://planetarycomputer.microsoft.com/api/stac/v1/collections/sentinel-2-l2a/items/S2B_MSIL2A_20220909T185929_R013_T10TES_20220910T222807',
+  assets: ['visual'],
+  async getSourceOptions(item, options) {
+    for (const source of options.sources) {
+      source.url = await sign(source.url);
+    }
+    return options;
+  },
+});
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const background = new TileLayer({
+  visible: false,
+  source: new XYZ({
+    url: 'https://api.maptiler.com/maps/pastel/{z}/{x}/{y}.png?key=' + key,
+    tileSize: 512,
+  }),
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [background, layer],
+  view: new View({
+    center: [0, 0],
+    zoom: 0,
+  }),
+});
+
+layer.on('sourceready', () => {
+  const item = layer.getItem();
+  const view = map.getView();
+  view.fit(transformExtent(item.bbox, 'EPSG:4326', view.getProjection()));
+  background.setVisible(true);
+});

--- a/examples/stac.html
+++ b/examples/stac.html
@@ -1,0 +1,12 @@
+---
+layout: example.html
+title: STAC Item
+shortdesc: Rendering a STAC Item as a layer.
+docs: >
+  Assets from SpatioTemporal Asset Catalog (STAC) Items can be rendered as layers.
+tags: "stac, geotiff, cog"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: <Your API key from https://www.maptiler.com/cloud/>
+---
+<div id="map" class="map"></div>

--- a/examples/stac.js
+++ b/examples/stac.js
@@ -1,0 +1,40 @@
+import Map from '../src/ol/Map.js';
+import STAC from '../src/ol/layer/STAC.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+import XYZ from '../src/ol/source/XYZ.js';
+import proj4 from 'proj4';
+import {register} from '../src/ol/proj/proj4.js';
+import {transformExtent} from '../src/ol/proj.js';
+
+register(proj4); // required to support source reprojection
+
+const layer = new STAC({
+  url: 'https://s3.us-west-2.amazonaws.com/sentinel-cogs/sentinel-s2-l2a-cogs/10/T/ES/2022/7/S2A_10TES_20220726_0_L2A/S2A_10TES_20220726_0_L2A.json',
+  assets: ['visual'],
+});
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const background = new TileLayer({
+  visible: false,
+  source: new XYZ({
+    url: 'https://api.maptiler.com/maps/pastel/{z}/{x}/{y}.png?key=' + key,
+    tileSize: 512,
+  }),
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [background, layer],
+  view: new View({
+    center: [0, 0],
+    zoom: 0,
+  }),
+});
+
+layer.on('sourceready', () => {
+  const item = layer.getItem();
+  const view = map.getView();
+  view.fit(transformExtent(item.bbox, 'EPSG:4326', view.getProjection()));
+  background.setVisible(true);
+});

--- a/src/ol/layer/STAC.js
+++ b/src/ol/layer/STAC.js
@@ -1,0 +1,312 @@
+/**
+ * @module ol/layer/STAC
+ */
+import GeoTIFF from '../source/GeoTIFF.js';
+import WebGLTileLayer from './WebGLTile.js';
+import {
+  fromEPSGCode,
+  isRegistered as isProj4Registered,
+} from '../proj/proj4.js';
+
+/**
+ * @typedef {Object} Item
+ * @property {string} type The item type ("Feature").
+ * @property {string} stac_version The STAC version.
+ * @property {string} id The item identifier.
+ * @property {import("geojson").GeoJSON|null} geometry The item footprint.
+ * @property {Array<number>} [bbox] The bounding box (only required if geometry is null).
+ * @property {Object} properties The item properties.
+ * @property {Array<Link>} links Links to other resources.
+ * @property {Object<string, Asset>} assets Asset lookup.
+ * @property {string} collection The collection id (if the item is part of a collection).
+ */
+
+/**
+ * @typedef {Object} Link
+ * @property {string} href The URL.
+ * @property {string} rel The link relationship.
+ * @property {string} [type] The media type.
+ * @property {string} [title] The link title.
+ */
+
+/**
+ * @typedef {Object} Asset
+ * @property {string} href The asset URL.
+ * @property {string} [title] The asset title.
+ * @property {string} [description] The asset description.
+ * @property {string} [type] The media type.
+ * @property {Array<string>} [roles] The asset roles.
+ */
+
+/**
+ * @typedef {import("../source/GeoTIFF.js").Options} SourceOptions
+ */
+
+/**
+ * @param {Asset} asset The asset.
+ * @return {number} A relative ranking (lower is better).
+ */
+function getAssetTypeRank(asset) {
+  if (!asset.type) {
+    return Infinity;
+  }
+  const type = asset.type.toLowerCase();
+  if (type === 'image/tiff; application=geotiff; profile=cloud-optimized') {
+    return 0;
+  }
+  if (type === 'image/vnd.stac.geotiff; cloud-optimized=true') {
+    return 0;
+  }
+  if (type.includes('geotiff')) {
+    if (type.includes('cloud-optimized')) {
+      return 0;
+    }
+    return 1;
+  }
+  if (type.includes('image/tiff')) {
+    return 2;
+  }
+  return Infinity;
+}
+
+/**
+ * @param {Asset} asset The asset.
+ * @return {number} The relative ranking (lower is better).
+ */
+function getAssetRolesRank(asset) {
+  const roles = asset.roles;
+  if (!roles) {
+    return Infinity;
+  }
+  for (let i = 0; i < roles.length; ++i) {
+    const role = roles[i];
+    if (role === 'overview') {
+      return 0;
+    }
+    if (role === 'data') {
+      return 1;
+    }
+  }
+  return Infinity;
+}
+
+/**
+ * @param {Object<string, Asset>} assets A lookup of assets.
+ * @return {Array<Asset>} The assets to be rendered.
+ */
+function assetSelectorByRank(assets) {
+  /** @type {Array<Asset>} */
+  const array = [];
+
+  for (const k in assets) {
+    array.push(assets[k]);
+  }
+
+  array.sort((a, b) => {
+    const aTypeRank = getAssetTypeRank(a);
+    const bTypeRank = getAssetTypeRank(b);
+    if (aTypeRank < bTypeRank) {
+      return -1;
+    }
+    if (aTypeRank > bTypeRank) {
+      return 1;
+    }
+    return getAssetRolesRank(a) - getAssetRolesRank(b);
+  });
+
+  return [array[0]];
+}
+
+/**
+ * @param {Array<string>} keys The asset keys.
+ * @return {AssetSelector} An asset selector.
+ */
+function getAssetSelectorByKeys(keys) {
+  return function (assets) {
+    return keys.map((key) => {
+      const asset = assets[key];
+      if (!asset) {
+        throw new Error(`No asset with key "${key}" found`);
+      }
+      return asset;
+    });
+  };
+}
+
+/**
+ * @typedef {function(Object<string, Asset>):Array<Asset>} AssetSelector
+ */
+
+/**
+ * @typedef {Object} Options
+ * @property {Array<string>|AssetSelector} [assets] The selector for the assets to be rendered.  This can be an
+ * array of strings corresponding to asset keys or a function that returns an array of assets
+ * given item's asset lookup object.
+ * @property {string} [url] The STAC item URL.  One of `url` or `item` must be provided.
+ * @property {Object} [item] The STAC item metadata.  One of `url` or `item` must be provided.
+ * @property {function(Item, SourceOptions):(SourceOptions|Promise<SourceOptions>)} [getSourceOptions] Optional function that can be used to
+ * configure the underlying source.  The function will be called with the STAC Item metadata and the current source options.
+ * The function can do any additional work and return the completed options or a promise for the same.
+ * @property {import("./WebGLTile.js").Style} [style] Style to apply to the layer.
+ * @property {number} [opacity=1] Opacity (0, 1).
+ * @property {boolean} [visible=true] Visibility.
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * rendered outside of this extent.
+ * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
+ * for layers that are added to the map's `layers` collection, or `Infinity` when the layer's `setMap()`
+ * method was used.
+ * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
+ * visible.
+ * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
+ * be visible.
+ * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will be
+ * visible.
+ * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
+ * be visible.
+ * @property {number} [preload=0] Preload. Load low-resolution tiles up to `preload` levels. `0`
+ * means no preloading.
+ * @property {number} [cacheSize=512] The internal texture cache size.  This needs to be large enough to render
+ * two zoom levels worth of tiles.
+ * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
+ */
+
+/**
+ * @classdesc
+ * Renders assets from a STAC Item.
+ *
+ * @extends WebGLTileLayer
+ * @api
+ */
+class STACLayer extends WebGLTileLayer {
+  /**
+   * @param {Options} options Layer options.
+   */
+  constructor(options) {
+    const superOptions = Object.assign({}, options);
+
+    delete superOptions.assets;
+    delete superOptions.url;
+    delete superOptions.item;
+    delete superOptions.getSourceOptions;
+
+    super(superOptions);
+
+    /**
+     * @type {AssetSelector}
+     * @private
+     */
+    this.assetSelector_;
+    if (!options.assets) {
+      this.assetSelector_ = assetSelectorByRank;
+    } else if (Array.isArray(options.assets)) {
+      this.assetSelector_ = getAssetSelectorByKeys(options.assets);
+    } else {
+      this.assetSelector_ = options.assets;
+    }
+
+    /**
+     * @type {function(Item, SourceOptions):(SourceOptions|Promise<SourceOptions>)}
+     * @private
+     */
+    this.getSourceOptions_ = options.getSourceOptions;
+
+    /**
+     * @type {Item}
+     * @private
+     */
+    this.item_;
+
+    if (options.item) {
+      this.configure_(options.item).catch((error) => this.handleError_(error));
+      return;
+    }
+
+    const url = options.url;
+    if (!url) {
+      throw new Error('Either url or item must be provided');
+    }
+
+    fetch(url)
+      .then((response) => response.json())
+      .then((item) => this.configure_(item))
+      .catch((error) => this.handleError_(error));
+  }
+
+  /**
+   * @param {Error} error The error.
+   * @private
+   */
+  handleError_(error) {
+    // TODO: error state, event, or callback?
+    console.error(error); // eslint-disable-line no-console
+  }
+
+  /**
+   * @param {Item} item The item data.
+   * @return {Promise} Resolves when complete.
+   * @private
+   */
+  configure_(item) {
+    this.item_ = item;
+    const assets = this.assetSelector_(item.assets);
+    return this.updateSource_(assets);
+  }
+
+  /**
+   * @param {Array<Asset>} assets The assets to render.
+   * @private
+   */
+  async updateSource_(assets) {
+    /**
+     * @type {SourceOptions}
+     */
+    let options = {
+      sources: assets.map((asset) => ({
+        url: asset.href,
+      })),
+    };
+
+    const item = this.item_;
+    let projection;
+    if (isProj4Registered()) {
+      const epsgCode = item.properties['proj:epsg'];
+      if (epsgCode) {
+        try {
+          projection = await fromEPSGCode(epsgCode);
+        } catch (_) {
+          // pass
+        }
+        if (projection) {
+          options.projection = projection;
+        }
+      }
+    }
+
+    if (this.getSourceOptions_) {
+      options = await this.getSourceOptions_(item, options);
+    }
+
+    const source = new GeoTIFF(options);
+    this.setSource(source);
+  }
+
+  /**
+   * Update the assets to be rendered.
+   * @param {Array<string>} keys Asset keys.
+   */
+  setAssets(keys) {
+    const assets = getAssetSelectorByKeys(keys)(this.item_.assets);
+    this.updateSource_(assets);
+  }
+
+  /**
+   * Get the item metadata.
+   * @return {Item} The item.
+   */
+  getItem() {
+    return this.item_;
+  }
+}
+
+export default STACLayer;

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -361,6 +361,8 @@ function getMaxForDataType(array) {
  * If instead you want to work with the raw values in a style expression, set this to `false`.  Setting this option
  * to `false` will make it so any `min` and `max` properties on sources are ignored.
  * @property {boolean} [opaque=false] Whether the layer is opaque.
+ * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoTIFF metadata
+ * will be read for projection information.
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
@@ -384,7 +386,7 @@ class GeoTIFFSource extends DataTile {
     super({
       state: 'loading',
       tileGrid: null,
-      projection: null,
+      projection: options.projection || null,
       opaque: options.opaque,
       transition: options.transition,
       interpolate: options.interpolate !== false,


### PR DESCRIPTION
This adds a STAC layer for rendering assets from an item.  It currently creates a tile layer with a GeoTIFF source, but eventually could do other things too.

Examples
 * Using the [Registry of Open Data on AWS](https://deploy-preview-14101--ol-site.netlify.app/en/latest/examples/stac.html)
 * Using [Planetary Computer](https://deploy-preview-14101--ol-site.netlify.app/en/latest/examples/planetary-computer.html)

I'm opening this up to gather ideas on what would make it more convenient.  If we rely just on the STAC core, I don't think we can add all that much convenience (feels just as easy to create a GeoTIFF source).  If we rely on extensions, I think we will have a hard time drawing a line (there are many extensions) and maintaining compatibility (core and all extensions are versioned independently).  Ideally we could provide just the right "hooks" or options for users to not have to write too much application code to do what they want.

Here is a description of the current options/methods:

The `getSourceOptions` option lets users provide a function that returns options for the source given item metadata.  This can also return a promise in cases where async work needs to be performed.  The [Planetary Computer example](https://deploy-preview-14101--ol-site.netlify.app/en/latest/examples/planetary-computer.html) uses this option to [sign](https://planetarycomputer.microsoft.com/docs/concepts/sas/) the asset URLs before the source is created.

The `getItem` method can be used to get the item metadata after the source is ready.  The examples use this method in a `sourceready` event handler to fit the view to the item's bbox.

The `assets` option is used to provide an array of keys that map to assets for the source.  This can also be a function that picks the assets from the lookup.  If no `assets` option is provided, we try to rank the assets based on the type and roles - though this is probably only marginally useful (often there are many `data` and many `overview` COG assets, hard to guess which one(s) would be best).

Band stats would be nice to make use of (if the [raster extension](https://github.com/stac-extensions/raster#statistics-object) is being used).  I also have a branch going that extracts and updates stats from the tiles as they load.  I want to settle on something that works in both cases (stats available in metadata and stats only available after rendering).

Curious to get thoughts from others (cc @m-mohr).