### PR TITLE
No else after return

### DIFF
--- a/examples/clusters-dynamic.js
+++ b/examples/clusters-dynamic.js
@@ -174,10 +174,9 @@ function clusterStyle(feature) {
         }),
       }),
     ];
-  } else {
-    const originalFeature = feature.get('features')[0];
-    return clusterMemberStyle(originalFeature);
   }
+  const originalFeature = feature.get('features')[0];
+  return clusterMemberStyle(originalFeature);
 }
 
 const vectorSource = new VectorSource({

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -85,9 +85,8 @@ const flightsLayer = new VectorLayer({
     // render the feature with the layer style
     if (feature.get('finished')) {
       return style;
-    } else {
-      return null;
     }
+    return null;
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "es-main": "^1.0.2",
         "eslint": "^8.0.1",
-        "eslint-config-openlayers": "^16.2.3",
+        "eslint-config-openlayers": "^17.0.0",
         "expect.js": "0.3.1",
         "express": "^4.17.1",
         "front-matter": "^4.0.0",
@@ -4487,9 +4487,9 @@
       }
     },
     "node_modules/eslint-config-openlayers": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-16.2.3.tgz",
-      "integrity": "sha512-hVbKywAXPC36ERDPfHB9eipS6r1hSPK15bY6X722Gx1Ayqi6iKR0vGSgjDV5COTDLsNQI87wsrAtUNiXfElMGg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-17.0.0.tgz",
+      "integrity": "sha512-eTXvS5CMGV9/IOvT+02zkJ1AlBM4pFMqKghImjJ+BJy3BATCtrxXE/8Sv7DKMqiOHmK1Q03nreqXQxlMjkMtDw==",
       "dev": true,
       "dependencies": {
         "eslint-config-prettier": "^8.3.0",
@@ -14388,9 +14388,9 @@
       }
     },
     "eslint-config-openlayers": {
-      "version": "16.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-16.2.3.tgz",
-      "integrity": "sha512-hVbKywAXPC36ERDPfHB9eipS6r1hSPK15bY6X722Gx1Ayqi6iKR0vGSgjDV5COTDLsNQI87wsrAtUNiXfElMGg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-17.0.0.tgz",
+      "integrity": "sha512-eTXvS5CMGV9/IOvT+02zkJ1AlBM4pFMqKghImjJ+BJy3BATCtrxXE/8Sv7DKMqiOHmK1Q03nreqXQxlMjkMtDw==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "es-main": "^1.0.2",
     "eslint": "^8.0.1",
-    "eslint-config-openlayers": "^16.2.3",
+    "eslint-config-openlayers": "^17.0.0",
     "expect.js": "0.3.1",
     "express": "^4.17.1",
     "front-matter": "^4.0.0",

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -315,21 +315,20 @@ class Feature extends BaseObject {
 export function createStyleFunction(obj) {
   if (typeof obj === 'function') {
     return obj;
-  } else {
-    /**
-     * @type {Array<import("./style/Style.js").default>}
-     */
-    let styles;
-    if (Array.isArray(obj)) {
-      styles = obj;
-    } else {
-      assert(typeof (/** @type {?} */ (obj).getZIndex) === 'function', 41); // Expected an `import("./style/Style.js").Style` or an array of `import("./style/Style.js").Style`
-      const style = /** @type {import("./style/Style.js").default} */ (obj);
-      styles = [style];
-    }
-    return function () {
-      return styles;
-    };
   }
+  /**
+   * @type {Array<import("./style/Style.js").default>}
+   */
+  let styles;
+  if (Array.isArray(obj)) {
+    styles = obj;
+  } else {
+    assert(typeof (/** @type {?} */ (obj).getZIndex) === 'function', 41); // Expected an `import("./style/Style.js").Style` or an array of `import("./style/Style.js").Style`
+    const style = /** @type {import("./style/Style.js").default} */ (obj);
+    styles = [style];
+  }
+  return function () {
+    return styles;
+  };
 }
 export default Feature;

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -826,9 +826,8 @@ class Map extends BaseObject {
       return typeof target === 'string'
         ? document.getElementById(target)
         : target;
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**
@@ -855,12 +854,8 @@ class Map extends BaseObject {
     const frameState = this.frameState_;
     if (!frameState) {
       return null;
-    } else {
-      return applyTransform(
-        frameState.pixelToCoordinateTransform,
-        pixel.slice()
-      );
     }
+    return applyTransform(frameState.pixelToCoordinateTransform, pixel.slice());
   }
 
   /**
@@ -992,12 +987,11 @@ class Map extends BaseObject {
     const frameState = this.frameState_;
     if (!frameState) {
       return null;
-    } else {
-      return applyTransform(
-        frameState.coordinateToPixelTransform,
-        coordinate.slice(0, 2)
-      );
     }
+    return applyTransform(
+      frameState.coordinateToPixelTransform,
+      coordinate.slice(0, 2)
+    );
   }
 
   /**

--- a/src/ol/Observable.js
+++ b/src/ol/Observable.js
@@ -94,9 +94,8 @@ class Observable extends EventTarget {
         keys[i] = listen(this, type[i], listener);
       }
       return keys;
-    } else {
-      return listen(this, /** @type {string} */ (type), listener);
     }
+    return listen(this, /** @type {string} */ (type), listener);
   }
 
   /**

--- a/src/ol/TileRange.js
+++ b/src/ol/TileRange.js
@@ -146,9 +146,8 @@ export function createOrUpdate(minX, maxX, minY, maxY, tileRange) {
     tileRange.minY = minY;
     tileRange.maxY = maxY;
     return tileRange;
-  } else {
-    return new TileRange(minX, maxX, minY, maxY);
   }
+  return new TileRange(minX, maxX, minY, maxY);
 }
 
 export default TileRange;

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -908,9 +908,8 @@ class View extends BaseObject {
         Math.abs(w * Math.cos(rotation)) + Math.abs(h * Math.sin(rotation)),
         Math.abs(w * Math.sin(rotation)) + Math.abs(h * Math.cos(rotation)),
       ];
-    } else {
-      return size;
     }
+    return size;
   }
 
   /**
@@ -974,9 +973,8 @@ class View extends BaseObject {
       hints[0] = this.hints_[0];
       hints[1] = this.hints_[1];
       return hints;
-    } else {
-      return this.hints_.slice();
     }
+    return this.hints_.slice();
   }
 
   /**
@@ -1308,11 +1306,10 @@ class View extends BaseObject {
         this.resolutions_[baseLevel] /
         Math.pow(zoomFactor, clamp(zoom - baseLevel, 0, 1))
       );
-    } else {
-      return (
-        this.maxResolution_ / Math.pow(this.zoomFactor_, zoom - this.minZoom_)
-      );
     }
+    return (
+      this.maxResolution_ / Math.pow(this.zoomFactor_, zoom - this.minZoom_)
+    );
   }
 
   /**
@@ -2083,12 +2080,10 @@ export function createRotationConstraint(options) {
       return rotationNone;
     } else if (typeof constrainRotation === 'number') {
       return createSnapToN(constrainRotation);
-    } else {
-      return rotationNone;
     }
-  } else {
-    return disable;
+    return rotationNone;
   }
+  return disable;
 }
 
 /**

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -78,41 +78,38 @@ export function linearFindNearest(arr, target, direction) {
     return 0;
   } else if (target <= arr[n - 1]) {
     return n - 1;
-  } else {
-    let i;
-    if (direction > 0) {
-      for (i = 1; i < n; ++i) {
-        if (arr[i] < target) {
-          return i - 1;
-        }
-      }
-    } else if (direction < 0) {
-      for (i = 1; i < n; ++i) {
-        if (arr[i] <= target) {
-          return i;
-        }
-      }
-    } else {
-      for (i = 1; i < n; ++i) {
-        if (arr[i] == target) {
-          return i;
-        } else if (arr[i] < target) {
-          if (typeof direction === 'function') {
-            if (direction(target, arr[i - 1], arr[i]) > 0) {
-              return i - 1;
-            } else {
-              return i;
-            }
-          } else if (arr[i - 1] - target < target - arr[i]) {
-            return i - 1;
-          } else {
-            return i;
-          }
-        }
+  }
+  let i;
+  if (direction > 0) {
+    for (i = 1; i < n; ++i) {
+      if (arr[i] < target) {
+        return i - 1;
       }
     }
-    return n - 1;
+  } else if (direction < 0) {
+    for (i = 1; i < n; ++i) {
+      if (arr[i] <= target) {
+        return i;
+      }
+    }
+  } else {
+    for (i = 1; i < n; ++i) {
+      if (arr[i] == target) {
+        return i;
+      } else if (arr[i] < target) {
+        if (typeof direction === 'function') {
+          if (direction(target, arr[i - 1], arr[i]) > 0) {
+            return i - 1;
+          }
+          return i;
+        } else if (arr[i - 1] - target < target - arr[i]) {
+          return i - 1;
+        }
+        return i;
+      }
+    }
   }
+  return n - 1;
 }
 
 /**

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -38,9 +38,8 @@ const NAMED_COLOR_RE_ = /^([a-z]*)$|^hsla?\(.*\)$/i;
 export function asString(color) {
   if (typeof color === 'string') {
     return color;
-  } else {
-    return toString(color);
   }
+  return toString(color);
 }
 
 /**
@@ -56,9 +55,8 @@ function fromNamed(color) {
     const rgb = getComputedStyle(el).color;
     document.body.removeChild(el);
     return rgb;
-  } else {
-    return '';
   }
+  return '';
 }
 
 /**
@@ -124,9 +122,8 @@ export const fromString = (function () {
 export function asArray(color) {
   if (Array.isArray(color)) {
     return color;
-  } else {
-    return fromString(color);
   }
+  return fromString(color);
 }
 
 /**

--- a/src/ol/colorlike.js
+++ b/src/ol/colorlike.js
@@ -23,7 +23,6 @@ import {toString} from './color.js';
 export function asColorLike(color) {
   if (Array.isArray(color)) {
     return toString(color);
-  } else {
-    return color;
   }
+  return color;
 }

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -228,9 +228,8 @@ export function format(coordinate, template, fractionDigits) {
     return template
       .replace('{x}', coordinate[0].toFixed(fractionDigits))
       .replace('{y}', coordinate[1].toFixed(fractionDigits));
-  } else {
-    return '';
   }
+  return '';
 }
 
 /**
@@ -365,9 +364,8 @@ export function toStringHDMS(coordinate, fractionDigits) {
       ' ' +
       degreesToStringHDMS('EW', coordinate[0], fractionDigits)
     );
-  } else {
-    return '';
   }
+  return '';
 }
 
 /**

--- a/src/ol/easing.js
+++ b/src/ol/easing.js
@@ -53,7 +53,6 @@ export function linear(t) {
 export function upAndDown(t) {
   if (t < 0.5) {
     return inAndOut(2 * t);
-  } else {
-    return 1 - inAndOut(2 * (t - 0.5));
   }
+  return 1 - inAndOut(2 * (t - 0.5));
 }

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -60,14 +60,13 @@ export function buffer(extent, value, dest) {
     dest[2] = extent[2] + value;
     dest[3] = extent[3] + value;
     return dest;
-  } else {
-    return [
-      extent[0] - value,
-      extent[1] - value,
-      extent[2] + value,
-      extent[3] + value,
-    ];
   }
+  return [
+    extent[0] - value,
+    extent[1] - value,
+    extent[2] + value,
+    extent[3] + value,
+  ];
 }
 
 /**
@@ -84,9 +83,8 @@ export function clone(extent, dest) {
     dest[2] = extent[2];
     dest[3] = extent[3];
     return dest;
-  } else {
-    return extent.slice();
   }
+  return extent.slice();
 }
 
 /**
@@ -216,9 +214,8 @@ export function createOrUpdate(minX, minY, maxX, maxY, dest) {
     dest[2] = maxX;
     dest[3] = maxY;
     return dest;
-  } else {
-    return [minX, minY, maxX, maxY];
   }
+  return [minX, minY, maxX, maxY];
 }
 
 /**
@@ -719,9 +716,8 @@ export function returnOrUpdate(extent, dest) {
     dest[2] = extent[2];
     dest[3] = extent[3];
     return dest;
-  } else {
-    return extent;
   }
+  return extent;
 }
 
 /**

--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -141,9 +141,8 @@ class EsriJSON extends JSONFeature {
         );
       }
       return features;
-    } else {
-      return [this.readFeatureFromObject(object, options)];
     }
+    return [this.readFeatureFromObject(object, options)];
   }
 
   /**
@@ -171,9 +170,8 @@ class EsriJSON extends JSONFeature {
       );
       const crs = spatialReference.wkid;
       return getProjection('EPSG:' + crs);
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -294,7 +294,6 @@ export function transformExtentWithOptions(extent, options) {
     !equivalentProjection(featureProjection, dataProjection)
   ) {
     return transformExtent(extent, dataProjection, featureProjection);
-  } else {
-    return extent;
   }
+  return extent;
 }

--- a/src/ol/format/GML3.js
+++ b/src/ol/format/GML3.js
@@ -125,9 +125,8 @@ class GML3 extends GMLBase {
     if (lineStrings) {
       const multiLineString = new MultiLineString(lineStrings);
       return multiLineString;
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -305,9 +304,8 @@ class GML3 extends GMLBase {
         ends.push(flatCoordinates.length);
       }
       return new Polygon(flatCoordinates, 'XYZ', ends);
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -327,9 +325,8 @@ class GML3 extends GMLBase {
     if (flatCoordinates) {
       const lineString = new LineString(flatCoordinates, 'XYZ');
       return lineString;
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**

--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -332,18 +332,17 @@ class GMLBase extends XMLFeature {
     }
     if (!asFeature) {
       return values;
-    } else {
-      const feature = new Feature(values);
-      if (geometryName) {
-        feature.setGeometryName(geometryName);
-      }
-      const fid =
-        node.getAttribute('fid') || getAttributeNS(node, this.namespace, 'id');
-      if (fid) {
-        feature.setId(fid);
-      }
-      return feature;
     }
+    const feature = new Feature(values);
+    if (geometryName) {
+      feature.setGeometryName(geometryName);
+    }
+    const fid =
+      node.getAttribute('fid') || getAttributeNS(node, this.namespace, 'id');
+    if (fid) {
+      feature.setId(fid);
+    }
+    return feature;
   }
 
   /**
@@ -383,9 +382,8 @@ class GMLBase extends XMLFeature {
     );
     if (coordinates) {
       return new MultiPoint(coordinates);
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -460,9 +458,8 @@ class GMLBase extends XMLFeature {
     if (flatCoordinates) {
       const lineString = new LineString(flatCoordinates, 'XYZ');
       return lineString;
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -480,9 +477,8 @@ class GMLBase extends XMLFeature {
     );
     if (ring) {
       return ring;
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -520,9 +516,8 @@ class GMLBase extends XMLFeature {
         ends.push(flatCoordinates.length);
       }
       return new Polygon(flatCoordinates, 'XYZ', ends);
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**

--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -203,9 +203,8 @@ class GPX extends XMLFeature {
       if (features) {
         this.handleReadExtensions_(features);
         return features;
-      } else {
-        return [];
       }
+      return [];
     }
     return [];
   }

--- a/src/ol/format/IGC.js
+++ b/src/ol/format/IGC.js
@@ -166,9 +166,8 @@ class IGC extends TextFeature {
     const feature = this.readFeatureFromText(text, options);
     if (feature) {
       return [feature];
-    } else {
-      return [];
     }
+    return [];
   }
 }
 

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -202,9 +202,8 @@ function getObject(source) {
     return object ? /** @type {Object} */ (object) : null;
   } else if (source !== null) {
     return source;
-  } else {
-    return null;
   }
+  return null;
 }
 
 export default JSONFeature;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -509,9 +509,8 @@ class KML extends XMLFeature {
     const features = pushParseAndPop([], parsersNS, node, objectStack, this);
     if (features) {
       return features;
-    } else {
-      return undefined;
     }
+    return undefined;
   }
 
   /**
@@ -636,9 +635,8 @@ class KML extends XMLFeature {
     ]);
     if (feature) {
       return feature;
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**
@@ -659,18 +657,16 @@ class KML extends XMLFeature {
       ]);
       if (features) {
         return features;
-      } else {
-        return [];
       }
+      return [];
     } else if (localName == 'Placemark') {
       const feature = this.readPlacemark_(node, [
         this.getReadOptions(node, options),
       ]);
       if (feature) {
         return [feature];
-      } else {
-        return [];
       }
+      return [];
     } else if (localName == 'kml') {
       features = [];
       for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
@@ -680,9 +676,8 @@ class KML extends XMLFeature {
         }
       }
       return features;
-    } else {
-      return [];
     }
+    return [];
   }
 
   /**
@@ -700,9 +695,8 @@ class KML extends XMLFeature {
       return this.readNameFromDocument(doc);
     } else if (isDocument(source)) {
       return this.readNameFromDocument(/** @type {Document} */ (source));
-    } else {
-      return this.readNameFromNode(/** @type {Element} */ (source));
     }
+    return this.readNameFromNode(/** @type {Element} */ (source));
   }
 
   /**
@@ -1070,9 +1064,8 @@ function findStyle(styleValue, defaultStyle, sharedStyles) {
     return styleValue;
   } else if (typeof styleValue === 'string') {
     return findStyle(sharedStyles[styleValue], defaultStyle, sharedStyles);
-  } else {
-    return defaultStyle;
   }
+  return defaultStyle;
 }
 
 /**
@@ -1092,9 +1085,8 @@ function readColor(node) {
       parseInt(hexColor.substr(2, 2), 16),
       parseInt(hexColor.substr(0, 2), 16) / 255,
     ];
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -1136,9 +1128,8 @@ function readURI(node) {
   if (baseURI) {
     const url = new URL(s, baseURI);
     return url.href;
-  } else {
-    return s;
   }
+  return s;
 }
 
 /**
@@ -1158,9 +1149,8 @@ function readStyleURL(node) {
   if (baseURI) {
     const url = new URL(s, baseURI);
     return url.href;
-  } else {
-    return s;
   }
+  return s;
 }
 
 /**
@@ -1621,9 +1611,8 @@ function readIcon(node, objectStack) {
   const iconObject = pushParseAndPop({}, ICON_PARSERS, node, objectStack);
   if (iconObject) {
     return iconObject;
-  } else {
-    return null;
   }
+  return null;
 }
 
 /**
@@ -1677,9 +1666,8 @@ function readLineString(node, objectStack) {
     const lineString = new LineString(flatCoordinates, 'XYZ');
     lineString.setProperties(properties, true);
     return lineString;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -1701,9 +1689,8 @@ function readLinearRing(node, objectStack) {
     ]);
     polygon.setProperties(properties, true);
     return polygon;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -1795,9 +1782,8 @@ function readPoint(node, objectStack) {
     const point = new Point(flatCoordinates, 'XYZ');
     point.setProperties(properties, true);
     return point;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -1838,9 +1824,8 @@ function readPolygon(node, objectStack) {
     const polygon = new Polygon(flatCoordinates, 'XYZ', ends);
     polygon.setProperties(properties, true);
     return polygon;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**

--- a/src/ol/format/Polyline.js
+++ b/src/ol/format/Polyline.js
@@ -118,10 +118,9 @@ class Polyline extends TextFeature {
     const geometry = feature.getGeometry();
     if (geometry) {
       return this.writeGeometryText(geometry, options);
-    } else {
-      assert(false, 40); // Expected `feature` to have a geometry
-      return '';
     }
+    assert(false, 40); // Expected `feature` to have a geometry
+    return '';
   }
 
   /**

--- a/src/ol/format/TextFeature.js
+++ b/src/ol/format/TextFeature.js
@@ -199,9 +199,8 @@ class TextFeature extends FeatureFormat {
 function getText(source) {
   if (typeof source === 'string') {
     return source;
-  } else {
-    return '';
   }
+  return '';
 }
 
 export default TextFeature;

--- a/src/ol/format/TopoJSON.js
+++ b/src/ol/format/TopoJSON.js
@@ -147,9 +147,8 @@ class TopoJSON extends JSONFeature {
         }
       }
       return features;
-    } else {
-      return [];
     }
+    return [];
   }
 
   /**

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -375,11 +375,10 @@ class WFS extends XMLFeature {
       return this.readTransactionResponseFromDocument(
         /** @type {Document} */ (source)
       );
-    } else {
-      return this.readTransactionResponseFromNode(
-        /** @type {Element} */ (source)
-      );
     }
+    return this.readTransactionResponseFromNode(
+      /** @type {Element} */ (source)
+    );
   }
 
   /**
@@ -400,11 +399,10 @@ class WFS extends XMLFeature {
       return this.readFeatureCollectionMetadataFromDocument(
         /** @type {Document} */ (source)
       );
-    } else {
-      return this.readFeatureCollectionMetadataFromNode(
-        /** @type {Element} */ (source)
-      );
     }
+    return this.readFeatureCollectionMetadataFromNode(
+      /** @type {Element} */ (source)
+    );
   }
 
   /**
@@ -821,9 +819,8 @@ function getTypeName(featurePrefix, featureType) {
   // The featureType already contains the prefix.
   if (featureType.startsWith(prefix)) {
     return featureType;
-  } else {
-    return prefix + featureType;
   }
+  return prefix + featureType;
 }
 
 /**

--- a/src/ol/format/WKB.js
+++ b/src/ol/format/WKB.js
@@ -917,9 +917,8 @@ function getDataView(source) {
     return new DataView(source.buffer, source.byteOffset, source.byteLength);
   } else if (source instanceof ArrayBuffer) {
     return new DataView(source);
-  } else {
-    return null;
   }
+  return null;
 }
 
 export default WKB;

--- a/src/ol/format/WKT.js
+++ b/src/ol/format/WKT.js
@@ -540,53 +540,52 @@ class Parser {
         }
         const geometries = this.parseGeometryCollectionText_();
         return new GeometryCollection(geometries);
-      } else {
-        const ctor = GeometryConstructor[geomType];
-        if (!ctor) {
-          throw new Error('Invalid geometry type: ' + geomType);
-        }
-
-        let coordinates;
-
-        if (isEmpty) {
-          if (geomType == 'POINT') {
-            coordinates = [NaN, NaN];
-          } else {
-            coordinates = [];
-          }
-        } else {
-          switch (geomType) {
-            case 'POINT': {
-              coordinates = this.parsePointText_();
-              break;
-            }
-            case 'LINESTRING': {
-              coordinates = this.parseLineStringText_();
-              break;
-            }
-            case 'POLYGON': {
-              coordinates = this.parsePolygonText_();
-              break;
-            }
-            case 'MULTIPOINT': {
-              coordinates = this.parseMultiPointText_();
-              break;
-            }
-            case 'MULTILINESTRING': {
-              coordinates = this.parseMultiLineStringText_();
-              break;
-            }
-            case 'MULTIPOLYGON': {
-              coordinates = this.parseMultiPolygonText_();
-              break;
-            }
-            default:
-              break;
-          }
-        }
-
-        return new ctor(coordinates, this.layout_);
       }
+      const ctor = GeometryConstructor[geomType];
+      if (!ctor) {
+        throw new Error('Invalid geometry type: ' + geomType);
+      }
+
+      let coordinates;
+
+      if (isEmpty) {
+        if (geomType == 'POINT') {
+          coordinates = [NaN, NaN];
+        } else {
+          coordinates = [];
+        }
+      } else {
+        switch (geomType) {
+          case 'POINT': {
+            coordinates = this.parsePointText_();
+            break;
+          }
+          case 'LINESTRING': {
+            coordinates = this.parseLineStringText_();
+            break;
+          }
+          case 'POLYGON': {
+            coordinates = this.parsePolygonText_();
+            break;
+          }
+          case 'MULTIPOINT': {
+            coordinates = this.parseMultiPointText_();
+            break;
+          }
+          case 'MULTILINESTRING': {
+            coordinates = this.parseMultiLineStringText_();
+            break;
+          }
+          case 'MULTIPOLYGON': {
+            coordinates = this.parseMultiPolygonText_();
+            break;
+          }
+          default:
+            break;
+        }
+      }
+
+      return new ctor(coordinates, this.layout_);
     }
     throw new Error(this.formatErrorMessage_());
   }

--- a/src/ol/format/XML.js
+++ b/src/ol/format/XML.js
@@ -25,9 +25,8 @@ class XML {
       return this.readFromDocument(doc);
     } else if (isDocument(source)) {
       return this.readFromDocument(/** @type {Document} */ (source));
-    } else {
-      return this.readFromNode(/** @type {Element} */ (source));
     }
+    return this.readFromNode(/** @type {Element} */ (source));
   }
 
   /**

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -51,9 +51,8 @@ class XMLFeature extends FeatureFormat {
         /** @type {Document} */ (source),
         options
       );
-    } else {
-      return this.readFeatureFromNode(/** @type {Element} */ (source), options);
     }
+    return this.readFeatureFromNode(/** @type {Element} */ (source), options);
   }
 
   /**
@@ -65,9 +64,8 @@ class XMLFeature extends FeatureFormat {
     const features = this.readFeaturesFromDocument(doc, options);
     if (features.length > 0) {
       return features[0];
-    } else {
-      return null;
     }
+    return null;
   }
 
   /**
@@ -98,12 +96,8 @@ class XMLFeature extends FeatureFormat {
         /** @type {Document} */ (source),
         options
       );
-    } else {
-      return this.readFeaturesFromNode(
-        /** @type {Element} */ (source),
-        options
-      );
     }
+    return this.readFeaturesFromNode(/** @type {Element} */ (source), options);
   }
 
   /**
@@ -155,12 +149,8 @@ class XMLFeature extends FeatureFormat {
         /** @type {Document} */ (source),
         options
       );
-    } else {
-      return this.readGeometryFromNode(
-        /** @type {Element} */ (source),
-        options
-      );
     }
+    return this.readGeometryFromNode(/** @type {Element} */ (source), options);
   }
 
   /**
@@ -198,9 +188,8 @@ class XMLFeature extends FeatureFormat {
       return this.readProjectionFromDocument(doc);
     } else if (isDocument(source)) {
       return this.readProjectionFromDocument(/** @type {Document} */ (source));
-    } else {
-      return this.readProjectionFromNode(/** @type {Element} */ (source));
     }
+    return this.readProjectionFromNode(/** @type {Element} */ (source));
   }
 
   /**

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -21,9 +21,8 @@ export function readBooleanString(string) {
   const m = /^\s*(true|1)|(false|0)\s*$/.exec(string);
   if (m) {
     return m[1] !== undefined || false;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -54,9 +53,8 @@ export function readDecimalString(string) {
   const m = /^\s*([+\-]?\d*\.?\d+(?:e[+\-]?\d+)?)\s*$/i.exec(string);
   if (m) {
     return parseFloat(m[1]);
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -76,9 +74,8 @@ export function readNonNegativeIntegerString(string) {
   const m = /^\s*(\d+)\s*$/.exec(string);
   if (m) {
     return parseInt(m[1], 10);
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**

--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -72,9 +72,8 @@ class Circle extends SimpleGeometry {
       }
       closestPoint.length = this.stride;
       return squaredDistance;
-    } else {
-      return minSquaredDistance;
     }
+    return minSquaredDistance;
   }
 
   /**

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -195,10 +195,9 @@ class GeometryCollection extends Geometry {
       const simplifiedGeometryCollection = new GeometryCollection(null);
       simplifiedGeometryCollection.setGeometriesArray(simplifiedGeometries);
       return simplifiedGeometryCollection;
-    } else {
-      this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
-      return this;
     }
+    this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
+    return this;
   }
 
   /**

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -55,9 +55,8 @@ class Point extends SimpleGeometry {
       }
       closestPoint.length = stride;
       return squaredDistance;
-    } else {
-      return minSquaredDistance;
     }
+    return minSquaredDistance;
   }
 
   /**

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -121,16 +121,15 @@ class SimpleGeometry extends Geometry {
     const simplifiedFlatCoordinates = simplifiedGeometry.getFlatCoordinates();
     if (simplifiedFlatCoordinates.length < this.flatCoordinates.length) {
       return simplifiedGeometry;
-    } else {
-      // Simplification did not actually remove any coordinates.  We now know
-      // that any calls to getSimplifiedGeometry with a squaredTolerance less
-      // than or equal to the current squaredTolerance will also not have any
-      // effect.  This allows us to short circuit simplification (saving CPU
-      // cycles) and prevents the cache of simplified geometries from filling
-      // up with useless identical copies of this geometry (saving memory).
-      this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
-      return this;
     }
+    // Simplification did not actually remove any coordinates.  We now know
+    // that any calls to getSimplifiedGeometry with a squaredTolerance less
+    // than or equal to the current squaredTolerance will also not have any
+    // effect.  This allows us to short circuit simplification (saving CPU
+    // cycles) and prevents the cache of simplified geometries from filling
+    // up with useless identical copies of this geometry (saving memory).
+    this.simplifiedGeometryMaxMinSquaredTolerance = squaredTolerance;
+    return this;
   }
 
   /**
@@ -185,9 +184,8 @@ class SimpleGeometry extends Geometry {
           this.layout = 'XY';
           this.stride = 2;
           return;
-        } else {
-          coordinates = /** @type {Array} */ (coordinates[0]);
         }
+        coordinates = /** @type {Array} */ (coordinates[0]);
       }
       stride = coordinates.length;
       layout = getLayoutForStride(stride);
@@ -336,17 +334,16 @@ export function transformGeom2D(simpleGeometry, transform, dest) {
   const flatCoordinates = simpleGeometry.getFlatCoordinates();
   if (!flatCoordinates) {
     return null;
-  } else {
-    const stride = simpleGeometry.getStride();
-    return transform2D(
-      flatCoordinates,
-      0,
-      flatCoordinates.length,
-      stride,
-      transform,
-      dest
-    );
   }
+  const stride = simpleGeometry.getStride();
+  return transform2D(
+    flatCoordinates,
+    0,
+    flatCoordinates.length,
+    stride,
+    transform,
+    dest
+  );
 }
 
 export default SimpleGeometry;

--- a/src/ol/geom/flat/closest.js
+++ b/src/ol/geom/flat/closest.js
@@ -172,9 +172,8 @@ export function assignClosestPoint(
       }
       closestPoint.length = stride;
       return squaredDistance;
-    } else {
-      return minSquaredDistance;
     }
+    return minSquaredDistance;
   }
   tmpPoint = tmpPoint ? tmpPoint : [NaN, NaN];
   let index = offset + stride;

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -72,9 +72,8 @@ export function getInteriorPointOfArray(
   if (dest) {
     dest.push(pointX, y, maxSegmentLength);
     return dest;
-  } else {
-    return [pointX, y, maxSegmentLength];
   }
+  return [pointX, y, maxSegmentLength];
 }
 
 /**

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -93,17 +93,15 @@ export function lineStringCoordinateAtM(
       coordinate = flatCoordinates.slice(offset, offset + stride);
       coordinate[stride - 1] = m;
       return coordinate;
-    } else {
-      return null;
     }
+    return null;
   } else if (flatCoordinates[end - 1] < m) {
     if (extrapolate) {
       coordinate = flatCoordinates.slice(end - stride, end);
       coordinate[stride - 1] = m;
       return coordinate;
-    } else {
-      return null;
     }
+    return null;
   }
   // FIXME use O(1) search
   if (m == flatCoordinates[offset + stride - 1]) {
@@ -174,18 +172,16 @@ export function lineStringsCoordinateAtM(
       coordinate = flatCoordinates.slice(0, stride);
       coordinate[stride - 1] = m;
       return coordinate;
-    } else {
-      return null;
     }
+    return null;
   }
   if (flatCoordinates[flatCoordinates.length - 1] < m) {
     if (extrapolate) {
       coordinate = flatCoordinates.slice(flatCoordinates.length - stride);
       coordinate[stride - 1] = m;
       return coordinate;
-    } else {
-      return null;
     }
+    return null;
   }
   for (let i = 0, ii = ends.length; i < ii; ++i) {
     const end = ends[i];

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -260,9 +260,8 @@ class DragBox extends PointerInteraction {
         )
       );
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 
   /**

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -148,15 +148,14 @@ class DragPan extends PointerInteraction {
         view.endInteraction();
       }
       return false;
-    } else {
-      if (this.kinetic_) {
-        // reset so we don't overestimate the kinetic energy after
-        // after one finger up, tiny drag, second finger up
-        this.kinetic_.begin();
-      }
-      this.lastCentroid = null;
-      return true;
     }
+    if (this.kinetic_) {
+      // reset so we don't overestimate the kinetic energy after
+      // after one finger up, tiny drag, second finger up
+      this.kinetic_.begin();
+    }
+    this.lastCentroid = null;
+    return true;
   }
 
   /**
@@ -180,9 +179,8 @@ class DragPan extends PointerInteraction {
       // detected. This is to prevent nasty pans after pinch.
       this.noKinetic_ = this.targetPointers.length > 1;
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 }
 

--- a/src/ol/interaction/DragRotate.js
+++ b/src/ol/interaction/DragRotate.js
@@ -116,9 +116,8 @@ class DragRotate extends PointerInteraction {
       map.getView().beginInteraction();
       this.lastAngle_ = undefined;
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 }
 

--- a/src/ol/interaction/DragRotateAndZoom.js
+++ b/src/ol/interaction/DragRotateAndZoom.js
@@ -128,9 +128,8 @@ class DragRotateAndZoom extends PointerInteraction {
       this.lastAngle_ = undefined;
       this.lastMagnitude_ = undefined;
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 }
 

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -517,9 +517,8 @@ function getEdgeHandler(fixedP1, fixedP2) {
     return function (point) {
       return boundingExtent([fixedP1, [fixedP2[0], point[1]]]);
     };
-  } else {
-    return null;
   }
+  return null;
 }
 
 /**

--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -203,9 +203,8 @@ class MouseWheelZoom extends Interaction {
 
     if (delta === 0) {
       return false;
-    } else {
-      this.lastDelta_ = delta;
     }
+    this.lastDelta_ = delta;
 
     const now = Date.now();
 

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -133,9 +133,8 @@ class PinchRotate extends PointerInteraction {
       const view = map.getView();
       view.endInteraction(this.duration_);
       return false;
-    } else {
-      return true;
     }
+    return true;
   }
 
   /**
@@ -154,9 +153,8 @@ class PinchRotate extends PointerInteraction {
         map.getView().beginInteraction();
       }
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 }
 

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -110,9 +110,8 @@ class PinchZoom extends PointerInteraction {
       const direction = this.lastScaleDelta_ > 1 ? 1 : -1;
       view.endInteraction(this.duration_, direction);
       return false;
-    } else {
-      return true;
     }
+    return true;
   }
 
   /**
@@ -130,9 +129,8 @@ class PinchZoom extends PointerInteraction {
         map.getView().beginInteraction();
       }
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
 }
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -314,9 +314,8 @@ export function createProjection(projection, defaultCode) {
     return get(defaultCode);
   } else if (typeof projection === 'string') {
     return get(projection);
-  } else {
-    return /** @type {Projection} */ (projection);
   }
+  return /** @type {Projection} */ (projection);
 }
 
 /**
@@ -444,10 +443,9 @@ export function equivalent(projection1, projection2) {
   const equalUnits = projection1.getUnits() === projection2.getUnits();
   if (projection1.getCode() === projection2.getCode()) {
     return equalUnits;
-  } else {
-    const transformFunc = getTransformFromProjections(projection1, projection2);
-    return transformFunc === cloneTransform && equalUnits;
   }
+  const transformFunc = getTransformFromProjections(projection1, projection2);
+  return transformFunc === cloneTransform && equalUnits;
 }
 
 /**

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -215,15 +215,14 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
         callback,
         matches
       );
-    } else {
-      return super.forEachFeatureAtCoordinate(
-        coordinate,
-        frameState,
-        hitTolerance,
-        callback,
-        matches
-      );
     }
+    return super.forEachFeatureAtCoordinate(
+      coordinate,
+      frameState,
+      hitTolerance,
+      callback,
+      matches
+    );
   }
 }
 

--- a/src/ol/resolutionconstraint.js
+++ b/src/ol/resolutionconstraint.js
@@ -115,9 +115,8 @@ export function createSnapToResolutions(
           return resolutions[z + 1];
         }
         return resolutions[z];
-      } else {
-        return undefined;
       }
+      return undefined;
     }
   );
 }
@@ -185,9 +184,8 @@ export function createSnapToPower(
         const zoomLevel = Math.max(minZoomLevel, cappedZoomLevel);
         const newResolution = maxResolution / Math.pow(power, zoomLevel);
         return clamp(newResolution, minResolution, cappedMaxRes);
-      } else {
-        return undefined;
       }
+      return undefined;
     }
   );
 }
@@ -236,9 +234,8 @@ export function createMinMaxResolution(
           cappedMaxRes,
           minResolution
         );
-      } else {
-        return undefined;
       }
+      return undefined;
     }
   );
 }

--- a/src/ol/rotationconstraint.js
+++ b/src/ol/rotationconstraint.js
@@ -14,9 +14,8 @@ import {toRadians} from './math.js';
 export function disable(rotation) {
   if (rotation !== undefined) {
     return 0;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -26,9 +25,8 @@ export function disable(rotation) {
 export function none(rotation) {
   if (rotation !== undefined) {
     return rotation;
-  } else {
-    return undefined;
   }
+  return undefined;
 }
 
 /**
@@ -51,9 +49,8 @@ export function createSnapToN(n) {
       if (rotation !== undefined) {
         rotation = Math.floor(rotation / theta + 0.5) * theta;
         return rotation;
-      } else {
-        return undefined;
       }
+      return undefined;
     }
   );
 }
@@ -78,12 +75,10 @@ export function createSnapToZero(tolerance) {
       if (rotation !== undefined) {
         if (Math.abs(rotation) <= tolerance) {
           return 0;
-        } else {
-          return rotation;
         }
-      } else {
-        return undefined;
+        return rotation;
       }
+      return undefined;
     }
   );
 }

--- a/src/ol/size.js
+++ b/src/ol/size.js
@@ -61,13 +61,12 @@ export function scale(size, ratio, dest) {
 export function toSize(size, dest) {
   if (Array.isArray(size)) {
     return size;
-  } else {
-    if (dest === undefined) {
-      dest = [size, size];
-    } else {
-      dest[0] = size;
-      dest[1] = size;
-    }
-    return dest;
   }
+  if (dest === undefined) {
+    dest = [size, size];
+  } else {
+    dest[0] = size;
+    dest[1] = size;
+  }
+  return dest;
 }

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -254,19 +254,18 @@ class BingMaps extends TileImage {
           function (tileCoord, pixelRatio, projection) {
             if (!tileCoord) {
               return undefined;
-            } else {
-              createOrUpdate(
-                tileCoord[0],
-                tileCoord[1],
-                tileCoord[2],
-                quadKeyTileCoord
-              );
-              let url = imageUrl;
-              if (hidpi) {
-                url += '&dpi=d1&device=mobile';
-              }
-              return url.replace('{quadkey}', quadKey(quadKeyTileCoord));
             }
+            createOrUpdate(
+              tileCoord[0],
+              tileCoord[1],
+              tileCoord[2],
+              quadKeyTileCoord
+            );
+            let url = imageUrl;
+            if (hidpi) {
+              url += '&dpi=d1&device=mobile';
+            }
+            return url.replace('{quadkey}', quadKey(quadKeyTileCoord));
           }
         );
       })

--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -316,12 +316,11 @@ class Cluster extends VectorSource {
     ]);
     if (this.createCustomCluster_) {
       return this.createCustomCluster_(geometry, features);
-    } else {
-      return new Feature({
-        geometry,
-        features,
-      });
     }
+    return new Feature({
+      geometry,
+      features,
+    });
   }
 }
 

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -176,40 +176,39 @@ class ImageSource extends Source {
         projection = sourceProjection;
       }
       return this.getImageInternal(extent, resolution, pixelRatio, projection);
-    } else {
-      if (this.reprojectedImage_) {
-        if (
-          this.reprojectedRevision_ == this.getRevision() &&
-          equivalent(this.reprojectedImage_.getProjection(), projection) &&
-          this.reprojectedImage_.getResolution() == resolution &&
-          equals(this.reprojectedImage_.getExtent(), extent)
-        ) {
-          return this.reprojectedImage_;
-        }
-        this.reprojectedImage_.dispose();
-        this.reprojectedImage_ = null;
-      }
-
-      this.reprojectedImage_ = new ReprojImage(
-        sourceProjection,
-        projection,
-        extent,
-        resolution,
-        pixelRatio,
-        function (extent, resolution, pixelRatio) {
-          return this.getImageInternal(
-            extent,
-            resolution,
-            pixelRatio,
-            sourceProjection
-          );
-        }.bind(this),
-        this.getInterpolate()
-      );
-      this.reprojectedRevision_ = this.getRevision();
-
-      return this.reprojectedImage_;
     }
+    if (this.reprojectedImage_) {
+      if (
+        this.reprojectedRevision_ == this.getRevision() &&
+        equivalent(this.reprojectedImage_.getProjection(), projection) &&
+        this.reprojectedImage_.getResolution() == resolution &&
+        equals(this.reprojectedImage_.getExtent(), extent)
+      ) {
+        return this.reprojectedImage_;
+      }
+      this.reprojectedImage_.dispose();
+      this.reprojectedImage_ = null;
+    }
+
+    this.reprojectedImage_ = new ReprojImage(
+      sourceProjection,
+      projection,
+      extent,
+      resolution,
+      pixelRatio,
+      function (extent, resolution, pixelRatio) {
+        return this.getImageInternal(
+          extent,
+          resolution,
+          pixelRatio,
+          sourceProjection
+        );
+      }.bind(this),
+      this.getInterpolate()
+    );
+    this.reprojectedRevision_ = this.getRevision();
+
+    return this.reprojectedImage_;
   }
 
   /**

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -273,9 +273,8 @@ function getScale(extent, size, metersPerUnit, dpi) {
   const mpp = 0.0254 / dpi;
   if (devH * mcsW > devW * mcsH) {
     return (mcsW * metersPerUnit) / (devW * mpp); // width limited
-  } else {
-    return (mcsH * metersPerUnit) / (devH * mpp); // height limited
   }
+  return (mcsH * metersPerUnit) / (devH * mpp); // height limited
 }
 
 export default ImageMapGuide;

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -74,9 +74,8 @@ function createMinion(operation) {
   function newWorkerImageData(data, width, height) {
     if (workerHasImageData) {
       return new ImageData(data, width, height);
-    } else {
-      return {data: data, width: width, height: height};
     }
+    return {data: data, width: width, height: height};
   }
 
   return function (data) {

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -270,9 +270,8 @@ class TileSource extends Source {
   getTileGridForProjection(projection) {
     if (!this.tileGrid) {
       return getTileGridForProjection(projection);
-    } else {
-      return this.tileGrid;
     }
+    return this.tileGrid;
   }
 
   /**
@@ -312,9 +311,8 @@ class TileSource extends Source {
     const tileSize = toSize(tileGrid.getTileSize(z), this.tmpSize);
     if (tilePixelRatio == 1) {
       return tileSize;
-    } else {
-      return scaleSize(tileSize, tilePixelRatio, this.tmpSize);
     }
+    return scaleSize(tileSize, tilePixelRatio, this.tmpSize);
   }
 
   /**

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -137,13 +137,13 @@ class TileImage extends UrlTile {
   canExpireCache() {
     if (this.tileCache.canExpireCache()) {
       return true;
-    } else {
-      for (const key in this.tileCacheForProjection) {
-        if (this.tileCacheForProjection[key].canExpireCache()) {
-          return true;
-        }
+    }
+    for (const key in this.tileCacheForProjection) {
+      if (this.tileCacheForProjection[key].canExpireCache()) {
+        return true;
       }
     }
+
     return false;
   }
 
@@ -174,9 +174,8 @@ class TileImage extends UrlTile {
       !equivalent(this.getProjection(), projection)
     ) {
       return 0;
-    } else {
-      return this.getGutter();
     }
+    return this.getGutter();
   }
 
   /**
@@ -209,9 +208,8 @@ class TileImage extends UrlTile {
       !equivalent(this.getProjection(), projection)
     ) {
       return false;
-    } else {
-      return super.getOpaque(projection);
     }
+    return super.getOpaque(projection);
   }
 
   /**
@@ -222,14 +220,13 @@ class TileImage extends UrlTile {
     const thisProj = this.getProjection();
     if (this.tileGrid && (!thisProj || equivalent(thisProj, projection))) {
       return this.tileGrid;
-    } else {
-      const projKey = getUid(projection);
-      if (!(projKey in this.tileGridForProjection)) {
-        this.tileGridForProjection[projKey] =
-          getTileGridForProjection(projection);
-      }
-      return this.tileGridForProjection[projKey];
     }
+    const projKey = getUid(projection);
+    if (!(projKey in this.tileGridForProjection)) {
+      this.tileGridForProjection[projKey] =
+        getTileGridForProjection(projection);
+    }
+    return this.tileGridForProjection[projKey];
   }
 
   /**
@@ -240,15 +237,14 @@ class TileImage extends UrlTile {
     const thisProj = this.getProjection();
     if (!thisProj || equivalent(thisProj, projection)) {
       return this.tileCache;
-    } else {
-      const projKey = getUid(projection);
-      if (!(projKey in this.tileCacheForProjection)) {
-        this.tileCacheForProjection[projKey] = new TileCache(
-          this.tileCache.highWaterMark
-        );
-      }
-      return this.tileCacheForProjection[projKey];
     }
+    const projKey = getUid(projection);
+    if (!(projKey in this.tileCacheForProjection)) {
+      this.tileCacheForProjection[projKey] = new TileCache(
+        this.tileCache.highWaterMark
+      );
+    }
+    return this.tileCacheForProjection[projKey];
   }
 
   /**
@@ -305,52 +301,50 @@ class TileImage extends UrlTile {
         pixelRatio,
         sourceProjection || projection
       );
-    } else {
-      const cache = this.getTileCacheForProjection(projection);
-      const tileCoord = [z, x, y];
-      let tile;
-      const tileCoordKey = getKey(tileCoord);
-      if (cache.containsKey(tileCoordKey)) {
-        tile = cache.get(tileCoordKey);
-      }
-      const key = this.getKey();
-      if (tile && tile.key == key) {
-        return tile;
-      } else {
-        const sourceTileGrid = this.getTileGridForProjection(sourceProjection);
-        const targetTileGrid = this.getTileGridForProjection(projection);
-        const wrappedTileCoord = this.getTileCoordForTileUrlFunction(
-          tileCoord,
-          projection
-        );
-        const newTile = new ReprojTile(
-          sourceProjection,
-          sourceTileGrid,
-          projection,
-          targetTileGrid,
-          tileCoord,
-          wrappedTileCoord,
-          this.getTilePixelRatio(pixelRatio),
-          this.getGutter(),
-          function (z, x, y, pixelRatio) {
-            return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);
-          }.bind(this),
-          this.reprojectionErrorThreshold_,
-          this.renderReprojectionEdges_,
-          this.getInterpolate()
-        );
-        newTile.key = key;
-
-        if (tile) {
-          newTile.interimTile = tile;
-          newTile.refreshInterimChain();
-          cache.replace(tileCoordKey, newTile);
-        } else {
-          cache.set(tileCoordKey, newTile);
-        }
-        return newTile;
-      }
     }
+    const cache = this.getTileCacheForProjection(projection);
+    const tileCoord = [z, x, y];
+    let tile;
+    const tileCoordKey = getKey(tileCoord);
+    if (cache.containsKey(tileCoordKey)) {
+      tile = cache.get(tileCoordKey);
+    }
+    const key = this.getKey();
+    if (tile && tile.key == key) {
+      return tile;
+    }
+    const sourceTileGrid = this.getTileGridForProjection(sourceProjection);
+    const targetTileGrid = this.getTileGridForProjection(projection);
+    const wrappedTileCoord = this.getTileCoordForTileUrlFunction(
+      tileCoord,
+      projection
+    );
+    const newTile = new ReprojTile(
+      sourceProjection,
+      sourceTileGrid,
+      projection,
+      targetTileGrid,
+      tileCoord,
+      wrappedTileCoord,
+      this.getTilePixelRatio(pixelRatio),
+      this.getGutter(),
+      function (z, x, y, pixelRatio) {
+        return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);
+      }.bind(this),
+      this.reprojectionErrorThreshold_,
+      this.renderReprojectionEdges_,
+      this.getInterpolate()
+    );
+    newTile.key = key;
+
+    if (tile) {
+      newTile.interimTile = tile;
+      newTile.refreshInterimChain();
+      cache.replace(tileCoordKey, newTile);
+    } else {
+      cache.set(tileCoordKey, newTile);
+    }
+    return newTile;
   }
 
   /**

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -480,28 +480,23 @@ class UTFGrid extends TileSource {
     const tileCoordKey = getKeyZXY(z, x, y);
     if (this.tileCache.containsKey(tileCoordKey)) {
       return this.tileCache.get(tileCoordKey);
-    } else {
-      const tileCoord = [z, x, y];
-      const urlTileCoord = this.getTileCoordForTileUrlFunction(
-        tileCoord,
-        projection
-      );
-      const tileUrl = this.tileUrlFunction_(
-        urlTileCoord,
-        pixelRatio,
-        projection
-      );
-      const tile = new CustomTile(
-        tileCoord,
-        tileUrl !== undefined ? TileState.IDLE : TileState.EMPTY,
-        tileUrl !== undefined ? tileUrl : '',
-        this.tileGrid.getTileCoordExtent(tileCoord),
-        this.preemptive_,
-        this.jsonp_
-      );
-      this.tileCache.set(tileCoordKey, tile);
-      return tile;
     }
+    const tileCoord = [z, x, y];
+    const urlTileCoord = this.getTileCoordForTileUrlFunction(
+      tileCoord,
+      projection
+    );
+    const tileUrl = this.tileUrlFunction_(urlTileCoord, pixelRatio, projection);
+    const tile = new CustomTile(
+      tileCoord,
+      tileUrl !== undefined ? TileState.IDLE : TileState.EMPTY,
+      tileUrl !== undefined ? tileUrl : '',
+      this.tileGrid.getTileCoordExtent(tileCoord),
+      this.preemptive_,
+      this.jsonp_
+    );
+    this.tileCache.set(tileCoordKey, tile);
+    return tile;
   }
 
   /**

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -603,9 +603,8 @@ class VectorSource extends Source {
       const geometry = feature.getGeometry();
       if (geometry.intersectsCoordinate(coordinate)) {
         return callback(feature);
-      } else {
-        return undefined;
       }
+      return undefined;
     });
   }
 
@@ -745,9 +744,8 @@ class VectorSource extends Source {
       );
     } else if (this.featuresCollection_) {
       return this.featuresCollection_.getArray().slice(0);
-    } else {
-      return [];
     }
+    return [];
   }
 
   /**
@@ -933,9 +931,8 @@ class VectorSource extends Source {
     const id = feature.getId();
     if (id !== undefined) {
       return id in this.idIndex_;
-    } else {
-      return getUid(feature) in this.uidIndex_;
     }
+    return getUid(feature) in this.uidIndex_;
   }
 
   /**

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -312,23 +312,22 @@ class WMTS extends TileImage {
       function (tileCoord, pixelRatio, projection) {
         if (!tileCoord) {
           return undefined;
-        } else {
-          const localContext = {
-            'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
-            'TileCol': tileCoord[1],
-            'TileRow': tileCoord[2],
-          };
-          Object.assign(localContext, dimensions);
-          let url = template;
-          if (requestEncoding == 'KVP') {
-            url = appendParams(url, localContext);
-          } else {
-            url = url.replace(/\{(\w+?)\}/g, function (m, p) {
-              return localContext[p];
-            });
-          }
-          return url;
         }
+        const localContext = {
+          'TileMatrix': tileGrid.getMatrixId(tileCoord[0]),
+          'TileCol': tileCoord[1],
+          'TileRow': tileCoord[2],
+        };
+        Object.assign(localContext, dimensions);
+        let url = template;
+        if (requestEncoding == 'KVP') {
+          url = appendParams(url, localContext);
+        } else {
+          url = url.replace(/\{(\w+?)\}/g, function (m, p) {
+            return localContext[p];
+          });
+        }
+        return url;
       }
     );
   }
@@ -381,9 +380,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
         const proj2 = getProjection(config['projection']);
         if (proj1 && proj2) {
           return equivalent(proj1, proj2);
-        } else {
-          return supportedCRS == config['projection'];
         }
+        return supportedCRS == config['projection'];
       });
     } else {
       idx = l['TileMatrixSetLink'].findIndex(function (elt) {
@@ -410,9 +408,8 @@ export function optionsFromCapabilities(wmtsCap, config) {
   idx = l['Style'].findIndex(function (elt) {
     if ('style' in config) {
       return elt['Title'] == config['style'];
-    } else {
-      return elt['isDefault'];
     }
+    return elt['isDefault'];
   });
   if (idx < 0) {
     idx = 0;

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -64,15 +64,13 @@ export class CustomTile extends ImageTile {
       if (image.width == tileSize[0] && image.height == tileSize[1]) {
         this.zoomifyImage_ = image;
         return image;
-      } else {
-        const context = createCanvasContext2D(tileSize[0], tileSize[1]);
-        context.drawImage(image, 0, 0);
-        this.zoomifyImage_ = context.canvas;
-        return context.canvas;
       }
-    } else {
-      return image;
+      const context = createCanvasContext2D(tileSize[0], tileSize[1]);
+      context.drawImage(image, 0, 0);
+      this.zoomifyImage_ = context.canvas;
+      return context.canvas;
     }
+    return image;
   }
 }
 
@@ -215,25 +213,24 @@ class Zoomify extends TileImage {
         function (tileCoord, pixelRatio, projection) {
           if (!tileCoord) {
             return undefined;
-          } else {
-            const tileCoordZ = tileCoord[0];
-            const tileCoordX = tileCoord[1];
-            const tileCoordY = tileCoord[2];
-            const tileIndex =
-              tileCoordX + tileCoordY * tierSizeInTiles[tileCoordZ][0];
-            const tileGroup =
-              ((tileIndex + tileCountUpToTier[tileCoordZ]) / tileWidth) | 0;
-            const localContext = {
-              'z': tileCoordZ,
-              'x': tileCoordX,
-              'y': tileCoordY,
-              'tileIndex': tileIndex,
-              'TileGroup': 'TileGroup' + tileGroup,
-            };
-            return template.replace(/\{(\w+?)\}/g, function (m, p) {
-              return localContext[p];
-            });
           }
+          const tileCoordZ = tileCoord[0];
+          const tileCoordX = tileCoord[1];
+          const tileCoordY = tileCoord[2];
+          const tileIndex =
+            tileCoordX + tileCoordY * tierSizeInTiles[tileCoordZ][0];
+          const tileGroup =
+            ((tileIndex + tileCountUpToTier[tileCoordZ]) / tileWidth) | 0;
+          const localContext = {
+            'z': tileCoordZ,
+            'x': tileCoordX,
+            'y': tileCoordY,
+            'tileIndex': tileIndex,
+            'TileGroup': 'TileGroup' + tileGroup,
+          };
+          return template.replace(/\{(\w+?)\}/g, function (m, p) {
+            return localContext[p];
+          });
         }
       );
     }

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -22,9 +22,8 @@ export function createOrUpdate(z, x, y, tileCoord) {
     tileCoord[1] = x;
     tileCoord[2] = y;
     return tileCoord;
-  } else {
-    return [z, x, y];
   }
+  return [z, x, y];
 }
 
 /**
@@ -92,7 +91,6 @@ export function withinExtentAndZ(tileCoord, tileGrid) {
   const tileRange = tileGrid.getFullTileRange(z);
   if (!tileRange) {
     return true;
-  } else {
-    return tileRange.containsXY(x, y);
   }
+  return tileRange.containsXY(x, y);
 }

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -44,9 +44,8 @@ export function wrapX(tileGrid, tileCoord, projection) {
     );
     center[0] += worldWidth * worldsAway;
     return tileGrid.getTileCoordForCoordAndZ(center, z);
-  } else {
-    return tileCoord;
   }
+  return tileCoord;
 }
 
 /**

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -310,9 +310,8 @@ class TileGrid {
   getOrigin(z) {
     if (this.origin_) {
       return this.origin_;
-    } else {
-      return this.origins_[z];
     }
+    return this.origins_[z];
   }
 
   /**
@@ -612,9 +611,8 @@ class TileGrid {
   getTileSize(z) {
     if (this.tileSize_) {
       return this.tileSize_;
-    } else {
-      return this.tileSizes_[z];
     }
+    return this.tileSizes_[z];
   }
 
   /**
@@ -626,9 +624,8 @@ class TileGrid {
       return this.extent_
         ? this.getTileRangeForExtentAndZ(this.extent_, z)
         : null;
-    } else {
-      return this.fullTileRanges_[z];
     }
+    return this.fullTileRanges_[z];
   }
 
   /**

--- a/src/ol/tileurlfunction.js
+++ b/src/ol/tileurlfunction.js
@@ -25,19 +25,18 @@ export function createFromTemplate(template, tileGrid) {
     function (tileCoord, pixelRatio, projection) {
       if (!tileCoord) {
         return undefined;
-      } else {
-        return template
-          .replace(zRegEx, tileCoord[0].toString())
-          .replace(xRegEx, tileCoord[1].toString())
-          .replace(yRegEx, tileCoord[2].toString())
-          .replace(dashYRegEx, function () {
-            const z = tileCoord[0];
-            const range = tileGrid.getFullTileRange(z);
-            assert(range, 55); // The {-y} placeholder requires a tile grid with extent
-            const y = range.getHeight() - tileCoord[2] - 1;
-            return y.toString();
-          });
       }
+      return template
+        .replace(zRegEx, tileCoord[0].toString())
+        .replace(xRegEx, tileCoord[1].toString())
+        .replace(yRegEx, tileCoord[2].toString())
+        .replace(dashYRegEx, function () {
+          const z = tileCoord[0];
+          const range = tileGrid.getFullTileRange(z);
+          assert(range, 55); // The {-y} placeholder requires a tile grid with extent
+          const y = range.getHeight() - tileCoord[2] - 1;
+          return y.toString();
+        });
     }
   );
 }
@@ -74,11 +73,10 @@ export function createFromTileUrlFunctions(tileUrlFunctions) {
     function (tileCoord, pixelRatio, projection) {
       if (!tileCoord) {
         return undefined;
-      } else {
-        const h = tileCoordHash(tileCoord);
-        const index = modulo(h, tileUrlFunctions.length);
-        return tileUrlFunctions[index](tileCoord, pixelRatio, projection);
       }
+      const h = tileCoordHash(tileCoord);
+      const index = modulo(h, tileUrlFunctions.length);
+      return tileUrlFunctions[index](tileCoord, pixelRatio, projection);
     }
   );
 }

--- a/test/browser/spec/ol/control/scaleline.test.js
+++ b/test/browser/spec/ol/control/scaleline.test.js
@@ -510,9 +510,8 @@ describe('ol.control.ScaleLine', function () {
         return 'mm';
       } else if (zoom > 10) {
         return 'm';
-      } else {
-        return 'km';
       }
+      return 'km';
     };
 
     const getImperialUnit = function (zoom) {
@@ -520,9 +519,8 @@ describe('ol.control.ScaleLine', function () {
         return 'in';
       } else if (zoom >= 10) {
         return 'ft';
-      } else {
-        return 'mi';
       }
+      return 'mi';
     };
 
     beforeEach(function () {

--- a/test/browser/spec/ol/net.test.js
+++ b/test/browser/spec/ol/net.test.js
@@ -58,9 +58,8 @@ describe('ol/net', function () {
       document.createElement = function (arg) {
         if (arg == 'script') {
           return element;
-        } else {
-          return origCreateElement.apply(document, arguments);
         }
+        return origCreateElement.apply(document, arguments);
       };
       head.appendChild = function (el) {
         if (el === element) {

--- a/test/browser/spec/ol/render/canvas/immediate.test.js
+++ b/test/browser/spec/ol/render/canvas/immediate.test.js
@@ -236,9 +236,8 @@ describe('ol.render.canvas.Immediate', function () {
                 .map(function (arg) {
                   if (typeof arg === 'number') {
                     return arg.toFixed(9);
-                  } else {
-                    return arg;
                   }
+                  return arg;
                 })
                 .join(', ') +
               ']'

--- a/test/browser/spec/ol/source/Tile.test.js
+++ b/test/browser/spec/ol/source/Tile.test.js
@@ -41,11 +41,10 @@ MockTile.prototype.getTile = function (z, x, y) {
   const key = getKeyZXY(z, x, y);
   if (this.tileCache.containsKey(key)) {
     return /** @type {!ol.Tile} */ (this.tileCache.get(key));
-  } else {
-    const tile = new Tile(key, 0); // IDLE
-    this.tileCache.set(key, tile);
-    return tile;
   }
+  const tile = new Tile(key, 0); // IDLE
+  this.tileCache.set(key, tile);
+  return tile;
 };
 
 describe('ol/source/Tile', function () {

--- a/test/browser/test-extensions.js
+++ b/test/browser/test-extensions.js
@@ -87,30 +87,29 @@
     // check whitespace
     if (options && options.includeWhiteSpace) {
       return node.childNodes;
-    } else {
-      const nodes = [];
-      for (let i = 0, ii = node.childNodes.length; i < ii; i++) {
-        const child = node.childNodes[i];
-        if (child.nodeType == 1) {
-          // element node, add it
+    }
+    const nodes = [];
+    for (let i = 0, ii = node.childNodes.length; i < ii; i++) {
+      const child = node.childNodes[i];
+      if (child.nodeType == 1) {
+        // element node, add it
+        nodes.push(child);
+      } else if (child.nodeType == 3) {
+        // text node, add if non empty
+        if (
+          child.nodeValue &&
+          child.nodeValue.replace(/^\s*(.*?)\s*$/, '$1') !== ''
+        ) {
           nodes.push(child);
-        } else if (child.nodeType == 3) {
-          // text node, add if non empty
-          if (
-            child.nodeValue &&
-            child.nodeValue.replace(/^\s*(.*?)\s*$/, '$1') !== ''
-          ) {
-            nodes.push(child);
-          }
         }
       }
-      if (options && options.ignoreElementOrder) {
-        nodes.sort(function (a, b) {
-          return a.nodeName > b.nodeName ? 1 : a.nodeName < b.nodeName ? -1 : 0;
-        });
-      }
-      return nodes;
     }
+    if (options && options.ignoreElementOrder) {
+      nodes.sort(function (a, b) {
+        return a.nodeName > b.nodeName ? 1 : a.nodeName < b.nodeName ? -1 : 0;
+      });
+    }
+    return nodes;
   }
 
   function assertElementNodesEqual(node1, node2, options, errors) {

--- a/test/node/ol/structs/priorityqueue.test.js
+++ b/test/node/ol/structs/priorityqueue.test.js
@@ -95,9 +95,8 @@ describe('ol/structs/PriorityQueue.js', function () {
       pq.priorityFunction_ = function (element) {
         if (i++ % 2 === 0) {
           return Math.abs(element - target);
-        } else {
-          return DROP;
         }
+        return DROP;
       };
       pq.reprioritize();
       expect(pq.getCount()).to.be(16);


### PR DESCRIPTION
This updates the linter config to disallow `else` after a `return`.  The idea here is to encourage [aligning the happy path to the left](https://medium.com/@matryer/line-of-sight-in-code-186dd7cdea88) (and otherwise avoid unnecessary indentation).

[Ignore whitespace](https://github.com/openlayers/openlayers/pull/14103/files?diff=unified&w=1) for easier review.