### PR TITLE
Add a sourceready event to layers

### DIFF
--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -8,10 +8,10 @@ import TileProperty from './TileProperty.js';
  * @template Return
  * @typedef {import("../Observable").OnSignature<import("../Observable").EventTypes, import("../events/Event.js").default, Return> &
  *   import("../Observable").OnSignature<import("./Base").BaseLayerObjectEventTypes|
- *     'change:source'|'change:preload'|'change:useInterimTilesOnError', import("../Object").ObjectEvent, Return> &
+ *     import("./Layer.js").LayerEventType|'change:preload'|'change:useInterimTilesOnError', import("../Object").ObjectEvent, Return> &
  *   import("../Observable").OnSignature<import("../render/EventType").LayerRenderEventTypes, import("../render/Event").default, Return> &
  *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|
- *   'change:source'|'change:preload'|'change:useInterimTilesOnError'|import("../render/EventType").LayerRenderEventTypes, Return>} BaseTileLayerOnSignature
+ *   import("./Layer.js").LayerEventType|'change:preload'|'change:useInterimTilesOnError'|import("../render/EventType").LayerRenderEventTypes, Return>} BaseTileLayerOnSignature
  */
 
 /**

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -10,10 +10,10 @@ import {assert} from '../asserts.js';
  * @template Return
  * @typedef {import("../Observable").OnSignature<import("../Observable").EventTypes, import("../events/Event.js").default, Return> &
  *   import("../Observable").OnSignature<import("./Base").BaseLayerObjectEventTypes|
- *     'change:source'|'change:preload'|'change:useInterimTilesOnError', import("../Object").ObjectEvent, Return> &
+ *     import("./Layer.js").LayerEventType|'change:preload'|'change:useInterimTilesOnError', import("../Object").ObjectEvent, Return> &
  *   import("../Observable").OnSignature<import("../render/EventType").LayerRenderEventTypes, import("../render/Event").default, Return> &
  *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|
- *     'change:source'|'change:preload'|'change:useInterimTilesOnError'|import("../render/EventType").LayerRenderEventTypes, Return>} VectorTileLayerOnSignature
+ *     import("./Layer.js").LayerEventType|'change:preload'|'change:useInterimTilesOnError'|import("../render/EventType").LayerRenderEventTypes, Return>} VectorTileLayerOnSignature
  */
 
 /**

--- a/test/node/ol/layer/Layer.test.js
+++ b/test/node/ol/layer/Layer.test.js
@@ -1,0 +1,114 @@
+import BaseEvent from '../../../../src/ol/events/Event.js';
+import Layer from '../../../../src/ol/layer/Layer.js';
+import Source from '../../../../src/ol/source/Source.js';
+import expect from '../../expect.js';
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+describe('ol/layer/Layer.js', () => {
+  describe('sourceready event', () => {
+    it('is dispatched when the source is ready', (done) => {
+      const source = new Source({state: 'loading'});
+      const layer = new Layer({source: source});
+
+      function handler(event) {
+        expect(event).to.be.a(BaseEvent);
+        expect(event.target).to.be(layer);
+        done();
+      }
+      layer.on('sourceready', handler);
+
+      source.setState('ready');
+    });
+
+    it('is dispatched even if the source is ready at construction', (done) => {
+      const source = new Source({});
+      const layer = new Layer({source: source});
+
+      function handler(event) {
+        expect(event).to.be.a(BaseEvent);
+        expect(event.target).to.be(layer);
+        done();
+      }
+      layer.on('sourceready', handler);
+    });
+
+    it('is not dispatched twice', async () => {
+      const source = new Source({state: 'loading'});
+      const layer = new Layer({source: source});
+
+      let calls = 0;
+      function handler(event) {
+        calls += 1;
+      }
+      layer.on('sourceready', handler);
+
+      layer.changed();
+      await delay(5);
+
+      source.setState('ready');
+      await delay(5);
+
+      source.changed();
+      await delay(5);
+
+      expect(calls).to.be(1);
+    });
+
+    it('is not dispatched after source is removed', async () => {
+      const source = new Source({state: 'loading'});
+      const layer = new Layer({source: source});
+
+      let calls = 0;
+      function handler(event) {
+        calls += 1;
+      }
+      layer.on('sourceready', handler);
+
+      layer.setSource(null);
+      source.setState('ready');
+      await delay(5);
+
+      expect(calls).to.be(0);
+    });
+
+    it('is dispatched if source is added later', async () => {
+      const layer = new Layer({});
+
+      let calls = 0;
+      function handler(event) {
+        calls += 1;
+      }
+      layer.on('sourceready', handler);
+
+      const source = new Source({state: 'ready'});
+      layer.setSource(source);
+      await delay(5);
+
+      expect(calls).to.be(1);
+    });
+
+    it('is dispatched if new source is set', async () => {
+      const layer = new Layer({source: new Source({})});
+
+      let calls = 0;
+      function handler(event) {
+        calls += 1;
+      }
+      layer.on('sourceready', handler);
+
+      await delay(5);
+      expect(calls).to.be(1);
+
+      const source = new Source({state: 'ready'});
+      layer.setSource(source);
+      await delay(5);
+
+      expect(calls).to.be(2);
+    });
+  });
+});


### PR DESCRIPTION
With this change, layers dispatch a `sourceready` event when their source is ready.  This makes it so applications don't have to track a source's previous state to get the same information from the generic `change` event.

See #14101.