### PR TITLE
Make track properties in Link interaction configurable

### DIFF
--- a/test/browser/spec/ol/interaction/Link.test.js
+++ b/test/browser/spec/ol/interaction/Link.test.js
@@ -67,5 +67,25 @@ describe('ol/interaction/Link', () => {
       view.setCenter([3, 4]);
       view.setRotation(0.5);
     });
+
+    it('accepts an array of properties to track', (done) => {
+      map.addInteraction(new Link({params: ['z', 'r']}));
+
+      map.once('moveend', () => {
+        const url = new URL(window.location.href);
+        const params = url.searchParams;
+        expect(params.get('z')).to.be('2');
+        expect(params.get('x')).to.be(null);
+        expect(params.get('y')).to.be(null);
+        expect(params.get('r')).to.be('0.5');
+        expect(params.get('l')).to.be(null);
+        done();
+      });
+
+      const view = map.getView();
+      view.setZoom(2);
+      view.setCenter([3, 4]);
+      view.setRotation(0.5);
+    });
   });
 });


### PR DESCRIPTION
This pull request adds a `trackProperties` option to `ol/interaction/Link`. With that, users can e.g. opt out of tracking the visible layers.

In addition, this pull request fixes an issue with history state when it is not purely managed by the Link interaction. This is done by passing the current `history.state` as first argument to `history.pushState()` or `history.replaceState()`