### PR TITLE
umd build

### DIFF
--- a/config/rollup-full-build-umd.js
+++ b/config/rollup-full-build-umd.js
@@ -1,0 +1,24 @@
+import commonjs from "@rollup/plugin-commonjs";
+import externalGlobals from "rollup-plugin-external-globals";
+import resolve from "@rollup/plugin-node-resolve";
+import { terser } from "rollup-plugin-terser";
+
+export default {
+  input: "build/index.js",
+  output: {
+    name: "ol",
+    format: "umd",
+    exports: "default",
+    file: "build/umd/ol.js",
+    sourcemap: true,
+  },
+  plugins: [
+    resolve({ moduleDirectories: ["build", "node_modules"] }),
+    commonjs(),
+    externalGlobals({
+      geotiff: "GeoTIFF",
+      "ol-mapbox-style": "olms",
+    }),
+    terser(),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build-examples": "shx rm -rf build/examples && webpack --config examples/webpack/config.mjs --mode production",
     "build-package": "npm run build-full && npm run copy-css && npm run generate-types && node tasks/prepare-package.js",
     "build-index": "shx rm -f build/index.js && npm run transpile && node tasks/generate-index.js",
-    "build-full": "shx rm -rf build/full && npm run build-index && npx rollup --config config/rollup-full-build.js",
+    "build-full": "shx rm -rf build/full && npm run build-index && npx rollup --config config/rollup-full-build.js && npx rollup --config config/rollup-full-build-umd.js",
     "copy-css": "shx cp src/ol/ol.css build/ol/ol.css",
     "generate-types": "tsc --project config/tsconfig-build.json --declaration --declarationMap --emitDeclarationOnly --outdir build/ol",
     "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build && node tasks/serialize-workers.cjs",


### PR DESCRIPTION
I thought a umd build could be usefull to some users...

Those changes allow to import the full ol lib built in es module like 

`import * as OpenLayers from '../../vendor/ol/ol.js';`

The built files are placed in the build/umd folder by the npm script `build-full` using the rollup-full-build-umd.js config file.

This pull request is related to the issue https://github.com/openlayers/openlayers/issues/14152

As @tschaub said, the umd build could have some problem releted to the GeoTIFF workers but I didn't tested anything about that.
