### PR TITLE
Use arrow functions instead of binding anonymous functions

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -553,7 +553,6 @@ class Map extends BaseObject {
     this.controls.forEach(
       /**
        * @param {import("./control/Control.js").default} control Control.
-       * @this {Map}
        */
       (control) => {
         control.setMap(this);
@@ -563,7 +562,6 @@ class Map extends BaseObject {
     this.interactions.forEach(
       /**
        * @param {import("./interaction/Interaction.js").default} interaction Interaction.
-       * @this {Map}
        */
       (interaction) => {
         interaction.setMap(this);

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -491,9 +491,9 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./control/Control.js").default>} event CollectionEvent
        */
-      function (event) {
+      (event) => {
         event.element.setMap(this);
-      }.bind(this)
+      }
     );
 
     this.controls.addEventListener(
@@ -501,9 +501,9 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./control/Control.js").default>} event CollectionEvent.
        */
-      function (event) {
+      (event) => {
         event.element.setMap(null);
-      }.bind(this)
+      }
     );
 
     this.interactions.addEventListener(
@@ -511,9 +511,9 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./interaction/Interaction.js").default>} event CollectionEvent.
        */
-      function (event) {
+      (event) => {
         event.element.setMap(this);
-      }.bind(this)
+      }
     );
 
     this.interactions.addEventListener(
@@ -521,9 +521,9 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./interaction/Interaction.js").default>} event CollectionEvent.
        */
-      function (event) {
+      (event) => {
         event.element.setMap(null);
-      }.bind(this)
+      }
     );
 
     this.overlays_.addEventListener(
@@ -531,9 +531,9 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./Overlay.js").default>} event CollectionEvent.
        */
-      function (event) {
+      (event) => {
         this.addOverlayInternal_(event.element);
-      }.bind(this)
+      }
     );
 
     this.overlays_.addEventListener(
@@ -541,13 +541,13 @@ class Map extends BaseObject {
       /**
        * @param {import("./Collection.js").CollectionEvent<import("./Overlay.js").default>} event CollectionEvent.
        */
-      function (event) {
+      (event) => {
         const id = event.element.getId();
         if (id !== undefined) {
           delete this.overlayIdIndex_[id.toString()];
         }
         event.element.setMap(null);
-      }.bind(this)
+      }
     );
 
     this.controls.forEach(
@@ -555,9 +555,9 @@ class Map extends BaseObject {
        * @param {import("./control/Control.js").default} control Control.
        * @this {Map}
        */
-      function (control) {
+      (control) => {
         control.setMap(this);
-      }.bind(this)
+      }
     );
 
     this.interactions.forEach(
@@ -565,9 +565,9 @@ class Map extends BaseObject {
        * @param {import("./interaction/Interaction.js").default} interaction Interaction.
        * @this {Map}
        */
-      function (interaction) {
+      (interaction) => {
         interaction.setMap(this);
-      }.bind(this)
+      }
     );
 
     this.overlays_.forEach(this.addOverlayInternal_.bind(this));

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -144,19 +144,15 @@ class MapBrowserEventHandler extends Target {
       this.dispatchEvent(newEvent);
     } else {
       // click
-      this.clickTimeoutId_ = setTimeout(
-        /** @this {MapBrowserEventHandler} */
-        () => {
-          this.clickTimeoutId_ = undefined;
-          const newEvent = new MapBrowserEvent(
-            MapBrowserEventType.SINGLECLICK,
-            this.map_,
-            pointerEvent
-          );
-          this.dispatchEvent(newEvent);
-        },
-        250
-      );
+      this.clickTimeoutId_ = setTimeout(() => {
+        this.clickTimeoutId_ = undefined;
+        const newEvent = new MapBrowserEvent(
+          MapBrowserEventType.SINGLECLICK,
+          this.map_,
+          pointerEvent
+        );
+        this.dispatchEvent(newEvent);
+      }, 250);
     }
   }
 

--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -146,7 +146,7 @@ class MapBrowserEventHandler extends Target {
       // click
       this.clickTimeoutId_ = setTimeout(
         /** @this {MapBrowserEventHandler} */
-        function () {
+        () => {
           this.clickTimeoutId_ = undefined;
           const newEvent = new MapBrowserEvent(
             MapBrowserEventType.SINGLECLICK,
@@ -154,7 +154,7 @@ class MapBrowserEventHandler extends Target {
             pointerEvent
           );
           this.dispatchEvent(newEvent);
-        }.bind(this),
+        },
         250
       );
     }

--- a/src/ol/TileCache.js
+++ b/src/ol/TileCache.js
@@ -36,14 +36,12 @@ class TileCache extends LRUCache {
     const key = this.peekFirstKey();
     const tileCoord = fromKey(key);
     const z = tileCoord[0];
-    this.forEach(
-      function (tile) {
-        if (tile.tileCoord[0] !== z) {
-          this.remove(getKey(tile.tileCoord));
-          tile.release();
-        }
-      }.bind(this)
-    );
+    this.forEach((tile) => {
+      if (tile.tileCoord[0] !== z) {
+        this.remove(getKey(tile.tileCoord));
+        tile.release();
+      }
+    });
   }
 }
 

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -141,7 +141,6 @@ export function xhr(url, format) {
    *      Function called when loading succeeded.
    * @param {function(): void} [failure] Failure
    *      Function called when loading failed.
-   * @this {import("./source/Vector").default}
    */
   return function (extent, resolution, projection, success, failure) {
     const source = /** @type {import("./source/Vector").default} */ (this);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -1060,20 +1060,17 @@ class Draw extends PointerInteraction {
     }
 
     this.lastDragTime_ = Date.now();
-    this.downTimeout_ = setTimeout(
-      function () {
-        this.handlePointerMove_(
-          new MapBrowserEvent(
-            MapBrowserEventType.POINTERMOVE,
-            event.map,
-            event.originalEvent,
-            false,
-            event.frameState
-          )
-        );
-      }.bind(this),
-      this.dragVertexDelay_
-    );
+    this.downTimeout_ = setTimeout(() => {
+      this.handlePointerMove_(
+        new MapBrowserEvent(
+          MapBrowserEventType.POINTERMOVE,
+          event.map,
+          event.originalEvent,
+          false,
+          event.frameState
+        )
+      );
+    }, this.dragVertexDelay_);
     this.downPx_ = event.pixel;
     return true;
   }

--- a/src/ol/interaction/KeyboardPan.js
+++ b/src/ol/interaction/KeyboardPan.js
@@ -81,7 +81,6 @@ class KeyboardPan extends Interaction {
    * pressed).
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
-   * @this {KeyboardPan}
    */
   handleEvent(mapBrowserEvent) {
     let stopEvent = false;

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -62,7 +62,6 @@ class KeyboardZoom extends Interaction {
    * key pressed was '+' or '-').
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
-   * @this {KeyboardZoom}
    */
   handleEvent(mapBrowserEvent) {
     let stopEvent = false;

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -461,7 +461,6 @@ class Select extends Interaction {
    * selected state of features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
-   * @this {Select}
    */
   handleEvent(mapBrowserEvent) {
     if (!this.condition_(mapBrowserEvent)) {

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -496,14 +496,14 @@ class Select extends Interaction {
          * @param {import("../layer/Layer.js").default} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
-        function (feature, layer) {
+        (feature, layer) => {
           if (!(feature instanceof Feature) || !this.filter_(feature, layer)) {
             return;
           }
           this.addFeatureLayerAssociation_(feature, layer);
           selected.push(feature);
           return !this.multi_;
-        }.bind(this),
+        },
         {
           layerFilter: this.layerFilter_,
           hitTolerance: this.hitTolerance_,
@@ -532,7 +532,7 @@ class Select extends Interaction {
          * @param {import("../layer/Layer.js").default} layer Layer.
          * @return {boolean|undefined} Continue to iterate over the features.
          */
-        function (feature, layer) {
+        (feature, layer) => {
           if (!(feature instanceof Feature) || !this.filter_(feature, layer)) {
             return;
           }
@@ -547,7 +547,7 @@ class Select extends Interaction {
             this.removeFeatureLayerAssociation_(feature);
           }
           return !this.multi_;
-        }.bind(this),
+        },
         {
           layerFilter: this.layerFilter_,
           hitTolerance: this.hitTolerance_,

--- a/src/ol/interaction/Translate.js
+++ b/src/ol/interaction/Translate.js
@@ -344,13 +344,14 @@ class Translate extends PointerInteraction {
   featuresAtPixel_(pixel, map) {
     return map.forEachFeatureAtPixel(
       pixel,
-      function (feature, layer) {
+      (feature, layer) => {
+        feature = /** @type {import("../Feature.js").default} */ (feature);
         if (this.filter_(feature, layer)) {
           if (!this.features_ || this.features_.getArray().includes(feature)) {
             return feature;
           }
         }
-      }.bind(this),
+      },
       {
         layerFilter: this.layerFilter_,
         hitTolerance: this.hitTolerance_,

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -414,11 +414,11 @@ class Graticule extends VectorLayer {
        * @param {import("../Feature").default} feature Feature
        * @return {Style} style
        */
-      this.lonLabelStyle_ = function (feature) {
+      this.lonLabelStyle_ = (feature) => {
         const label = feature.get('graticule_label');
         this.lonLabelStyleBase_.getText().setText(label);
         return this.lonLabelStyleBase_;
-      }.bind(this);
+      };
 
       /**
        * @type {Style}
@@ -446,11 +446,11 @@ class Graticule extends VectorLayer {
        * @param {import("../Feature").default} feature Feature
        * @return {Style} style
        */
-      this.latLabelStyle_ = function (feature) {
+      this.latLabelStyle_ = (feature) => {
         const label = feature.get('graticule_label');
         this.latLabelStyleBase_.getText().setText(label);
         return this.latLabelStyleBase_;
-      }.bind(this);
+      };
 
       this.meridiansLabels_ = [];
       this.parallelsLabels_ = [];

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -179,10 +179,10 @@ class Heatmap extends BaseVector {
       attributes: [
         {
           name: 'weight',
-          callback: function (feature) {
+          callback: (feature) => {
             const weight = this.weightFunction_(feature);
             return weight !== undefined ? clamp(weight, 0, 1) : 1;
-          }.bind(this),
+          },
         },
       ],
       vertexShader: `
@@ -268,14 +268,14 @@ class Heatmap extends BaseVector {
           gl_FragColor = v_hitColor;
         }`,
       uniforms: {
-        u_size: function () {
+        u_size: () => {
           return (this.get(Property.RADIUS) + this.get(Property.BLUR)) * 2;
-        }.bind(this),
-        u_blurSlope: function () {
+        },
+        u_blurSlope: () => {
           return (
             this.get(Property.RADIUS) / Math.max(1, this.get(Property.BLUR))
           );
-        }.bind(this),
+        },
       },
       postProcesses: [
         {
@@ -295,12 +295,12 @@ class Heatmap extends BaseVector {
               gl_FragColor.rgb *= gl_FragColor.a;
             }`,
           uniforms: {
-            u_gradientTexture: function () {
+            u_gradientTexture: () => {
               return this.gradient_;
-            }.bind(this),
-            u_opacity: function () {
+            },
+            u_opacity: () => {
               return this.getOpacity();
-            }.bind(this),
+            },
           },
         },
       ],

--- a/src/ol/render/webgl/BatchRenderer.js
+++ b/src/ol/render/webgl/BatchRenderer.js
@@ -162,7 +162,7 @@ class AbstractBatchRenderer {
        * @param {*} event Event.
        * @this {AbstractBatchRenderer}
        */
-      function (event) {
+      (event) => {
         const received = event.data;
 
         // this is not the response to our request: skip
@@ -192,7 +192,7 @@ class AbstractBatchRenderer {
         );
 
         callback();
-      }.bind(this);
+      };
 
     this.worker_.addEventListener('message', handleMessage);
   }

--- a/src/ol/render/webgl/BatchRenderer.js
+++ b/src/ol/render/webgl/BatchRenderer.js
@@ -160,7 +160,6 @@ class AbstractBatchRenderer {
     const handleMessage =
       /**
        * @param {*} event Event.
-       * @this {AbstractBatchRenderer}
        */
       (event) => {
         const received = event.data;

--- a/src/ol/render/webgl/LineStringBatchRenderer.js
+++ b/src/ol/render/webgl/LineStringBatchRenderer.js
@@ -77,12 +77,10 @@ class LineStringBatchRenderer extends AbstractBatchRenderer {
     }
 
     // loop on features to fill the render instructions
-    let batchEntry;
     const flatCoords = [];
     let renderIndex = 0;
-    let value;
     for (const featureUid in batch.entries) {
-      batchEntry = batch.entries[featureUid];
+      const batchEntry = batch.entries[featureUid];
       for (let i = 0, ii = batchEntry.flatCoordss.length; i < ii; i++) {
         flatCoords.length = batchEntry.flatCoordss[i].length;
         transform2D(
@@ -96,7 +94,7 @@ class LineStringBatchRenderer extends AbstractBatchRenderer {
 
         // custom attributes
         for (let k = 0, kk = this.customAttributes.length; k < kk; k++) {
-          value = this.customAttributes[k].callback(batchEntry.feature);
+          const value = this.customAttributes[k].callback(batchEntry.feature);
           batch.renderInstructions[renderIndex++] = value;
         }
 

--- a/src/ol/render/webgl/PointBatchRenderer.js
+++ b/src/ol/render/webgl/PointBatchRenderer.js
@@ -70,12 +70,10 @@ class PointBatchRenderer extends AbstractBatchRenderer {
     }
 
     // loop on features to fill the render instructions
-    let batchEntry;
     const tmpCoords = [];
     let renderIndex = 0;
-    let value;
     for (const featureUid in batch.entries) {
-      batchEntry = batch.entries[featureUid];
+      const batchEntry = batch.entries[featureUid];
       for (let i = 0, ii = batchEntry.flatCoordss.length; i < ii; i++) {
         tmpCoords[0] = batchEntry.flatCoordss[i][0];
         tmpCoords[1] = batchEntry.flatCoordss[i][1];
@@ -86,7 +84,7 @@ class PointBatchRenderer extends AbstractBatchRenderer {
 
         // pushing custom attributes
         for (let j = 0, jj = this.customAttributes.length; j < jj; j++) {
-          value = this.customAttributes[j].callback(batchEntry.feature);
+          const value = this.customAttributes[j].callback(batchEntry.feature);
           batch.renderInstructions[renderIndex++] = value;
         }
       }

--- a/src/ol/render/webgl/PolygonBatchRenderer.js
+++ b/src/ol/render/webgl/PolygonBatchRenderer.js
@@ -67,12 +67,10 @@ class PolygonBatchRenderer extends AbstractBatchRenderer {
     }
 
     // loop on features to fill the render instructions
-    let batchEntry;
     const flatCoords = [];
     let renderIndex = 0;
-    let value;
     for (const featureUid in batch.entries) {
-      batchEntry = batch.entries[featureUid];
+      const batchEntry = batch.entries[featureUid];
       for (let i = 0, ii = batchEntry.flatCoordss.length; i < ii; i++) {
         flatCoords.length = batchEntry.flatCoordss[i].length;
         transform2D(
@@ -86,7 +84,7 @@ class PolygonBatchRenderer extends AbstractBatchRenderer {
 
         // custom attributes
         for (let k = 0, kk = this.customAttributes.length; k < kk; k++) {
-          value = this.customAttributes[k].callback(batchEntry.feature);
+          const value = this.customAttributes[k].callback(batchEntry.feature);
           batch.renderInstructions[renderIndex++] = value;
         }
 

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -107,10 +107,10 @@ class LayerRenderer extends Observable {
        * @return {boolean} The tile range is fully loaded.
        * @this {LayerRenderer}
        */
-      function (zoom, tileRange) {
+      (zoom, tileRange) => {
         const callback = this.loadedTileCallback.bind(this, tiles, zoom);
         return source.forEachLoadedTile(projection, zoom, tileRange, callback);
-      }.bind(this)
+      }
     );
   }
   /**

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -105,7 +105,6 @@ class LayerRenderer extends Observable {
        * @param {number} zoom Zoom level.
        * @param {import("../TileRange.js").default} tileRange Tile range.
        * @return {boolean} The tile range is fully loaded.
-       * @this {LayerRenderer}
        */
       (zoom, tileRange) => {
         const callback = this.loadedTileCallback.bind(this, tiles, zoom);

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -144,30 +144,27 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
         }
       );
 
-      image.addEventListener(
-        EventType.CHANGE,
-        function () {
-          if (image.getState() !== ImageState.LOADED) {
-            return;
-          }
-          this.image_ = emptyImage ? null : image;
-          const imageResolution = image.getResolution();
-          const imagePixelRatio = image.getPixelRatio();
-          const renderedResolution =
-            (imageResolution * pixelRatio) / imagePixelRatio;
-          this.renderedResolution = renderedResolution;
-          this.coordinateToVectorPixelTransform_ = compose(
-            this.coordinateToVectorPixelTransform_,
-            width / 2,
-            height / 2,
-            1 / renderedResolution,
-            -1 / renderedResolution,
-            0,
-            -viewState.center[0],
-            -viewState.center[1]
-          );
-        }.bind(this)
-      );
+      image.addEventListener(EventType.CHANGE, () => {
+        if (image.getState() !== ImageState.LOADED) {
+          return;
+        }
+        this.image_ = emptyImage ? null : image;
+        const imageResolution = image.getResolution();
+        const imagePixelRatio = image.getPixelRatio();
+        const renderedResolution =
+          (imageResolution * pixelRatio) / imagePixelRatio;
+        this.renderedResolution = renderedResolution;
+        this.coordinateToVectorPixelTransform_ = compose(
+          this.coordinateToVectorPixelTransform_,
+          width / 2,
+          height / 2,
+          1 / renderedResolution,
+          -1 / renderedResolution,
+          0,
+          -viewState.center[0],
+          -viewState.center[1]
+        );
+      });
       image.load();
     }
 

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -681,7 +681,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
        * @param {import("../../Feature.js").default} feature Feature.
        * @this {CanvasVectorLayerRenderer}
        */
-      function (feature) {
+      (feature) => {
         let styles;
         const styleFunction =
           feature.getStyleFunction() || vectorLayer.getStyleFunction();
@@ -699,7 +699,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
           );
           ready = ready && !dirty;
         }
-      }.bind(this);
+      };
 
     const userExtent = toUserExtent(extent, projection);
     /** @type {Array<import("../../Feature.js").default>} */

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -679,7 +679,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const render =
       /**
        * @param {import("../../Feature.js").default} feature Feature.
-       * @this {CanvasVectorLayerRenderer}
        */
       (feature) => {
         let styles;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -301,7 +301,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       'message',
       /**
        * @param {*} event Event.
-       * @this {WebGLPointsLayerRenderer}
        */
       (event) => {
         const received = event.data;

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -303,7 +303,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
        * @param {*} event Event.
        * @this {WebGLPointsLayerRenderer}
        */
-      function (event) {
+      (event) => {
         const received = event.data;
         if (received.type === WebGLWorkerMessageType.GENERATE_POINT_BUFFERS) {
           const projectionTransform = received.projectionTransform;
@@ -337,7 +337,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
           this.getLayer().changed();
         }
-      }.bind(this)
+      }
     );
 
     /**
@@ -381,16 +381,14 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         this
       ),
     ];
-    source.forEachFeature(
-      function (feature) {
-        this.featureCache_[getUid(feature)] = {
-          feature: feature,
-          properties: feature.getProperties(),
-          geometry: feature.getGeometry(),
-        };
-        this.featureCount_++;
-      }.bind(this)
-    );
+    source.forEachFeature((feature) => {
+      this.featureCache_[getUid(feature)] = {
+        feature: feature,
+        properties: feature.getProperties(),
+        geometry: feature.getGeometry(),
+      };
+      this.featureCount_++;
+    });
   }
 
   afterHelperCreated() {

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -18,7 +18,7 @@ import {listen, unlistenByKey} from '../events.js';
 import {releaseCanvas} from '../dom.js';
 
 /**
- * @typedef {function(number, number, number, number) : import("../Tile.js").default} FunctionType
+ * @typedef {function(number, number, number, number) : (ReprojTile|import("../ImageTile.js").default)} FunctionType
  */
 
 /**
@@ -103,7 +103,7 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {!Array<import("../Tile.js").default>}
+     * @type {!Array<ReprojTile|import("../ImageTile.js").default>}
      */
     this.sourceTiles_ = [];
 
@@ -241,16 +241,14 @@ class ReprojTile extends Tile {
    */
   reproject_() {
     const sources = [];
-    this.sourceTiles_.forEach(
-      function (tile, i, arr) {
-        if (tile && tile.getState() == TileState.LOADED) {
-          sources.push({
-            extent: this.sourceTileGrid_.getTileCoordExtent(tile.tileCoord),
-            image: tile.getImage(),
-          });
-        }
-      }.bind(this)
-    );
+    this.sourceTiles_.forEach((tile) => {
+      if (tile && tile.getState() == TileState.LOADED) {
+        sources.push({
+          extent: this.sourceTileGrid_.getTileCoordExtent(tile.tileCoord),
+          image: tile.getImage(),
+        });
+      }
+    });
     this.sourceTiles_.length = 0;
 
     if (sources.length === 0) {
@@ -300,36 +298,34 @@ class ReprojTile extends Tile {
       let leftToLoad = 0;
 
       this.sourcesListenerKeys_ = [];
-      this.sourceTiles_.forEach(
-        function (tile, i, arr) {
-          const state = tile.getState();
-          if (state == TileState.IDLE || state == TileState.LOADING) {
-            leftToLoad++;
+      this.sourceTiles_.forEach((tile) => {
+        const state = tile.getState();
+        if (state == TileState.IDLE || state == TileState.LOADING) {
+          leftToLoad++;
 
-            const sourceListenKey = listen(
-              tile,
-              EventType.CHANGE,
-              function (e) {
-                const state = tile.getState();
-                if (
-                  state == TileState.LOADED ||
-                  state == TileState.ERROR ||
-                  state == TileState.EMPTY
-                ) {
-                  unlistenByKey(sourceListenKey);
-                  leftToLoad--;
-                  if (leftToLoad === 0) {
-                    this.unlistenSources_();
-                    this.reproject_();
-                  }
+          const sourceListenKey = listen(
+            tile,
+            EventType.CHANGE,
+            function (e) {
+              const state = tile.getState();
+              if (
+                state == TileState.LOADED ||
+                state == TileState.ERROR ||
+                state == TileState.EMPTY
+              ) {
+                unlistenByKey(sourceListenKey);
+                leftToLoad--;
+                if (leftToLoad === 0) {
+                  this.unlistenSources_();
+                  this.reproject_();
                 }
-              },
-              this
-            );
-            this.sourcesListenerKeys_.push(sourceListenKey);
-          }
-        }.bind(this)
-      );
+              }
+            },
+            this
+          );
+          this.sourcesListenerKeys_.push(sourceListenKey);
+        }
+      });
 
       if (leftToLoad === 0) {
         setTimeout(this.reproject_.bind(this), 0);

--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -202,51 +202,49 @@ class Triangulation {
 
       // Shift triangles to be as close to `leftBound` as possible
       // (if the distance is more than `worldWidth / 2` it can be closer.
-      this.triangles_.forEach(
-        function (triangle) {
-          if (
-            Math.max(
-              triangle.source[0][0],
-              triangle.source[1][0],
-              triangle.source[2][0]
-            ) -
-              leftBound >
-            this.sourceWorldWidth_ / 2
-          ) {
-            const newTriangle = [
-              [triangle.source[0][0], triangle.source[0][1]],
-              [triangle.source[1][0], triangle.source[1][1]],
-              [triangle.source[2][0], triangle.source[2][1]],
-            ];
-            if (newTriangle[0][0] - leftBound > this.sourceWorldWidth_ / 2) {
-              newTriangle[0][0] -= this.sourceWorldWidth_;
-            }
-            if (newTriangle[1][0] - leftBound > this.sourceWorldWidth_ / 2) {
-              newTriangle[1][0] -= this.sourceWorldWidth_;
-            }
-            if (newTriangle[2][0] - leftBound > this.sourceWorldWidth_ / 2) {
-              newTriangle[2][0] -= this.sourceWorldWidth_;
-            }
-
-            // Rarely (if the extent contains both the dateline and prime meridian)
-            // the shift can in turn break some triangles.
-            // Detect this here and don't shift in such cases.
-            const minX = Math.min(
-              newTriangle[0][0],
-              newTriangle[1][0],
-              newTriangle[2][0]
-            );
-            const maxX = Math.max(
-              newTriangle[0][0],
-              newTriangle[1][0],
-              newTriangle[2][0]
-            );
-            if (maxX - minX < this.sourceWorldWidth_ / 2) {
-              triangle.source = newTriangle;
-            }
+      this.triangles_.forEach((triangle) => {
+        if (
+          Math.max(
+            triangle.source[0][0],
+            triangle.source[1][0],
+            triangle.source[2][0]
+          ) -
+            leftBound >
+          this.sourceWorldWidth_ / 2
+        ) {
+          const newTriangle = [
+            [triangle.source[0][0], triangle.source[0][1]],
+            [triangle.source[1][0], triangle.source[1][1]],
+            [triangle.source[2][0], triangle.source[2][1]],
+          ];
+          if (newTriangle[0][0] - leftBound > this.sourceWorldWidth_ / 2) {
+            newTriangle[0][0] -= this.sourceWorldWidth_;
           }
-        }.bind(this)
-      );
+          if (newTriangle[1][0] - leftBound > this.sourceWorldWidth_ / 2) {
+            newTriangle[1][0] -= this.sourceWorldWidth_;
+          }
+          if (newTriangle[2][0] - leftBound > this.sourceWorldWidth_ / 2) {
+            newTriangle[2][0] -= this.sourceWorldWidth_;
+          }
+
+          // Rarely (if the extent contains both the dateline and prime meridian)
+          // the shift can in turn break some triangles.
+          // Detect this here and don't shift in such cases.
+          const minX = Math.min(
+            newTriangle[0][0],
+            newTriangle[1][0],
+            newTriangle[2][0]
+          );
+          const maxX = Math.max(
+            newTriangle[0][0],
+            newTriangle[1][0],
+            newTriangle[2][0]
+          );
+          if (maxX - minX < this.sourceWorldWidth_ / 2) {
+            triangle.source = newTriangle;
+          }
+        }
+      });
     }
 
     transformInvCache = {};

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -277,47 +277,42 @@ class BingMaps extends TileImage {
         this.getProjection()
       );
 
-      this.setAttributions(
-        function (frameState) {
-          const attributions = [];
-          const viewState = frameState.viewState;
-          const tileGrid = this.getTileGrid();
-          const z = tileGrid.getZForResolution(
-            viewState.resolution,
-            this.zDirection
-          );
-          const tileCoord = tileGrid.getTileCoordForCoordAndZ(
-            viewState.center,
-            z
-          );
-          const zoom = tileCoord[0];
-          resource.imageryProviders.map(function (imageryProvider) {
-            let intersecting = false;
-            const coverageAreas = imageryProvider.coverageAreas;
-            for (let i = 0, ii = coverageAreas.length; i < ii; ++i) {
-              const coverageArea = coverageAreas[i];
-              if (
-                zoom >= coverageArea.zoomMin &&
-                zoom <= coverageArea.zoomMax
-              ) {
-                const bbox = coverageArea.bbox;
-                const epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
-                const extent = applyTransform(epsg4326Extent, transform);
-                if (intersects(extent, frameState.extent)) {
-                  intersecting = true;
-                  break;
-                }
+      this.setAttributions((frameState) => {
+        const attributions = [];
+        const viewState = frameState.viewState;
+        const tileGrid = this.getTileGrid();
+        const z = tileGrid.getZForResolution(
+          viewState.resolution,
+          this.zDirection
+        );
+        const tileCoord = tileGrid.getTileCoordForCoordAndZ(
+          viewState.center,
+          z
+        );
+        const zoom = tileCoord[0];
+        resource.imageryProviders.map(function (imageryProvider) {
+          let intersecting = false;
+          const coverageAreas = imageryProvider.coverageAreas;
+          for (let i = 0, ii = coverageAreas.length; i < ii; ++i) {
+            const coverageArea = coverageAreas[i];
+            if (zoom >= coverageArea.zoomMin && zoom <= coverageArea.zoomMax) {
+              const bbox = coverageArea.bbox;
+              const epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
+              const extent = applyTransform(epsg4326Extent, transform);
+              if (intersects(extent, frameState.extent)) {
+                intersecting = true;
+                break;
               }
             }
-            if (intersecting) {
-              attributions.push(imageryProvider.attribution);
-            }
-          });
+          }
+          if (intersecting) {
+            attributions.push(imageryProvider.attribution);
+          }
+        });
 
-          attributions.push(TOS_ATTRIBUTION);
-          return attributions;
-        }.bind(this)
-      );
+        attributions.push(TOS_ATTRIBUTION);
+        return attributions;
+      });
     }
 
     this.setState('ready');

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -234,9 +234,8 @@ class DataTileSource extends TileSource {
       wrappedTileCoord,
       reprojTilePixelRatio,
       this.getGutterForProjection(sourceProjection),
-      function (z, x, y, pixelRatio) {
-        return this.getTile(z, x, y, pixelRatio, sourceProjection);
-      }.bind(this),
+      (z, x, y, pixelRatio) =>
+        this.getTile(z, x, y, pixelRatio, sourceProjection),
       this.getInterpolate()
     );
     newTile.key = this.getKey();

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -196,14 +196,8 @@ class ImageSource extends Source {
       extent,
       resolution,
       pixelRatio,
-      function (extent, resolution, pixelRatio) {
-        return this.getImageInternal(
-          extent,
-          resolution,
-          pixelRatio,
-          sourceProjection
-        );
-      }.bind(this),
+      (extent, resolution, pixelRatio) =>
+        this.getImageInternal(extent, resolution, pixelRatio, sourceProjection),
       this.getInterpolate()
     );
     this.reprojectedRevision_ = this.getRevision();

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -328,9 +328,8 @@ class TileImage extends UrlTile {
       wrappedTileCoord,
       this.getTilePixelRatio(pixelRatio),
       this.getGutter(),
-      function (z, x, y, pixelRatio) {
-        return this.getTileInternal(z, x, y, pixelRatio, sourceProjection);
-      }.bind(this),
+      (z, x, y, pixelRatio) =>
+        this.getTileInternal(z, x, y, pixelRatio, sourceProjection),
       this.reprojectionErrorThreshold_,
       this.renderReprojectionEdges_,
       this.getInterpolate()

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -148,12 +148,9 @@ export class CustomTile extends Tile {
       this.loadInternal_();
     } else {
       if (request === true) {
-        setTimeout(
-          function () {
-            callback(this.getData(coordinate));
-          }.bind(this),
-          0
-        );
+        setTimeout(() => {
+          callback(this.getData(coordinate));
+        }, 0);
       } else {
         callback(this.getData(coordinate));
       }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -500,26 +500,26 @@ class VectorSource extends Source {
       /**
        * @param {import("../Collection.js").CollectionEvent<import("../Feature.js").default<Geometry>>} evt The collection event
        */
-      function (evt) {
+      (evt) => {
         if (!modifyingCollection) {
           modifyingCollection = true;
           this.addFeature(evt.element);
           modifyingCollection = false;
         }
-      }.bind(this)
+      }
     );
     collection.addEventListener(
       CollectionEventType.REMOVE,
       /**
        * @param {import("../Collection.js").CollectionEvent<import("../Feature.js").default<Geometry>>} evt The collection event
        */
-      function (evt) {
+      (evt) => {
         if (!modifyingCollection) {
           modifyingCollection = true;
           this.removeFeature(evt.element);
           modifyingCollection = false;
         }
-      }.bind(this)
+      }
     );
     this.featuresCollection_ = collection;
   }
@@ -542,9 +542,9 @@ class VectorSource extends Source {
       }
     } else {
       if (this.featuresRtree_) {
-        const removeAndIgnoreReturn = function (feature) {
+        const removeAndIgnoreReturn = (feature) => {
           this.removeFeatureInternal(feature);
-        }.bind(this);
+        };
         this.featuresRtree_.forEach(removeAndIgnoreReturn);
         for (const id in this.nullGeometryFeatures_) {
           this.removeFeatureInternal(this.nullGeometryFeatures_[id]);
@@ -980,7 +980,7 @@ class VectorSource extends Source {
           extentToLoad,
           resolution,
           projection,
-          function (features) {
+          (features) => {
             --this.loadingExtentsCount_;
             this.dispatchEvent(
               new VectorSourceEvent(
@@ -989,13 +989,13 @@ class VectorSource extends Source {
                 features
               )
             );
-          }.bind(this),
-          function () {
+          },
+          () => {
             --this.loadingExtentsCount_;
             this.dispatchEvent(
               new VectorSourceEvent(VectorEventType.FEATURESLOADERROR)
             );
-          }.bind(this)
+          }
         );
         loadedExtentsRtree.insert(extentToLoad, {extent: extentToLoad.slice()});
       }

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -390,15 +390,11 @@ class VectorTile extends UrlTile {
       // make extent 1 pixel smaller so we don't load tiles for < 0.5 pixel render space
       const extent = tileGrid.getTileCoordExtent(urlTileCoord);
       bufferExtent(extent, -resolution, extent);
-      sourceTileGrid.forEachTileCoord(
-        extent,
-        sourceZ,
-        function (sourceTileCoord) {
-          empty =
-            empty &&
-            !this.tileUrlFunction(sourceTileCoord, pixelRatio, projection);
-        }.bind(this)
-      );
+      sourceTileGrid.forEachTileCoord(extent, sourceZ, (sourceTileCoord) => {
+        empty =
+          empty &&
+          !this.tileUrlFunction(sourceTileCoord, pixelRatio, projection);
+      });
     }
     const newTile = new VectorRenderTile(
       tileCoord,

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -273,13 +273,10 @@ class Zoomify extends TileImage {
     );
     const testTileUrl = tileUrlFunction(tileUrl, 1, null);
     const image = new Image();
-    image.addEventListener(
-      'error',
-      function () {
-        tileWidth = tileSize;
-        this.changed();
-      }.bind(this)
-    );
+    image.addEventListener('error', () => {
+      tileWidth = tileSize;
+      this.changed();
+    });
     image.src = testTileUrl;
   }
 }

--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -46,7 +46,7 @@ const DEFAULT_FRAGMENT_SHADER = `
 /**
  * @typedef {Object} UniformInternalDescription
  * @property {import("./Helper").UniformValue} value Value
- * @property {number} location Location
+ * @property {WebGLUniformLocation} location Location
  * @property {WebGLTexture} [texture] Texture
  * @private
  */
@@ -168,14 +168,12 @@ class WebGLPostProcessingPass {
      */
     this.uniforms_ = [];
     options.uniforms &&
-      Object.keys(options.uniforms).forEach(
-        function (name) {
-          this.uniforms_.push({
-            value: options.uniforms[name],
-            location: gl.getUniformLocation(this.renderTargetProgram_, name),
-          });
-        }.bind(this)
-      );
+      Object.keys(options.uniforms).forEach((name) => {
+        this.uniforms_.push({
+          value: options.uniforms[name],
+          location: gl.getUniformLocation(this.renderTargetProgram_, name),
+        });
+      });
   }
 
   /**


### PR DESCRIPTION
This makes use of arrow functions instead of creating an unnecessary anonymous function and calling bind on it.  It appears that TypeScript does a better job interpreting these arrow functions, so this change required a few updates to types.