### PR TITLE
Only TileImage as ReprojTile source tile type

### DIFF
--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -18,7 +18,7 @@ import {listen, unlistenByKey} from '../events.js';
 import {releaseCanvas} from '../dom.js';
 
 /**
- * @typedef {function(number, number, number, number) : (ReprojTile|import("../ImageTile.js").default)} FunctionType
+ * @typedef {function(number, number, number, number) : (import("../ImageTile.js").default)} FunctionType
  */
 
 /**
@@ -103,7 +103,7 @@ class ReprojTile extends Tile {
 
     /**
      * @private
-     * @type {!Array<ReprojTile|import("../ImageTile.js").default>}
+     * @type {!Array<import("../ImageTile.js").default>}
      */
     this.sourceTiles_ = [];
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -352,7 +352,7 @@ class TileImage extends UrlTile {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {!import("../proj/Projection.js").default} projection Projection.
-   * @return {!(ImageTile|ReprojTile)} Tile.
+   * @return {!ImageTile} Tile.
    * @protected
    */
   getTileInternal(z, x, y, pixelRatio, projection) {


### PR DESCRIPTION
`ol/source/ImageTile~createTile_` only returns `ImageTile` and `getTileInternal` only gets tiles by calling `createTile_` or getting tiles out of the cache that were also set in this method. So `ReprojTile` should be removed from `getTileInternal` return type.