### PR TITLE
Pixel as fixed length array

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -40,6 +40,7 @@ import {fromUserCoordinate, toUserCoordinate} from './proj.js';
 import {getUid} from './util.js';
 import {hasArea} from './size.js';
 import {listen, unlistenByKey} from './events.js';
+import {fromCoordinate as pixelFromCoordinate} from './pixel.js';
 import {removeNode} from './dom.js';
 
 /**
@@ -988,7 +989,7 @@ class Map extends BaseObject {
     }
     return applyTransform(
       frameState.coordinateToPixelTransform,
-      coordinate.slice(0, 2)
+      pixelFromCoordinate(coordinate)
     );
   }
 

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -454,11 +454,13 @@ class Overlay extends BaseObject {
         if (!centerPx) {
           return;
         }
-        const newCenterPx = [centerPx[0] + delta[0], centerPx[1] + delta[1]];
 
         const panOptions = panIntoViewOptions.animation || {};
         map.getView().animateInternal({
-          center: map.getCoordinateFromPixelInternal(newCenterPx),
+          center: map.getCoordinateFromPixelInternal([
+            centerPx[0] + delta[0],
+            centerPx[1] + delta[1],
+          ]),
           duration: panOptions.duration,
           easing: panOptions.easing,
         });

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -33,6 +33,7 @@ import {
   getTopRight,
 } from '../extent.js';
 import {clamp, squaredDistance, toFixed} from '../math.js';
+import {clone as clonePixel} from '../pixel.js';
 import {createEditingStyle} from '../style/Style.js';
 import {
   distance,
@@ -1116,7 +1117,7 @@ class Draw extends PointerInteraction {
     if (targets.length) {
       this.traceState_ = {
         active: true,
-        startPx: event.pixel.slice(),
+        startPx: clonePixel(event.pixel),
         targets: targets,
         targetIndex: -1,
       };

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -451,6 +451,9 @@ class Snap extends PointerInteraction {
     let minSquaredDistance = Infinity;
 
     const squaredPixelTolerance = this.pixelTolerance_ * this.pixelTolerance_;
+    /**
+     * @return {Result|null} The result.
+     */
     const getResult = () => {
       if (closestVertex) {
         const vertexPixel = map.getPixelFromCoordinate(closestVertex);

--- a/src/ol/pixel.js
+++ b/src/ol/pixel.js
@@ -5,8 +5,24 @@
 /**
  * An array with two elements, representing a pixel. The first element is the
  * x-coordinate, the second the y-coordinate of the pixel.
- * @typedef {Array<number>} Pixel
+ * @typedef {[number, number]} Pixel
  * @api
  */
 
-export let nothing;
+/**
+ * Create a copy of a pixel.
+ * @param {Pixel} pixel Input pixel.
+ * @return {Pixel} A new pixel with the same values as the input.
+ */
+export function clone(pixel) {
+  return /** @type {Pixel} */ (pixel.slice());
+}
+
+/**
+ * Create a pixel from the first two values of a coordinate.
+ * @param {import("./coordinate.js").Coordinate} coordinate Input coordinate.
+ * @return {Pixel} A pixel representing the coordinate.
+ */
+export function fromCoordinate(coordinate) {
+  return /** @type {Pixel} */ (coordinate.slice(0, 2));
+}

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -9,6 +9,7 @@ import {
   multiply as multiplyTransform,
   scale as scaleTransform,
 } from './transform.js';
+import {clone as clonePixel} from './pixel.js';
 import {getSquaredTolerance} from './renderer/vector.js';
 import {getTransformFromProjections, getUserProjection} from './proj.js';
 
@@ -135,5 +136,5 @@ export function getVectorContext(event) {
  * @api
  */
 export function getRenderPixel(event, pixel) {
-  return applyTransform(event.inversePixelTransform, pixel.slice(0));
+  return applyTransform(event.inversePixelTransform, clonePixel(pixel));
 }

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -9,6 +9,7 @@ import ImageState from '../../ImageState.js';
 import RBush from 'rbush';
 import ViewHint from '../../ViewHint.js';
 import {apply, compose, create} from '../../transform.js';
+import {clone as clonePixel} from '../../pixel.js';
 import {getHeight, getWidth, isEmpty, scaleFromCenter} from '../../extent.js';
 
 /**
@@ -67,7 +68,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
     }
     const vectorPixel = apply(
       this.coordinateToVectorPixelTransform_,
-      apply(this.renderedPixelToCoordinateTransform_, pixel.slice())
+      apply(this.renderedPixelToCoordinateTransform_, clonePixel(pixel))
     );
     return this.vectorRenderer_.getFeatures(vectorPixel);
   }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -482,17 +482,14 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       }
       const extent = tileGrid.getTileCoordExtent(tile.wrappedTileCoord);
       const corner = getTopLeft(extent);
-      const tilePixel = [
-        (coordinate[0] - corner[0]) / resolution,
-        (corner[1] - coordinate[1]) / resolution,
-      ];
+
       /** @type {Array<import("../../Feature.js").FeatureLike>} */
       const features = tile
         .getSourceTiles()
         .reduce(function (accumulator, sourceTile) {
           return accumulator.concat(sourceTile.getFeatures());
         }, []);
-      /** @type {ImageData|undefined} */
+
       let hitDetectionImageData = tile.hitDetectionImageData[layerUid];
       if (!hitDetectionImageData) {
         const tileSize = toSize(
@@ -523,7 +520,16 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
         );
         tile.hitDetectionImageData[layerUid] = hitDetectionImageData;
       }
-      resolve(hitDetect(tilePixel, features, hitDetectionImageData));
+
+      const result = hitDetect(
+        [
+          (coordinate[0] - corner[0]) / resolution,
+          (corner[1] - coordinate[1]) / resolution,
+        ],
+        features,
+        hitDetectionImageData
+      );
+      resolve(result);
     });
   }
 

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -118,9 +118,10 @@ export function setFromArray(transform1, transform2) {
  * Transforms the given coordinate with the given transform returning the
  * resulting, transformed coordinate. The coordinate will be modified in-place.
  *
+ * @template {Array} T
  * @param {Transform} transform The transformation.
- * @param {import("./coordinate.js").Coordinate|import("./pixel.js").Pixel} coordinate The coordinate to transform.
- * @return {import("./coordinate.js").Coordinate|import("./pixel.js").Pixel} return coordinate so that operations can be
+ * @param {T} coordinate The coordinate to transform.
+ * @return {T} return coordinate so that operations can be
  *     chained together.
  */
 export function apply(transform, coordinate) {


### PR DESCRIPTION
This updates the `Pixel` type to be a fixed length array.

TypeScript doesn't try to be clever about calls to `slice`.  Given a two element array, it treats the return from `pixel.slice()` as having unknown length.  In the same way (and more understandably), the return from `coordinate.slice(0, 2)` has unknown length.  This requires that we cast the return to retain the fixed length type.  I've added `clone` and `fromCoordinate` function to the `ol/pixel.js` module for this purpose.

In addition, TypeScript gives up on keeping track of array literals as fixed length after the first statement where they appear.  

For example, if the `clone` method expects a two element array, this does not work:
```js
const p = [1, 2];
const c = clone(p);
```

However, this does work:
```js
const c = clone([1, 2]);
```

If the array literal cannot be passed directly as an argument, this is an alternative:
```js
/** @type {import("./pixel.js").Pixel} */
const p = [1, 2];
const c = clone(p);
```

In TypeScript, the use of `as` is required in this case.

I've shifted a few expressions around to pass array literals directly as arguments.  If instead we want to have the type annotations, I can change that.

I'm not attached to these changes.  Mostly just wanted to see how much work would be involved.

Fixes #14167.