### PR TITLE
Take scale transform into account for viewport pixels

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -145,6 +145,7 @@ import {removeNode} from './dom.js';
  * element itself or the `id` of the element. If not specified at construction
  * time, {@link module:ol/Map~Map#setTarget} must be called for the map to be
  * rendered. If passed by element, the container can be in a secondary document.
+ * **Note:** CSS `transform` support for the target element is limited to `scale`.
  * @property {View|Promise<import("./View.js").ViewOptions>} [view] The map's view.  No layer sources will be
  * fetched unless this is specified at construction time or through
  * {@link module:ol/Map~Map#setView}.
@@ -778,12 +779,16 @@ class Map extends BaseObject {
 
   /**
    * Returns the map pixel position for a browser event relative to the viewport.
-   * @param {UIEvent} event Event.
+   * @param {UIEvent|{clientX: number, clientY: number}} event Event.
    * @return {import("./pixel.js").Pixel} Pixel.
    * @api
    */
   getEventPixel(event) {
-    const viewportPosition = this.viewport_.getBoundingClientRect();
+    const viewport = this.viewport_;
+    const viewportPosition = viewport.getBoundingClientRect();
+    const viewportSize = this.getSize();
+    const scaleX = viewportPosition.width / viewportSize[0];
+    const scaleY = viewportPosition.height / viewportSize[1];
     const eventPosition =
       //FIXME Are we really calling this with a TouchEvent anywhere?
       'changedTouches' in event
@@ -791,8 +796,8 @@ class Map extends BaseObject {
         : /** @type {MouseEvent} */ (event);
 
     return [
-      eventPosition.clientX - viewportPosition.left,
-      eventPosition.clientY - viewportPosition.top,
+      (eventPosition.clientX - viewportPosition.left) / scaleX,
+      (eventPosition.clientY - viewportPosition.top) / scaleY,
     ];
   }
 

--- a/src/ol/interaction/DragPan.js
+++ b/src/ol/interaction/DragPan.js
@@ -88,12 +88,13 @@ class DragPan extends PointerInteraction {
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
    */
   handleDragEvent(mapBrowserEvent) {
+    const map = mapBrowserEvent.map;
     if (!this.panning_) {
       this.panning_ = true;
-      this.getMap().getView().beginInteraction();
+      map.getView().beginInteraction();
     }
     const targetPointers = this.targetPointers;
-    const centroid = centroidFromPointers(targetPointers);
+    const centroid = map.getEventPixel(centroidFromPointers(targetPointers));
     if (targetPointers.length == this.lastPointersCount_) {
       if (this.kinetic_) {
         this.kinetic_.update(centroid[0], centroid[1]);

--- a/src/ol/interaction/PinchRotate.js
+++ b/src/ol/interaction/PinchRotate.js
@@ -109,11 +109,9 @@ class PinchRotate extends PointerInteraction {
     // rotate anchor point.
     // FIXME: should be the intersection point between the lines:
     //     touch0,touch1 and previousTouch0,previousTouch1
-    const viewportPosition = map.getViewport().getBoundingClientRect();
-    const centroid = centroidFromPointers(this.targetPointers);
-    centroid[0] -= viewportPosition.left;
-    centroid[1] -= viewportPosition.top;
-    this.anchor_ = map.getCoordinateFromPixelInternal(centroid);
+    this.anchor_ = map.getCoordinateFromPixelInternal(
+      map.getEventPixel(centroidFromPointers(this.targetPointers))
+    );
 
     // rotate
     if (this.rotating_) {

--- a/src/ol/interaction/PinchZoom.js
+++ b/src/ol/interaction/PinchZoom.js
@@ -87,11 +87,9 @@ class PinchZoom extends PointerInteraction {
     }
 
     // scale anchor point.
-    const viewportPosition = map.getViewport().getBoundingClientRect();
-    const centroid = centroidFromPointers(this.targetPointers);
-    centroid[0] -= viewportPosition.left;
-    centroid[1] -= viewportPosition.top;
-    this.anchor_ = map.getCoordinateFromPixelInternal(centroid);
+    this.anchor_ = map.getCoordinateFromPixelInternal(
+      map.getEventPixel(centroidFromPointers(this.targetPointers))
+    );
 
     // scale, bypass the resolution constraint
     map.render();

--- a/src/ol/interaction/Pointer.js
+++ b/src/ol/interaction/Pointer.js
@@ -190,7 +190,7 @@ class PointerInteraction extends Interaction {
 
 /**
  * @param {Array<PointerEvent>} pointerEvents List of events.
- * @return {import("../pixel.js").Pixel} Centroid pixel.
+ * @return {{clientX: number, clientY: number}} Centroid pixel.
  */
 export function centroid(pointerEvents) {
   const length = pointerEvents.length;
@@ -200,7 +200,7 @@ export function centroid(pointerEvents) {
     clientX += pointerEvents[i].clientX;
     clientY += pointerEvents[i].clientY;
   }
-  return [clientX / length, clientY / length];
+  return {clientX: clientX / length, clientY: clientY / length};
 }
 
 export default PointerInteraction;


### PR DESCRIPTION
This pull request is a simpler alternative to #14180. It also does not take other transforms than `scale` into account, so it adds a note to the map's `target` option about supported transforms.

Closes #14180
Fixes #14179
Fixes #13283