### PR TITLE
Use jsdelivr instead of unpkg

### DIFF
--- a/examples/animated-gif.html
+++ b/examples/animated-gif.html
@@ -7,6 +7,6 @@ docs: >
   Animation is achieved using the <a href="https://themadcreator.github.io/gifler/" target="_blank">Gifler</a> library.
 tags: "animation, vector, style, icon, gif"
 resources:
-  - https://unpkg.com/gifler@0.1.0/gifler.min.js
+  - https://cdn.jsdelivr.net/npm/gifler@0.1.0/gifler.min.js
 ---
 <div id="map" class="map"></div>

--- a/examples/clusters-dynamic.html
+++ b/examples/clusters-dynamic.html
@@ -11,6 +11,6 @@ docs: >
   <p>Features are styled differently depending on the power of the photovoltaic installation.</p>
 tags: "marker, cluster, vector, style, convex hull"
 resources:
-  - https://unpkg.com/monotone-chain-convex-hull@1.0.0/lib/index.js
+  - https://cdn.jsdelivr.net/npm/monotone-chain-convex-hull@1.0.0/lib/index.js
 ---
 <div id="map" class="map"></div>

--- a/examples/d3.html
+++ b/examples/d3.html
@@ -6,7 +6,7 @@ docs: >
   The example loads TopoJSON geometries and uses d3 (<code>d3.geo.path</code>) to render these geometries to a SVG element.
 tags: "d3"
 resources:
-  - https://unpkg.com/d3@7.4.4/dist/d3.min.js
-  - https://unpkg.com/topojson@3.0.2/dist/topojson.js
+  - https://cdn.jsdelivr.net/npm/d3@7.4.4/dist/d3.min.js
+  - https://cdn.jsdelivr.net/npm/topojson@3.0.2/dist/topojson.js
 ---
 <div id="map" class="map"></div>

--- a/examples/device-orientation.html
+++ b/examples/device-orientation.html
@@ -8,7 +8,7 @@ docs: >
   normalize the events from the browser.
 tags: "device, orientation, gyronorm"
 resources:
-  - https://unpkg.com/gyronorm@2.0.6/dist/gyronorm.complete.min.js
+  - https://cdn.jsdelivr.net/npm/gyronorm@2.0.6/dist/gyronorm.complete.min.js
 ---
 <div id="map" class="map"></div>
 <p>

--- a/examples/geolocation-orientation.html
+++ b/examples/geolocation-orientation.html
@@ -43,7 +43,7 @@ tags: "fullscreen, geolocation, orientation, mobile"
       <button id="geolocate" class="btn btn-primary">Geolocate Me!</button>
       <button id="simulate" class="btn btn-secondary">Simulate</button>
     </div>
-    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/elm-pep@1.0.6/dist/elm-pep.js"></script>
     <script src="geolocation-orientation.js"></script>
     <script src="common.js"></script>
   </body>

--- a/examples/jsts.html
+++ b/examples/jsts.html
@@ -7,6 +7,6 @@ docs: >
   with OpenLayers.
 tags: "vector, jsts, buffer"
 resources:
-  - https://unpkg.com/jsts@2.3.0/dist/jsts.min.js
+  - https://cdn.jsdelivr.net/npm/jsts@2.3.0/dist/jsts.min.js
 ---
 <div id="map" class="map"></div>

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -26,7 +26,7 @@ cloak:
   </head>
   <body>
     <div id="map" class="map"></div>
-    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/elm-pep@1.0.6/dist/elm-pep.js"></script>
     <script src="mobile-full-screen.js"></script>
     <script src="common.js"></script>
   </body>

--- a/examples/numpytile.html
+++ b/examples/numpytile.html
@@ -9,7 +9,7 @@ docs: >
   performs a contrast stretch by adjusting the style variables set on the layer.
 tags: "numpytiles, webgl"
 resources:
-  - https://unpkg.com/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js
+  - https://cdn.jsdelivr.net/npm/@planet/ol-numpytiles@2.0.2/umd/NumpyLoader.js
 ---
 <div id="map" class="map"></div>
 

--- a/examples/raster.html
+++ b/examples/raster.html
@@ -20,7 +20,7 @@ docs: >
   </p>
 tags: "raster, pixel, maptiler"
 resources:
-  - https://unpkg.com/d3@7.4.4/dist/d3.min.js
+  - https://cdn.jsdelivr.net/npm/d3@7.4.4/dist/d3.min.js
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -7,7 +7,7 @@
     if (!lzStringPromise) {
       lzStringPromise = new Promise(function (resolve, reject) {
         const script = document.createElement('script')
-        script.src = 'https://unpkg.com/lz-string@1.4.4/libs/lz-string.min.js';
+        script.src = 'https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js';
         document.head.append(script);
         script.addEventListener('load', resolve);
         script.addEventListener('error', reject);

--- a/examples/resources/mapbox-streets-v6-style.js
+++ b/examples/resources/mapbox-streets-v6-style.js
@@ -15,7 +15,7 @@ function createMapboxStreetsV6Style(Style, Fill, Stroke, Icon, Text) {
     var icon = iconCache[iconName];
     if (!icon) {
       icon = new Style({image: new Icon({
-        src: 'https://unpkg.com/@mapbox/maki@4.0.0/icons/' + iconName + '-15.svg',
+        src: 'https://cdn.jsdelivr.net/npm/@mapbox/maki@4.0.0/icons/' + iconName + '-15.svg',
         imgSize: [15, 15],
         crossOrigin: 'anonymous'
       })});

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -144,7 +144,7 @@
   &lt;/head&gt;
   &lt;body&gt;
 {{ indent contents spaces=4 }}    &lt;!-- Pointer events polyfill for old browsers, see https://caniuse.com/#feat=pointer --&gt;
-    &lt;script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;
+    &lt;script src="https://cdn.jsdelivr.net/npm/elm-pep@1.0.6/dist/elm-pep.js"&gt;&lt;/script&gt;
 {{#each js.remote}}
     &lt;script src="{{ . }}"&gt;&lt;/script&gt;
 {{/each}}
@@ -165,7 +165,7 @@
       </div>
     </div>
 
-    <script src="https://unpkg.com/elm-pep@1.0.6/dist/elm-pep.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/elm-pep@1.0.6/dist/elm-pep.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"></script>
 {{#each js.local}}
     <script src="{{{ . }}}"></script>

--- a/examples/topolis.html
+++ b/examples/topolis.html
@@ -7,7 +7,7 @@ docs: >
   with OpenLayers, enabling creating and editing topological geometry. Standard interaction draws edges, snapping to existing edges. Delete an edge by drawing a new edge crossing the one to delete.
 tags: "draw, edit, vector, topology, topolis"
 resources:
-  - https://unpkg.com/topolis@0.2.5/dist/topolis.js
+  - https://cdn.jsdelivr.net/npm/topolis@0.2.5/dist/topolis.js
   - https://code.jquery.com/jquery-3.6.0.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.min.js
   - https://cdnjs.cloudflare.com/ajax/libs/toastr.js/2.1.3/toastr.min.css


### PR DESCRIPTION
Yesterday, when I noticed an outage of unpkg.com, I decided to switch the URLs for external packages from unpkg to jsdelivr.