### PR TITLE
Set willReadFrequently option on `ol/source/Raster` shared context

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -924,11 +924,15 @@ function getImageData(layer, frameState) {
   }
 
   if (!sharedContext) {
-    sharedContext = createCanvasContext2D(width, height);
+    sharedContext = createCanvasContext2D(width, height, undefined, {
+      willReadFrequently: true,
+    });
   } else {
     const canvas = sharedContext.canvas;
     if (canvas.width !== width || canvas.height !== height) {
-      sharedContext = createCanvasContext2D(width, height);
+      sharedContext = createCanvasContext2D(width, height, undefined, {
+        willReadFrequently: true,
+      });
     } else {
       sharedContext.clearRect(0, 0, width, height);
     }


### PR DESCRIPTION
This prevents the `willReadFrequently` Chrome warning in `ol/source/Raster` when a WebGL layer canvas is drawn to a 2d canvas before the ImageData is obtained.  The same context can also be used to resize a 2d canvas, but as `ol/source/Raster` uses a pixel ratio of 1 that is unlikely.

The overhead of drawing a 2d canvas to another canvas of the same size outweighs the advantage of using `willReadFrequently` so the warning will continue to be seen in that situation (`willReadFrequently` cannot be changed after a context is created).
