### PR TITLE
Pass transition option along to reproj data tile

### DIFF
--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -191,12 +191,12 @@ class DataTileSource extends TileSource {
    * @param {number} z Tile coordinate z.
    * @param {number} x Tile coordinate x.
    * @param {number} y Tile coordinate y.
-   * @param {import("../proj/Projection.js").default} targetProjection The output projection.
-   * @param {import("../proj/Projection.js").default} sourceProjection The input projection.
+   * @param {import("../proj/Projection.js").default} targetProj The output projection.
+   * @param {import("../proj/Projection.js").default} sourceProj The input projection.
    * @return {!DataTile} Tile.
    */
-  getReprojTile_(z, x, y, targetProjection, sourceProjection) {
-    const cache = this.getTileCacheForProjection(targetProjection);
+  getReprojTile_(z, x, y, targetProj, sourceProj) {
+    const cache = this.getTileCacheForProjection(targetProj);
     const tileCoordKey = getKeyZXY(z, x, y);
     if (cache.containsKey(tileCoordKey)) {
       const tile = cache.get(tileCoordKey);
@@ -218,26 +218,30 @@ class DataTileSource extends TileSource {
       })
     );
 
-    const sourceTileGrid = this.getTileGridForProjection(sourceProjection);
-    const targetTileGrid = this.getTileGridForProjection(targetProjection);
+    const sourceTileGrid = this.getTileGridForProjection(sourceProj);
+    const targetTileGrid = this.getTileGridForProjection(targetProj);
     const tileCoord = [z, x, y];
     const wrappedTileCoord = this.getTileCoordForTileUrlFunction(
       tileCoord,
-      targetProjection
+      targetProj
     );
-    const newTile = new ReprojDataTile(
-      sourceProjection,
-      sourceTileGrid,
-      targetProjection,
-      targetTileGrid,
-      tileCoord,
-      wrappedTileCoord,
-      reprojTilePixelRatio,
-      this.getGutterForProjection(sourceProjection),
-      (z, x, y, pixelRatio) =>
-        this.getTile(z, x, y, pixelRatio, sourceProjection),
-      this.getInterpolate()
+
+    const options = Object.assign(
+      {
+        sourceProj,
+        sourceTileGrid,
+        targetProj,
+        targetTileGrid,
+        tileCoord,
+        wrappedTileCoord,
+        pixelRatio: reprojTilePixelRatio,
+        gutter: this.getGutterForProjection(sourceProj),
+        getTileFunction: (z, x, y, pixelRatio) =>
+          this.getTile(z, x, y, pixelRatio, sourceProj),
+      },
+      this.tileOptions
     );
+    const newTile = new ReprojDataTile(options);
     newTile.key = this.getKey();
     return newTile;
   }

--- a/test/browser/spec/ol/reproj/DataTile.test.js
+++ b/test/browser/spec/ol/reproj/DataTile.test.js
@@ -1,5 +1,6 @@
 import DataTileSource from '../../../../../src/ol/source/DataTile.js';
 import Map from '../../../../../src/ol/Map.js';
+import ReprojDataTile from '../../../../../src/ol/reproj/DataTile.js';
 import View from '../../../../../src/ol/View.js';
 import WebGLTileLayer from '../../../../../src/ol/layer/WebGLTile.js';
 import {
@@ -9,7 +10,7 @@ import {
   transform,
   transformExtent,
 } from '../../../../../src/ol/proj.js';
-import {createXYZ} from '../../../../../src/ol/tilegrid.js';
+import {createXYZ, getForProjection} from '../../../../../src/ol/tilegrid.js';
 import {register} from '../../../../../src/ol/proj/proj4.js';
 
 describe('ol/reproj/DataTile', () => {
@@ -46,13 +47,49 @@ describe('ol/reproj/DataTile', () => {
   });
 
   afterEach(() => {
-    map.setTarget(null);
-    mapR.setTarget(null);
+    if (map) {
+      map.setTarget(null);
+    }
+    if (mapR) {
+      mapR.setTarget(null);
+    }
     document.body.removeChild(target);
     document.body.removeChild(targetR);
     delete proj4.defs['EPSG:27700'];
     clearAllProjections();
     addCommon();
+  });
+
+  it('accepts a transition option', () => {
+    const sourceProj = getProjection('EPSG:4326');
+    const targetProj = getProjection('EPSG:3857');
+
+    /**
+     * @type {import("../../../../../src/ol/reproj/DataTile.js").Options}
+     */
+    const options = {
+      sourceProj,
+      sourceTileGrid: getForProjection(sourceProj),
+      targetProj,
+      targetTileGrid: getForProjection(targetProj),
+      tileCoord: [0, 0, 0],
+      pixelRatio: 1,
+      gutter: 0,
+      getTileFunction: (z, x, y, pixelRatio) => null,
+    };
+
+    const withTransition = new ReprojDataTile({
+      ...options,
+      transition: 42,
+    });
+
+    const withoutTransition = new ReprojDataTile({
+      ...options,
+      transition: 0,
+    });
+
+    expect(withTransition.getAlpha('test', 0)).to.be.lessThan(1);
+    expect(withoutTransition.getAlpha('test', 0)).to.be(1);
   });
 
   it('pixel data reprojected from EPSG:4326 to EPSG:3857 exactly matches original', (done) => {

--- a/test/rendering/cases/cog-f32-nodata-explicit-nan/main.js
+++ b/test/rendering/cases/cog-f32-nodata-explicit-nan/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   sources: [{url: '/data/raster/elevation-f32.tif', nodata: NaN}],
 });
 

--- a/test/rendering/cases/cog-f32-nodata/main.js
+++ b/test/rendering/cases/cog-f32-nodata/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   sources: [{url: '/data/raster/elevation-f32.tif'}],
 });
 

--- a/test/rendering/cases/cog-i16-nodata/main.js
+++ b/test/rendering/cases/cog-i16-nodata/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   sources: [{url: '/data/raster/elevation-i16.tif'}],
 });
 

--- a/test/rendering/cases/cog-masked/main.js
+++ b/test/rendering/cases/cog-masked/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   convertToRGB: true,
   sources: [{url: '/data/raster/masked.tif'}],
 });

--- a/test/rendering/cases/cog-rgb-auto/main.js
+++ b/test/rendering/cases/cog-rgb-auto/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   convertToRGB: 'auto',
   sources: [{url: '/data/raster/masked.tif'}],
 });

--- a/test/rendering/cases/cog-rgb-no-auto/main.js
+++ b/test/rendering/cases/cog-rgb-no-auto/main.js
@@ -3,6 +3,7 @@ import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   convertToRGB: false,
   sources: [{url: '/data/raster/masked.tif'}],
 });

--- a/test/rendering/cases/webgl-reproj-float/main.js
+++ b/test/rendering/cases/webgl-reproj-float/main.js
@@ -4,6 +4,7 @@ import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 import View from '../../../../src/ol/View.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   convertToRGB: true,
   normalize: false,
   sources: [

--- a/test/rendering/cases/webgl-reproj/main.js
+++ b/test/rendering/cases/webgl-reproj/main.js
@@ -4,6 +4,7 @@ import TileLayer from '../../../../src/ol/layer/WebGLTile.js';
 import View from '../../../../src/ol/View.js';
 
 const source = new GeoTIFF({
+  transition: 0,
   convertToRGB: true,
   sources: [{url: '/data/raster/non-square-pixels.tif'}],
 });


### PR DESCRIPTION
This makes it so reprojected data tiles respect the `transition` option passed to a source.