### PR TITLE
Add wrapX support to the MousePosition control

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,14 @@
 ## Upgrade notes
 
+### Next version
+
+#### Fixed `wrapX` behavior of `ol/control/MousePosition`
+
+Previously, `ol/control/MousePosition` always displayed coordinates as-is. Now it has a `wrapX` option,
+which is `true` by default. This avoids longitudes aoutside the -180 to 180 degrees range.
+
+If you want the previous behavior, which displays coordinates with longitudes less than -180 or greater than 180, configure the control with `wrapX: false`.
+
 ### 7.1.0
 
 #### Notice to full build users

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -138,7 +138,7 @@ class MousePosition extends Control {
      * @private
      * @type {boolean}
      */
-    this.wrapX_ = options.wrapX;
+    this.wrapX_ = options.wrapX === false ? false : true;
   }
 
   /**

--- a/src/ol/control/MousePosition.js
+++ b/src/ol/control/MousePosition.js
@@ -11,6 +11,7 @@ import {
   identityTransform,
 } from '../proj.js';
 import {listen} from '../events.js';
+import {wrapX} from '../coordinate.js';
 
 /**
  * @type {string}
@@ -46,6 +47,8 @@ const COORDINATE_FORMAT = 'coordinateFormat';
  * initially and the last position is retained when the mouse leaves the viewport.
  * When a string is provided (e.g. `'no position'` or `''` for an empty string) it is used as a
  * placeholder.
+ * @property {boolean} [wrapX=true] Wrap the world horizontally on the projection's antimeridian, if it
+ * is a global projection.
  */
 
 /**
@@ -130,6 +133,12 @@ class MousePosition extends Control {
      * @type {?import("../proj.js").TransformFunction}
      */
     this.transform_ = null;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.wrapX_ = options.wrapX;
   }
 
   /**
@@ -258,6 +267,11 @@ class MousePosition extends Control {
           );
         }
         this.transform_(coordinate, coordinate);
+        if (this.wrapX_) {
+          const projection =
+            userProjection || this.getProjection() || this.mapProjection_;
+          wrapX(coordinate, projection);
+        }
         const coordinateFormat = this.getCoordinateFormat();
         if (coordinateFormat) {
           html = coordinateFormat(coordinate);

--- a/test/browser/spec/ol/control/mouseposition.test.js
+++ b/test/browser/spec/ol/control/mouseposition.test.js
@@ -2,6 +2,11 @@ import EventType from '../../../../../src/ol/pointer/EventType.js';
 import Map from '../../../../../src/ol/Map.js';
 import MousePosition from '../../../../../src/ol/control/MousePosition.js';
 import View from '../../../../../src/ol/View.js';
+import {
+  clearUserProjection,
+  fromLonLat,
+  useGeographic,
+} from '../../../../../src/ol/proj.js';
 
 describe('ol/control/MousePosition', function () {
   describe('constructor', function () {
@@ -46,6 +51,7 @@ describe('ol/control/MousePosition', function () {
       });
     });
     afterEach(function () {
+      clearUserProjection();
       map.dispose();
       document.body.removeChild(target);
     });
@@ -118,6 +124,45 @@ describe('ol/control/MousePosition', function () {
         simulateEvent(EventType.POINTEROUT, width + 1, height + 1);
         expect(element.innerHTML).to.be('');
       });
+    });
+
+    it('does not wrapX by default', function () {
+      const ctrl = new MousePosition();
+      ctrl.setMap(map);
+      map.getView().setCenter([-360, 0]);
+      map.renderSync();
+      simulateEvent(EventType.POINTERMOVE, 0, 0);
+      expect(ctrl.element.innerHTML).to.be('-360,0');
+    });
+
+    it('can wrapX', function () {
+      const ctrl = new MousePosition({wrapX: true});
+      ctrl.setMap(map);
+      map.getView().setCenter([-360, 0]);
+      map.renderSync();
+      simulateEvent(EventType.POINTERMOVE, 0, 0);
+      expect(ctrl.element.innerHTML).to.be('0,0');
+    });
+
+    it('can wrapX with projection', function () {
+      const ctrl = new MousePosition({wrapX: true, projection: 'EPSG:4326'});
+      map.setView(new View({resolution: 1}));
+      ctrl.setMap(map);
+      map.getView().setCenter(fromLonLat([-360, 0]));
+      map.renderSync();
+      simulateEvent(EventType.POINTERMOVE, 0, 0);
+      expect(ctrl.element.innerHTML).to.be('0,0');
+    });
+
+    it('can wrapX with user projection', function () {
+      useGeographic();
+      const ctrl = new MousePosition({wrapX: true, projection: 'EPSG:4326'});
+      map.setView(new View({resolution: 1}));
+      ctrl.setMap(map);
+      map.getView().setCenter([-360, 0]);
+      map.renderSync();
+      simulateEvent(EventType.POINTERMOVE, 0, 0);
+      expect(ctrl.element.innerHTML).to.be('0,0');
     });
   });
 });

--- a/test/browser/spec/ol/control/mouseposition.test.js
+++ b/test/browser/spec/ol/control/mouseposition.test.js
@@ -126,8 +126,8 @@ describe('ol/control/MousePosition', function () {
       });
     });
 
-    it('does not wrapX by default', function () {
-      const ctrl = new MousePosition();
+    it('can opt out of wrapX', function () {
+      const ctrl = new MousePosition({wrapX: false});
       ctrl.setMap(map);
       map.getView().setCenter([-360, 0]);
       map.renderSync();
@@ -136,7 +136,7 @@ describe('ol/control/MousePosition', function () {
     });
 
     it('can wrapX', function () {
-      const ctrl = new MousePosition({wrapX: true});
+      const ctrl = new MousePosition();
       ctrl.setMap(map);
       map.getView().setCenter([-360, 0]);
       map.renderSync();
@@ -145,7 +145,7 @@ describe('ol/control/MousePosition', function () {
     });
 
     it('can wrapX with projection', function () {
-      const ctrl = new MousePosition({wrapX: true, projection: 'EPSG:4326'});
+      const ctrl = new MousePosition({projection: 'EPSG:4326'});
       map.setView(new View({resolution: 1}));
       ctrl.setMap(map);
       map.getView().setCenter(fromLonLat([-360, 0]));
@@ -156,7 +156,7 @@ describe('ol/control/MousePosition', function () {
 
     it('can wrapX with user projection', function () {
       useGeographic();
-      const ctrl = new MousePosition({wrapX: true, projection: 'EPSG:4326'});
+      const ctrl = new MousePosition({projection: 'EPSG:4326'});
       map.setView(new View({resolution: 1}));
       ctrl.setMap(map);
       map.getView().setCenter([-360, 0]);


### PR DESCRIPTION
This pull request adds convenience for those who want to display coordinates in the expected range of the projection for global projections:
```js
new MousePosition({wrapX: true});
```

Fixes #3899
Fixes #14231