### PR TITLE
Change loading spinner to use map viewport.

### DIFF
--- a/examples/load-events.css
+++ b/examples/load-events.css
@@ -1,10 +1,8 @@
 .map {
   background: #85ccf9;
-  position: relative;
 }
 #map {
   height: 400px;
-  position: relative;
 }
 
 @keyframes spinner {

--- a/examples/load-events.js
+++ b/examples/load-events.js
@@ -24,8 +24,8 @@ const map = new Map({
 });
 
 map.on('loadstart', function () {
-  map.getTargetElement().classList.add('spinner');
+  map.getViewport().classList.add('spinner');
 });
 map.on('loadend', function () {
-  map.getTargetElement().classList.remove('spinner');
+  map.getViewport().classList.remove('spinner');
 });


### PR DESCRIPTION
Just a little improvement to the load-events example. Because the map viewport is already positioned relative to the map wrapper implementing code should not need to change the positioning of their wrapper. This makes it easier to implement the loading spinner from this example.

The `position: relative;` is required so that the spinner displays in the center of the map. Otherwise if the map wrapper is not `position: relative;` then the spinner will always be in the middle of the browser window, not necessarily the center of the map.

Although this does work, I'm curious, are there any downsides to using the map viewport for this?
