### PR TITLE
Update COG path

### DIFF
--- a/examples/cog.js
+++ b/examples/cog.js
@@ -5,7 +5,7 @@ import TileLayer from '../src/ol/layer/WebGLTile.js';
 const source = new GeoTIFF({
   sources: [
     {
-      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/TCI.tif',
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/TCI.tif',
     },
   ],
 });


### PR DESCRIPTION
Fixes #14234

The `TCI` file seems unavailable via the `/2020/` path but is available via the `/36/Q/WD/2020/7/` path.
https://deploy-preview-14236--ol-site.netlify.app/en/latest/examples/cog.html

(The corresponding `B04` and `B08` files used in other examples continue to be available via the shorter path).
