### PR TITLE
Use wkt definitions in EPSG.io Search example

### DIFF
--- a/examples/reprojection-by-code.js
+++ b/examples/reprojection-by-code.js
@@ -107,7 +107,7 @@ function search(query) {
           if (result) {
             const code = result['code'];
             const name = result['name'];
-            const proj4def = result['proj4'];
+            const proj4def = result['wkt'];
             const bbox = result['bbox'];
             if (
               code &&


### PR DESCRIPTION
Fixes #14235

It seems impractical to download large grid shift files on demand, in a real application these would be preloaded, so for the purposes of the example use the wkt definition which contains datum and works with proj4..