### PR TITLE
Hitdetect tolerance for WebGLPoints layer

### DIFF
--- a/src/ol/renderer/Map.js
+++ b/src/ol/renderer/Map.js
@@ -164,9 +164,7 @@ class MapRenderer extends Disposable {
     const order = 1 / matches.length;
     matches.forEach((m, i) => (m.distanceSq += i * order));
     matches.sort((a, b) => a.distanceSq - b.distanceSq);
-    matches.some((m) => {
-      return (result = m.callback(m.feature, m.layer, m.geometry));
-    });
+    matches.some((m) => (result = m.callback(m.feature, m.layer, m.geometry)));
     return result;
   }
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -693,7 +693,10 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       coordinate.slice()
     );
 
-    const data = this.hitRenderTarget_.readPixel(pixel[0] / 2, pixel[1] / 2);
+    const data = this.hitRenderTarget_.readPixel(
+      Math.round(pixel[0]) / 2,
+      Math.round(pixel[1]) / 2
+    );
     const color = [data[0] / 255, data[1] / 255, data[2] / 255, data[3] / 255];
     const index = colorDecodeId(color);
     const opacity = this.hitRenderInstructions_[index];
@@ -723,8 +726,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     let world = startWorld;
 
     this.hitRenderTarget_.setSize([
-      Math.floor(frameState.size[0] / 2),
-      Math.floor(frameState.size[1] / 2),
+      Math.ceil(frameState.size[0] / 2),
+      Math.ceil(frameState.size[1] / 2),
     ]);
 
     this.helper.useProgram(this.hitProgram_, frameState);

--- a/src/ol/webgl/RenderTarget.js
+++ b/src/ol/webgl/RenderTarget.js
@@ -129,7 +129,9 @@ class WebGLRenderTarget {
    * @api
    */
   readPixel(x, y) {
-    if (x < 0 || y < 0 || x > this.size_[0] || y >= this.size_[1]) {
+    x = Math.floor(x);
+    y = Math.floor(y);
+    if (x < 0 || y < 0 || x >= this.size_[0] || y >= this.size_[1]) {
       tmpArray4[0] = 0;
       tmpArray4[1] = 0;
       tmpArray4[2] = 0;
@@ -138,8 +140,7 @@ class WebGLRenderTarget {
     }
 
     this.readAll();
-    const index =
-      Math.floor(x) + (this.size_[1] - Math.floor(y) - 1) * this.size_[0];
+    const index = x + (this.size_[1] - y - 1) * this.size_[0];
     tmpArray4[0] = this.data_[index * 4];
     tmpArray4[1] = this.data_[index * 4 + 1];
     tmpArray4[2] = this.data_[index * 4 + 2];

--- a/test/browser/spec/ol/webgl/rendertarget.test.js
+++ b/test/browser/spec/ol/webgl/rendertarget.test.js
@@ -2,7 +2,10 @@ import WebGLHelper from '../../../../../src/ol/webgl/Helper.js';
 import WebGLRenderTarget from '../../../../../src/ol/webgl/RenderTarget.js';
 
 describe('ol.webgl.RenderTarget', function () {
-  let helper, testImage_4x4;
+  /** @type {WebGLHelper} */
+  let helper;
+  /** @type {ImageData} */
+  let testImage_4x4;
 
   beforeEach(function () {
     helper = new WebGLHelper();
@@ -129,13 +132,22 @@ describe('ol.webgl.RenderTarget', function () {
       data = rt.readPixel(3, -1);
       expect(data).to.eql([0, 0, 0, 0]);
 
-      data = rt.readPixel(6, 2);
+      data = rt.readPixel(4, 2);
       expect(data).to.eql([0, 0, 0, 0]);
 
-      data = rt.readPixel(2, 7);
+      data = rt.readPixel(2, 4);
       expect(data).to.eql([0, 0, 0, 0]);
+
+      data = rt.readPixel(0, 0);
+      expect(data).not.to.eql([0, 0, 0, 0]);
 
       data = rt.readPixel(2, 3);
+      expect(data).not.to.eql([0, 0, 0, 0]);
+
+      data = rt.readPixel(1, 3.5);
+      expect(data).not.to.eql([0, 0, 0, 0]);
+
+      data = rt.readPixel(3.5, 1);
       expect(data).not.to.eql([0, 0, 0, 0]);
     });
   });


### PR DESCRIPTION
Fixes #14154

This implements hit-tolerance for the WebGLPoints layer. It will still only find maximum one feature.
Finding more than one feature would work with hit-tolerance enabled, but it would only find some features when they are overlapping.

