### PR TITLE
Update ArcGIS MapServer examples service url

### DIFF
--- a/examples/arcgis-image.js
+++ b/examples/arcgis-image.js
@@ -4,8 +4,8 @@ import {ImageArcGISRest, OSM} from '../src/ol/source.js';
 import {Image as ImageLayer, Tile as TileLayer} from '../src/ol/layer.js';
 
 const url =
-  'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/' +
-  'Specialty/ESRI_StateCityHighway_USA/MapServer';
+  'https://sampleserver6.arcgisonline.com/ArcGIS/rest/services/' +
+  'USA/MapServer';
 
 const layers = [
   new TileLayer({

--- a/examples/arcgis-tiled.js
+++ b/examples/arcgis-tiled.js
@@ -4,8 +4,8 @@ import View from '../src/ol/View.js';
 import {OSM, TileArcGISRest} from '../src/ol/source.js';
 
 const url =
-  'https://sampleserver1.arcgisonline.com/ArcGIS/rest/services/' +
-  'Specialty/ESRI_StateCityHighway_USA/MapServer';
+  'https://sampleserver6.arcgisonline.com/ArcGIS/rest/services/' +
+  'USA/MapServer';
 
 const layers = [
   new TileLayer({


### PR DESCRIPTION
Esri's sampleserver1 is no longer accessible https://community.esri.com/t5/arcgis-api-for-javascript-questions/sampleserver1-arcgisonline-com-returning-503s/m-p/1200099  There is a similar service available on sampleserver6.