### PR TITLE
Update more COG paths

### DIFF
--- a/examples/cog-colors.js
+++ b/examples/cog-colors.js
@@ -68,12 +68,12 @@ const source = new GeoTIFF({
   sources: [
     {
       // visible red, band 1 in the style expression above
-      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B04.tif',
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/B04.tif',
       max: 10000,
     },
     {
       // near infrared, band 2 in the style expression above
-      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B08.tif',
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/B08.tif',
       max: 10000,
     },
   ],

--- a/examples/cog-math.js
+++ b/examples/cog-math.js
@@ -6,12 +6,12 @@ const source = new GeoTIFF({
   sources: [
     {
       // visible red, band 1 in the style expression above
-      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B04.tif',
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/B04.tif',
       max: 10000,
     },
     {
       // near infrared, band 2 in the style expression above
-      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36QWD_20200701_0_L2A/B08.tif',
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/B08.tif',
       max: 10000,
     },
   ],


### PR DESCRIPTION
The `B04` and `B08` file short paths which were still working in #14236 are no longer working, but can be accessed using the same path as needed by the `TCI` file.
