### PR TITLE
Add a PMTiles example

### DIFF
--- a/examples/pmtiles-elevation.css
+++ b/examples/pmtiles-elevation.css
@@ -1,0 +1,7 @@
+table.controls td {
+  padding: 2px 5px;
+}
+table.controls td:nth-child(3) {
+  text-align: right;
+  min-width: 3em;
+}

--- a/examples/pmtiles-elevation.html
+++ b/examples/pmtiles-elevation.html
@@ -1,0 +1,37 @@
+---
+layout: example.html
+title: PMTiles Shaded Relief
+shortdesc: Elevation data from PMTiles.
+docs: >
+  This example shows a shaded relief rendering of elevation data from
+  a [PMTiles](https://github.com/protomaps/PMTiles) source.
+resources:
+  - https://unpkg.com/pmtiles@2.4.0/dist/index.js
+tags: "pmtiles, elevation, data tiles"
+---
+<div id="map" class="map"></div>
+<table class="controls">
+  <tr>
+    <td>elevation</td>
+    <td colspan="2" id="elevationOut"></td>
+  </tr>
+  <tr>
+    <td>location</td>
+    <td colspan="2" id="locationOut"></td>
+  </tr>
+  <tr>
+    <td><label for="vert">vertical exaggeration:</label></td>
+    <td><input id="vert" type="range" min="5" max="50" value="10"/></td>
+    <td><span id="vertOut"></span> x</td>
+  </tr>
+  <tr>
+    <td><label for="sunEl">sun elevation:</label></td>
+    <td><input id="sunEl" type="range" min="0" max="90" value="45"/></td>
+    <td><span id="sunElOut"></span> °</td>
+  </tr>
+  <tr>
+    <td><label for="sunAz">sun azimuth:</label></td>
+    <td><input id="sunAz" type="range" min="0" max="360" value="45"/></td>
+    <td><span id="sunAzOut"></span> °</td>
+  </tr>
+</table>

--- a/examples/pmtiles-elevation.js
+++ b/examples/pmtiles-elevation.js
@@ -1,0 +1,132 @@
+/* global pmtiles */
+import DataTile from '../src/ol/source/DataTile.js';
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+import {useGeographic} from '../src/ol/proj.js';
+
+useGeographic();
+
+const tiles = new pmtiles.PMTiles(
+  'https://pub-9288c68512ed46eca46ddcade307709b.r2.dev/protomaps-sample-datasets/terrarium_z9.pmtiles'
+);
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener('load', () => resolve(img));
+    img.addEventListener('error', () => reject(new Error('load failed')));
+    img.src = src;
+  });
+}
+
+const size = 256;
+const canvas = document.createElement('canvas');
+canvas.width = size;
+canvas.height = size;
+const context = canvas.getContext('2d', {willReadFrequently: true});
+
+async function loader(z, x, y) {
+  const response = await tiles.getZxy(z, x, y);
+  const blob = new Blob([response.data]);
+  const src = URL.createObjectURL(blob);
+  const img = await loadImage(src);
+  context.drawImage(img, 0, 0);
+  URL.revokeObjectURL(src);
+  return context.getImageData(0, 0, size, size).data;
+}
+
+// The method used to extract elevations from the DEM.
+function elevation(xOffset, yOffset) {
+  const red = ['band', 1, xOffset, yOffset];
+  const green = ['band', 2, xOffset, yOffset];
+  const blue = ['band', 3, xOffset, yOffset];
+  return ['-', ['+', ['*', 256 * 256, red], ['*', 256, green], blue], 32768];
+}
+
+// Generates a shaded relief image given elevation data.  Uses a 3x3
+// neighborhood for determining slope and aspect.
+const dp = ['*', 2, ['resolution']];
+const z0x = ['*', ['var', 'vert'], elevation(-1, 0)];
+const z1x = ['*', ['var', 'vert'], elevation(1, 0)];
+const dzdx = ['/', ['-', z1x, z0x], dp];
+const z0y = ['*', ['var', 'vert'], elevation(0, -1)];
+const z1y = ['*', ['var', 'vert'], elevation(0, 1)];
+const dzdy = ['/', ['-', z1y, z0y], dp];
+const slope = ['atan', ['^', ['+', ['^', dzdx, 2], ['^', dzdy, 2]], 0.5]];
+const aspect = ['clamp', ['atan', ['-', 0, dzdx], dzdy], -Math.PI, Math.PI];
+const sunEl = ['*', Math.PI / 180, ['var', 'sunEl']];
+const sunAz = ['*', Math.PI / 180, ['var', 'sunAz']];
+
+const incidence = [
+  '+',
+  ['*', ['sin', sunEl], ['cos', slope]],
+  ['*', ['*', ['cos', sunEl], ['sin', slope]], ['cos', ['-', sunAz, aspect]]],
+];
+
+const variables = {};
+
+const layer = new TileLayer({
+  source: new DataTile({
+    loader,
+    wrapX: true,
+    maxZoom: 9,
+    attributions:
+      "<a href='https://github.com/tilezen/joerd/blob/master/docs/attribution.md#attribution'>Tilezen Jörð</a>",
+  }),
+  style: {
+    variables: variables,
+    color: ['array', incidence, incidence, incidence, 1],
+  },
+});
+
+const controlIds = ['vert', 'sunEl', 'sunAz'];
+controlIds.forEach(function (id) {
+  const control = document.getElementById(id);
+  const output = document.getElementById(id + 'Out');
+  function updateValues() {
+    output.innerText = control.value;
+    variables[id] = Number(control.value);
+  }
+  updateValues();
+  control.addEventListener('input', function () {
+    updateValues();
+    layer.updateStyleVariables(variables);
+  });
+});
+
+const map = new Map({
+  target: 'map',
+  layers: [layer],
+  view: new View({
+    center: [0, 0],
+    zoom: 1,
+  }),
+});
+
+function getElevation(data) {
+  const red = data[0];
+  const green = data[1];
+  const blue = data[2];
+  return red * 256 + green + blue / 256 - 32768;
+}
+
+function formatLocation([lon, lat]) {
+  const NS = lat < 0 ? 'S' : 'N';
+  const EW = lon < 0 ? 'W' : 'E';
+  return `${Math.abs(lat).toFixed(1)}° ${NS}, ${Math.abs(lon).toFixed(
+    1
+  )}° ${EW}`;
+}
+
+const elevationOut = document.getElementById('elevationOut');
+const locationOut = document.getElementById('locationOut');
+function displayPixelValue(event) {
+  const data = layer.getData(event.pixel);
+  if (!data) {
+    return;
+  }
+  elevationOut.innerText = getElevation(data).toLocaleString() + ' m';
+  locationOut.innerText = formatLocation(event.coordinate);
+}
+map.on(['pointermove', 'click'], displayPixelValue);

--- a/examples/webgl-shaded-relief.js
+++ b/examples/webgl-shaded-relief.js
@@ -17,11 +17,8 @@ function elevation(xOffset, yOffset) {
   return [
     '+',
     ['*', 256, ['band', 1, xOffset, yOffset]],
-    [
-      '+',
-      ['*', 2 * 256, ['band', 2, xOffset, yOffset]],
-      ['*', 3 * 256, ['band', 3, xOffset, yOffset]],
-    ],
+    ['*', 2 * 256, ['band', 2, xOffset, yOffset]],
+    ['*', 3 * 256, ['band', 3, xOffset, yOffset]],
   ];
 }
 

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -566,12 +566,9 @@ Operators['*'] = {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
-    assertArgsCount(args, 2);
+    assertArgsMinCount(args, 2);
     assertNumbers(args);
-    return `(${expressionToGlsl(context, args[0])} * ${expressionToGlsl(
-      context,
-      args[1]
-    )})`;
+    return `(${args.map((arg) => expressionToGlsl(context, arg)).join(' * ')})`;
   },
 };
 
@@ -594,12 +591,10 @@ Operators['+'] = {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
-    assertArgsCount(args, 2);
+    assertArgsMinCount(args, 2);
     assertNumbers(args);
-    return `(${expressionToGlsl(context, args[0])} + ${expressionToGlsl(
-      context,
-      args[1]
-    )})`;
+
+    return `(${args.map((arg) => expressionToGlsl(context, arg)).join(' + ')})`;
   },
 };
 

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -220,6 +220,14 @@ describe('ol/style/expressions', function () {
       expect(expressionToGlsl(context, ['time'])).to.eql('u_time');
       expect(expressionToGlsl(context, ['zoom'])).to.eql('u_zoom');
       expect(expressionToGlsl(context, ['resolution'])).to.eql('u_resolution');
+
+      expect(expressionToGlsl(context, ['+', 1, 2, 3, 4])).to.eql(
+        '(1.0 + 2.0 + 3.0 + 4.0)'
+      );
+      expect(expressionToGlsl(context, ['*', 1, 2, 3, 4])).to.eql(
+        '(1.0 * 2.0 * 3.0 * 4.0)'
+      );
+
       expect(
         expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])
       ).to.eql('((a_size * 0.001) + 12.0)');


### PR DESCRIPTION
This adds an example inspired by the [PMTiles MapLibre example](https://protomaps.github.io/PMTiles/examples/maplibre_raster_dem.html).

https://deploy-preview-14256--ol-site.netlify.app/en/latest/examples/pmtiles-elevation.html

Since PMTiles [encodes its raster data](https://github.com/protomaps/PMTiles/blob/master/spec/v3/spec.md#header-design) as PNG, JPG, or WEBP, it makes more sense to use an image tile source rather than the data tile source, but I'm partial to the API of the data tile source.  So instead of hacking things together with a `tileUrlFunction` and a `tileLoadFunction`, I opted to go with a data source and hack my way to the typed arrays that we want via a canvas.

Ideally, an image source would accept a `loader` that was called with `z, x, y` and returned a promise for an image.  I'd like to add that as an option for the existing source, but it feels like it might be easier to start from scratch with a new image source.
