### PR TITLE
Add support for images in data tiles

### DIFF
--- a/examples/pmtiles-elevation.js
+++ b/examples/pmtiles-elevation.js
@@ -20,20 +20,13 @@ function loadImage(src) {
   });
 }
 
-const size = 256;
-const canvas = document.createElement('canvas');
-canvas.width = size;
-canvas.height = size;
-const context = canvas.getContext('2d', {willReadFrequently: true});
-
 async function loader(z, x, y) {
   const response = await tiles.getZxy(z, x, y);
   const blob = new Blob([response.data]);
   const src = URL.createObjectURL(blob);
-  const img = await loadImage(src);
-  context.drawImage(img, 0, 0);
+  const image = await loadImage(src);
   URL.revokeObjectURL(src);
-  return context.getImageData(0, 0, size, size).data;
+  return image;
 }
 
 // The method used to extract elevations from the DEM.

--- a/src/ol/DataTile.js
+++ b/src/ol/DataTile.js
@@ -3,17 +3,87 @@
  */
 import Tile from './Tile.js';
 import TileState from './TileState.js';
+import {createCanvasContext2D} from './dom.js';
 
 /**
- * Data that can be used with a DataTile.  For increased browser compatibility, use
- * Uint8Array instead of Uint8ClampedArray where possible.
- * @typedef {Uint8Array|Uint8ClampedArray|Float32Array|DataView} Data
+ * @typedef {HTMLImageElement|HTMLCanvasElement|HTMLVideoElement} ImageLike
  */
+
+/**
+ * @typedef {Uint8Array|Uint8ClampedArray|Float32Array|DataView} ArrayLike
+ */
+
+/**
+ * Data that can be used with a DataTile.
+ * @typedef {ArrayLike|ImageLike} Data
+ */
+
+/**
+ * @param {Data} data Tile data.
+ * @return {ImageLike|null} The image-like data.
+ */
+export function asImageLike(data) {
+  return data instanceof Image ||
+    data instanceof HTMLCanvasElement ||
+    data instanceof HTMLVideoElement
+    ? data
+    : null;
+}
+
+/**
+ * @param {Data} data Tile data.
+ * @return {ArrayLike|null} The array-like data.
+ */
+export function asArrayLike(data) {
+  return data instanceof Uint8Array ||
+    data instanceof Uint8ClampedArray ||
+    data instanceof Float32Array ||
+    data instanceof DataView
+    ? data
+    : null;
+}
+
+/**
+ * @type {CanvasRenderingContext2D|null}
+ */
+let sharedContext = null;
+
+/**
+ * @param {ImageLike} image The image.
+ * @return {Uint8ClampedArray} The data.
+ */
+export function toArray(image) {
+  if (!sharedContext) {
+    sharedContext = createCanvasContext2D(
+      image.width,
+      image.height,
+      undefined,
+      {willReadFrequently: true}
+    );
+  }
+  const canvas = sharedContext.canvas;
+  const width = image.width;
+  if (canvas.width !== width) {
+    canvas.width = width;
+  }
+  const height = image.height;
+  if (canvas.height !== height) {
+    canvas.height = height;
+  }
+  sharedContext.drawImage(image, width, height);
+  return sharedContext.getImageData(0, 0, width, height).data;
+}
+
+/**
+ * @type {import('./size.js').Size}
+ */
+const defaultSize = [256, 256];
 
 /**
  * @typedef {Object} Options
  * @property {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
- * @property {function(): Promise<Data>} loader Data loader.
+ * @property {function(): Promise<Data>} loader Data loader.  For loaders that generate images,
+ * the promise should not resolve until the image is loaded.
  * @property {number} [transition=250] A duration for tile opacity
  * transitions in milliseconds. A duration of 0 disables the opacity transition.
  * @property {boolean} [interpolate=false] Use interpolated values when resampling.  By default,
@@ -53,10 +123,10 @@ class DataTile extends Tile {
     this.error_ = null;
 
     /**
-     * @type {import('./size.js').Size}
+     * @type {import('./size.js').Size|null}
      * @private
      */
-    this.size_ = options.size || [256, 256];
+    this.size_ = options.size || null;
   }
 
   /**
@@ -64,7 +134,14 @@ class DataTile extends Tile {
    * @return {import('./size.js').Size} Tile size.
    */
   getSize() {
-    return this.size_;
+    if (this.size_) {
+      return this.size_;
+    }
+    const imageData = asImageLike(this.data_);
+    if (imageData) {
+      return [imageData.width, imageData.height];
+    }
+    return defaultSize;
   }
 
   /**

--- a/src/ol/reproj/DataTile.js
+++ b/src/ol/reproj/DataTile.js
@@ -3,7 +3,7 @@
  */
 import {ERROR_THRESHOLD} from './common.js';
 
-import DataTile from '../DataTile.js';
+import DataTile, {asArrayLike, asImageLike, toArray} from '../DataTile.js';
 import EventType from '../events/EventType.js';
 import TileState from '../TileState.js';
 import Triangulation from './Triangulation.js';
@@ -271,7 +271,16 @@ class ReprojDataTile extends DataTile {
       }
       const size = tile.getSize();
       const gutter = this.gutter_;
-      const tileData = tile.getData();
+      /**
+       * @type {import("../DataTile.js").ArrayLike}
+       */
+      let tileData;
+      const arrayData = asArrayLike(tile.getData());
+      if (arrayData) {
+        tileData = arrayData;
+      } else {
+        tileData = toArray(asImageLike(tile.getData()));
+      }
       const pixelSize = [size[0] + 2 * gutter, size[1] + 2 * gutter];
       const isFloat = tileData instanceof Float32Array;
       const pixelCount = pixelSize[0] * pixelSize[1];

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -29,6 +29,7 @@ import {toSize} from '../size.js';
  * @typedef {Object} Options
  * @property {Loader} [loader] Data loader.  Called with z, x, and y tile coordinates.
  * Returns {@link import("../DataTile.js").Data data} for a tile or a promise for the same.
+ * For loaders that generate images, the promise should not resolve until the image is loaded.
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [maxZoom=42] Optional max zoom level. Not used if `tileGrid` is provided.


### PR DESCRIPTION
This makes it so data tiles can contain image data in addition to array data.

Adding support for images in data tiles makes sense as part of a larger plan to render all raster tiles with the WebGL tile renderer.  The plan could look something like this:
 1. Add support for images in data tiles (this branch).
 2. Add a new `ImageTile` (or similarly named) source that extends the `DataTile` source.  This would take a `url` option that would be a convenience for constructing a `loader`.  The `url` could be `string|Array<string>|function(number, number, number):string` (the function form would return a url given z, x, and y tile coordinates.  Deprecate the (canvas) tile layer, the `TileImage` source, and lots of other things.
 3. In a major release, rename the `WebGLTile` layer to `Tile` and remove all the deprecated things.  The `DataTile` things could be renamed to `RasterTile` (so `RasterTile` and `VectorTile` would be the two tile classes in the API).