### PR TITLE
Include file extensions in examples and docs

### DIFF
--- a/config/jsdoc/api/template/tmpl/container.tmpl
+++ b/config/jsdoc/api/template/tmpl/container.tmpl
@@ -24,7 +24,7 @@
       if (ancestors) {
         parts.push(ancestors.split('~').shift());
       }
-      var importPath = parts.join('/');
+      var importPath = parts.join('/') + '.js';
     ?>
       <?js
         var nameParts = doc.name.split('/');

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -280,9 +280,8 @@ export default class ExampleBuilder {
   transformJsSource(source) {
     return (
       source
-        // remove "../src/" prefix and ".js" to have the same import syntax as the documentation
+        // remove "../src/" prefix to have the same import syntax as the documentation
         .replace(/'\.\.\/src\//g, "'")
-        .replace(/\.js';/g, "';")
         // Remove worker loader import and modify `new Worker()` to add source
         .replace(/import Worker from 'worker-loader![^\n]*\n/g, '')
         .replace('new Worker()', "new Worker('./worker.js', {type: 'module'})")

--- a/site/src/doc/faq.md
+++ b/site/src/doc/faq.md
@@ -54,8 +54,8 @@ The projection of your map can be set through the `view`-property. Here are some
 examples:
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
 
 // OpenLayers comes with support for the World Geodetic System 1984, EPSG:4326:
 const map = new Map({
@@ -68,11 +68,11 @@ const map = new Map({
 ```
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
 import proj4 from 'proj4';
-import {register} from 'ol/proj/proj4';
-import {get as getProjection} from 'ol/proj';
+import {register} from 'ol/proj/proj4.js';
+import {get as getProjection} from 'ol/proj.js';
 
 // To use other projections, you have to register the projection in OpenLayers.
 // This can easily be done with [http://proj4js.org/](proj4)
@@ -113,10 +113,10 @@ coordinates for the center have to be provided in that projection. Chances are
 that your map looks like this:
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
-import TileLayer from 'ol/layer/Tile';
-import OSM from 'ol/source/OSM';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import OSM from 'ol/source/OSM.js';
 
 const washingtonLonLat = [-77.036667, 38.895];
 const map = new Map({
@@ -142,11 +142,11 @@ The solution is easy: Provide the coordinates projected into Web Mercator.
 OpenLayers has some helpful utility methods to assist you:
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
-import TileLayer from 'ol/layer/Tile';
-import OSM from 'ol/source/OSM';
-import {fromLonLat} from 'ol/proj';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import OSM from 'ol/source/OSM.js';
+import {fromLonLat} from 'ol/proj.js';
 
 const washingtonLonLat = [-77.036667, 38.895];
 const washingtonWebMercator = fromLonLat(washingtonLonLat);
@@ -171,7 +171,7 @@ If you told OpenLayers about a custom projection (see above), you can use the
 following method to transform a coordinate from WGS84 to your projection:
 
 ```javascript
-import {transform} from 'ol/proj';
+import {transform} from 'ol/proj.js';
 // assuming that OpenLayers knows about EPSG:21781, see above
 const swissCoord = transform([8.23, 46.86], 'EPSG:4326', 'EPSG:21781');
 ```
@@ -210,11 +210,11 @@ So the next step would be to put the decimal coordinates into an array and use
 it as center:
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
-import TileLayer from 'ol/layer/Tile';
-import OSM from 'ol/source/OSM';
-import {fromLonLat} from 'ol/proj';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import OSM from 'ol/source/OSM.js';
+import {fromLonLat} from 'ol/proj.js';
 
 const schladming = [47.394167, 13.689167]; // caution partner, read on...
 // since we are using OSM, we have to transform the coordinates...
@@ -246,11 +246,11 @@ e.g. try to change the map center.
 Ok, then let's flip the coordinates:
 
 ```javascript
-import Map from 'ol/Map';
-import View from 'ol/View';
-import TileLayer from 'ol/layer/Tile';
-import OSM from 'ol/source/OSM';
-import {fromLonLat} from 'ol/proj';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import OSM from 'ol/source/OSM.js';
+import {fromLonLat} from 'ol/proj.js';
 
 const schladming = [13.689167, 47.394167]; // longitude first, then latitude
 // since we are using OSM, we have to transform the coordinates...
@@ -287,8 +287,8 @@ Suppose you want to load a KML file and display the contained features on the
 map. Code like the following could be used:
 
 ```javascript
-import VectorLayer from 'ol/layer/Vector';
-import KMLSource from 'ol/source/KML';
+import VectorLayer from 'ol/layer/Vector.js';
+import KMLSource from 'ol/source/KML.js';
 
 const vector = new VectorLayer({
   source: new KMLSource({
@@ -302,8 +302,8 @@ You may ask yourself how many features are in that KML, and try something like
 the following:
 
 ```javascript
-import VectorLayer from 'ol/layer/Vector';
-import KMLSource from 'ol/source/KML';
+import VectorLayer from 'ol/layer/Vector.js';
+import KMLSource from 'ol/source/KML.js';
 
 const vector = new VectorLayer({
   source: new KMLSource({
@@ -362,7 +362,7 @@ icons, the actual geometry of a feature might be too far away and is not conside
 In this case, set the `renderBuffer` property of `VectorLayer` (the default value is 100px):
 
 ```javascript
-import VectorLayer from 'ol/layer/Vector';
+import VectorLayer from 'ol/layer/Vector.js';
 
 const vectorLayer = new VectorLayer({
   ...
@@ -382,7 +382,7 @@ There is currently no built-in way to react to element's size changes, as [Resiz
 There is however an easy to use [polyfill](https://github.com/que-etc/resize-observer-polyfill):
 
 ```javascript
-import Map from 'ol/Map';
+import Map from 'ol/Map.js';
 import ResizeObserver from 'resize-observer-polyfill';
 
 const mapElement = document.querySelector('#map')

--- a/site/src/doc/quickstart.md
+++ b/site/src/doc/quickstart.md
@@ -58,21 +58,22 @@ Open the `main.js` file in a text editor.  It should look something like this:
 
 ```js
 import './style.css';
-import {Map, View} from 'ol';
-import TileLayer from 'ol/layer/Tile';
-import OSM from 'ol/source/OSM';
+import Map from 'ol/Map.js';
+import OSM from 'ol/source/OSM.js';
+import TileLayer from 'ol/layer/Tile.js';
+import View from 'ol/View.js';
 
 const map = new Map({
   target: 'map',
   layers: [
     new TileLayer({
-      source: new OSM()
-    })
+      source: new OSM(),
+    }),
   ],
   view: new View({
     center: [0, 0],
-    zoom: 2
-  })
+    zoom: 2,
+  }),
 });
 ```
 

--- a/site/src/doc/tutorials/background.md
+++ b/site/src/doc/tutorials/background.md
@@ -26,8 +26,8 @@ The library is intended for use on both desktop/laptop and mobile devices, and s
 OpenLayers modules with CamelCase names provide classes as default exports, and may contain additional constants or functions as named exports:
 
 ```js
-import Map from 'ol/Map';
-import View from 'ol/View';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
 ```
 
 Class hierarchies grouped by their parent are provided in a subfolder of the package, e.g. `layer/`.
@@ -36,12 +36,12 @@ For convenience, these are also available as named exports, e.g.
 
 ```js
 import {Map, View} from 'ol';
-import {Tile, Vector} from 'ol/layer';
+import {Tile, Vector} from 'ol/layer.js';
 ```
 
 In addition to these re-exported classes, modules with lowercase names also provide constants or functions as named exports:
 
 ```js
 import {getUid} from 'ol';
-import {fromLonLat} from 'ol/proj';
+import {fromLonLat} from 'ol/proj.js';
 ```

--- a/site/src/doc/tutorials/concepts.md
+++ b/site/src/doc/tutorials/concepts.md
@@ -18,7 +18,7 @@ The markup below could be used to create a `<div>` that contains your map.
 The script below constructs a map that is rendered in the `<div>` above, using the `map` id of the element as a selector.
 
 ```js
-import Map from 'ol/Map';
+import Map from 'ol/Map.js';
 
 const map = new Map({target: 'map'});
 ```
@@ -28,7 +28,7 @@ const map = new Map({target: 'map'});
 The map is not responsible for things like center, zoom level and projection of the map. Instead, these are properties of a `ol/View` instance.
 
 ```js
-import View from 'ol/View';
+import View from 'ol/View.js';
 
 map.setView(new View({
   center: [0, 0],
@@ -46,7 +46,7 @@ The `zoom` option is a convenient way to specify the map resolution. The availab
 To get remote data for a layer, OpenLayers uses `ol/source/Source` subclasses. These are available for free and commercial map tile services like OpenStreetMap or Bing, for OGC sources like WMS or WMTS, and for vector data in formats like GeoJSON or KML.
 
 ```js
-import OSM from 'ol/source/OSM';
+import OSM from 'ol/source/OSM.js';
 
 const source = OSM();
 ```
@@ -61,7 +61,7 @@ A layer is a visual representation of data from a source. OpenLayers has four ba
  * `ol/layer/VectorTile` - Renders data that is provided as vector tiles.
 
 ```js
-import TileLayer from 'ol/layer/Tile';
+import TileLayer from 'ol/layer/Tile.js';
 
 // ...
 const layer = new TileLayer({source: source});
@@ -73,10 +73,10 @@ map.addLayer(layer);
 The above snippets can be combined into a single script that renders a map with a single tile layer:
 
 ```js
-import Map from 'ol/Map';
-import View from 'ol/View';
-import OSM from 'ol/source/OSM';
-import TileLayer from 'ol/layer/Tile';
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import OSM from 'ol/source/OSM.js';
+import TileLayer from 'ol/layer/Tile.js';
 
 new Map({
   layers: [

--- a/site/src/doc/tutorials/raster-reprojection.md
+++ b/site/src/doc/tutorials/raster-reprojection.md
@@ -14,9 +14,10 @@ The view in any Proj4js supported coordinate reference system is possible and pr
 The API usage is very simple. Just specify proper projection (e.g. using [EPSG](https://epsg.io) code) on `ol/View`:
 
 ```js
-import {Map, View} from 'ol';
-import TileLayer from 'ol/layer/Tile';
-import TileWMS from 'ol/source/TileWMS';
+import Map from 'ol/Map.js';
+import TileLayer from 'ol/layer/Tile.js';
+import TileWMS from 'ol/source/TileWMS.js';
+import View from 'ol/View.js';
 
 const map = new Map({
   target: 'map',
@@ -58,8 +59,8 @@ Following example shows definition of a [British National Grid](https://epsg.io/
 
 ```js
 import proj4 from 'proj4';
-import {get as getProjection} from 'ol/proj';
-import {register} from 'ol/proj/proj4';
+import {get as getProjection} from 'ol/proj.js';
+import {register} from 'ol/proj/proj4.js';
 
 proj4.defs('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 ' +
     '+x_0=400000 +y_0=-100000 +ellps=airy ' +

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -49,9 +49,9 @@ import {listen, unlistenByKey} from './events.js';
  *
  * ```js
  *
- * import Feature from 'ol/Feature';
- * import Polygon from 'ol/geom/Polygon';
- * import Point from 'ol/geom/Point';
+ * import Feature from 'ol/Feature.js';
+ * import Polygon from 'ol/geom/Polygon.js';
+ * import Point from 'ol/geom/Point.js';
  *
  * const feature = new Feature({
  *   geometry: new Polygon(polyCoords),

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -186,10 +186,10 @@ function setLayerMapProperty(layer, map) {
  * The map is the core component of OpenLayers. For a map to render, a view,
  * one or more layers, and a target container are needed:
  *
- *     import Map from 'ol/Map';
- *     import View from 'ol/View';
- *     import TileLayer from 'ol/layer/Tile';
- *     import OSM from 'ol/source/OSM';
+ *     import Map from 'ol/Map.js';
+ *     import View from 'ol/View.js';
+ *     import TileLayer from 'ol/layer/Tile.js';
+ *     import OSM from 'ol/source/OSM.js';
  *
  *     const map = new Map({
  *       view: new View({

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -98,7 +98,7 @@ const Property = {
  *
  * Example:
  *
- *     import Overlay from 'ol/Overlay';
+ *     import Overlay from 'ol/Overlay.js';
  *
  *     // ...
  *     const popup = new Overlay({

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -19,7 +19,7 @@ import {easeIn} from './easing.js';
  * error handling:
  *
  * ```js
- * import TileState from 'ol/TileState';
+ * import TileState from 'ol/TileState.js';
  *
  * source.setTileLoadFunction(function(tile, src) {
  *   const xhr = new XMLHttpRequest();

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -25,7 +25,7 @@ import {padNumber} from './string.js';
  *
  * Example:
  *
- *     import {add} from 'ol/coordinate';
+ *     import {add} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     add(coord, [-2, 4]);
@@ -119,7 +119,7 @@ export function closestOnSegment(coordinate, segment) {
  *
  * Example without specifying the fractional digits:
  *
- *     import {createStringXY} from 'ol/coordinate';
+ *     import {createStringXY} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const stringifyFunc = createStringXY();
@@ -128,7 +128,7 @@ export function closestOnSegment(coordinate, segment) {
  *
  * Example with explicitly specifying 2 fractional digits:
  *
- *     import {createStringXY} from 'ol/coordinate';
+ *     import {createStringXY} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const stringifyFunc = createStringXY(2);
@@ -199,7 +199,7 @@ export function degreesToStringHDMS(hemispheres, degrees, fractionDigits) {
  *
  * Example without specifying the fractional digits:
  *
- *     import {format} from 'ol/coordinate';
+ *     import {format} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const template = 'Coordinate is ({x}|{y}).';
@@ -208,7 +208,7 @@ export function degreesToStringHDMS(hemispheres, degrees, fractionDigits) {
  *
  * Example explicitly specifying the fractional digits:
  *
- *     import {format} from 'ol/coordinate';
+ *     import {format} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const template = 'Coordinate is ({x}|{y}).';
@@ -254,7 +254,7 @@ export function equals(coordinate1, coordinate2) {
  *
  * Example:
  *
- *     import {rotate} from 'ol/coordinate';
+ *     import {rotate} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const rotateRadians = Math.PI / 2; // 90 degrees
@@ -282,7 +282,7 @@ export function rotate(coordinate, angle) {
  *
  * Example:
  *
- *     import {scale as scaleCoordinate} from 'ol/coordinate';
+ *     import {scale as scaleCoordinate} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const scale = 1.2;
@@ -337,7 +337,7 @@ export function squaredDistanceToSegment(coordinate, segment) {
  *
  * Example without specifying fractional digits:
  *
- *     import {toStringHDMS} from 'ol/coordinate';
+ *     import {toStringHDMS} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const out = toStringHDMS(coord);
@@ -345,7 +345,7 @@ export function squaredDistanceToSegment(coordinate, segment) {
  *
  * Example explicitly specifying 1 fractional digit:
  *
- *     import {toStringHDMS} from 'ol/coordinate';
+ *     import {toStringHDMS} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const out = toStringHDMS(coord, 1);
@@ -373,7 +373,7 @@ export function toStringHDMS(coordinate, fractionDigits) {
  *
  * Example without specifying fractional digits:
  *
- *     import {toStringXY} from 'ol/coordinate';
+ *     import {toStringXY} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const out = toStringXY(coord);
@@ -381,7 +381,7 @@ export function toStringHDMS(coordinate, fractionDigits) {
  *
  * Example explicitly specifying 1 fractional digit:
  *
- *     import {toStringXY} from 'ol/coordinate';
+ *     import {toStringXY} from 'ol/coordinate.js';
  *
  *     const coord = [7.85, 47.983333];
  *     const out = toStringXY(coord, 1);

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -80,7 +80,7 @@ const tempSegment = [];
  *
  * Example:
  *
- *     import Snap from 'ol/interaction/Snap';
+ *     import Snap from 'ol/interaction/Snap.js';
  *
  *     const snap = new Snap({
  *       source: source

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -48,9 +48,9 @@ import {getTransformFromProjections, getUserProjection} from './proj.js';
  * The units for geometry coordinates are css pixels relative to the top left
  * corner of the canvas element.
  * ```js
- * import {toContext} from 'ol/render';
- * import Fill from 'ol/style/Fill';
- * import Polygon from 'ol/geom/Polygon';
+ * import {toContext} from 'ol/render.js';
+ * import Fill from 'ol/style/Fill.js';
+ * import Polygon from 'ol/geom/Polygon.js';
  *
  * const canvas = document.createElement('canvas');
  * const render = toContext(

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -86,9 +86,9 @@ export class VectorSourceEvent extends Event {
  * Example:
  *
  * ```js
- * import {Vector} from 'ol/source';
- * import {GeoJSON} from 'ol/format';
- * import {bbox} from 'ol/loadingstrategy';
+ * import Vector from 'ol/source/Vector.js';
+ * import GeoJSON from 'ol/format/GeoJSON.js';
+ * import {bbox} from 'ol/loadingstrategy.js';
  *
  * const vectorSource = new Vector({
  *   format: new GeoJSON(),

--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -64,7 +64,7 @@ import {assert} from '../asserts.js';
  *
  * If no style is defined, the following default style is used:
  * ```js
- *  import {Circle, Fill, Stroke, Style} from 'ol/style';
+ *  import {Circle, Fill, Stroke, Style} from 'ol/style.js';
  *
  *  const fill = new Fill({
  *    color: 'rgba(255,255,255,0.4)',
@@ -88,7 +88,7 @@ import {assert} from '../asserts.js';
  *
  * A separate editing style has the following defaults:
  * ```js
- *  import {Circle, Fill, Stroke, Style} from 'ol/style';
+ *  import {Circle, Fill, Stroke, Style} from 'ol/style.js';
  *
  *  const styles = {};
  *  const white = [255, 255, 255, 1];


### PR DESCRIPTION
This updates the import paths in our docs and examples to include the filename extensions.  Excluding the extension works when a module loader has file system access, guesses, or can be configured to add a file extension.  Including the extension works everywhere.