### PR TITLE
Add resolutions option to Raster source

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,12 @@
 
 ### Next version
 
+#### Rendered resolutions of `ol/source/Raster`
+
+Previously, `ol/source/Raster` processed input sources at the current view resolution, which caused interpolation artefacts in cases where input sources were up- or downsampled. Now, `ol/source/Raster` picks up the resolutions from the first input source that has resolutions configured (either implicitly through a tile grid in the case of tile sources, or directly when configured through the `resolutions` constructor option). This improves the rendered output in most cases.
+
+If the previous behavior is desired, configure the source with `resolutions: null`.
+
 #### Fixed `wrapX` behavior of `ol/control/MousePosition`
 
 Previously, `ol/control/MousePosition` always displayed coordinates as-is. Now it has a `wrapX` option,

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -133,8 +133,6 @@ const raster = new Raster({
   sources: [elevation],
   operationType: 'image',
   operation: shade,
-  // avoid interpolation artefacts by only rendering native elevation resolutions
-  resolutions: elevation.getTileGrid().getResolutions(),
 });
 
 const map = new Map({

--- a/examples/shaded-relief.js
+++ b/examples/shaded-relief.js
@@ -126,12 +126,15 @@ function shade(inputs, data) {
 const elevation = new XYZ({
   url: 'https://{a-d}.tiles.mapbox.com/v3/aj.sf-dem/{z}/{x}/{y}.png',
   crossOrigin: 'anonymous',
+  maxZoom: 13,
 });
 
 const raster = new Raster({
   sources: [elevation],
   operationType: 'image',
   operation: shade,
+  // avoid interpolation artefacts by only rendering native elevation resolutions
+  resolutions: elevation.getTileGrid().getResolutions(),
 });
 
 const map = new Map({
@@ -149,7 +152,6 @@ const map = new Map({
     extent: [-13675026, 4439648, -13580856, 4580292],
     center: [-13615645, 4497969],
     minZoom: 10,
-    maxZoom: 16,
     zoom: 13,
   }),
 });

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -146,6 +146,13 @@ class ImageSource extends Source {
   }
 
   /**
+   * @param {Array<number>|null} resolutions Resolutions.
+   */
+  setResolutions(resolutions) {
+    this.resolutions_ = resolutions;
+  }
+
+  /**
    * @protected
    * @param {number} resolution Resolution.
    * @return {number} Resolution.

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -158,9 +158,10 @@ class ImageSource extends Source {
    * @return {number} Resolution.
    */
   findNearestResolution(resolution) {
-    if (this.resolutions_) {
-      const idx = linearFindNearest(this.resolutions_, resolution, 0);
-      resolution = this.resolutions_[idx];
+    const resolutions = this.getResolutions();
+    if (resolutions) {
+      const idx = linearFindNearest(resolutions, resolution, 0);
+      resolution = resolutions[idx];
     }
     return resolution;
   }

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -592,16 +592,8 @@ class RasterSource extends ImageSource {
       this.layers_[i].addEventListener(EventType.CHANGE, changed);
     }
 
-    if (options.resolutions !== null) {
-      for (let i = 0, ii = this.layers_.length; i < ii; ++i) {
-        const source = this.layers_[i].getSource();
-        const resolutions = source.getResolutions();
-        if (resolutions) {
-          this.setResolutions(resolutions);
-          break;
-        }
-      }
-    }
+    /** @type {boolean} */
+    this.useResolutions_ = options.resolutions !== null;
 
     /**
      * @private
@@ -885,6 +877,27 @@ class RasterSource extends ImageSource {
     if (frameState.animate) {
       requestAnimationFrame(this.changed.bind(this));
     }
+  }
+
+  /**
+   * @param {import("../proj/Projection").default} [projection] Projection.
+   * @return {Array<number>|null} Resolutions.
+   */
+  getResolutions(projection) {
+    if (!this.useResolutions_) {
+      return null;
+    }
+    let resolutions = super.getResolutions();
+    if (!resolutions) {
+      for (let i = 0, ii = this.layers_.length; i < ii; ++i) {
+        const source = this.layers_[i].getSource();
+        resolutions = source.getResolutions(projection);
+        if (resolutions) {
+          break;
+        }
+      }
+    }
+    return resolutions;
   }
 
   disposeInternal() {

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -514,6 +514,16 @@ export class RasterSourceEvent extends Event {
  * `'pixel'` operations are assumed, and operations will be called with an
  * array of pixels from input sources.  If set to `'image'`, operations will
  * be called with an array of ImageData objects from input sources.
+ * @property {Array<number>} [resolutions] Resolutions. If specified, raster operations will only
+ * be run at the given resolutions.  By default, operations will be run at the any view resolution.
+ * Use this option to optimize rendering of data from tile sources:
+ * ```js
+ * const raster = new RasterSource({
+ *   sources: [tileSource],
+ *   resolutions: tileSource.geTileGrid().getResolutions(),
+ *   // ...
+ * });
+ * ```
  */
 
 /***
@@ -542,6 +552,7 @@ class RasterSource extends ImageSource {
   constructor(options) {
     super({
       projection: null,
+      resolutions: options.resolutions,
     });
 
     /***
@@ -715,9 +726,14 @@ class RasterSource extends ImageSource {
 
     const center = getCenter(extent);
 
-    frameState.extent = extent.slice();
     frameState.size[0] = Math.round(getWidth(extent) / resolution);
     frameState.size[1] = Math.round(getHeight(extent) / resolution);
+    frameState.extent = [
+      center[0] - (frameState.size[0] * resolution) / 2,
+      center[1] - (frameState.size[1] * resolution) / 2,
+      center[0] + (frameState.size[0] * resolution) / 2,
+      center[1] + (frameState.size[1] * resolution) / 2,
+    ];
     frameState.time = Date.now();
 
     const viewState = frameState.viewState;
@@ -757,6 +773,7 @@ class RasterSource extends ImageSource {
       return null;
     }
 
+    resolution = this.findNearestResolution(resolution);
     const frameState = this.updateFrameState_(extent, resolution, projection);
     this.requestedFrameState_ = frameState;
 

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -783,7 +783,7 @@ class RasterSource extends ImageSource {
       const renderedExtent = this.renderedImageCanvas_.getExtent();
       if (
         resolution !== renderedResolution ||
-        !equals(extent, renderedExtent)
+        !equals(frameState.extent, renderedExtent)
       ) {
         this.renderedImageCanvas_ = null;
       }

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -2,7 +2,6 @@
  * @module ol/source/Source
  */
 import BaseObject from '../Object.js';
-import {abstract} from '../util.js';
 import {get as getProjection} from '../proj.js';
 
 /**
@@ -152,11 +151,10 @@ class Source extends BaseObject {
   }
 
   /**
-   * @abstract
    * @return {Array<number>|null} Resolutions.
    */
   getResolutions() {
-    return abstract();
+    return null;
   }
 
   /**

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -151,9 +151,10 @@ class Source extends BaseObject {
   }
 
   /**
+   * @param {import("../proj/Projection").default} [projection] Projection.
    * @return {Array<number>|null} Resolutions.
    */
-  getResolutions() {
+  getResolutions(projection) {
     return null;
   }
 

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -232,13 +232,17 @@ class TileSource extends Source {
   }
 
   /**
+   * @param {import("../proj/Projection").default} [projection] Projection.
    * @return {Array<number>|null} Resolutions.
    */
-  getResolutions() {
-    if (!this.tileGrid) {
+  getResolutions(projection) {
+    const tileGrid = projection
+      ? this.getTileGridForProjection(projection)
+      : this.tileGrid;
+    if (!tileGrid) {
       return null;
     }
-    return this.tileGrid.getResolutions();
+    return tileGrid.getResolutions();
   }
 
   /**

--- a/test/browser/spec/ol/source/raster.test.js
+++ b/test/browser/spec/ol/source/raster.test.js
@@ -138,6 +138,19 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
       view.setZoom(0);
     });
 
+    it('uses resolutions from the first source where available', function () {
+      greenSource.setResolutions([100, 10, 1]);
+      const source = new RasterSource({
+        threads: 0,
+        sources: [redSource, greenSource, blueSource],
+        operation: function (inputs) {
+          return inputs[0];
+        },
+      });
+
+      expect(source.getResolutions()).to.eql([100, 10, 1]);
+    });
+
     it('accepts a "resolutions" option', function (done) {
       const source = new RasterSource({
         threads: 0,
@@ -157,6 +170,20 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
       const view = map.getView();
       view.setCenter([0, 0]);
       view.setZoom(0);
+    });
+
+    it('uses the view resolution when "resolutions" are set to null', function () {
+      redSource.setResolutions([100, 10, 1]);
+      const source = new RasterSource({
+        threads: 0,
+        sources: [redSource],
+        resolutions: null,
+        operation: function (inputs) {
+          return inputs[0];
+        },
+      });
+
+      expect(source.getResolutions()).to.be(null);
     });
 
     it('disposes the processor when disposed', function () {

--- a/test/browser/spec/ol/source/raster.test.js
+++ b/test/browser/spec/ol/source/raster.test.js
@@ -138,6 +138,27 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
       view.setZoom(0);
     });
 
+    it('accepts a "resolutions" option', function (done) {
+      const source = new RasterSource({
+        threads: 0,
+        sources: [redSource],
+        resolutions: [1],
+        operation: function (inputs) {
+          return inputs[0];
+        },
+      });
+
+      source.on('afteroperations', function (event) {
+        expect(event.resolution).to.equal(1);
+        done();
+      });
+
+      map.getLayers().item(0).setSource(source);
+      const view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+    });
+
     it('disposes the processor when disposed', function () {
       const source = new RasterSource({
         threads: 0,

--- a/test/rendering/cases/source-raster-webgl/main.js
+++ b/test/rendering/cases/source-raster-webgl/main.js
@@ -24,6 +24,7 @@ const raster = new RasterSource({
       }),
     }),
   ],
+  resolutions: null,
   threads: 0, // Avoid using workers to work with puppeteer
   operation: function (pixels) {
     const pixel = pixels[0];


### PR DESCRIPTION
This pull request adds a `resolutions` option (which also exists on other Image sources) to force rendering to the specified resolutions. This allows for better results when input sources are tile sources, by setting the Raster source resolutions to the input source's tile resolutions.

I updated the [shaded-relief example](https://deploy-preview-14282--ol-site.netlify.app/en/latest/examples/shaded-relief.html) to make use of that. With the view's `maxZoom` restriction removed, and a sensible `maxZoom` on the input source, the shaded relief is rendered much more nicely when zoomed in.