### PR TITLE
Update example showing COG with external overviews

### DIFF
--- a/examples/cog-overviews.html
+++ b/examples/cog-overviews.html
@@ -4,9 +4,7 @@ title: GeoTIFF with Overviews
 shortdesc: Rendering a GeoTIFF with external overviews as a layer.
 docs: >
   In some cases, a GeoTIFF may have external overviews.  This example uses the
-  `overviews` property to provide URLs for the external overviews.  The example
-  composes a false color composite using shortwave infrared (B6), near infrared (B5),
-  and visible green (B3) bands from a Landsat 8 image.
-tags: "cog"
+  `overviews` property to provide URL for a file containing external overviews.
+tags: "cog, overview"
 ---
 <div id="map" class="map"></div>

--- a/examples/cog-overviews.js
+++ b/examples/cog-overviews.js
@@ -2,35 +2,11 @@ import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 
-// scale values in this range to 0 - 1
-const min = 10000;
-const max = 15000;
-
-const base =
-  'https://landsat-pds.s3.amazonaws.com/c1/L8/139/045/LC08_L1TP_139045_20170304_20170316_01_T1/LC08_L1TP_139045_20170304_20170316_01_T1';
-
 const source = new GeoTIFF({
   sources: [
     {
-      url: `${base}_B6.TIF`,
-      overviews: [`${base}_B6.TIF.ovr`],
-      min: min,
-      max: max,
-      nodata: 0,
-    },
-    {
-      url: `${base}_B5.TIF`,
-      overviews: [`${base}_B5.TIF.ovr`],
-      min: min,
-      max: max,
-      nodata: 0,
-    },
-    {
-      url: `${base}_B3.TIF`,
-      overviews: [`${base}_B3.TIF.ovr`],
-      min: min,
-      max: max,
-      nodata: 0,
+      url: 'https://openlayers.org/data/raster/no-overviews.tif',
+      overviews: ['https://openlayers.org/data/raster/no-overviews.tif.ovr'],
     },
   ],
 });
@@ -39,9 +15,6 @@ const map = new Map({
   target: 'map',
   layers: [
     new TileLayer({
-      style: {
-        saturation: -0.3,
-      },
       source: source,
     }),
   ],


### PR DESCRIPTION
This updates the data used in the [external overview example](https://deploy-preview-14286--ol-site.netlify.app/en/latest/examples/cog-overviews.html).

Fixes #13535.

I notice that mobile Safari is issuing an `OPTIONS` preflight request for this example, and GitHub pages responds with a 405.  The example should work when deployed, but this looks like it will be a limitation for mobile Safari in some cases with cross-origin data requests (it looks like a bug to me given that the request headers are in the [CORS safe list](https://fetch.spec.whatwg.org/#cors-safelisted-request-header).)

**Update:** the example works in the latest mobile Safari, so it looks like the issue above was an upstream bug.

<img src="https://user-images.githubusercontent.com/41094/201186326-706562ea-7a4f-4b3c-99cb-7cbbd5694b68.jpg" width="300">
