### PR TITLE
Use ResizeObserver instead of resize event

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OpenLayers appreciates contributions of all kinds.  We especially want to thank 
 [![ela-compil logo](./sponsor-logos/ela-compil.png)](https://ela.pl/)
 
 > We develop leading Physical Security Information Management (PSIM) software.
-> OpenLayers is the core of our map engine and we love it! 
+> OpenLayers is the core of our map engine and we love it!
 > https://elacompil.recruitee.com/
 
 <br>
@@ -93,6 +93,7 @@ For older browsers and platforms (Android 4.x, iOS v12 and older, Safari v12 and
 * [`fetch`](https://caniuse.com/fetch): Available from [polyfill.io](https://polyfill.io/).
 * [`requestAnimationFrame`](https://caniuse.com/requestanimationframe): Available from [polyfill.io](https://polyfill.io/).
 * [`element.prototype.classList` (`add`/`remove`)](https://caniuse.com/classlist): Available from [polyfill.io](https://polyfill.io/).
+* [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver): Available from [polyfill.io](https://polyfill.io/)
 * [`URL` API](https://caniuse.com/url): Available from [polyfill.io](https://polyfill.io/) or [core-js](https://cdnjs.com/libraries/core-js/).
 * [`TextDecoder`](https://caniuse.com/textencoder): Available from [polyfill.io](https://polyfill.io/).
 * [`Number.isInteger`](https://caniuse.com/isInteger): Available from [polyfill.io](https://polyfill.io/) or [core-js](https://cdnjs.com/libraries/core-js/).

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -26,6 +26,10 @@ The control will now by default keep displaying the last mouse position when the
 
 The `PluggableMap` class has been removed.  If you want to create a custom map class, extend the `Map` class instead.
 
+#### ol/Map
+
+A [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is added to the map target element and therefore `updateSize` no longer needs to be called when the map's target has been resized.
+
 ### 6.15.0
 
 #### Deprecated `tilePixelRatio` option for data tile sources.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -371,30 +371,3 @@ const vectorLayer = new VectorLayer({
 ```
 
 The recommended value is the size of the largest symbol, line width or label.
-
-## Why is zooming or clicking in the map off/inaccurate?
-
-OpenLayers does not update the map when the container element is resized. This can be caused by progressive updates
-to CSS styles or manually resizing the map. When that happens, any interaction will become inaccurate: the map would zoom in and out, and end up not being centered on the pointer. This makes it hard to do certain interactions, e.g. selecting the desired feature.
-
-There is currently no built-in way to react to element's size changes, as [Resize Observer API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is only implemented in Chrome.
-
-There is however an easy to use [polyfill](https://github.com/que-etc/resize-observer-polyfill):
-
-```javascript
-import Map from 'ol/Map';
-import ResizeObserver from 'resize-observer-polyfill';
-
-const mapElement = document.querySelector('#map')
-const map = new Map({
-  target: mapElement
-})
-
-const sizeObserver = new ResizeObserver(() => {
-  map.updateSize()
-})
-sizeObserver.observe(mapElement)
-
-// called when the map is destroyed
-// sizeObserver.disconnect()
-```

--- a/doc/tutorials/background.md
+++ b/doc/tutorials/background.md
@@ -19,7 +19,7 @@ OpenLayers is available as [`ol` npm package](https://npmjs.com/package/ol), whi
 
 By default, OpenLayers uses a performance optimized Canvas renderer.
 
-OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](https://262.ecma-international.org/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, [polyfills](https://polyfill.io/), the application bundle needs to be transpiled (e.g. using [Babel](https://babeljs.io/)) and bundled with polyfills for `fetch`, `requestAnimationFrame`, `Element.prototype.classList`, `URL`, `TextDecoder` and `Number.isInteger`.
+OpenLayers runs on all modern browsers that support [HTML5](https://html.spec.whatwg.org/multipage/) and [ECMAScript 5](https://262.ecma-international.org/5.1/). This includes Chrome, Firefox, Safari and Edge. For older browsers and platforms like Internet Explorer (down to version 9) and Android 4.x, the application bundle needs to be transpiled (e.g. using [Babel](https://babeljs.io/)) and bundled with [polyfills](https://polyfill.io/) for `fetch`, `requestAnimationFrame`, `Element.prototype.classList`, `URL`, `TextDecoder`, `Number.isInteger`, and [`ResizeObserver`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
 
 The library is intended for use on both desktop/laptop and mobile devices, and supports pointer and touch interactions.
 

--- a/examples/attributions.js
+++ b/examples/attributions.js
@@ -27,5 +27,5 @@ function checkSize() {
   attribution.setCollapsed(small);
 }
 
-window.addEventListener('resize', checkSize);
+map.on('change:size', checkSize);
 checkSize();

--- a/examples/min-zoom.js
+++ b/examples/min-zoom.js
@@ -28,7 +28,7 @@ const map = new Map({
   view: view,
 });
 
-window.addEventListener('resize', function () {
+map.on('change:size', function () {
   const minZoom = getMinZoom();
   if (minZoom !== view.getMinZoom()) {
     view.setMinZoom(minZoom);

--- a/examples/print-to-scale.js
+++ b/examples/print-to-scale.js
@@ -124,7 +124,6 @@ exportButton.addEventListener(
         scaleLine.setDpi();
         map.getTargetElement().style.width = '';
         map.getTargetElement().style.height = '';
-        map.updateSize();
         map.getView().setResolution(viewResolution);
         exportButton.disabled = false;
         document.body.style.cursor = 'auto';
@@ -135,7 +134,6 @@ exportButton.addEventListener(
     scaleLine.setDpi(resolution);
     map.getTargetElement().style.width = width + 'px';
     map.getTargetElement().style.height = height + 'px';
-    map.updateSize();
     map.getView().setResolution(scaleResolution);
   },
   false

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -638,7 +638,6 @@ class Map extends BaseObject {
   }
 
   /**
-   *
    * Clean up.
    */
   disposeInternal() {
@@ -1219,8 +1218,9 @@ class Map extends BaseObject {
    * @private
    */
   handleSizeChanged_() {
-    if (this.getView() && !this.getView().getAnimating()) {
-      this.getView().resolveConstraints(0);
+    const view = this.getView();
+    if (view && !view.getAnimating()) {
+      view.resolveConstraints(0);
     }
 
     this.render();
@@ -1711,17 +1711,18 @@ class Map extends BaseObject {
    */
   updateViewportSize_() {
     const view = this.getView();
-    if (view) {
-      let size = undefined;
-      const computedStyle = getComputedStyle(this.viewport_);
-      if (computedStyle.width && computedStyle.height) {
-        size = [
-          parseInt(computedStyle.width, 10),
-          parseInt(computedStyle.height, 10),
-        ];
-      }
-      view.setViewportSize(size);
+    if (!view) {
+      return;
     }
+    let size = undefined;
+    const computedStyle = getComputedStyle(this.viewport_);
+    if (computedStyle.width && computedStyle.height) {
+      size = [
+        parseInt(computedStyle.width, 10),
+        parseInt(computedStyle.height, 10),
+      ];
+    }
+    view.setViewportSize(size);
   }
 }
 

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -460,6 +460,12 @@ class Map extends BaseObject {
 
     /**
      * @private
+     * @type {ResizeObserver}
+     */
+    this.resizeObserver_ = new ResizeObserver(() => this.updateSize());
+
+    /**
+     * @private
      * @type {TileQueue}
      */
     this.tileQueue_ = new TileQueue(
@@ -1293,7 +1299,6 @@ class Map extends BaseObject {
         PASSIVE_EVENT_LISTENERS ? {passive: false} : false
       );
 
-      const defaultView = this.getOwnerDocument().defaultView;
       const keyboardEventTarget = !this.keyboardEventTarget_
         ? targetElement
         : this.keyboardEventTarget_;
@@ -1310,8 +1315,8 @@ class Map extends BaseObject {
           this.handleBrowserEvent,
           this
         ),
-        listen(defaultView, EventType.RESIZE, this.updateSize, this),
       ];
+      this.resizeObserver_.observe(targetElement);
     }
 
     this.updateSize();
@@ -1411,6 +1416,7 @@ class Map extends BaseObject {
     if (this.animationDelayKey_) {
       cancelAnimationFrame(this.animationDelayKey_);
     }
+    this.updateSize();
     this.animationDelay_();
   }
 

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1685,24 +1685,30 @@ class Map extends BaseObject {
         parseFloat(computedStyle['borderBottomWidth']);
       if (!isNaN(width) && !isNaN(height)) {
         size = [width, height];
-        if (
-          !hasArea(size) &&
-          !!(
-            targetElement.offsetWidth ||
-            targetElement.offsetHeight ||
-            targetElement.getClientRects().length
-          )
-        ) {
-          // eslint-disable-next-line
-          console.warn(
-            "No map visible because the map container's width or height are 0."
-          );
-        }
       }
     }
 
-    this.setSize(size);
-    this.updateViewportSize_();
+    if (
+      size &&
+      !hasArea(size) &&
+      (targetElement.offsetWidth ||
+        targetElement.offsetHeight ||
+        targetElement.getClientRects().length)
+    ) {
+      // eslint-disable-next-line
+      console.warn(
+        "No map visible because the map container's width or height are 0."
+      );
+    }
+
+    const oldSize = this.getSize();
+    if (
+      size !== oldSize &&
+      (!size || !oldSize || size[0] !== oldSize[0] || size[1] !== oldSize[1])
+    ) {
+      this.updateViewportSize_();
+      this.setSize(size);
+    }
   }
 
   /**

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -920,12 +920,10 @@ class View extends BaseObject {
    * to avoid performance hit and layout reflow.
    * This should be done on map size change.
    * Note: the constraints are not resolved during an animation to avoid stopping it
-   * @param {import("./size.js").Size} [opt_size] Viewport size; if undefined, [100, 100] is assumed
+   * @param {import("./size.js").Size} [opt_size=[100,100]] Viewport size
    */
   setViewportSize(opt_size) {
-    this.viewportSize_ = Array.isArray(opt_size)
-      ? opt_size.slice()
-      : [100, 100];
+    this.viewportSize_ = opt_size ? opt_size.slice() : [100, 100];
     if (!this.getAnimating()) {
       this.resolveConstraints(0);
     }

--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -261,7 +261,6 @@ class FullScreen extends Control {
         replaceNode(this.labelNode_, this.labelActiveNode_);
         this.dispatchEvent(FullScreenEventType.LEAVEFULLSCREEN);
       }
-      map.updateSize();
     }
   }
 

--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -298,7 +298,6 @@ class OverviewMap extends Control {
       if (view) {
         this.bindView_(view);
         if (view.isDef()) {
-          this.ovmap_.updateSize();
           this.resetExtent_();
         }
       }
@@ -324,11 +323,6 @@ class OverviewMap extends Control {
       }
       const newView = this.getMap().getView();
       this.bindView_(newView);
-    } else if (
-      !this.ovmap_.isRendered() &&
-      (event.key === MapProperty.TARGET || event.key === MapProperty.SIZE)
-    ) {
-      this.ovmap_.updateSize();
     }
   }
 
@@ -571,7 +565,6 @@ class OverviewMap extends Control {
         ovmap.render();
         return;
       }
-      ovmap.updateSize();
       this.resetExtent_();
       this.updateBoxAfterOvmapIsRendered_();
     }

--- a/src/ol/events/EventType.js
+++ b/src/ol/events/EventType.js
@@ -33,7 +33,6 @@ export default {
   KEYDOWN: 'keydown',
   KEYPRESS: 'keypress',
   LOAD: 'load',
-  RESIZE: 'resize',
   TOUCHMOVE: 'touchmove',
   WHEEL: 'wheel',
 };

--- a/test/browser/spec/ol/control/scaleline.test.js
+++ b/test/browser/spec/ol/control/scaleline.test.js
@@ -223,7 +223,7 @@ describe('ol.control.ScaleLine', function () {
     let degreesHtml;
     let imperialHtml;
     let usHtml;
-    beforeEach(function (done) {
+    beforeEach(function () {
       ctrl = new ScaleLine();
       ctrl.setMap(map);
       map.setView(
@@ -232,10 +232,8 @@ describe('ol.control.ScaleLine', function () {
           zoom: 0,
         })
       );
-      map.once('postrender', function () {
-        metricHtml = ctrl.element.innerHTML;
-        done();
-      });
+      map.renderSync();
+      metricHtml = ctrl.element.innerHTML;
     });
     afterEach(function () {
       map.setView(null);

--- a/test/browser/spec/ol/interaction/dragrotateandzoom.test.js
+++ b/test/browser/spec/ol/interaction/dragrotateandzoom.test.js
@@ -20,7 +20,7 @@ describe('ol.interaction.DragRotateAndZoom', function () {
     const width = 360;
     const height = 180;
 
-    beforeEach(function (done) {
+    beforeEach(function () {
       target = document.createElement('div');
       const style = target.style;
       style.position = 'absolute';
@@ -42,9 +42,7 @@ describe('ol.interaction.DragRotateAndZoom', function () {
           resolution: 1,
         }),
       });
-      map.once('postrender', function () {
-        done();
-      });
+      map.renderSync();
     });
 
     afterEach(function () {

--- a/test/browser/spec/ol/interaction/dragzoom.test.js
+++ b/test/browser/spec/ol/interaction/dragzoom.test.js
@@ -20,7 +20,7 @@ describe('ol.interaction.DragZoom', function () {
   const width = 360;
   const height = 180;
 
-  beforeEach(function (done) {
+  beforeEach(function () {
     target = document.createElement('div');
     const style = target.style;
     style.position = 'absolute';
@@ -41,9 +41,7 @@ describe('ol.interaction.DragZoom', function () {
         multiWorld: true,
       }),
     });
-    map.once('postrender', function () {
-      done();
-    });
+    map.renderSync();
   });
 
   afterEach(function () {

--- a/test/browser/spec/ol/interaction/draw.test.js
+++ b/test/browser/spec/ol/interaction/draw.test.js
@@ -38,7 +38,7 @@ describe('ol.interaction.Draw', function () {
   const width = 360;
   const height = 180;
 
-  beforeEach(function (done) {
+  beforeEach(function () {
     target = document.createElement('div');
     const style = target.style;
     style.position = 'absolute';
@@ -58,9 +58,7 @@ describe('ol.interaction.Draw', function () {
         resolution: 1,
       }),
     });
-    map.once('postrender', function () {
-      done();
-    });
+    map.renderSync();
   });
 
   afterEach(function () {

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -32,7 +32,7 @@ describe('ol.interaction.Modify', function () {
   const width = 360;
   const height = 180;
 
-  beforeEach(function (done) {
+  beforeEach(function () {
     target = document.createElement('div');
 
     const style = target.style;
@@ -72,10 +72,7 @@ describe('ol.interaction.Modify', function () {
         resolution: 1,
       }),
     });
-
-    map.once('postrender', function () {
-      done();
-    });
+    map.renderSync();
   });
 
   afterEach(function () {

--- a/test/browser/spec/ol/interaction/select.test.js
+++ b/test/browser/spec/ol/interaction/select.test.js
@@ -17,7 +17,7 @@ describe('ol.interaction.Select', function () {
   const width = 360;
   const height = 180;
 
-  beforeEach(function (done) {
+  beforeEach(function () {
     target = document.createElement('div');
 
     const style = target.style;
@@ -75,10 +75,7 @@ describe('ol.interaction.Select', function () {
         resolution: 1,
       }),
     });
-
-    map.once('postrender', function () {
-      done();
-    });
+    map.renderSync();
   });
 
   afterEach(function () {

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -28,7 +28,7 @@ describe('ol.interaction.Snap', function () {
     const width = 360;
     const height = 180;
 
-    beforeEach(function (done) {
+    beforeEach(function () {
       target = document.createElement('div');
 
       const style = target.style;
@@ -47,10 +47,7 @@ describe('ol.interaction.Snap', function () {
           resolution: 1,
         }),
       });
-
-      map.once('postrender', function () {
-        done();
-      });
+      map.renderSync();
     });
 
     afterEach(function () {
@@ -287,7 +284,7 @@ describe('ol.interaction.Snap', function () {
 
     let restoreRAF;
 
-    beforeEach((done) => {
+    beforeEach(() => {
       restoreRAF = overrideRAF();
 
       useGeographic();
@@ -309,10 +306,7 @@ describe('ol.interaction.Snap', function () {
           zoom: 0,
         }),
       });
-
-      map.once('postrender', () => {
-        done();
-      });
+      map.renderSync();
     });
 
     afterEach(() => {

--- a/test/browser/spec/ol/interaction/translate.test.js
+++ b/test/browser/spec/ol/interaction/translate.test.js
@@ -18,7 +18,7 @@ describe('ol.interaction.Translate', function () {
   const width = 360;
   const height = 180;
 
-  beforeEach(function (done) {
+  beforeEach(function () {
     target = document.createElement('div');
     const style = target.style;
     style.position = 'absolute';
@@ -47,9 +47,7 @@ describe('ol.interaction.Translate', function () {
         resolution: 1,
       }),
     });
-    map.once('postrender', function () {
-      done();
-    });
+    map.renderSync();
   });
 
   afterEach(function () {

--- a/test/browser/spec/ol/renderer/layer.test.js
+++ b/test/browser/spec/ol/renderer/layer.test.js
@@ -103,7 +103,7 @@ describe('ol/renderer/Layer', function () {
   describe('manageTilePyramid behavior', function () {
     let target, map, view, source;
 
-    beforeEach(function (done) {
+    beforeEach(function () {
       target = document.createElement('div');
       Object.assign(target.style, {
         position: 'absolute',
@@ -133,9 +133,7 @@ describe('ol/renderer/Layer', function () {
           }),
         ],
       });
-      map.once('postrender', function () {
-        done();
-      });
+      map.renderSync();
     });
 
     afterEach(function () {

--- a/test/rendering/test.js
+++ b/test/rendering/test.js
@@ -182,6 +182,7 @@ async function renderPage(page, entry, options) {
     waitUntil: 'networkidle0',
   });
   const config = await renderCalled;
+  await sleep(1000);
   options.log.debug('screenshot', entry);
   await page.screenshot({path: getActualScreenshotPath(entry)});
   return config;


### PR DESCRIPTION
This pull request should make it unnecessary to call `map.updateSize()` manually in most cases, even when the map is inside a shadow DOM.

Closes #13913 (although it may not cover everything that @MoonE had in mind there)
Fixes #14247 