### PR TITLE
Rename numberSafeCompareFunction to ascending

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -13,7 +13,7 @@
  */
 export function binarySearch(haystack, needle, comparator) {
   let mid, cmp;
-  comparator = comparator || numberSafeCompareFunction;
+  comparator = comparator || ascending;
   let low = 0;
   let high = haystack.length;
   let found = false;
@@ -39,13 +39,13 @@ export function binarySearch(haystack, needle, comparator) {
 }
 
 /**
- * Compare function for array sort that is safe for numbers.
+ * Compare function sorting arrays in ascending order.  Safe to use for numeric values.
  * @param {*} a The first object to be compared.
  * @param {*} b The second object to be compared.
  * @return {number} A negative number, zero, or a positive number as the first
  *     argument is less than, equal to, or greater than the second.
  */
-export function numberSafeCompareFunction(a, b) {
+export function ascending(a, b) {
   return a > b ? 1 : a < b ? -1 : 0;
 }
 
@@ -202,7 +202,7 @@ export function stableSort(arr, compareFnc) {
  * @return {boolean} Return index.
  */
 export function isSorted(arr, func, strict) {
-  const compare = func || numberSafeCompareFunction;
+  const compare = func || ascending;
   return arr.every(function (currentVal, index) {
     if (index === 0) {
       return true;

--- a/src/ol/geom/flat/interiorpoint.js
+++ b/src/ol/geom/flat/interiorpoint.js
@@ -1,8 +1,8 @@
 /**
  * @module ol/geom/flat/interiorpoint
  */
+import {ascending} from '../../array.js';
 import {linearRingsContainsXY} from './contains.js';
-import {numberSafeCompareFunction} from '../../array.js';
 
 /**
  * Calculates a point that is likely to lie in the interior of the linear rings.
@@ -50,7 +50,7 @@ export function getInteriorPointOfArray(
   // inside the linear ring.
   let pointX = NaN;
   let maxSegmentLength = -Infinity;
-  intersections.sort(numberSafeCompareFunction);
+  intersections.sort(ascending);
   x1 = intersections[0];
   for (i = 1, ii = intersections.length; i < ii; ++i) {
     x2 = intersections[i];

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -3,6 +3,7 @@
  */
 
 import Executor from './Executor.js';
+import {ascending} from '../../array.js';
 import {buffer, createEmpty, extendCoordinate} from '../../extent.js';
 import {
   compose as composeTransform,
@@ -10,7 +11,6 @@ import {
 } from '../../transform.js';
 import {createCanvasContext2D} from '../../dom.js';
 import {isEmpty} from '../../obj.js';
-import {numberSafeCompareFunction} from '../../array.js';
 import {transform2D} from '../../geom/flat/transform.js';
 
 /**
@@ -252,7 +252,7 @@ class ExecutorGroup {
 
     /** @type {Array<number>} */
     const zs = Object.keys(this.executorsByZIndex_).map(Number);
-    zs.sort(numberSafeCompareFunction);
+    zs.sort(ascending);
 
     let i, j, executors, executor, result;
     for (i = zs.length - 1; i >= 0; --i) {
@@ -324,7 +324,7 @@ class ExecutorGroup {
   ) {
     /** @type {Array<number>} */
     const zs = Object.keys(this.executorsByZIndex_).map(Number);
-    zs.sort(numberSafeCompareFunction);
+    zs.sort(ascending);
 
     // setup clipping so that the parts of over-simplified geometries are not
     // visible outside the current extent when panning

--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -4,10 +4,10 @@
 
 import CanvasImmediateRenderer from './Immediate.js';
 import {Icon} from '../../style.js';
+import {ascending} from '../../array.js';
 import {clamp} from '../../math.js';
 import {createCanvasContext2D} from '../../dom.js';
 import {intersects} from '../../extent.js';
-import {numberSafeCompareFunction} from '../../array.js';
 
 export const HIT_DETECT_RESOLUTION = 0.5;
 
@@ -143,9 +143,7 @@ export function createHitDetectionImageData(
     }
   }
 
-  const zIndexKeys = Object.keys(featuresByZIndex)
-    .map(Number)
-    .sort(numberSafeCompareFunction);
+  const zIndexKeys = Object.keys(featuresByZIndex).map(Number).sort(ascending);
   for (let i = 0, ii = zIndexKeys.length; i < ii; ++i) {
     const byGeometryType = featuresByZIndex[zIndexKeys[i]];
     for (const type in byGeometryType) {

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -12,6 +12,7 @@ import {
   makeInverse,
   toString as toTransformString,
 } from '../../transform.js';
+import {ascending} from '../../array.js';
 import {
   containsCoordinate,
   createEmpty,
@@ -25,7 +26,6 @@ import {
 } from '../../extent.js';
 import {fromUserExtent} from '../../proj.js';
 import {getUid} from '../../util.js';
-import {numberSafeCompareFunction} from '../../array.js';
 import {toSize} from '../../size.js';
 
 /**
@@ -420,7 +420,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     this.renderedTiles.length = 0;
     /** @type {Array<number>} */
     let zs = Object.keys(tilesToDrawByZ).map(Number);
-    zs.sort(numberSafeCompareFunction);
+    zs.sort(ascending);
 
     let clips, clipZs, currentClip;
     if (

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -19,6 +19,7 @@ import {
   scale as scaleTransform,
   translate as translateTransform,
 } from '../../transform.js';
+import {ascending} from '../../array.js';
 import {
   boundingExtent,
   containsCoordinate,
@@ -35,7 +36,6 @@ import {
 } from '../../tilecoord.js';
 import {fromUserExtent} from '../../proj.js';
 import {getUid} from '../../util.js';
-import {numberSafeCompareFunction} from '../../array.js';
 import {toSize} from '../../size.js';
 
 export const Uniforms = {
@@ -562,9 +562,7 @@ class WebGLTileLayerRenderer extends WebGLLayerRenderer {
     this.helper.useProgram(this.program_, frameState);
     this.helper.prepareDraw(frameState, !blend);
 
-    const zs = Object.keys(tileTexturesByZ)
-      .map(Number)
-      .sort(numberSafeCompareFunction);
+    const zs = Object.keys(tileTexturesByZ).map(Number).sort(ascending);
 
     const centerX = viewState.center[0];
     const centerY = viewState.center[1];

--- a/test/node/ol/array.test.js
+++ b/test/node/ol/array.test.js
@@ -515,10 +515,10 @@ describe('ol/array.js', function () {
 
   describe('numberSafeCompareFunction', function () {
     it('sorts as expected', function () {
-      const arr = [40, 200, 3000];
-      // default sort would yield [200, 3000, 40]
+      const arr = [3000, 40, 200];
       arr.sort(numberSafeCompareFunction);
-      expect(arr).to.eql(arr);
+      // default sort would yield [200, 3000, 40]
+      expect(arr).to.eql([40, 200, 3000]);
     });
   });
 

--- a/test/node/ol/array.test.js
+++ b/test/node/ol/array.test.js
@@ -1,11 +1,11 @@
 import expect from '../expect.js';
 import {
+  ascending,
   binarySearch,
   equals,
   extend,
   isSorted,
   linearFindNearest,
-  numberSafeCompareFunction,
   remove,
   reverseSubArray,
   stableSort,
@@ -513,12 +513,24 @@ describe('ol/array.js', function () {
     });
   });
 
-  describe('numberSafeCompareFunction', function () {
-    it('sorts as expected', function () {
+  describe('ascending', function () {
+    it('sorts integers in ascending order', function () {
       const arr = [3000, 40, 200];
-      arr.sort(numberSafeCompareFunction);
+      arr.sort(ascending);
       // default sort would yield [200, 3000, 40]
       expect(arr).to.eql([40, 200, 3000]);
+    });
+
+    it('sorts floats in ascending order', function () {
+      const arr = [-2.0, -2.1, -1.9];
+      arr.sort(ascending);
+      expect(arr).to.eql([-2.1, -2.0, -1.9]);
+    });
+
+    it('sorts strings in ascending order', function () {
+      const arr = ['bravo', 'alpha', 'delta'];
+      arr.sort(ascending);
+      expect(arr).to.eql(['alpha', 'bravo', 'delta']);
     });
   });
 


### PR DESCRIPTION
The `numberSafeCompareFunction` is a comparison function that can be used to sort arrays in ascending order.  It works for numbers as well as strings.  This change updates the name to reflect the type of sort (ascending).