### PR TITLE
Ensure `change:position` event is fired if identify transform used

### DIFF
--- a/src/ol/Geolocation.js
+++ b/src/ol/Geolocation.js
@@ -224,7 +224,7 @@ class Geolocation extends BaseObject {
       this.position_[1] = coords.latitude;
     }
     const projectedPosition = this.transform_(this.position_);
-    this.set(Property.POSITION, projectedPosition);
+    this.set(Property.POSITION, projectedPosition.slice());
     this.set(Property.SPEED, coords.speed === null ? undefined : coords.speed);
     const geometry = circularPolygon(this.position_, coords.accuracy);
     geometry.applyTransform(this.transform_);


### PR DESCRIPTION
Fixes #14317

`slice()` the projected position coordinates array to ensure a change event is triggered as an identity transform, either from an undefined projection or one without transforms, will return `this.position_` which will be the same array despite having changed contents.
