### PR TITLE
Updated extensions for Stamen tiles

### DIFF
--- a/src/ol/source/Stamen.js
+++ b/src/ol/source/Stamen.js
@@ -21,11 +21,11 @@ const ATTRIBUTIONS = [
  */
 const LayerConfig = {
   'terrain': {
-    extension: 'jpg',
+    extension: 'png',
     opaque: true,
   },
   'terrain-background': {
-    extension: 'jpg',
+    extension: 'png',
     opaque: true,
   },
   'terrain-labels': {


### PR DESCRIPTION
The `terrain` and `terrain-background` tiles are `png` instead of `jpg`.  This change avoids the 301 redirect.

E.g. 
 * https://stamen-tiles-c.a.ssl.fastly.net/terrain/12/653/1582.jpg
 * https://stamen-tiles-c.a.ssl.fastly.net/terrain-background/12/653/1582.jpg
