### PR TITLE
Mark OGC tile sources as stable

### DIFF
--- a/examples/ogc-map-tiles-geographic.html
+++ b/examples/ogc-map-tiles-geographic.html
@@ -3,9 +3,7 @@ layout: example.html
 title: OGC Map Tiles (Geographic)
 shortdesc: Rendering map tiles from an OGC API – Tiles service.
 docs: >
-  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide map tiles.  Because the specification
-  has not yet been finalized, the <code>OGCMapTile</code> source is not yet part of the stable API.
+  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide map tiles.
 tags: "ogc"
-experimental: true
 ---
 <div id="map" class="map"></div>

--- a/examples/ogc-map-tiles-geographic.js
+++ b/examples/ogc-map-tiles-geographic.js
@@ -8,7 +8,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new OGCMapTile({
-        url: 'https://maps.ecere.com/ogcapi/collections/blueMarble/map/tiles/WorldCRS84Quad',
+        url: 'https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WorldCRS84Quad',
       }),
     }),
   ],

--- a/examples/ogc-map-tiles.html
+++ b/examples/ogc-map-tiles.html
@@ -3,9 +3,7 @@ layout: example.html
 title: OGC Map Tiles
 shortdesc: Rendering map tiles from an OGC API – Tiles service.
 docs: >
-  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide map tiles.  Because the specification
-  has not yet been finalized, the <code>OGCMapTile</code> source is not yet part of the stable API.
+  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide map tiles.
 tags: "ogc"
-experimental: true
 ---
 <div id="map" class="map"></div>

--- a/examples/ogc-map-tiles.js
+++ b/examples/ogc-map-tiles.js
@@ -8,7 +8,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new OGCMapTile({
-        url: 'https://maps.ecere.com/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad',
+        url: 'https://maps.gnosis.earth/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad',
       }),
     }),
   ],

--- a/examples/ogc-vector-tiles.html
+++ b/examples/ogc-vector-tiles.html
@@ -3,9 +3,7 @@ layout: example.html
 title: OGC Vector Tiles
 shortdesc: Rendering vector tiles from an OGC API – Tiles service.
 docs: >
-  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide vector tiles.  Because the specification
-  has not yet been finalized, the <code>OGCVectorTile</code> source is not yet part of the stable API.
+  The <a href="https://ogcapi.ogc.org/tiles/">OGC API – Tiles</a> specification describes how a service can provide vector tiles.
 tags: "ogc, vector"
-experimental: true
 ---
 <div id="map" class="map"></div>

--- a/examples/ogc-vector-tiles.js
+++ b/examples/ogc-vector-tiles.js
@@ -9,9 +9,15 @@ const map = new Map({
   layers: [
     new VectorTileLayer({
       source: new OGCVectorTile({
-        url: 'https://maps.ecere.com/ogcapi/collections/NaturalEarth:cultural:ne_10m_admin_0_countries/tiles/WebMercatorQuad',
+        url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:cultural:ne_10m_admin_0_countries/tiles/WebMercatorQuad',
         format: new MVT(),
       }),
+      background: '#d1d1d1',
+      style: {
+        'stroke-width': 0.6,
+        'stroke-color': '#8c8b8b',
+        'fill-color': '#f7f7e9',
+      },
     }),
   ],
   view: new View({

--- a/src/ol/source/OGCMapTile.js
+++ b/src/ol/source/OGCMapTile.js
@@ -40,6 +40,7 @@ import {error as logError} from '../console.js';
  * Layer source for map tiles from an [OGC API - Tiles](https://ogcapi.ogc.org/tiles/) service that provides "map" type tiles.
  * The service must conform to at least the core (http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/core)
  * and tileset (http://www.opengis.net/spec/ogcapi-tiles-1/1.0/conf/tileset) conformance classes.
+ * @api
  */
 class OGCMapTile extends TileImage {
   /**

--- a/src/ol/source/OGCVectorTile.js
+++ b/src/ol/source/OGCVectorTile.js
@@ -44,6 +44,7 @@ import {error as logError} from '../console.js';
  * Vector tile sets may come in a variety of formats (e.g. GeoJSON, MVT).  The `format` option is used to determine
  * which of the advertised media types is used.  If you need to force the use of a particular media type, you can
  * provide the `mediaType` option.
+ * @api
  */
 class OGCVectorTile extends VectorTile {
   /**


### PR DESCRIPTION
The OGC API – Tiles core v1 spec [has been published](https://opengeospatial.github.io/ogcna-auto-review/20-057.html), so we can mark the vector and map tile sources as part of the API now.