### PR TITLE
Introduce `width` and `height` to Icon style

### DIFF
--- a/examples/icon-width.html
+++ b/examples/icon-width.html
@@ -23,4 +23,8 @@ resources:
     <input id="height-input" name="height" type="number" value="40"/>
     <button id="clear-height-button">clear</button>
   </div>
+  <div style="margin: 1em 0;">
+    <label for="height">Scale approx.:</label>
+    <span id="scale"></span>
+  </div>
 </div>

--- a/examples/icon-width.html
+++ b/examples/icon-width.html
@@ -4,9 +4,23 @@ title: Icon Symbolizer width and height
 shortdesc: Example using the width and height properties of an icon.
 docs: >
   Example using the width and height properties of an icon.
-tags: "vector, style, icon, marker, width"
+  Adjust the actual <strong>width</strong> and <strong>height</strong> with the input fields above.
+tags: "vector, style, icon, marker, width, height"
 resources:
   - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css
   - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js
 ---
 <div id="map" class="map"><div id="popup"></div></div>
+
+<div class="controls">
+  <div style="margin: 1em 0;">
+    <label for="width">Width:</label>
+    <input id="width-input" name="width" type="number" value="40"/>
+    <button id="clear-width-button">clear</button>
+  </div>
+  <div style="margin: 1em 0;">
+    <label for="height">Height:</label>
+    <input id="height-input" name="height" type="number" value="40"/>
+    <button id="clear-height-button">clear</button>
+  </div>
+</div>

--- a/examples/icon-width.html
+++ b/examples/icon-width.html
@@ -1,0 +1,12 @@
+---
+layout: example.html
+title: Icon Symbolizer width and height
+shortdesc: Example using the width and height properties of an icon.
+docs: >
+  Example using the width and height properties of an icon.
+tags: "vector, style, icon, marker, width"
+resources:
+  - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css
+  - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js
+---
+<div id="map" class="map"><div id="popup"></div></div>

--- a/examples/icon-width.js
+++ b/examples/icon-width.js
@@ -1,0 +1,93 @@
+import Feature from '../src/ol/Feature.js';
+import Map from '../src/ol/Map.js';
+import Overlay from '../src/ol/Overlay.js';
+import Point from '../src/ol/geom/Point.js';
+import TileJSON from '../src/ol/source/TileJSON.js';
+import VectorSource from '../src/ol/source/Vector.js';
+import View from '../src/ol/View.js';
+import {Icon, Style} from '../src/ol/style.js';
+import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
+
+const iconFeature = new Feature({
+  geometry: new Point([0, 0]),
+  name: 'Null Island',
+  population: 4000,
+  rainfall: 500,
+});
+
+const iconStyle = new Style({
+  image: new Icon({
+    src: 'data/icon.png',
+    width: 50,
+    height: 40,
+  }),
+});
+
+iconFeature.setStyle(iconStyle);
+
+const vectorSource = new VectorSource({
+  features: [iconFeature],
+});
+
+const vectorLayer = new VectorLayer({
+  source: vectorSource,
+});
+
+const rasterLayer = new TileLayer({
+  source: new TileJSON({
+    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    crossOrigin: '',
+  }),
+});
+
+const map = new Map({
+  layers: [rasterLayer, vectorLayer],
+  target: document.getElementById('map'),
+  view: new View({
+    center: [0, 0],
+    zoom: 3,
+  }),
+});
+
+const element = document.getElementById('popup');
+
+const popup = new Overlay({
+  element: element,
+  positioning: 'bottom-center',
+  stopEvent: false,
+});
+map.addOverlay(popup);
+
+let popover;
+function disposePopover() {
+  if (popover) {
+    popover.dispose();
+    popover = undefined;
+  }
+}
+// display popup on click
+map.on('click', function (evt) {
+  const feature = map.forEachFeatureAtPixel(evt.pixel, function (feature) {
+    return feature;
+  });
+  disposePopover();
+  if (!feature) {
+    return;
+  }
+  popup.setPosition(evt.coordinate);
+  popover = new bootstrap.Popover(element, {
+    placement: 'top',
+    html: true,
+    content: feature.get('name'),
+  });
+  popover.show();
+});
+
+// change mouse cursor when over marker
+map.on('pointermove', function (e) {
+  const pixel = map.getEventPixel(e.originalEvent);
+  const hit = map.hasFeatureAtPixel(pixel);
+  map.getTarget().style.cursor = hit ? 'pointer' : '';
+});
+// Close the popup when the map is moved
+map.on('movestart', disposePopover);

--- a/examples/icon-width.js
+++ b/examples/icon-width.js
@@ -46,7 +46,6 @@ clearHeightButton.addEventListener('click', () => {
   iconFeature.changed();
 });
 
-
 const vectorSource = new VectorSource({
   features: [iconFeature],
 });

--- a/examples/icon-width.js
+++ b/examples/icon-width.js
@@ -46,11 +46,13 @@ heightInput.addEventListener('input', (event) => {
 clearWidthButton.addEventListener('click', () => {
   widthInput.value = undefined;
   iconStyle.getImage().setWidth(undefined);
+  scaleSpan.innerText = formatScale(iconStyle.getImage().getScale());
   iconFeature.changed();
 });
 clearHeightButton.addEventListener('click', () => {
   heightInput.value = undefined;
   iconStyle.getImage().setHeight(undefined);
+  scaleSpan.innerText = formatScale(iconStyle.getImage().getScale());
   iconFeature.changed();
 });
 

--- a/examples/icon-width.js
+++ b/examples/icon-width.js
@@ -11,6 +11,7 @@ const widthInput = document.getElementById('width-input');
 const heightInput = document.getElementById('height-input');
 const clearWidthButton = document.getElementById('clear-width-button');
 const clearHeightButton = document.getElementById('clear-height-button');
+const scaleSpan = document.getElementById('scale');
 
 const iconFeature = new Feature({
   geometry: new Point([0, 0]),
@@ -27,13 +28,20 @@ const iconStyle = new Style({
 });
 iconFeature.setStyle(iconStyle);
 
+const image = iconStyle.getImage().getImage();
+image.addEventListener('load', () => {
+  scaleSpan.innerText = formatScale(iconStyle.getImage().getScale());
+});
+
 widthInput.addEventListener('input', (event) => {
   iconStyle.getImage().setWidth(event.target.value);
   iconFeature.changed();
+  scaleSpan.innerText = formatScale(iconStyle.getImage().getScale());
 });
 heightInput.addEventListener('input', (event) => {
   iconStyle.getImage().setHeight(event.target.value);
   iconFeature.changed();
+  scaleSpan.innerText = formatScale(iconStyle.getImage().getScale());
 });
 clearWidthButton.addEventListener('click', () => {
   widthInput.value = undefined;
@@ -69,3 +77,9 @@ new Map({
     zoom: 3,
   }),
 });
+
+function formatScale(scale) {
+  return Array.isArray(scale)
+    ? '[' + scale?.map((v) => v.toFixed(2)).join(', ') + ']'
+    : scale;
+}

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -60,6 +60,7 @@ const messages = {
   66: '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled. This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`',
   67: 'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both',
   68: 'A VectorTile source can only be rendered if it has a projection compatible with the view projection',
+  69: '`width` or `height` cannot be provided together with `scale`',
 };
 
 /**

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -60,7 +60,7 @@ const messages = {
   66: '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled. This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`',
   67: 'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both',
   68: 'A VectorTile source can only be rendered if it has a projection compatible with the view projection',
-  69: '`width` or `height` cannot be provided together with `scale` or `size`',
+  69: '`width` or `height` cannot be provided together with `scale`',
 };
 
 /**

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -60,7 +60,7 @@ const messages = {
   66: '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled. This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`',
   67: 'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both',
   68: 'A VectorTile source can only be rendered if it has a projection compatible with the view projection',
-  69: '`width` or `height` cannot be provided together with `scale` or `imgSize`',
+  69: '`width` or `height` cannot be provided together with `scale` or `size`',
 };
 
 /**

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -60,7 +60,7 @@ const messages = {
   66: '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled. This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`',
   67: 'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both',
   68: 'A VectorTile source can only be rendered if it has a projection compatible with the view projection',
-  69: '`width` or `height` cannot be provided together with `scale`',
+  69: '`width` or `height` cannot be provided together with `scale` or `imgSize`',
 };
 
 /**

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -43,8 +43,8 @@ import {getUid} from '../util.js';
  * @property {Array<number>} [displacement=[0, 0]] Displacement of the icon in pixels.
  * Positive values will shift the icon right and up.
  * @property {number} [opacity=1] Opacity of the icon.
- * @property {number} [width] The width of the icon in pixels. This can't be used together with `scale` or `size`.
- * @property {number} [height] The height of the icon in pixels. This can't be used together with `scale` or `size`.
+ * @property {number} [width] The width of the icon in pixels. This can't be used together with `scale`.
+ * @property {number} [height] The height of the icon in pixels. This can't be used together with `scale`.
  * @property {number|import("../size.js").Size} [scale=1] Scale.
  * @property {boolean} [rotateWithView=false] Whether to rotate the icon with the view.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
@@ -165,7 +165,7 @@ class Icon extends ImageStyle {
     }
     assert(src !== undefined && src.length > 0, 6); // A defined and non-empty `src` or `image` must be provided
 
-    // `width` or `height` cannot be provided together with `scale` or `size`
+    // `width` or `height` cannot be provided together with `scale`
     assert(
       !(
         (options.width !== undefined || options.height !== undefined) &&

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -236,7 +236,7 @@ class Icon extends ImageStyle {
     /**
      * Recalculate the scale if width or height where given.
      */
-    if (this.width_ > 0 || this.height_ > 0) {
+    if (this.width_ !== undefined || this.height_ !== undefined) {
       const image = this.getImage(1);
       const setScale = () => {
         this.updateScaleFromWidthAndHeight(this.width_, this.height_);

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -43,8 +43,8 @@ import {getUid} from '../util.js';
  * @property {Array<number>} [displacement=[0, 0]] Displacement of the icon in pixels.
  * Positive values will shift the icon right and up.
  * @property {number} [opacity=1] Opacity of the icon.
- * @property {number} [width] The width of the icon in pixels.
- * @property {number} [height] The height of the icon in pixels.
+ * @property {number} [width] The width of the icon in pixels. This can't be used together with `scale` or `size`.
+ * @property {number} [height] The height of the icon in pixels. This can't be used together with `scale` or `size`.
  * @property {number|import("../size.js").Size} [scale=1] Scale.
  * @property {boolean} [rotateWithView=false] Whether to rotate the icon with the view.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -169,7 +169,7 @@ class Icon extends ImageStyle {
     assert(
       !(
         (options.width !== undefined || options.height !== undefined) &&
-        (options.scale !== undefined || this.size_ !== undefined)
+        options.scale !== undefined
       ),
       69
     );

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -293,13 +293,13 @@ class Icon extends ImageStyle {
   updateScaleFromWidthAndHeight(width, height) {
     const image = this.getImage(1);
     if (width !== undefined && height !== undefined) {
-      this.setScale([width / image.width, height / image.height]);
+      super.setScale([width / image.width, height / image.height]);
     } else if (width !== undefined) {
-      this.setScale([width / image.width, width / image.width]);
+      super.setScale([width / image.width, width / image.width]);
     } else if (height !== undefined) {
-      this.setScale([height / image.height, height / image.height]);
+      super.setScale([height / image.height, height / image.height]);
     } else {
-      this.setScale([1, 1]);
+      super.setScale([1, 1]);
     }
   }
 
@@ -513,6 +513,28 @@ class Icon extends ImageStyle {
   setHeight(height) {
     this.height_ = height;
     this.updateScaleFromWidthAndHeight(this.width_, height);
+  }
+
+  /**
+   * Set the scale and updates the width and height correspondingly.
+   *
+   * @param {number|import("../size.js").Size} scale Scale.
+   * @override
+   * @api
+   */
+  setScale(scale) {
+    super.setScale(scale);
+    const image = this.getImage(1);
+    if (image) {
+      const widthScale = Array.isArray(scale) ? scale[0] : scale;
+      if (widthScale !== undefined) {
+        this.width_ = widthScale * image.width;
+      }
+      const heightScale = Array.isArray(scale) ? scale[1] : scale;
+      if (heightScale !== undefined) {
+        this.height_ = heightScale * image.height;
+      }
+    }
   }
 
   /**

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -8,7 +8,6 @@ import {asArray} from '../color.js';
 import {assert} from '../asserts.js';
 import {get as getIconImage} from './IconImage.js';
 import {getUid} from '../util.js';
-import {toSize} from '../size.js';
 
 /**
  * @typedef {'fraction' | 'pixels'} IconAnchorUnits
@@ -166,11 +165,11 @@ class Icon extends ImageStyle {
     }
     assert(src !== undefined && src.length > 0, 6); // A defined and non-empty `src` or `image` must be provided
 
-    // `width` or `height` cannot be provided together with `scale`
+    // `width` or `height` cannot be provided together with `scale` or `imgSize`
     assert(
       !(
         (options.width !== undefined || options.height !== undefined) &&
-        options.scale !== undefined
+        (options.scale !== undefined || this.imgSize_ !== undefined)
       ),
       69
     );
@@ -284,28 +283,23 @@ class Icon extends ImageStyle {
   }
 
   /**
+   * Set the scale of the Icon by calculating it from given width and height and the
+   * width and height of the image.
+   *
    * @private
    * @param {number} width The width.
    * @param {number} height The height.
    */
   updateScaleFromWidthAndHeight(width, height) {
     const image = this.getImage(1);
-    const scale = toSize(this.getScale());
-    if (width > 0 && height > 0) {
-      this.setScale([
-        (width * scale[0]) / image.width,
-        (height * scale[1]) / image.height,
-      ]);
-    } else if (width > 0) {
-      this.setScale([
-        (width * scale[0]) / image.width,
-        (width * scale[1]) / image.width,
-      ]);
+    if (width !== undefined && height !== undefined) {
+      this.setScale([width / image.width, height / image.height]);
+    } else if (width !== undefined) {
+      this.setScale([width / image.width, width / image.width]);
+    } else if (height !== undefined) {
+      this.setScale([height / image.height, height / image.height]);
     } else {
-      this.setScale([
-        (height * scale[0]) / image.height,
-        (height * scale[1]) / image.height,
-      ]);
+      this.setScale([1, 1]);
     }
   }
 
@@ -507,6 +501,7 @@ class Icon extends ImageStyle {
    * @param {number} width The width to set.
    */
   setWidth(width) {
+    this.width_ = width;
     this.updateScaleFromWidthAndHeight(width, this.height_);
   }
 
@@ -516,6 +511,7 @@ class Icon extends ImageStyle {
    * @param {number} height The height to set.
    */
   setHeight(height) {
+    this.height_ = height;
     this.updateScaleFromWidthAndHeight(this.width_, height);
   }
 

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -165,11 +165,11 @@ class Icon extends ImageStyle {
     }
     assert(src !== undefined && src.length > 0, 6); // A defined and non-empty `src` or `image` must be provided
 
-    // `width` or `height` cannot be provided together with `scale` or `imgSize`
+    // `width` or `height` cannot be provided together with `scale` or `size`
     assert(
       !(
         (options.width !== undefined || options.height !== undefined) &&
-        (options.scale !== undefined || this.imgSize_ !== undefined)
+        (options.scale !== undefined || this.size_ !== undefined)
       ),
       69
     );

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -258,6 +258,7 @@ class ImageStyle {
   setRotation(rotation) {
     this.rotation_ = rotation;
   }
+
   /**
    * Set the scale.
    *

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -357,12 +357,52 @@ describe('ol.style.Icon', function () {
     });
   });
 
-  describe('#width', function () {
+  describe('#width/height', function () {
+    // 3px * 4px sized white gif
+    const img =
+      'data:image/gif;base64,' +
+      'R0lGODlhAwAEAIABAP7+/vDy9SH+EUNyZWF0ZWQgd2l0aCBHSU1QACH5BAEKAAEALAAAAAADAAQAAAIDhI9WADs=';
+    it('scale is set correctly if configured with width only', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+        width: 6,
+      });
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getScale()).to.eql([2, 2]);
+        done();
+      });
+      iconStyle.load();
+    });
+    it('scale is set correctly if configured with height only', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+        height: 12,
+      });
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getScale()).to.eql([3, 3]);
+        done();
+      });
+      iconStyle.load();
+    });
+    it('scale is set correctly if used with width and height', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+        width: 6,
+        height: 12,
+      });
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getScale()).to.eql([2, 3]);
+        done();
+      });
+      iconStyle.load();
+    });
     it('getWidth returns the expected value', function () {
       const iconStyle = new Icon({
         src,
         width: 10,
-        height: 20,
       });
       expect(iconStyle.getWidth()).to.eql(10);
     });
@@ -370,19 +410,14 @@ describe('ol.style.Icon', function () {
       const iconStyle = new Icon({
         src,
         width: 10,
-        height: 20,
       });
       expect(iconStyle.getWidth()).to.eql(10);
-      iconStyle.setWidth(100);
-      expect(iconStyle.getWidth()).to.eql(100);
+      iconStyle.setWidth(30);
+      expect(iconStyle.getWidth()).to.eql(30);
     });
-  });
-
-  describe('#height', function () {
     it('getHeight returns the expected value', function () {
       const iconStyle = new Icon({
         src,
-        width: 10,
         height: 20,
       });
       expect(iconStyle.getHeight()).to.eql(20);
@@ -390,12 +425,37 @@ describe('ol.style.Icon', function () {
     it('setHeight updates the height', function () {
       const iconStyle = new Icon({
         src,
-        width: 10,
         height: 20,
       });
       expect(iconStyle.getHeight()).to.eql(20);
       iconStyle.setHeight(200);
       expect(iconStyle.getHeight()).to.eql(200);
+    });
+    it('setScale updates the width and height', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+      });
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        iconStyle.setScale(2);
+        expect(iconStyle.getWidth()).to.eql(6);
+        expect(iconStyle.getHeight()).to.eql(8);
+        done();
+      });
+      iconStyle.load();
+    });
+    it('setScale with array updates the width and height', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+      });
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        iconStyle.setScale([3, 4]);
+        expect(iconStyle.getWidth()).to.eql(9);
+        expect(iconStyle.getHeight()).to.eql(16);
+        done();
+      });
+      iconStyle.load();
     });
   });
 });

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -356,4 +356,46 @@ describe('ol.style.Icon', function () {
       expect(iconStyle.getImageSize()).to.eql(imgSize);
     });
   });
+
+  describe('#width', function () {
+    it('getWidth returns the expected value', function () {
+      const iconStyle = new Icon({
+        src,
+        width: 10,
+        height: 20,
+      });
+      expect(iconStyle.getWidth()).to.eql(10);
+    });
+    it('setWidth updates the width', function () {
+      const iconStyle = new Icon({
+        src,
+        width: 10,
+        height: 20,
+      });
+      expect(iconStyle.getWidth()).to.eql(10);
+      iconStyle.setWidth(100);
+      expect(iconStyle.getWidth()).to.eql(100);
+    });
+  });
+
+  describe('#height', function () {
+    it('getHeight returns the expected value', function () {
+      const iconStyle = new Icon({
+        src,
+        width: 10,
+        height: 20,
+      });
+      expect(iconStyle.getHeight()).to.eql(20);
+    });
+    it('setHeight updates the height', function () {
+      const iconStyle = new Icon({
+        src,
+        width: 10,
+        height: 20,
+      });
+      expect(iconStyle.getHeight()).to.eql(20);
+      iconStyle.setHeight(200);
+      expect(iconStyle.getHeight()).to.eql(200);
+    });
+  });
 });


### PR DESCRIPTION
This introduces the `width` and `height` property to the `Icon` style.

It includes an example.

![openlayers_width_height](https://user-images.githubusercontent.com/1849416/206224064-7a56c67b-e6a6-46d3-b345-f5ba3b737706.gif)

The code is highlighy influenced by https://codesandbox.io/s/icon-forked-uof9by?file=/main.js so kudos to @mike-000 

addresses #13508