### PR TITLE
webgl2-support && tests changed

### DIFF
--- a/examples/numpytile.js
+++ b/examples/numpytile.js
@@ -29,7 +29,7 @@ function numpyTileLoader(z, x, y) {
           dataTile[px * 5 + 2] = numpyData.data[bandSize * 2 + y * 256 + x];
           dataTile[px * 5 + 3] = numpyData.data[bandSize * 3 + y * 256 + x];
           dataTile[px * 5 + 4] =
-            numpyData.data[bandSize * 4 + y * 256 + x] > 0 ? 1.0 : 0;
+            numpyData.data[bandSize * 4 + y * 256 + x] > 0 ? 255 : 0;
         }
       }
       return dataTile;

--- a/src/ol/webgl.js
+++ b/src/ol/webgl.js
@@ -76,6 +76,18 @@ export const UNSIGNED_INT = 0x1405;
  */
 export const FLOAT = 0x1406;
 
+/**
+ * @const
+ * @type {number}
+ */
+export const RGB32F = 0x8815;
+
+/**
+ * @const
+ * @type {number}
+ */
+export const RGBA32F = 0x8814;
+
 /** end of goog.webgl constants
  */
 
@@ -83,12 +95,18 @@ export const FLOAT = 0x1406;
  * @const
  * @type {Array<string>}
  */
-const CONTEXT_IDS = ['experimental-webgl', 'webgl', 'webkit-3d', 'moz-webgl'];
+const CONTEXT_IDS = [
+  'webgl2',
+  'experimental-webgl',
+  'webgl',
+  'webkit-3d',
+  'moz-webgl',
+];
 
 /**
  * @param {HTMLCanvasElement} canvas Canvas.
  * @param {Object} [attributes] Attributes.
- * @return {WebGLRenderingContext} WebGL rendering context.
+ * @return {WebGLRenderingContext | WebGL2RenderingContext} WebGL rendering context.
  */
 export function getContext(canvas, attributes) {
   attributes = Object.assign(
@@ -102,8 +120,11 @@ export function getContext(canvas, attributes) {
   for (let i = 0; i < ii; ++i) {
     try {
       const context = canvas.getContext(CONTEXT_IDS[i], attributes);
+
       if (context) {
-        return /** @type {!WebGLRenderingContext} */ (context);
+        return /** @type {!WebGLRenderingContext | !WebGL2RenderingContext} */ (
+          context
+        );
       }
     } catch (e) {
       // pass

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -338,7 +338,7 @@ class WebGLHelper extends Disposable {
 
     /**
      * @private
-     * @type {WebGLRenderingContext}
+     * @type {WebGLRenderingContext | WebGL2RenderingContext}
      */
     this.gl_ = getContext(this.canvas_);
 

--- a/src/ol/webgl/TileTexture.js
+++ b/src/ol/webgl/TileTexture.js
@@ -9,7 +9,7 @@ import ImageTile from '../ImageTile.js';
 import ReprojTile from '../reproj/Tile.js';
 import TileState from '../TileState.js';
 import WebGLArrayBuffer from './Buffer.js';
-import {ARRAY_BUFFER, STATIC_DRAW} from '../webgl.js';
+import {ARRAY_BUFFER, RGB32F, RGBA32F, STATIC_DRAW} from '../webgl.js';
 import {createCanvasContext2D} from '../dom.js';
 import {toSize} from '../size.js';
 
@@ -80,9 +80,13 @@ function uploadDataTexture(
   }
 
   let format;
+  let internalFormat;
   switch (bandCount) {
     case 1: {
       format = gl.LUMINANCE;
+      textureType = gl.UNSIGNED_BYTE;
+      data = new Uint8Array(Array.prototype.slice.call(data));
+
       break;
     }
     case 2: {
@@ -90,10 +94,12 @@ function uploadDataTexture(
       break;
     }
     case 3: {
+      internalFormat = data instanceof Float32Array ? RGB32F : gl.RGB;
       format = gl.RGB;
       break;
     }
     case 4: {
+      internalFormat = data instanceof Float32Array ? RGBA32F : gl.RGBA;
       format = gl.RGBA;
       break;
     }
@@ -104,10 +110,11 @@ function uploadDataTexture(
 
   const oldUnpackAlignment = gl.getParameter(gl.UNPACK_ALIGNMENT);
   gl.pixelStorei(gl.UNPACK_ALIGNMENT, unpackAlignment);
+
   gl.texImage2D(
     gl.TEXTURE_2D,
     0,
-    format,
+    internalFormat ? internalFormat : format,
     size[0],
     size[1],
     0,
@@ -115,6 +122,7 @@ function uploadDataTexture(
     textureType,
     data
   );
+
   gl.pixelStorei(gl.UNPACK_ALIGNMENT, oldUnpackAlignment);
 }
 

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -587,7 +587,10 @@ describe('ol/layer/WebGLTile', function () {
   it('dispatches a precompose event with WebGL context', (done) => {
     let called = false;
     layer.on('precompose', (event) => {
-      expect(event.context).to.be.a(WebGLRenderingContext);
+      expect(
+        event.context instanceof WebGLRenderingContext ||
+          event.context instanceof WebGL2RenderingContext
+      ).to.eql(true);
       called = true;
     });
 
@@ -602,7 +605,10 @@ describe('ol/layer/WebGLTile', function () {
   it('dispatches a prerender event with WebGL context and inverse pixel transform', (done) => {
     let called = false;
     layer.on('prerender', (event) => {
-      expect(event.context).to.be.a(WebGLRenderingContext);
+      expect(
+        event.context instanceof WebGLRenderingContext ||
+          event.context instanceof WebGL2RenderingContext
+      ).to.eql(true);
       const mapSize = event.frameState.size;
       const bottomLeft = getRenderPixel(event, [0, mapSize[1]]);
       expect(bottomLeft).to.eql([0, 0]);
@@ -620,7 +626,10 @@ describe('ol/layer/WebGLTile', function () {
   it('dispatches a postrender event with WebGL context and inverse pixel transform', (done) => {
     let called = false;
     layer.on('postrender', (event) => {
-      expect(event.context).to.be.a(WebGLRenderingContext);
+      expect(
+        event.context instanceof WebGLRenderingContext ||
+          event.context instanceof WebGL2RenderingContext
+      ).to.eql(true);
       const mapSize = event.frameState.size;
       const topRight = getRenderPixel(event, [mapSize[1], 0]);
       const pixelRatio = event.frameState.pixelRatio;

--- a/test/browser/spec/ol/webgl/helper.test.js
+++ b/test/browser/spec/ol/webgl/helper.test.js
@@ -80,7 +80,10 @@ describe('ol/webgl/WebGLHelper', function () {
       });
 
       it('initialized WebGL context & canvas', function () {
-        expect(h.getGL() instanceof WebGLRenderingContext).to.eql(true);
+        expect(
+          h.getGL() instanceof WebGLRenderingContext ||
+            h.getGL() instanceof WebGL2RenderingContext
+        ).to.eql(true);
         expect(h.getCanvas() instanceof HTMLCanvasElement).to.eql(true);
       });
 


### PR DESCRIPTION
Possible fix for #13529.

I have made a devices investigation and find out there are multiple newer devices not supporting OES_texture_float and many more not supporting OES_texture_float_linear, which makes NumpyTiles example and many more applications of this concept unuseful. However, many of these devices supports WebGL2, which natively support working with floating point by default. Also, there always could be devices not supporting OES_texture_float_linear, but we can fallback then to gl.NEAREST - as already implemented.

 Could you please make a revision of my merge request to get to main OL branch to support many more devices?