### PR TITLE
Fix typo in Helper.js & inconsistency in ShaderBuilder.js comment.

### DIFF
--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -841,7 +841,7 @@ class WebGLHelper extends Disposable {
     gl.linkProgram(program);
 
     if (!gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS)) {
-      const message = `Fragment shader compliation failed: ${gl.getShaderInfoLog(
+      const message = `Fragment shader compilation failed: ${gl.getShaderInfoLog(
         fragmentShader
       )}`;
       throw new Error(message);

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -262,7 +262,7 @@ export class ShaderBuilder {
    * Generates a symbol vertex shader from the builder parameters,
    * intended to be used on point geometries.
    *
-   * Three uniforms are hardcoded in all shaders: `u_projectionMatrix`, `u_offsetScaleMatrix`,
+   * Four uniforms are hardcoded in all shaders: `u_projectionMatrix`, `u_offsetScaleMatrix`,
    * `u_offsetRotateMatrix`, `u_time`.
    *
    * The following attributes are hardcoded and expected to be present in the vertex buffers:

--- a/test/browser/spec/ol/webgl/helper.test.js
+++ b/test/browser/spec/ol/webgl/helper.test.js
@@ -226,7 +226,7 @@ describe('ol/webgl/WebGLHelper', function () {
         expect(() =>
           h.getProgram(INVALID_FRAGMENT_SHADER, VERTEX_SHADER)
         ).to.throwException(
-          /Fragment shader compliation failed: ERROR: 0:5: 'oops' : undeclared identifier/
+          /Fragment shader compilation failed: ERROR: 0:5: 'oops' : undeclared identifier/
         );
       });
     });


### PR DESCRIPTION
Fixed Helper.js typo ("compliation" --> "compilation")

Fixed ShareBuilder.js inconsistency ("Three" --> "Four" since there are 4 uniforms values listed)