### PR TITLE
Fix build index

### DIFF
--- a/config/jsdoc/info/publish.js
+++ b/config/jsdoc/info/publish.js
@@ -25,7 +25,6 @@ exports.publish = function (data, opts) {
       return true;
     }
     return (
-      typeof this.define === 'object' &&
       !['file', 'event', 'module'].includes(this.kind) &&
       this.meta &&
       this.meta.path &&


### PR DESCRIPTION
Fixes #14401.

The previous fix in #14398 did not restore all of the full build. It looks like I got the old taffydb query wrong there. Going back in the history of that file, it looks like we use `doc.define` in the other conditions anyway, so there should not be a need to filter out docs where `define` is not set.