### PR TITLE
Add .babelrc and .prettierrc to CodeSandbox export

### DIFF
--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -78,7 +78,25 @@
             'index.html': {content: html},
             'main.js': {content: js},
             'package.json': {content: pkgJson},
-            'sandbox.config.json': {content: '{"template": "parcel"}'}
+            'sandbox.config.json': {content: '{"template": "parcel"}'},
+            '.babelrc': {content: '{}'},
+            '.prettierrc': {
+              content: JSON.stringify(
+                {
+                  printWidth: 80,
+                  tabWidth: 2,
+                  useTabs: false,
+                  semi: true,
+                  singleQuote: true,
+                  trailingComma: 'es5',
+                  bracketSpacing: false,
+                  jsxBracketSameLine: false,
+                  fluid: false,
+                },
+                undefined,
+                2
+              ),
+            },
           };
           if (worker) {
             files['worker.js'] = {content: worker}


### PR DESCRIPTION
Fixes #14417

Adds an empty `.babelrc` entry to prevent transpiling.
Also adds a `.prettierrc` entry so the linting is preserved when saving changes.
