### PR TITLE
adding optional parameter to cancelAnimations to fix use case where c…

### DIFF
--- a/examples/animation.html
+++ b/examples/animation.html
@@ -17,3 +17,6 @@ tags: "animation"
 <button id="fly-to-bern">Fly to Bern</button>
 <button id="rotate-around-rome">Rotate around Rome</button>
 <button id="tour">Take a tour</button>
+<button id="never-ending-tour">Take never ending tour</button>
+<button id="cancel-animation">Cancel Animation</button>
+<button id="cancel-animation-and-callback">Cancel Animation And Callback</button>

--- a/examples/animation.js
+++ b/examples/animation.js
@@ -4,6 +4,7 @@ import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
 import {easeIn, easeOut} from '../src/ol/easing.js';
 import {fromLonLat} from '../src/ol/proj.js';
+import {never} from "ol/events/condition.js";
 
 const london = fromLonLat([-0.12755, 51.507222]);
 const moscow = fromLonLat([37.6178, 55.7517]);
@@ -195,3 +196,26 @@ function tour() {
 }
 
 onClick('tour', tour);
+
+function neverEndingTour() {
+  const locations = [london, bern, rome, moscow, istanbul];
+  const duration = 2000;
+  view.animate(
+      { center: london, duration: duration },
+              { center: bern, duration: duration },
+              { center: rome, duration: duration },
+              { center: moscow, duration: duration },
+              { center: istanbul, duration: duration },
+      neverEndingTour
+      );
+}
+
+onClick('never-ending-tour', neverEndingTour);
+
+onClick('cancel-animation', function () {
+  view.cancelAnimations(false);
+});
+
+onClick('cancel-animation-and-callback', function () {
+  view.cancelAnimations(true);
+});

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -715,13 +715,18 @@ class View extends BaseObject {
    * Cancel any ongoing animations.
    * @api
    */
-  cancelAnimations() {
+  cancelAnimations(cancelCallback = false) {
     this.setHint(ViewHint.ANIMATING, -this.hints_[ViewHint.ANIMATING]);
     let anchor;
     for (let i = 0, ii = this.animations_.length; i < ii; ++i) {
       const series = this.animations_[i];
       if (series[0].callback) {
-        animationCallback(series[0].callback, false);
+        if(cancelCallback){
+          this.animations_[0].callback = function (){return false}
+        }
+        else {
+          animationCallback(series[0].callback, false);
+        }
       }
       if (!anchor) {
         for (let j = 0, jj = series.length; j < jj; ++j) {


### PR DESCRIPTION
Addresses issue https://github.com/openlayers/openlayers/issues/14421

Adds an optional parameter ```cancelCallback``` (defaults to ```false```) to ```view.cancelAnimations(cancelCallback)``` that allows for the following use cases:
- preserves current default behavior: *animation series* is canceled but callback function still fires
- adds option to cancel callback function as well, which is useful to cancel looping animations, for example

To demo:
1. Open ```examples/animation.html``` in browser
2. Click **Never ending tour**
3. Click **Cancel Animation** to demo current behavior
4. Notice animation never stops since only the current animation series is canceled and the callback, ```neverEndingTour``` is still called
5. Refresh the page and restart the **Never ending tour**
6. Click **Cancel Animation And Callback**
7. Notice the animation stops

I believe adding this parameter adds conceptual clarity on how to cancel more types of animations while also preserving default behaior.