### PR TITLE
Fix for issue  #14389

### DIFF
--- a/src/ol/format/GMLBase.js
+++ b/src/ol/format/GMLBase.js
@@ -5,6 +5,7 @@
 // of GEOMETRY_PARSERS_ and methods using GEOMETRY_PARSERS_ do not expect
 // envelopes/extents, only geometries!
 import Feature from '../Feature.js';
+import Geometry from '../geom/Geometry.js';
 import LineString from '../geom/LineString.js';
 import LinearRing from '../geom/LinearRing.js';
 import MultiLineString from '../geom/MultiLineString.js';
@@ -313,7 +314,7 @@ class GMLBase extends XMLFeature {
       }
 
       const len = n.attributes.length;
-      if (len > 0) {
+      if (len > 0 && !(value instanceof Geometry)) {
         value = {_content_: value};
         for (let i = 0; i < len; i++) {
           const attName = n.attributes[i].name;


### PR DESCRIPTION
Fixes  openlayers/openlayers#14389

Do not use a wrapper-object, if value is a geometry. This causes a TypeError in Feature.handleGeometryChanged_

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
