### PR TITLE
Store images as canvas for more efficient reuse

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -34,6 +34,9 @@ class ImageWrapper extends ImageBase {
    * @param {string} src Image source URI.
    * @param {?string} crossOrigin Cross origin.
    * @param {LoadFunction} imageLoadFunction Image load function.
+   * @param {CanvasRenderingContext2D} [context] Canvas context. When provided, the image will be
+   *    drawn into the context's canvas, and `getImage()` will return the canvas once the image
+   *    has finished loading.
    */
   constructor(
     extent,
@@ -41,7 +44,8 @@ class ImageWrapper extends ImageBase {
     pixelRatio,
     src,
     crossOrigin,
-    imageLoadFunction
+    imageLoadFunction,
+    context
   ) {
     super(extent, resolution, pixelRatio, ImageState.IDLE);
 
@@ -59,6 +63,12 @@ class ImageWrapper extends ImageBase {
     if (crossOrigin !== null) {
       this.image_.crossOrigin = crossOrigin;
     }
+
+    /**
+     * @private
+     * @type {CanvasRenderingContext2D}
+     */
+    this.context_ = context;
 
     /**
      * @private
@@ -84,6 +94,17 @@ class ImageWrapper extends ImageBase {
    * @api
    */
   getImage() {
+    if (
+      this.state == ImageState.LOADED &&
+      this.context_ &&
+      !(this.image_ instanceof HTMLCanvasElement)
+    ) {
+      const canvas = this.context_.canvas;
+      canvas.width = this.image_.width;
+      canvas.height = this.image_.height;
+      this.context_.drawImage(this.image_, 0, 0);
+      this.image_ = this.context_.canvas;
+    }
     return this.image_;
   }
 

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -44,7 +44,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
    * @return {HTMLCanvasElement|HTMLImageElement|HTMLVideoElement} Image.
    */
   getImage() {
-    return !this.image_ ? null : this.image_.getImage();
+    return this.image_ ? this.image_.getImage() : null;
   }
 
   /**
@@ -122,7 +122,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     }
 
     const imageExtent = this.image_.getExtent();
-    const img = this.image_.getImage();
+    const img = this.getImage();
 
     const imageMapWidth = getWidth(imageExtent);
     const col = Math.floor(
@@ -211,7 +211,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       }
     }
 
-    const img = image.getImage();
+    const img = this.getImage();
 
     const transform = composeTransform(
       this.tempTransform,

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -8,6 +8,7 @@ import ImageWrapper from '../Image.js';
 import {appendParams} from '../uri.js';
 import {assert} from '../asserts.js';
 import {containsExtent, getHeight, getWidth} from '../extent.js';
+import {createCanvasContext2D} from '../dom.js';
 
 /**
  * @typedef {Object} Options
@@ -63,6 +64,12 @@ class ImageArcGISRest extends ImageSource {
       projection: options.projection,
       resolutions: options.resolutions,
     });
+
+    /**
+     * @private
+     * @type {CanvasRenderingContext2D}
+     */
+    this.context_ = createCanvasContext2D(1, 1);
 
     /**
      * @private
@@ -207,7 +214,8 @@ class ImageArcGISRest extends ImageSource {
       pixelRatio,
       url,
       this.crossOrigin_,
-      this.imageLoadFunction_
+      this.imageLoadFunction_,
+      this.context_
     );
 
     this.renderedRevision_ = this.getRevision();

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -13,6 +13,7 @@ import {
   getWidth,
   scaleFromCenter,
 } from '../extent.js';
+import {createCanvasContext2D} from '../dom.js';
 
 /**
  * @typedef {Object} Options
@@ -53,6 +54,12 @@ class ImageMapGuide extends ImageSource {
       projection: options.projection,
       resolutions: options.resolutions,
     });
+
+    /**
+     * @private
+     * @type {CanvasRenderingContext2D}
+     */
+    this.context_ = createCanvasContext2D(1, 1);
 
     /**
      * @private
@@ -182,7 +189,8 @@ class ImageMapGuide extends ImageSource {
         pixelRatio,
         imageUrl,
         this.crossOrigin_,
-        this.imageLoadFunction_
+        this.imageLoadFunction_,
+        this.context_
       );
       image.addEventListener(
         EventType.CHANGE,

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -73,7 +73,8 @@ class Static extends ImageSource {
       1,
       this.url_,
       crossOrigin,
-      imageLoadFunction
+      imageLoadFunction,
+      createCanvasContext2D(1, 1)
     );
 
     /**

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -18,6 +18,7 @@ import {
   getHeight,
   getWidth,
 } from '../extent.js';
+import {createCanvasContext2D} from '../dom.js';
 import {get as getProjection, transform} from '../proj.js';
 
 /**
@@ -79,6 +80,12 @@ class ImageWMS extends ImageSource {
       projection: options.projection,
       resolutions: options.resolutions,
     });
+
+    /**
+     * @private
+     * @type {CanvasRenderingContext2D}
+     */
+    this.context_ = createCanvasContext2D(1, 1);
 
     /**
      * @private
@@ -355,7 +362,8 @@ class ImageWMS extends ImageSource {
       pixelRatio,
       url,
       this.crossOrigin_,
-      this.imageLoadFunction_
+      this.imageLoadFunction_,
+      this.context_
     );
 
     this.renderedRevision_ = this.getRevision();

--- a/test/browser/spec/ol/image.test.js
+++ b/test/browser/spec/ol/image.test.js
@@ -1,4 +1,7 @@
-import {listenImage} from '../../../../src/ol/Image.js';
+import ImageState from '../../../../src/ol/ImageState.js';
+import ImageWrapper, {listenImage} from '../../../../src/ol/Image.js';
+import {createCanvasContext2D} from '../../../../src/ol/dom.js';
+import {defaultImageLoadFunction} from '../../../../src/ol/source/Image.js';
 
 describe('HTML Image loading', function () {
   let handleLoad, handleError, img;
@@ -51,5 +54,32 @@ describe('HTML Image loading', function () {
       expect(handleError.called).to.be(false);
       done();
     }, 200);
+  });
+});
+
+describe('getImage() with context', function () {
+  let image;
+  this.beforeEach(function (done) {
+    image = new ImageWrapper(
+      [0, 0, 1, 1],
+      1,
+      1,
+      'spec/ol/data/dot.png',
+      null,
+      defaultImageLoadFunction,
+      createCanvasContext2D()
+    );
+    image.addEventListener('change', function () {
+      if (image.getState() === ImageState.LOADED) {
+        done();
+      }
+    });
+    image.load();
+  });
+
+  it('renders the image to the provided context, returns its canvas', function () {
+    expect(image.image_).to.be.a(HTMLImageElement);
+    expect(image.getImage()).to.be.a(HTMLCanvasElement);
+    expect(image.context_.canvas).to.eql(image.getImage());
   });
 });


### PR DESCRIPTION
Fixes #14436.
Probably also fixes #13362.

This pull request changes the Image wrapper so it can store the loaded image in the canvas of a provided context. This speeds up `renderFrame()` on maps with many image layers on large screens, because the image does not have to be decoded over and over during `drawImage()` to the target canvas.

To avoid storing the image twice (once as image, once as canvas), the Image wrapper will replace the `image_` with the provided context's canvas on the first `getImage()` call. To avoid creating a new context whenever the extent changes, which is problematic on iOS due to the limited canvas memory, the sources that use the Image wrapper get a new `context_` member, so only a single context is created.
