### PR TITLE
Add more browsers that support OffscreenCanvas

### DIFF
--- a/examples/offscreen-canvas.html
+++ b/examples/offscreen-canvas.html
@@ -3,7 +3,7 @@ layout: example.html
 title: Vector tiles rendered in an offscreen canvas
 shortdesc: Example of a map that delegates rendering to a worker.
 docs: >
-  The map in this example is rendered in a web worker, using `OffscreenCanvas`. **Note:** This is currently only supported in Chrome and Edge.
+  The map in this example is rendered in a web worker, using `OffscreenCanvas`. **Note:** This is currently only supported in Chrome, Edge, Firefox > 105, Safari > 16.4.
 tags: "worker, offscreencanvas, vector-tiles"
 experimental: true
 sources:


### PR DESCRIPTION
Good news, OffscreenCanvas will soon be supported in all mainstream browsers. Firefox already supports it, and it has only recently also landed in Safari Technology Preview.