### PR TITLE
Use multisurface and multicurve for GML 3.2 and WFS 2.0

### DIFF
--- a/src/ol/format/GML32.js
+++ b/src/ol/format/GML32.js
@@ -33,6 +33,20 @@ class GML32 extends GML3 {
       ? options.schemaLocation
       : this.namespace + ' http://schemas.opengis.net/gml/3.2.1/gml.xsd';
   }
+
+  /**
+   * @param {Node} node Node.
+   * @param {import("../geom/Geometry.js").default|import("../extent.js").Extent} geometry Geometry.
+   * @param {Array<*>} objectStack Node stack.
+   */
+  writeGeometryElement(node, geometry, objectStack) {
+    const context = objectStack[objectStack.length - 1];
+    objectStack[objectStack.length - 1] = Object.assign(
+      {multiCurve: true, multiSurface: true},
+      context
+    );
+    super.writeGeometryElement(node, geometry, objectStack);
+  }
 }
 
 GML32.prototype.namespace = 'http://www.opengis.net/gml/3.2';

--- a/test/browser/spec/ol/format/wfs.test.js
+++ b/test/browser/spec/ol/format/wfs.test.js
@@ -697,6 +697,49 @@ describe('ol.format.WFS', function () {
       expect(serialized.firstElementChild).to.xmleql(parse(text));
     });
 
+    it('WFS v2 creates an intersects filter with a MultiSurface', function () {
+      const text = `
+        <wfs:Query xmlns:wfs="http://www.opengis.net/wfs/2.0"
+             typeNames="area" srsName="EPSG:4326"
+             xmlns:topp="http://www.openplans.org/topp">
+          <Filter xmlns="http://www.opengis.net/fes/2.0">
+            <Intersects>
+              <ValueReference>the_geom</ValueReference>
+                <MultiSurface xmlns="http://www.opengis.net/gml/3.2">
+                  <surfaceMember>
+                    <Polygon>
+                      <exterior>
+                        <LinearRing>
+                          <posList srsDimension="2">10 20 10 25 15 25 15 20 10 20</posList>
+                        </LinearRing>
+                      </exterior>
+                    </Polygon>
+                  </surfaceMember>
+                </MultiSurface>
+              </Intersects>
+            </Filter>        
+        </wfs:Query>`;
+      const serialized = new WFS({version: '2.0.0'}).writeGetFeature({
+        srsName: 'EPSG:4326',
+        featureTypes: ['area'],
+        filter: intersectsFilter(
+          'the_geom',
+          new MultiPolygon([
+            [
+              [
+                [10, 20],
+                [10, 25],
+                [15, 25],
+                [15, 20],
+                [10, 20],
+              ],
+            ],
+          ])
+        ),
+      });
+      expect(serialized.firstElementChild).to.xmleql(parse(text));
+    });
+
     it('creates a within filter', function () {
       const text =
         '<wfs:Query xmlns:wfs="http://www.opengis.net/wfs" ' +


### PR DESCRIPTION
WFS GetFeature requests with `Intersects` filter currently fail when `version: '2.0.0'` is used. This is because WFS 2.0 uses GML 3.2 as format, where `MultiPolygon` and `MultiLineString` are deprecated in favor of `MultiSurface` and `MultiCurve`.

GML 3.2 already uses `MultiSurface` and `MultiCurve` by default when an instance of `ol/format/GML32` is created. With this pull request, the same defaults are applied when the prototype is used by other formats, e.g. WFS.