### PR TITLE
New isVisible() and getAttributions() methods on Layer

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -213,6 +213,13 @@ import {fromExtent as polygonFromExtent} from './geom/Polygon.js';
  */
 
 /**
+ * Like {@link import("./Map.js").FrameState}, but just `viewState` and `extent`.
+ * @typedef {Object} ViewStateAndExtent
+ * @property {State} viewState View state.
+ * @property {import("./extent.js").Extent} extent Extent.
+ */
+
+/**
  * Default min zoom level for the map view.
  * @type {number}
  */
@@ -1240,6 +1247,16 @@ class View extends BaseObject {
       nextRotation: this.nextRotation_,
       rotation: rotation,
       zoom: this.getZoom(),
+    };
+  }
+
+  /**
+   * @return {ViewStateAndExtent} Like `FrameState`, but just `viewState` and `extent`.
+   */
+  getViewStateAndExtent() {
+    return {
+      viewState: this.getState(),
+      extent: this.calculateExtent(),
     };
   }
 

--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -5,7 +5,6 @@ import Control from './Control.js';
 import EventType from '../events/EventType.js';
 import {CLASS_COLLAPSED, CLASS_CONTROL, CLASS_UNSELECTABLE} from '../css.js';
 import {equals} from '../array.js';
-import {inView} from '../layer/Layer.js';
 import {removeChildren, replaceNode} from '../dom.js';
 
 /**
@@ -191,60 +190,21 @@ class Attribution extends Control {
    * @private
    */
   collectSourceAttributions_(frameState) {
-    /**
-     * Used to determine if an attribution already exists.
-     * @type {!Object<string, boolean>}
-     */
-    const lookup = {};
+    const visibleAttributions = Array.from(
+      new Set(
+        this.getMap()
+          .getAllLayers()
+          .flatMap((layer) => layer.getAttributions(frameState))
+      )
+    );
 
-    /**
-     * A list of visible attributions.
-     * @type {Array<string>}
-     */
-    const visibleAttributions = [];
-
-    let collapsible = true;
-    const layerStatesArray = frameState.layerStatesArray;
-    for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
-      const layerState = layerStatesArray[i];
-      if (!inView(layerState, frameState.viewState)) {
-        continue;
-      }
-
-      const source = /** @type {import("../layer/Layer.js").default} */ (
-        layerState.layer
-      ).getSource();
-      if (!source) {
-        continue;
-      }
-
-      const attributionGetter = source.getAttributions();
-      if (!attributionGetter) {
-        continue;
-      }
-
-      const attributions = attributionGetter(frameState);
-      if (!attributions) {
-        continue;
-      }
-
-      collapsible =
-        collapsible && source.getAttributionsCollapsible() !== false;
-
-      if (Array.isArray(attributions)) {
-        for (let j = 0, jj = attributions.length; j < jj; ++j) {
-          if (!(attributions[j] in lookup)) {
-            visibleAttributions.push(attributions[j]);
-            lookup[attributions[j]] = true;
-          }
-        }
-      } else {
-        if (!(attributions in lookup)) {
-          visibleAttributions.push(attributions);
-          lookup[attributions] = true;
-        }
-      }
-    }
+    const collapsible = !this.getMap()
+      .getAllLayers()
+      .some(
+        (layer) =>
+          layer.getSource() &&
+          layer.getSource().getAttributionsCollapsible() === false
+      );
     if (!this.overrideCollapsible_) {
       this.setCollapsible(collapsible);
     }

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -10,10 +10,10 @@ import {get as getProjection} from '../proj.js';
  */
 
 /**
- * A function that takes a {@link module:ol/Map~FrameState} and returns a string or
+ * A function that takes a {@link import("../View.js").ViewStateAndExtent} and returns a string or
  * an array of strings representing source attributions.
  *
- * @typedef {function(import("../Map.js").FrameState): (string|Array<string>)} Attribution
+ * @typedef {function(import("../View.js").ViewStateAndExtent): (string|Array<string>)} Attribution
  */
 
 /**

--- a/test/browser/spec/ol/layer/Layer.test.js
+++ b/test/browser/spec/ol/layer/Layer.test.js
@@ -455,6 +455,72 @@ describe('ol/layer/Layer', function () {
     });
   });
 
+  describe('#isVisible', function () {
+    let layer, view;
+
+    beforeEach(function () {
+      layer = new Layer({
+        source: new Source({
+          projection: 'EPSG:4326',
+        }),
+      });
+      view = new View({
+        projection: 'EPSG:4326',
+        center: [0, 0],
+        zoom: 0,
+      });
+    });
+
+    it('returns true if the layer is visible', function () {
+      layer.setVisible(true);
+      expect(layer.isVisible(view)).to.be(true);
+    });
+
+    it('returns false if the layer is not visible', function () {
+      layer.setVisible(false);
+      expect(layer.isVisible(view)).to.be(false);
+    });
+
+    it('returns false if the layer is not in view', function () {
+      layer.setExtent([15, 47, 16, 48]);
+      view.setZoom(14);
+      expect(layer.isVisible(view)).to.be(false);
+    });
+
+    it('returns false if the layer is not within zoom range', function () {
+      layer.setMinZoom(2);
+      expect(layer.isVisible(view)).to.be(false);
+    });
+  });
+
+  describe('#getAttributions', function () {
+    const attributions = ['foo'];
+    let layer, view;
+
+    beforeEach(function () {
+      layer = new Layer({
+        source: new Source({
+          attributions: attributions,
+          projection: getProjection('EPSG:4326'),
+        }),
+      });
+      view = new View({
+        projection: 'EPSG:4326',
+        center: [0, 0],
+        zoom: 0,
+      });
+    });
+
+    it('returns the attributions', function () {
+      expect(layer.getAttributions(view)).to.be(attributions);
+    });
+
+    it('returns an empty array when the layer is not visible', function () {
+      layer.setVisible(false);
+      expect(layer.getAttributions(view)).to.eql([]);
+    });
+  });
+
   describe('#getSource', function () {
     it('gets the layer source', function () {
       const source = new Source({projection: getProjection('EPSG:4326')});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2017", "dom", "webworker"],                 /* Specify library files to be included in the compilation. */
+    "lib": ["es2019", "dom", "webworker"],                 /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     "checkJs": true,                          /* Report errors in .js files. */
     "skipLibCheck": true,


### PR DESCRIPTION
This pull request adds something that I've been wishing for often when working with layers - an `isVisible(view)` method on the layer. And a `getAttributions(view)` method which makes use of the former, to make it easier to collect attributions from all or some layers of the map. This new method also simplifies the `Attribution` control's `collectSourceAttributions_()` method.

Replaces and closes #14454.
Fixes #14453.