### PR TITLE
Use .transform() instead of .setTransform() when rendering image or text

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -148,6 +148,9 @@ Please note that not all the point styling options are yet supported by WebGL re
 * dash and line joins for outlines
 * fill patterns
 
+##### Immediate renderer does not change the context transform
+
+Previously with some styles involving image or text scale or rotation, or view rotation `ol/render/canvas/Immediate#drawFeature` and `ol/render/canvas/Immediate#drawGeometry` might reset any canvas context transform set by the application.  If you were relying on this unintended and inconsistent behavior the application must now reset the context itself.
 
 ### 7.5.0
 

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -439,7 +439,7 @@ export function drawImageOrLabel(
     context.globalAlpha *= opacity;
   }
   if (transform) {
-    context.setTransform.apply(context, transform);
+    context.transform.apply(context, transform);
   }
 
   if (/** @type {*} */ (labelOrImage).contextInstructions) {

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -325,7 +325,8 @@ class CanvasImmediateRenderer extends VectorContext {
           -centerX,
           -centerY
         );
-        context.setTransform.apply(context, localTransform);
+        context.save();
+        context.transform.apply(context, localTransform);
         context.translate(centerX, centerY);
         context.scale(this.imageScale_[0], this.imageScale_[1]);
         context.drawImage(
@@ -339,7 +340,7 @@ class CanvasImmediateRenderer extends VectorContext {
           this.imageWidth_,
           this.imageHeight_
         );
-        context.setTransform(1, 0, 0, 1, 0, 0);
+        context.restore();
       } else {
         context.drawImage(
           this.image_,
@@ -401,6 +402,7 @@ class CanvasImmediateRenderer extends VectorContext {
         this.textScale_[0] != 1 ||
         this.textScale_[1] != 1
       ) {
+        context.save();
         context.translate(x - this.textOffsetX_, y - this.textOffsetY_);
         context.rotate(rotation);
         context.translate(this.textOffsetX_, this.textOffsetY_);
@@ -411,7 +413,7 @@ class CanvasImmediateRenderer extends VectorContext {
         if (this.textFillState_) {
           context.fillText(this.text_, 0, 0);
         }
-        context.setTransform(1, 0, 0, 1, 0, 0);
+        context.restore();
       } else {
         if (this.textStrokeState_) {
           context.strokeText(this.text_, x, y);

--- a/test/browser/spec/ol/render/canvas/index.test.js
+++ b/test/browser/spec/ol/render/canvas/index.test.js
@@ -114,7 +114,7 @@ describe('ol.render.canvas', function () {
     it('draws the image with correct parameters', function () {
       const layerContext = {
         save: sinon.spy(),
-        setTransform: sinon.spy(),
+        transform: sinon.spy(),
         drawImage: sinon.spy(),
         restore: sinon.spy(),
         globalAlpha: 1,
@@ -143,8 +143,8 @@ describe('ol.render.canvas', function () {
       );
 
       expect(layerContext.save.callCount).to.be(1);
-      expect(layerContext.setTransform.callCount).to.be(1);
-      expect(layerContext.setTransform.firstCall.args).to.eql(transform);
+      expect(layerContext.transform.callCount).to.be(1);
+      expect(layerContext.transform.firstCall.args).to.eql(transform);
       expect(layerContext.drawImage.callCount).to.be(1);
       expect(layerContext.globalAlpha).to.be(0.5);
       expect(layerContext.restore.callCount).to.be(1);


### PR DESCRIPTION
Fixes #14478

Allows rotated images and text, and line placement text to be displayed offset as expected following a context translate() or scale() in a prerender event.  No rendering tests broken by this change.

Also fix similar issue in immediate renderer.