### PR TITLE
Improve the performance of remove Snap interaction

### DIFF
--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -244,14 +244,6 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature.
-   * @private
-   */
-  forEachFeatureAdd_(feature) {
-    this.addFeature(feature);
-  }
-
-  /**
    * @return {import("../Collection.js").default<import("../Feature.js").default>|Array<import("../Feature.js").default>} Features.
    * @private
    */
@@ -411,7 +403,7 @@ class Snap extends PointerInteraction {
           )
         );
       }
-      features.forEach(this.forEachFeatureAdd_.bind(this));
+      features.forEach((feature) => this.addFeature(feature));
     }
   }
 

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -252,14 +252,6 @@ class Snap extends PointerInteraction {
   }
 
   /**
-   * @param {import("../Feature.js").default} feature Feature.
-   * @private
-   */
-  forEachFeatureRemove_(feature) {
-    this.removeFeature(feature);
-  }
-
-  /**
    * @return {import("../Collection.js").default<import("../Feature.js").default>|Array<import("../Feature.js").default>} Features.
    * @private
    */
@@ -381,7 +373,9 @@ class Snap extends PointerInteraction {
     if (currentMap) {
       keys.forEach(unlistenByKey);
       keys.length = 0;
-      features.forEach(this.forEachFeatureRemove_.bind(this));
+      this.rBush_.clear();
+      Object.values(this.featureChangeListenerKeys_).forEach(unlistenByKey);
+      this.featureChangeListenerKeys_ = {};
     }
     super.setMap(map);
 

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -402,4 +402,58 @@ describe('ol.interaction.Snap', function () {
       expect(event.pixel).to.eql(expectedPixel);
     });
   });
+
+  describe('setMap', function () {
+    let target, map;
+
+    const width = 360;
+    const height = 180;
+
+    const featureNum = 10000;
+    const maxLon = 180;
+    const maxLat = 90;
+    const featureCollection = new Collection();
+
+    for (let i = 0; i < featureNum; i++) {
+      const point = new Feature(new Point([Math.random() * maxLon, Math.random() * maxLat]));
+      featureCollection.push(point);
+    }
+
+    beforeEach(function (done) {
+      target = document.createElement('div');
+
+      const style = target.style;
+      style.position = 'absolute';
+      style.left = '-1000px';
+      style.top = '-1000px';
+      style.width = width + 'px';
+      style.height = height + 'px';
+      document.body.appendChild(target);
+
+      map = new Map({
+        target: target,
+        view: new View({
+          projection: 'EPSG:4326',
+          center: [0, 0],
+          resolution: 1,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      map.dispose();
+      document.body.removeChild(target);
+      clearUserProjection();
+    });
+    
+    it('add and remove snap interaction', function () {
+      const snapInteraction = new Snap({
+        features: featureCollection,
+      });
+      snapInteraction.setMap(map);
+      expect(snapInteraction.getMap()).to.eql(map);
+      snapInteraction.setMap(null);
+      expect(snapInteraction.getMap()).to.be(null);
+    });
+  });
 });

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -404,56 +404,38 @@ describe('ol.interaction.Snap', function () {
   });
 
   describe('setMap', function () {
-    let target, map;
+    let map, featureCollection;
 
-    const width = 360;
-    const height = 180;
-
-    const featureNum = 10000;
-    const maxLon = 180;
-    const maxLat = 90;
-    const featureCollection = new Collection();
-
-    for (let i = 0; i < featureNum; i++) {
-      const point = new Feature(new Point([Math.random() * maxLon, Math.random() * maxLat]));
-      featureCollection.push(point);
-    }
-
-    beforeEach(function (done) {
-      target = document.createElement('div');
-
-      const style = target.style;
-      style.position = 'absolute';
-      style.left = '-1000px';
-      style.top = '-1000px';
-      style.width = width + 'px';
-      style.height = height + 'px';
-      document.body.appendChild(target);
-
+    beforeEach(function () {
+      setUserProjection();
       map = new Map({
-        target: target,
+        target: createMapDiv(),
         view: new View({
-          projection: 'EPSG:4326',
           center: [0, 0],
-          resolution: 1,
+          zoom: 0,
         }),
       });
+      featureCollection = new Collection();
+      featureCollection.push(new Feature(new Point([0, 0])));
     });
 
     afterEach(function () {
-      map.dispose();
-      document.body.removeChild(target);
+      disposeMap(map);
       clearUserProjection();
     });
-    
-    it('add and remove snap interaction', function () {
+
+    it('adds and removes feature listeners', function () {
+      const feature = featureCollection.item(0);
       const snapInteraction = new Snap({
         features: featureCollection,
       });
+      expect(feature.getListeners('change')).to.be(undefined);
       snapInteraction.setMap(map);
       expect(snapInteraction.getMap()).to.eql(map);
+      expect(feature.getListeners('change').length).to.be(1);
       snapInteraction.setMap(null);
       expect(snapInteraction.getMap()).to.be(null);
+      expect(feature.getListeners('change')).to.be(undefined);
     });
   });
 });


### PR DESCRIPTION
#14515 This commit fixes Issue 14515.
When the Snap Source has 13,000 features，the time of remove Snap Interaction will reduced from 6.5s to 150ms