### PR TITLE
Update ESRI World Basemap url in examples

### DIFF
--- a/examples/drag-and-drop-custom-mvt.js
+++ b/examples/drag-and-drop-custom-mvt.js
@@ -115,7 +115,7 @@ function download(fullpath, filename) {
 
 document.getElementById('download-mvt').addEventListener('click', function () {
   const fullpath =
-    'https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer/tile/' +
+    'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/tile/' +
     tileCoordZ.value +
     '/' +
     tileCoordY.value +

--- a/examples/vector-tile-info.js
+++ b/examples/vector-tile-info.js
@@ -14,7 +14,7 @@ const map = new Map({
     new VectorTileLayer({
       source: new VectorTileSource({
         format: new MVT(),
-        url: 'https://basemaps.arcgis.com/v1/arcgis/rest/services/World_Basemap/VectorTileServer/tile/{z}/{y}/{x}.pbf',
+        url: 'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/tile/{z}/{y}/{x}.pbf',
       }),
     }),
   ],


### PR DESCRIPTION
The ESRI World Basemap v1 url is returning 400 Invalid URL.  Update it to the v2 url.