### PR TITLE
Fix a padding setter bug of ol.View when using useGeographic()

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -507,7 +507,7 @@ class View extends BaseObject {
   set padding(padding) {
     let oldPadding = this.padding_;
     this.padding_ = padding;
-    const center = this.getCenter();
+    const center = this.getCenterInternal();
     if (center) {
       const newPadding = padding || [0, 0, 0, 0];
       oldPadding = oldPadding || [0, 0, 0, 0];

--- a/test/node/ol/View.test.js
+++ b/test/node/ol/View.test.js
@@ -1,0 +1,31 @@
+import View from '../../../src/ol/View.js';
+import expect from '../expect.js';
+import {
+  addCommon,
+  clearAllProjections,
+  clearUserProjection,
+  useGeographic,
+} from '../../../src/ol/proj.js';
+
+describe('ol/View.js', function () {
+  afterEach(function () {
+    clearAllProjections();
+    clearUserProjection();
+    addCommon();
+  });
+
+  describe('padding', function () {
+    it('returns the same coordinates after padding reset', function () {
+      useGeographic();
+      const view = new View({
+        center: [135, 35],
+        zoom: 6,
+      });
+      const center = view.getCenter();
+      view.padding = [0, 0, 0, 0];
+      const point = view.getCenter();
+      expect(point[0]).to.roughlyEqual(center[0], 1e-9);
+      expect(point[1]).to.roughlyEqual(center[1], 1e-9);
+    });
+  });
+});


### PR DESCRIPTION
Setting `padding` of `View` instance after creation corrupts center coordinates when using `useGeographic()`.
```js
useGeographic();
const view = new View({
  center: [135, 35],
  zoom: 6,
});

const center = view.getCenter();
// [ 135, 34.999999999999986 ]

view.padding = [0, 0, 0, 0];

const point = view.getCenter();
// [ 0.001212725633561354, 0.0003144103494321371 ]
```
This should be `center == point` roughly because there is no change about the padding.

This PR fixes the bug, and includes a test for it.