### PR TITLE
[github workflow] clean up artifacts after depoyment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -94,3 +94,25 @@ jobs:
             } else {
               console.log(`Preview URL comment already added to PR #${pullRequestNumber}`);
             }
+            
+      - name: Clean up artifact
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id}}
+            });
+            const artifact = artifacts.data.artifacts.filter(
+              artifact => artifact.name === 'site'
+            )[0];
+            if (!artifact) {
+              throw new Error('No site artifact found');
+            }
+            await github.rest.actions.deleteArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id
+            });


### PR DESCRIPTION
This frees up unnecessarily occupied storage which otherwise counts towards the organization's quota.