### PR TITLE
View / safeguard against negative hint values to avoid unexpected behaviour

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1854,8 +1854,10 @@ class View extends BaseObject {
    * @param {import("./coordinate.js").Coordinate} [anchor] The origin of the transformation.
    */
   endInteractionInternal(duration, resolutionDirection, anchor) {
+    if (!this.getInteracting()) {
+      return;
+    }
     this.setHint(ViewHint.INTERACTING, -1);
-
     this.resolveConstraints(duration, resolutionDirection, anchor);
   }
 

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -2010,6 +2010,13 @@ describe('ol/View', function () {
       view.endInteraction();
       expect(view.getHints()[1]).to.be(0);
     });
+
+    it('does not allow hint value to become negative', function () {
+      view.beginInteraction();
+      view.endInteraction();
+      view.endInteraction();
+      expect(view.getHints()[1]).to.be(0);
+    });
   });
 
   describe('#getConstrainedZoom()', function () {


### PR DESCRIPTION
This could happen e.g. in case `view.endInteraction()` was used too many times, which then might cause unexpected behaviours in dependent logic such as the webgl points renderer.

Fixes https://github.com/openlayers/openlayers/issues/14544

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
