### PR TITLE
Avoid rendering a tile more than once

### DIFF
--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -9,6 +9,7 @@ import {create} from '../../../../../../src/ol/transform.js';
 import {createCanvasContext2D} from '../../../../../../src/ol/dom.js';
 import {get} from '../../../../../../src/ol/proj.js';
 import {getUid} from '../../../../../../src/ol/util.js';
+import {newTileTextureLookup} from '../../../../../../src/ol/renderer/webgl/TileLayer.js';
 
 describe('ol/renderer/webgl/TileLayer', function () {
   /** @type {import("../../../../../../src/ol/renderer/webgl/TileLayer.js").default} */
@@ -121,7 +122,13 @@ describe('ol/renderer/webgl/TileLayer', function () {
     it('enqueues tiles at a single zoom level (preload: 0)', () => {
       renderer.prepareFrame(frameState);
       const extent = [-1, -1, 1, 1];
-      renderer.enqueueTiles(frameState, extent, 10, {}, tileLayer.getPreload());
+      renderer.enqueueTiles(
+        frameState,
+        extent,
+        10,
+        newTileTextureLookup(),
+        tileLayer.getPreload()
+      );
 
       const source = tileLayer.getSource();
       const sourceKey = getUid(source);
@@ -142,7 +149,13 @@ describe('ol/renderer/webgl/TileLayer', function () {
       tileLayer.setPreload(2);
       renderer.prepareFrame(frameState);
       const extent = [-1, -1, 1, 1];
-      renderer.enqueueTiles(frameState, extent, 10, {}, tileLayer.getPreload());
+      renderer.enqueueTiles(
+        frameState,
+        extent,
+        10,
+        newTileTextureLookup(),
+        tileLayer.getPreload()
+      );
 
       const source = tileLayer.getSource();
       const sourceKey = getUid(source);
@@ -172,7 +185,13 @@ describe('ol/renderer/webgl/TileLayer', function () {
       tileLayer.setMinZoom(9);
       renderer.prepareFrame(frameState);
       const extent = [-1, -1, 1, 1];
-      renderer.enqueueTiles(frameState, extent, 10, {}, tileLayer.getPreload());
+      renderer.enqueueTiles(
+        frameState,
+        extent,
+        10,
+        newTileTextureLookup(),
+        tileLayer.getPreload()
+      );
 
       const source = tileLayer.getSource();
       const sourceKey = getUid(source);
@@ -201,7 +220,13 @@ describe('ol/renderer/webgl/TileLayer', function () {
       tileLayer.setMinZoom(9);
       renderer.prepareFrame(frameState);
       const extent = [-1, -1, 1, 1];
-      renderer.enqueueTiles(frameState, extent, 10, {}, tileLayer.getPreload());
+      renderer.enqueueTiles(
+        frameState,
+        extent,
+        10,
+        newTileTextureLookup(),
+        tileLayer.getPreload()
+      );
 
       const source = tileLayer.getSource();
       const sourceKey = getUid(source);


### PR DESCRIPTION
While reworking the canvas tile layer renderer in #14262, I discovered that the WebGL tile renderer does quite a bit of duplicate rendering.  This was was not apparent until porting the logic to the canvas tile rendering because of the difference in alpha blending – with the canvas renderer, partially transparent tiles were rendered with too much opacity.

The duplication occurs when adding tile textures to the lookup by zoom level.  Previously, we unconditionally added a tile texture to the lookup.  With the change here, we only add it to the lookup if it has not already been added.  This avoids duplicates when considering tiles at alt zoom levels when the target zoom level tiles have not yet loaded.  Previously, if two adjacent tiles at the target zoom level were not yet loaded and shared the same alt tile from a higher zoom level, that alt tile would be rendered twice.  There is also potential for duplication when animating a view transition – tiles from the target extent may be rendered more than once if they also intersect the source extent.
