### PR TITLE
Fix issue with external map example

### DIFF
--- a/examples/resources/external-map-map.html
+++ b/examples/resources/external-map-map.html
@@ -9,7 +9,8 @@
         margin: 0;
       }
       .map {
-        height: 100%;
+        height: 100vh;
+        width: 100vw;
       }
       .map.unusable .ol-mask {
         height: 100%;


### PR DESCRIPTION
Sets the map class in the external map example to use vh and vw units, rather than percentage.

Fixes #14569 

