### PR TITLE
Automatically update URL of examples page based on search query

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -52,7 +52,7 @@
       <nav class="collapse navbar-collapse" id="olmenu">
         <form role="search">
           <div class="input-group">
-            <input name="q" type="text" id="keywords" class="form-control search-query" placeholder="Search" aria-label="Examples" aria-describedby="count" autocomplete="off" autofocus>
+            <input name="q" type="search" id="keywords" class="form-control search-query" placeholder="Search" aria-label="Examples" aria-describedby="count" autocomplete="off" autofocus>
             <span class="input-group-text text-white bg-transparent" id="count"></span>
           </div>
         </form>

--- a/examples/index.js
+++ b/examples/index.js
@@ -85,20 +85,20 @@
     updateHistoryState(text);
   }
 
-  function updateHistoryState(text){
+  function updateHistoryState(text) {
     text = text.trim();
-    let params = new URLSearchParams(window.location.search);
+    const params = new URLSearchParams(window.location.search);
     if (text.length === 0) {
       params.delete('q');
-    }else{
-      params.set('q',text);
+    } else {
+      params.set('q', text);
     }
     
     let fullUrl = window.location.pathname;
-    if(params.toString().length !== 0){
-      fullUrl += `?${params.toString()}`
+    if(params.toString().length !== 0) {
+      fullUrl += `?${params.toString()}`;
     }
-    history.replaceState(null,'',fullUrl);
+    history.replaceState(null, '', fullUrl);
   }
 
   const params = new URLSearchParams(window.location.search);

--- a/examples/index.js
+++ b/examples/index.js
@@ -93,9 +93,8 @@
     } else {
       params.set('q', text);
     }
-    
     let fullUrl = window.location.pathname;
-    if(params.toString().length !== 0) {
+    if (params.toString().length !== 0) {
       fullUrl += `?${params.toString()}`;
     }
     history.replaceState(null, '', fullUrl);

--- a/examples/index.js
+++ b/examples/index.js
@@ -82,6 +82,23 @@
   function filterList(text) {
     const examples = getMatchingExamples(text);
     listExamples(examples);
+    updateHistoryState(text);
+  }
+
+  function updateHistoryState(text){
+    text = text.trim();
+    let params = new URLSearchParams(window.location.search);
+    if (text.length === 0) {
+      params.delete('q');
+    }else{
+      params.set('q',text);
+    }
+    
+    let fullUrl = window.location.pathname;
+    if(params.toString().length !== 0){
+      fullUrl += `?${params.toString()}`
+    }
+    history.replaceState(null,'',fullUrl);
   }
 
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
This PR updates the examples page to automatically update the URL when typing keywords in the search bar using the History API. This allows users' searches to be remembered when they go back to the examples page, and makes it slightly easier to share the URL of a set of examples.

This also changes the type of the input to `search`, which allows users to more easily clear their search with the 'x' the browser adds to search inputs, rather than having to delete the text manually.

The implementation uses [History.replaceState](https://developer.mozilla.org/en-US/docs/Web/API/History/replaceState) to continually update the URL without adding lots of items to the history. It will retain additional query parameters and only replaces/removes the 'q' parameter, so if additional parameters are used/added in the future, this will not effect it.

There are probably slightly cleaner/cleverer ways of doing the `updateHistoryState` function I added, but this works and is relatively simple. Suggestions welcome.

Closes #14574 
