### PR TITLE
Add latest typescript to CodeSandbox devDependencies

### DIFF
--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -56,7 +56,10 @@
       const js = document.getElementById('example-js-source').innerText;
       const workerContainer = document.getElementById('example-worker-source');
       const worker = workerContainer ? workerContainer.innerText : undefined;
-      const pkgJson = document.getElementById('example-pkg-source').innerText;
+      let pkgJson = document.getElementById('example-pkg-source').innerText;
+      pkgJson = JSON.parse(pkgJson);
+      pkgJson['devDependencies']['typescript'] = 'latest';
+      pkgJson = JSON.stringify(pkgJson, undefined, 2);
 
       const unique = new Set();
       const localResources = (js.match(/'(?:\.\/)?(?:data|resources)\/[^']*'/g) || [])


### PR DESCRIPTION
While adding an empty `.babelrc` in #14419 prevented unwanted transpiling by CodeSandbox after #14279 it appears that the default parcel template in CodeSandbox uses an old version of Babel for parsing the application JavaScript and as noted in https://github.com/openlayers/openlayers/pull/14445#issuecomment-1475247856 modern syntax such as optional chaining (which would have been useful in the example in https://github.com/openlayers/openlayers/issues/14582#issuecomment-1474852682) is rejected.  If the unneeded `'@babel/core': 'latest',` removed from live example by #14279 is injected into the `package.json` supplied to CodeSandbox it fixes the problem.  This is an external use so it does not need to be an OpenLayers dependency.