### PR TITLE
Avoid unnecessary else if indentation

### DIFF
--- a/examples/clusters-dynamic.js
+++ b/examples/clusters-dynamic.js
@@ -72,11 +72,11 @@ let clickFeature, clickResolution;
  * Style for clusters with features that are too close to each other, activated on click.
  * @param {Feature} cluster A cluster with overlapping members.
  * @param {number} resolution The current view resolution.
- * @return {Style} A style to render an expanded view of the cluster members.
+ * @return {Style|null} A style to render an expanded view of the cluster members.
  */
 function clusterCircleStyle(cluster, resolution) {
   if (cluster !== clickFeature || resolution !== clickResolution) {
-    return;
+    return null;
   }
   const clusterMembers = cluster.get('features');
   const centerCoordinates = cluster.getGeometry().getCoordinates();
@@ -141,11 +141,11 @@ let hoverFeature;
 /**
  * Style for convex hulls of clusters, activated on hover.
  * @param {Feature} cluster The cluster feature.
- * @return {Style} Polygon style for the convex hull of the cluster.
+ * @return {Style|null} Polygon style for the convex hull of the cluster.
  */
 function clusterHullStyle(cluster) {
   if (cluster !== hoverFeature) {
-    return;
+    return null;
   }
   const originalFeatures = cluster.get('features');
   const points = originalFeatures.map((feature) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "es-main": "^1.0.2",
         "eslint": "^8.0.1",
-        "eslint-config-openlayers": "^17.0.0",
+        "eslint-config-openlayers": "^18.0.0",
         "expect.js": "0.3.1",
         "express": "^4.17.1",
         "front-matter": "^4.0.0",
@@ -151,17 +151,17 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.30.0.tgz",
-      "integrity": "sha512-U30cjaHCjdUqtbMgChJl80BP25GSRWg0/1R3UdB2ksitAo2oDYdRMrvzwuM21jcsFbEcLNAqwQGTCg+5CVbSIA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
+      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.1.0"
+        "jsdoc-type-pratt-parser": "~4.0.0"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2872,14 +2872,14 @@
       }
     },
     "node_modules/eslint-config-openlayers": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-17.0.0.tgz",
-      "integrity": "sha512-eTXvS5CMGV9/IOvT+02zkJ1AlBM4pFMqKghImjJ+BJy3BATCtrxXE/8Sv7DKMqiOHmK1Q03nreqXQxlMjkMtDw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-18.0.0.tgz",
+      "integrity": "sha512-CSd25+Mp7fO+R2jztBMLFGj5ZT3uuStBcH4cgWO9e9Gh1HB4LHH/GrTWMVSJ5VccU502tMEDDTyh75u0SczI6A==",
       "dev": true,
       "dependencies": {
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.1",
-        "eslint-plugin-jsdoc": "^39.3.0",
+        "eslint-plugin-jsdoc": "^40.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "prettier": "^2.4.1"
@@ -3061,21 +3061,21 @@
       "dev": true
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "39.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.0.tgz",
-      "integrity": "sha512-zEdkpezjIhG7gq4MbwLBKaD3cWsJkT7uTAJcIbLohQWR7OVwhPOBLPqpftBt8uzy0ZL+3jlbiaSXik4+VmN6JQ==",
+      "version": "40.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.1.0.tgz",
+      "integrity": "sha512-ANvrhiu62VlSorARM0hup60VQsS3hNyp0Ca7cnJDj8tpJzM7tNhBVqMVYXSuLzEmqrpwx6aAh+NAN2DdAGG5fQ==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.30.0",
+        "@es-joy/jsdoccomment": "~0.37.0",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.7",
+        "esquery": "^1.5.0",
+        "semver": "^7.3.8",
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18"
+        "node": "^14 || ^16 || ^17 || ^18 || ^19"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"
@@ -3307,9 +3307,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -5037,9 +5037,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -7766,9 +7766,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "node_modules/spdy": {
@@ -9242,14 +9242,14 @@
       "dev": true
     },
     "@es-joy/jsdoccomment": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.30.0.tgz",
-      "integrity": "sha512-U30cjaHCjdUqtbMgChJl80BP25GSRWg0/1R3UdB2ksitAo2oDYdRMrvzwuM21jcsFbEcLNAqwQGTCg+5CVbSIA==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.37.0.tgz",
+      "integrity": "sha512-hjK0wnsPCYLlF+HHB4R/RbUjOWeLW2SlarB67+Do5WsKILOkmIZvvPJFbtWSmbypxcjpoECLAMzoao0D4Bg5ZQ==",
       "dev": true,
       "requires": {
         "comment-parser": "1.3.1",
         "esquery": "^1.4.0",
-        "jsdoc-type-pratt-parser": "~3.1.0"
+        "jsdoc-type-pratt-parser": "~4.0.0"
       }
     },
     "@eslint-community/eslint-utils": {
@@ -11524,14 +11524,14 @@
       }
     },
     "eslint-config-openlayers": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-17.0.0.tgz",
-      "integrity": "sha512-eTXvS5CMGV9/IOvT+02zkJ1AlBM4pFMqKghImjJ+BJy3BATCtrxXE/8Sv7DKMqiOHmK1Q03nreqXQxlMjkMtDw==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-openlayers/-/eslint-config-openlayers-18.0.0.tgz",
+      "integrity": "sha512-CSd25+Mp7fO+R2jztBMLFGj5ZT3uuStBcH4cgWO9e9Gh1HB4LHH/GrTWMVSJ5VccU502tMEDDTyh75u0SczI6A==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.1",
-        "eslint-plugin-jsdoc": "^39.3.0",
+        "eslint-plugin-jsdoc": "^40.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
         "prettier": "^2.4.1"
@@ -11684,17 +11684,17 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "39.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.0.tgz",
-      "integrity": "sha512-zEdkpezjIhG7gq4MbwLBKaD3cWsJkT7uTAJcIbLohQWR7OVwhPOBLPqpftBt8uzy0ZL+3jlbiaSXik4+VmN6JQ==",
+      "version": "40.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-40.1.0.tgz",
+      "integrity": "sha512-ANvrhiu62VlSorARM0hup60VQsS3hNyp0Ca7cnJDj8tpJzM7tNhBVqMVYXSuLzEmqrpwx6aAh+NAN2DdAGG5fQ==",
       "dev": true,
       "requires": {
-        "@es-joy/jsdoccomment": "~0.30.0",
+        "@es-joy/jsdoccomment": "~0.37.0",
         "comment-parser": "1.3.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
-        "esquery": "^1.4.0",
-        "semver": "^7.3.7",
+        "esquery": "^1.5.0",
+        "semver": "^7.3.8",
         "spdx-expression-parse": "^3.0.1"
       },
       "dependencies": {
@@ -11757,9 +11757,9 @@
       }
     },
     "esquery": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.2.tgz",
-      "integrity": "sha512-JVSoLdTlTDkmjFmab7H/9SL9qGSyjElT3myyKp7krqjVFQCDLmj1QFaCLRFBszBKI0XVZaiiXvuPIX3ZwHe1Ng==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -13052,9 +13052,9 @@
       }
     },
     "jsdoc-type-pratt-parser": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz",
-      "integrity": "sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-4.0.0.tgz",
+      "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
     },
     "json-parse-even-better-errors": {
@@ -15142,9 +15142,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
       "dev": true
     },
     "spdy": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "es-main": "^1.0.2",
     "eslint": "^8.0.1",
-    "eslint-config-openlayers": "^17.0.0",
+    "eslint-config-openlayers": "^18.0.0",
     "expect.js": "0.3.1",
     "express": "^4.17.1",
     "front-matter": "^4.0.0",

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -2095,9 +2095,11 @@ export function createRotationConstraint(options) {
     const constrainRotation = options.constrainRotation;
     if (constrainRotation === undefined || constrainRotation === true) {
       return createSnapToZero();
-    } else if (constrainRotation === false) {
+    }
+    if (constrainRotation === false) {
       return rotationNone;
-    } else if (typeof constrainRotation === 'number') {
+    }
+    if (typeof constrainRotation === 'number') {
       return createSnapToN(constrainRotation);
     }
     return rotationNone;

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -76,7 +76,8 @@ export function linearFindNearest(arr, target, direction) {
   const n = arr.length;
   if (arr[0] <= target) {
     return 0;
-  } else if (target <= arr[n - 1]) {
+  }
+  if (target <= arr[n - 1]) {
     return n - 1;
   }
   let i;
@@ -96,13 +97,15 @@ export function linearFindNearest(arr, target, direction) {
     for (i = 1; i < n; ++i) {
       if (arr[i] == target) {
         return i;
-      } else if (arr[i] < target) {
+      }
+      if (arr[i] < target) {
         if (typeof direction === 'function') {
           if (direction(target, arr[i - 1], arr[i]) > 0) {
             return i - 1;
           }
           return i;
-        } else if (arr[i - 1] - target < target - arr[i]) {
+        }
+        if (arr[i - 1] - target < target - arr[i]) {
           return i - 1;
         }
         return i;

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -899,13 +899,15 @@ export function wrapAndSliceX(extent, projection) {
     if (getWidth(extent) > worldWidth) {
       // the extent wraps around on itself
       return [[projectionExtent[0], extent[1], projectionExtent[2], extent[3]]];
-    } else if (extent[0] < projectionExtent[0]) {
+    }
+    if (extent[0] < projectionExtent[0]) {
       // the extent crosses the anti meridian, so it needs to be sliced
       return [
         [extent[0] + worldWidth, extent[1], projectionExtent[2], extent[3]],
         [projectionExtent[0], extent[1], extent[2], extent[3]],
       ];
-    } else if (extent[2] > projectionExtent[2]) {
+    }
+    if (extent[2] > projectionExtent[2]) {
       // the extent crosses the anti meridian, so it needs to be sliced
       return [
         [extent[0], extent[1], projectionExtent[2], extent[3]],

--- a/src/ol/format/IIIFInfo.js
+++ b/src/ol/format/IIIFInfo.js
@@ -329,12 +329,12 @@ class IIIFInfo {
   }
 
   /**
-   * @return {Versions} Major IIIF version.
+   * @return {Versions|undefined} Major IIIF version.
    * @api
    */
   getImageApiVersion() {
     if (this.imageInfo === undefined) {
-      return;
+      return undefined;
     }
     let context = this.imageInfo['@context'] || 'ol-no-context';
     if (typeof context == 'string') {
@@ -366,12 +366,12 @@ class IIIFInfo {
 
   /**
    * @param {Versions} version Optional IIIF image API version
-   * @return {string} Compliance level as it appears in the IIIF image information
+   * @return {string|undefined} Compliance level as it appears in the IIIF image information
    * response.
    */
   getComplianceLevelEntryFromProfile(version) {
     if (this.imageInfo === undefined || this.imageInfo.profile === undefined) {
-      return;
+      return undefined;
     }
     if (version === undefined) {
       version = this.getImageApiVersion();
@@ -405,6 +405,7 @@ class IIIFInfo {
         break;
       default:
     }
+    return undefined;
   }
 
   /**
@@ -421,12 +422,12 @@ class IIIFInfo {
   }
 
   /**
-   * @return {SupportedFeatures} Image formats, qualities and region / size calculation
+   * @return {SupportedFeatures|undefined} Image formats, qualities and region / size calculation
    * methods that are supported by the IIIF service.
    */
   getComplianceLevelSupportedFeatures() {
     if (this.imageInfo === undefined) {
-      return;
+      return undefined;
     }
     const version = this.getImageApiVersion();
     const level = this.getComplianceLevelFromProfile(version);
@@ -438,19 +439,19 @@ class IIIFInfo {
 
   /**
    * @param {PreferredOptions} [preferredOptions] Optional options for preferred format and quality.
-   * @return {import("../source/IIIF.js").Options} IIIF tile source ready constructor options.
+   * @return {import("../source/IIIF.js").Options|undefined} IIIF tile source ready constructor options.
    * @api
    */
   getTileSourceOptions(preferredOptions) {
     const options = preferredOptions || {},
       version = this.getImageApiVersion();
     if (version === undefined) {
-      return;
+      return undefined;
     }
     const imageOptions =
       version === undefined ? undefined : versionFunctions[version](this);
     if (imageOptions === undefined) {
-      return;
+      return undefined;
     }
     return {
       url: imageOptions.url,

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -200,7 +200,8 @@ function getObject(source) {
   if (typeof source === 'string') {
     const object = JSON.parse(source);
     return object ? /** @type {Object} */ (object) : null;
-  } else if (source !== null) {
+  }
+  if (source !== null) {
     return source;
   }
   return null;

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -659,7 +659,8 @@ class KML extends XMLFeature {
         return features;
       }
       return [];
-    } else if (localName == 'Placemark') {
+    }
+    if (localName == 'Placemark') {
       const feature = this.readPlacemark_(node, [
         this.getReadOptions(node, options),
       ]);
@@ -667,7 +668,8 @@ class KML extends XMLFeature {
         return [feature];
       }
       return [];
-    } else if (localName == 'kml') {
+    }
+    if (localName == 'kml') {
       features = [];
       for (let n = node.firstElementChild; n; n = n.nextElementSibling) {
         const fs = this.readFeaturesFromNode(n, options);
@@ -690,10 +692,12 @@ class KML extends XMLFeature {
   readName(source) {
     if (!source) {
       return undefined;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readNameFromDocument(doc);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readNameFromDocument(/** @type {Document} */ (source));
     }
     return this.readNameFromNode(/** @type {Element} */ (source));
@@ -1062,7 +1066,8 @@ function createFeatureStyleFunction(
 function findStyle(styleValue, defaultStyle, sharedStyles) {
   if (Array.isArray(styleValue)) {
     return styleValue;
-  } else if (typeof styleValue === 'string') {
+  }
+  if (typeof styleValue === 'string') {
     return findStyle(sharedStyles[styleValue], defaultStyle, sharedStyles);
   }
   return defaultStyle;
@@ -1911,7 +1916,8 @@ function readStyle(node, objectStack) {
                   return type !== 'Polygon' && type !== 'MultiPolygon';
                 })
             );
-          } else if (type !== 'Polygon' && type !== 'MultiPolygon') {
+          }
+          if (type !== 'Polygon' && type !== 'MultiPolygon') {
             return geometry;
           }
         },
@@ -1938,7 +1944,8 @@ function readStyle(node, objectStack) {
                   return type === 'Polygon' || type === 'MultiPolygon';
                 })
             );
-          } else if (type === 'Polygon' || type === 'MultiPolygon') {
+          }
+          if (type === 'Polygon' || type === 'MultiPolygon') {
             return geometry;
           }
         },

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -368,10 +368,12 @@ class WFS extends XMLFeature {
   readTransactionResponse(source) {
     if (!source) {
       return undefined;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readTransactionResponseFromDocument(doc);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readTransactionResponseFromDocument(
         /** @type {Document} */ (source)
       );
@@ -392,10 +394,12 @@ class WFS extends XMLFeature {
   readFeatureCollectionMetadata(source) {
     if (!source) {
       return undefined;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFeatureCollectionMetadataFromDocument(doc);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readFeatureCollectionMetadataFromDocument(
         /** @type {Document} */ (source)
       );

--- a/src/ol/format/WKB.js
+++ b/src/ol/format/WKB.js
@@ -910,12 +910,14 @@ function decodeHexString(text) {
 function getDataView(source) {
   if (typeof source === 'string') {
     return decodeHexString(source);
-  } else if (ArrayBuffer.isView(source)) {
+  }
+  if (ArrayBuffer.isView(source)) {
     if (source instanceof DataView) {
       return source;
     }
     return new DataView(source.buffer, source.byteOffset, source.byteLength);
-  } else if (source instanceof ArrayBuffer) {
+  }
+  if (source instanceof ArrayBuffer) {
     return new DataView(source);
   }
   return null;

--- a/src/ol/format/XML.js
+++ b/src/ol/format/XML.js
@@ -20,10 +20,12 @@ class XML {
   read(source) {
     if (!source) {
       return null;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFromDocument(doc);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readFromDocument(/** @type {Document} */ (source));
     }
     return this.readFromNode(/** @type {Element} */ (source));

--- a/src/ol/format/XMLFeature.js
+++ b/src/ol/format/XMLFeature.js
@@ -43,10 +43,12 @@ class XMLFeature extends FeatureFormat {
   readFeature(source, options) {
     if (!source) {
       return null;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFeatureFromDocument(doc, options);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readFeatureFromDocument(
         /** @type {Document} */ (source),
         options
@@ -88,10 +90,12 @@ class XMLFeature extends FeatureFormat {
   readFeatures(source, options) {
     if (!source) {
       return [];
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readFeaturesFromDocument(doc, options);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readFeaturesFromDocument(
         /** @type {Document} */ (source),
         options
@@ -141,10 +145,12 @@ class XMLFeature extends FeatureFormat {
   readGeometry(source, options) {
     if (!source) {
       return null;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readGeometryFromDocument(doc, options);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readGeometryFromDocument(
         /** @type {Document} */ (source),
         options
@@ -183,10 +189,12 @@ class XMLFeature extends FeatureFormat {
   readProjection(source) {
     if (!source) {
       return null;
-    } else if (typeof source === 'string') {
+    }
+    if (typeof source === 'string') {
       const doc = parse(source);
       return this.readProjectionFromDocument(doc);
-    } else if (isDocument(source)) {
+    }
+    if (isDocument(source)) {
       return this.readProjectionFromDocument(/** @type {Document} */ (source));
     }
     return this.readProjectionFromNode(/** @type {Element} */ (source));

--- a/src/ol/geom/flat/interpolate.js
+++ b/src/ol/geom/flat/interpolate.js
@@ -95,7 +95,8 @@ export function lineStringCoordinateAtM(
       return coordinate;
     }
     return null;
-  } else if (flatCoordinates[end - 1] < m) {
+  }
+  if (flatCoordinates[end - 1] < m) {
     if (extrapolate) {
       coordinate = flatCoordinates.slice(end - stride, end);
       coordinate[stride - 1] = m;
@@ -190,7 +191,8 @@ export function lineStringsCoordinateAtM(
     }
     if (m < flatCoordinates[offset + stride - 1]) {
       return null;
-    } else if (m <= flatCoordinates[end - 1]) {
+    }
+    if (m <= flatCoordinates[end - 1]) {
       return lineStringCoordinateAtM(
         flatCoordinates,
         offset,

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -513,7 +513,8 @@ function getEdgeHandler(fixedP1, fixedP2) {
     return function (point) {
       return boundingExtent([fixedP1, [point[0], fixedP2[1]]]);
     };
-  } else if (fixedP1[1] == fixedP2[1]) {
+  }
+  if (fixedP1[1] == fixedP2[1]) {
     return function (point) {
       return boundingExtent([fixedP1, [fixedP2[0], point[1]]]);
     };

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -47,7 +47,7 @@ import {listen, unlistenByKey} from '../events.js';
 
 /**
  * @param  {import("../source/Vector.js").VectorSourceEvent|import("../Collection.js").CollectionEvent<import("../Feature.js").default>} evt Event.
- * @return {import("../Feature.js").default} Feature.
+ * @return {import("../Feature.js").default|null} Feature.
  */
 function getFeatureFromEvent(evt) {
   if (
@@ -55,7 +55,8 @@ function getFeatureFromEvent(evt) {
   ) {
     return /** @type {import("../source/Vector.js").VectorSourceEvent} */ (evt)
       .feature;
-  } else if (
+  }
+  if (
     /** @type {import("../Collection.js").CollectionEvent<import("../Feature.js").default>} */ (
       evt
     ).element
@@ -64,6 +65,7 @@ function getFeatureFromEvent(evt) {
       evt
     ).element;
   }
+  return null;
 }
 
 const tempSegment = [];
@@ -277,7 +279,9 @@ class Snap extends PointerInteraction {
    */
   handleFeatureAdd_(evt) {
     const feature = getFeatureFromEvent(evt);
-    this.addFeature(feature);
+    if (feature) {
+      this.addFeature(feature);
+    }
   }
 
   /**
@@ -286,7 +290,9 @@ class Snap extends PointerInteraction {
    */
   handleFeatureRemove_(evt) {
     const feature = getFeatureFromEvent(evt);
-    this.removeFeature(feature);
+    if (feature) {
+      this.removeFeature(feature);
+    }
   }
 
   /**

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -343,7 +343,7 @@ class Layer extends BaseLayer {
    * @param {?import("../Map.js").FrameState} frameState Frame state.
    * @param {HTMLElement} target Target which the renderer may (but need not) use
    * for rendering its content.
-   * @return {HTMLElement} The rendered element.
+   * @return {HTMLElement|null} The rendered element.
    */
   render(frameState, target) {
     const layerRenderer = this.getRenderer();
@@ -352,6 +352,7 @@ class Layer extends BaseLayer {
       this.rendered = true;
       return layerRenderer.renderFrame(frameState, target);
     }
+    return null;
   }
 
   /**

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -311,7 +311,8 @@ export function clearAllProjections() {
 export function createProjection(projection, defaultCode) {
   if (!projection) {
     return get(defaultCode);
-  } else if (typeof projection === 'string') {
+  }
+  if (typeof projection === 'string') {
     return get(projection);
   }
   return /** @type {Projection} */ (projection);

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -580,7 +580,8 @@ class VectorSource extends Source {
   forEachFeature(callback) {
     if (this.featuresRtree_) {
       return this.featuresRtree_.forEach(callback);
-    } else if (this.featuresCollection_) {
+    }
+    if (this.featuresCollection_) {
       this.featuresCollection_.forEach(callback);
     }
   }
@@ -630,7 +631,8 @@ class VectorSource extends Source {
   forEachFeatureInExtent(extent, callback) {
     if (this.featuresRtree_) {
       return this.featuresRtree_.forEachInExtent(extent, callback);
-    } else if (this.featuresCollection_) {
+    }
+    if (this.featuresCollection_) {
       this.featuresCollection_.forEach(callback);
     }
   }
@@ -742,7 +744,8 @@ class VectorSource extends Source {
       return [].concat(
         ...extents.map((anExtent) => this.featuresRtree_.getInExtent(anExtent))
       );
-    } else if (this.featuresCollection_) {
+    }
+    if (this.featuresCollection_) {
       return this.featuresCollection_.getArray().slice(0);
     }
     return [];

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -117,7 +117,8 @@ class LRUCache {
     assert(entry !== undefined, 15); // Tried to get a value for a key that does not exist in the cache
     if (entry === this.newest_) {
       return entry.value_;
-    } else if (entry === this.oldest_) {
+    }
+    if (entry === this.oldest_) {
       this.oldest_ = /** @type {Entry} */ (this.oldest_.newer);
       this.oldest_.older = null;
     } else {

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -36,6 +36,7 @@ function getImport(symbol, member) {
     const importName = from.replace(/[.\/]+/g, '_');
     return `import {${member} as ${importName}$${member}} from '${from}.js';`;
   }
+  return '';
 }
 
 /**
@@ -66,6 +67,7 @@ function formatSymbolExport(symbol, namespaces, imports) {
     imports[imp] = true;
     return line;
   }
+  return '';
 }
 
 /**

--- a/test/browser/spec/ol/control/scaleline.test.js
+++ b/test/browser/spec/ol/control/scaleline.test.js
@@ -506,9 +506,11 @@ describe('ol.control.ScaleLine', function () {
     const getMetricUnit = function (zoom) {
       if (zoom > 30) {
         return 'μm';
-      } else if (zoom > 20) {
+      }
+      if (zoom > 20) {
         return 'mm';
-      } else if (zoom > 10) {
+      }
+      if (zoom > 10) {
         return 'm';
       }
       return 'km';
@@ -517,7 +519,8 @@ describe('ol.control.ScaleLine', function () {
     const getImperialUnit = function (zoom) {
       if (zoom >= 21) {
         return 'in';
-      } else if (zoom >= 10) {
+      }
+      if (zoom >= 10) {
         return 'ft';
       }
       return 'mi';

--- a/test/browser/spec/ol/source/cluster.test.js
+++ b/test/browser/spec/ol/source/cluster.test.js
@@ -43,7 +43,8 @@ describe('ol.source.Cluster', function () {
           const geom = feature.getGeometry();
           if (geom.getType() == 'Point') {
             return geom;
-          } else if (geom.getType() == 'Polygon') {
+          }
+          if (geom.getType() == 'Polygon') {
             return geom.getInteriorPoint();
           }
           return null;


### PR DESCRIPTION
This updates the ESLint config to avoid unnecessary `else if` blocks after `return` (we already avoid `else`, but still have lots of unnecessary indents using `else if`).

The updated config includes an updated JSDoc plugin that is more strict about `@return` types.