### PR TITLE
IconStyle setScale() fixes relating to width and height

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next version
 
+#### `ol/style/Icon`
+
+The `width` and `height` options cannot be used together with `scale`.  To prevent conflicts the `.setScale()` method will now clear any width or height settings.
+
 ### 7.2.0
 
 #### Rendered resolutions of `ol/source/Raster`

--- a/examples/icon-width.js
+++ b/examples/icon-width.js
@@ -83,5 +83,5 @@ new Map({
 function formatScale(scale) {
   return Array.isArray(scale)
     ? '[' + scale?.map((v) => v.toFixed(2)).join(', ') + ']'
-    : scale;
+    : scale.toFixed(2);
 }

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -236,16 +236,19 @@ class Icon extends ImageStyle {
     /**
      * Recalculate the scale if width or height were given.
      */
-    if (this.width_ !== undefined || this.height_ !== undefined) {
-      const image = this.getImage(1);
-      const setScale = () => {
+    const recalculate = () => {
+      if (this.width_ !== undefined || this.height_ !== undefined) {
         this.updateScaleFromWidthAndHeight(this.width_, this.height_);
-      };
-      if (image.width > 0) {
-        this.updateScaleFromWidthAndHeight(this.width_, this.height_);
-      } else {
-        image.addEventListener('load', setScale);
       }
+    };
+    if (this.getImageState() == ImageState.LOADED) {
+      recalculate();
+    } else {
+      const listener = () => {
+        this.unlistenImageChange(listener);
+        recalculate();
+      };
+      this.listenImageChange(listener);
     }
   }
 
@@ -296,15 +299,17 @@ class Icon extends ImageStyle {
    * @param {number} height The height.
    */
   updateScaleFromWidthAndHeight(width, height) {
-    const image = this.getImage(1);
-    if (width !== undefined && height !== undefined) {
-      super.setScale([width / image.width, height / image.height]);
-    } else if (width !== undefined) {
-      super.setScale([width / image.width, width / image.width]);
-    } else if (height !== undefined) {
-      super.setScale([height / image.height, height / image.height]);
-    } else {
-      super.setScale([1, 1]);
+    if (this.getImageState() == ImageState.LOADED) {
+      const image = this.getImage(1);
+      if (width !== undefined && height !== undefined) {
+        super.setScale([width / image.width, height / image.height]);
+      } else if (width !== undefined) {
+        super.setScale([width / image.width, width / image.width]);
+      } else if (height !== undefined) {
+        super.setScale([height / image.height, height / image.height]);
+      } else {
+        super.setScale(1);
+      }
     }
   }
 
@@ -504,6 +509,7 @@ class Icon extends ImageStyle {
    * Set the width of the icon in pixels.
    *
    * @param {number} width The width to set.
+   * @api
    */
   setWidth(width) {
     this.width_ = width;
@@ -514,6 +520,7 @@ class Icon extends ImageStyle {
    * Set the height of the icon in pixels.
    *
    * @param {number} height The height to set.
+   * @api
    */
   setHeight(height) {
     this.height_ = height;
@@ -521,25 +528,16 @@ class Icon extends ImageStyle {
   }
 
   /**
-   * Set the scale and updates the width and height correspondingly.
+   * Set the scale (any width or height settings will be cleared).
    *
    * @param {number|import("../size.js").Size} scale Scale.
    * @override
    * @api
    */
   setScale(scale) {
+    this.width_ = undefined;
+    this.height_ = undefined;
     super.setScale(scale);
-    const image = this.getImage(1);
-    if (image) {
-      const widthScale = Array.isArray(scale) ? scale[0] : scale;
-      if (widthScale !== undefined) {
-        this.width_ = widthScale * image.width;
-      }
-      const heightScale = Array.isArray(scale) ? scale[1] : scale;
-      if (heightScale !== undefined) {
-        this.height_ = heightScale * image.height;
-      }
-    }
   }
 
   /**

--- a/test/browser/spec/ol/renderer/vector.test.js
+++ b/test/browser/spec/ol/renderer/vector.test.js
@@ -50,14 +50,14 @@ describe('ol.renderer.vector', function () {
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = iconStyle.iconImage_.listeners_['change'];
-        expect(listeners.length).to.eql(1);
+        expect(listeners.length).to.eql(2);
 
         // call #2
         renderFeature(builderGroup, feature, style, squaredTolerance, listener);
 
         expect(iconStyleLoadSpy.calledOnce).to.be.ok();
         listeners = iconStyle.iconImage_.listeners_['change'];
-        expect(listeners.length).to.eql(1);
+        expect(listeners.length).to.eql(2);
       });
     });
 

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -171,6 +171,28 @@ describe('ol.style.Icon', function () {
       expect(original.getHeight()).to.eql(clone.getHeight());
       expect(original.getScale()).to.eql(clone.getScale());
     });
+
+    it('setScale() does not cause an array or width/height to be set when cloned', (done) => {
+      const original = new Icon({
+        src: src,
+        width: 10,
+        height: 5,
+      });
+      const iconImage = original.iconImage_;
+      iconImage.addEventListener('change', () => {
+        original.setScale(2);
+        let clone;
+        expect(() => (clone = original.clone())).to.not.throwException();
+        expect(original.getWidth()).to.eql(undefined);
+        expect(original.getWidth()).to.eql(clone.getWidth());
+        expect(original.getHeight()).to.eql(undefined);
+        expect(original.getHeight()).to.eql(clone.getHeight());
+        expect(original.getScale()).to.eql(2);
+        expect(original.getScale()).to.eql(clone.getScale());
+        done();
+      });
+      original.load();
+    });
   });
 
   describe('#getAnchor', function () {
@@ -419,14 +441,27 @@ describe('ol.style.Icon', function () {
       });
       expect(iconStyle.getWidth()).to.eql(10);
     });
-    it('setWidth updates the width', function () {
+    it('setWidth updates the width, and scale when image is loaded', function (done) {
       const iconStyle = new Icon({
-        src,
-        width: 10,
+        src: img,
+        width: 9,
       });
-      expect(iconStyle.getWidth()).to.eql(10);
+      expect(iconStyle.getWidth()).to.eql(9);
+      expect(iconStyle.getScale()).to.eql(1);
       iconStyle.setWidth(30);
       expect(iconStyle.getWidth()).to.eql(30);
+      expect(iconStyle.getScale()).to.eql(1);
+
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getWidth()).to.eql(30);
+        expect(iconStyle.getScale()).to.eql([10, 10]);
+        iconStyle.setWidth(9);
+        expect(iconStyle.getWidth()).to.eql(9);
+        expect(iconStyle.getScale()).to.eql([3, 3]);
+        done();
+      });
+      iconStyle.load();
     });
     it('getHeight returns the expected value', function () {
       const iconStyle = new Icon({
@@ -435,24 +470,67 @@ describe('ol.style.Icon', function () {
       });
       expect(iconStyle.getHeight()).to.eql(20);
     });
-    it('setHeight updates the height', function () {
+    it('setHeight updates the height, and scale when image is loaded', function (done) {
       const iconStyle = new Icon({
-        src,
+        src: img,
         height: 20,
       });
       expect(iconStyle.getHeight()).to.eql(20);
+      expect(iconStyle.getScale()).to.eql(1);
       iconStyle.setHeight(200);
       expect(iconStyle.getHeight()).to.eql(200);
+      expect(iconStyle.getScale()).to.eql(1);
+
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getHeight()).to.eql(200);
+        expect(iconStyle.getScale()).to.eql([50, 50]);
+        iconStyle.setHeight(20);
+        expect(iconStyle.getHeight()).to.eql(20);
+        expect(iconStyle.getScale()).to.eql([5, 5]);
+        done();
+      });
+      iconStyle.load();
     });
-    it('setScale updates the width and height', function (done) {
+    it('setWidth and setHeight update scale independently', function (done) {
+      const iconStyle = new Icon({
+        src: img,
+      });
+      expect(iconStyle.getWidth()).to.eql(undefined);
+      expect(iconStyle.getHeight()).to.eql(undefined);
+      expect(iconStyle.getScale()).to.eql(1);
+      iconStyle.setWidth(9);
+      iconStyle.setHeight(20);
+      expect(iconStyle.getWidth()).to.eql(9);
+      expect(iconStyle.getHeight()).to.eql(20);
+      expect(iconStyle.getScale()).to.eql(1);
+
+      const iconImage = iconStyle.iconImage_;
+      iconImage.addEventListener('change', function () {
+        expect(iconStyle.getWidth()).to.eql(9);
+        expect(iconStyle.getHeight()).to.eql(20);
+        expect(iconStyle.getScale()).to.eql([3, 5]);
+        iconStyle.setWidth(30);
+        expect(iconStyle.getWidth()).to.eql(30);
+        expect(iconStyle.getHeight()).to.eql(20);
+        expect(iconStyle.getScale()).to.eql([10, 5]);
+        iconStyle.setHeight(200);
+        expect(iconStyle.getWidth()).to.eql(30);
+        expect(iconStyle.getHeight()).to.eql(200);
+        expect(iconStyle.getScale()).to.eql([10, 50]);
+        done();
+      });
+      iconStyle.load();
+    });
+    it('setScale clears the width and height', function (done) {
       const iconStyle = new Icon({
         src: img,
       });
       const iconImage = iconStyle.iconImage_;
       iconImage.addEventListener('change', function () {
         iconStyle.setScale(2);
-        expect(iconStyle.getWidth()).to.eql(6);
-        expect(iconStyle.getHeight()).to.eql(8);
+        expect(iconStyle.getWidth()).to.eql(undefined);
+        expect(iconStyle.getHeight()).to.eql(undefined);
         done();
       });
       iconStyle.load();
@@ -464,8 +542,8 @@ describe('ol.style.Icon', function () {
       const iconImage = iconStyle.iconImage_;
       iconImage.addEventListener('change', function () {
         iconStyle.setScale([3, 4]);
-        expect(iconStyle.getWidth()).to.eql(9);
-        expect(iconStyle.getHeight()).to.eql(16);
+        expect(iconStyle.getWidth()).to.eql(undefined);
+        expect(iconStyle.getHeight()).to.eql(undefined);
         done();
       });
       iconStyle.load();


### PR DESCRIPTION
Fixes #14575

Ensure the `setScale()` method clears any conflicting width or height settings, and revise the documentation.
Ensure that scale is only returned as an array if set as such, or auto-calculated when width/height are set, including when cloned.
Document the `setWidth()` and `setHeight()` methods (as used in the example) in the API.
