### PR TITLE
Avoid unexpected behavior with Icon width and height

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next version
 
+#### `ol/style/Icon#setScale()` restriction
+
+When an `Icon` style is configured with a `width` and/or `height`, calling `setScale()` on the `Icon` style now throws an exception. This is because depending on the type of the icon image (image or canvas) and its loading state, it cannot be guaranteed that `width`, `height` and `scale` can be kept in sync synchronously.
+
 ### 7.2.0
 
 #### Rendered resolutions of `ol/source/Raster`

--- a/src/ol/AssertionError.js
+++ b/src/ol/AssertionError.js
@@ -60,7 +60,7 @@ const messages = {
   66: '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled. This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`',
   67: 'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both',
   68: 'A VectorTile source can only be rendered if it has a projection compatible with the view projection',
-  69: '`width` or `height` cannot be provided together with `scale`',
+  69: '`width` or `height` cannot be provided together with `scale` or `size`',
 };
 
 /**

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -43,8 +43,12 @@ import {getUid} from '../util.js';
  * @property {Array<number>} [displacement=[0, 0]] Displacement of the icon in pixels.
  * Positive values will shift the icon right and up.
  * @property {number} [opacity=1] Opacity of the icon.
- * @property {number} [width] The width of the icon in pixels. This can't be used together with `scale`.
- * @property {number} [height] The height of the icon in pixels. This can't be used together with `scale`.
+ * @property {number} [width] The width of the image in pixels. This can't be used together with `scale`,
+ * because the x `scale` will be calculated from the `width` divided by the image width (i.e. `imgSize` or the
+ * width of the provided `img` or `src`).
+ * @property {number} [height]  The height of the image in pixels. This can't be used together with `scale`,
+ * because the y `scale` will be calculated from the `height` divided by the image height (i.e. `imgSize` or the
+ * height of the provided `img` or `src`).
  * @property {number|import("../size.js").Size} [scale=1] Scale.
  * @property {boolean} [rotateWithView=false] Whether to rotate the icon with the view.
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
@@ -521,28 +525,19 @@ class Icon extends ImageStyle {
   }
 
   /**
-   * Set the scale and updates the width and height correspondingly.
+   * Set the scale and updates the width and height correspondingly. Will throw an error when
+   * the icon style was constructed with a `width` or `height` option.
    *
    * @param {number|import("../size.js").Size} scale Scale.
-   * @override
    * @api
    */
   setScale(scale) {
-    super.setScale(scale);
-    const image = this.getImage(1);
-    if (
-      image &&
-      (image instanceof HTMLCanvasElement || (image.src && image.complete))
-    ) {
-      const widthScale = Array.isArray(scale) ? scale[0] : scale;
-      if (widthScale !== undefined) {
-        this.width_ = widthScale * image.width;
-      }
-      const heightScale = Array.isArray(scale) ? scale[1] : scale;
-      if (heightScale !== undefined) {
-        this.height_ = heightScale * image.height;
-      }
+    if (this.width_ !== undefined || this.height_ !== undefined) {
+      throw new Error(
+        'Can only set scale when `width` and `height` were not set'
+      );
     }
+    super.setScale(scale);
   }
 
   /**

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -43,10 +43,10 @@ import {getUid} from '../util.js';
  * @property {Array<number>} [displacement=[0, 0]] Displacement of the icon in pixels.
  * Positive values will shift the icon right and up.
  * @property {number} [opacity=1] Opacity of the icon.
- * @property {number} [width] The width of the image in pixels. This can't be used together with `scale`,
+ * @property {number} [width] The width of the image in pixels. This can't be used together with `scale` or `size`,
  * because the x `scale` will be calculated from the `width` divided by the image width (i.e. `imgSize` or the
  * width of the provided `img` or `src`).
- * @property {number} [height]  The height of the image in pixels. This can't be used together with `scale`,
+ * @property {number} [height]  The height of the image in pixels. This can't be used together with `scale` or `size`,
  * because the y `scale` will be calculated from the `height` divided by the image height (i.e. `imgSize` or the
  * height of the provided `img` or `src`).
  * @property {number|import("../size.js").Size} [scale=1] Scale.
@@ -169,11 +169,11 @@ class Icon extends ImageStyle {
     }
     assert(src !== undefined && src.length > 0, 6); // A defined and non-empty `src` or `image` must be provided
 
-    // `width` or `height` cannot be provided together with `scale`
+    // `width` or `height` cannot be provided together with `scale` or `size`
     assert(
       !(
         (options.width !== undefined || options.height !== undefined) &&
-        options.scale !== undefined
+        (options.scale !== undefined || options.size !== undefined)
       ),
       69
     );

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -238,13 +238,13 @@ class Icon extends ImageStyle {
      */
     if (this.width_ !== undefined || this.height_ !== undefined) {
       const image = this.getImage(1);
-      const setScale = () => {
+      const updateScale = () => {
         this.updateScaleFromWidthAndHeight(this.width_, this.height_);
       };
-      if (image.width > 0) {
-        this.updateScaleFromWidthAndHeight(this.width_, this.height_);
+      if (image instanceof HTMLCanvasElement || (image.src && image.complete)) {
+        updateScale();
       } else {
-        image.addEventListener('load', setScale);
+        image.addEventListener('load', updateScale);
       }
     }
   }
@@ -530,7 +530,10 @@ class Icon extends ImageStyle {
   setScale(scale) {
     super.setScale(scale);
     const image = this.getImage(1);
-    if (image) {
+    if (
+      image &&
+      (image instanceof HTMLCanvasElement || (image.src && image.complete))
+    ) {
       const widthScale = Array.isArray(scale) ? scale[0] : scale;
       if (widthScale !== undefined) {
         this.width_ = widthScale * image.width;

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -131,6 +131,22 @@ describe('ol.style.Icon', function () {
       });
     });
 
+    it('preserves the scale', (done) => {
+      const original = new Icon({
+        src: 'spec/ol/data/dot.png',
+      });
+      original.setScale(2);
+      expect(original.getScale()).to.be(2);
+      const clone = original.clone();
+      expect(original.getScale()).to.eql(clone.getScale());
+      original.load();
+      original.getImage(1).addEventListener('load', () => {
+        const clone = original.clone();
+        expect(original.getScale()).to.eql(clone.getScale());
+        done();
+      });
+    });
+
     it('the clone does not reference the same objects as the original', function () {
       const original = new Icon({
         anchor: [1, 0],

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -388,12 +388,12 @@ describe('ol.style.Icon', function () {
 
   describe('#width/height', function () {
     // 3px * 4px sized white gif
-    const img =
+    const src =
       'data:image/gif;base64,' +
       'R0lGODlhAwAEAIABAP7+/vDy9SH+EUNyZWF0ZWQgd2l0aCBHSU1QACH5BAEKAAEALAAAAAADAAQAAAIDhI9WADs=';
     it('scale is set correctly if configured with width only', function (done) {
       const iconStyle = new Icon({
-        src: img,
+        src,
         width: 6,
       });
       const iconImage = iconStyle.iconImage_;
@@ -405,7 +405,7 @@ describe('ol.style.Icon', function () {
     });
     it('scale is set correctly if configured with height only', function (done) {
       const iconStyle = new Icon({
-        src: img,
+        src,
         height: 12,
       });
       const iconImage = iconStyle.iconImage_;
@@ -417,7 +417,7 @@ describe('ol.style.Icon', function () {
     });
     it('scale is set correctly if used with width and height', function (done) {
       const iconStyle = new Icon({
-        src: img,
+        src,
         width: 6,
         height: 12,
       });
@@ -460,28 +460,26 @@ describe('ol.style.Icon', function () {
       iconStyle.setHeight(200);
       expect(iconStyle.getHeight()).to.eql(200);
     });
-    it('setScale updates the width and height', function (done) {
+    it('setScale throws when configured with width and height', function (done) {
       const iconStyle = new Icon({
-        src: img,
+        src,
+        width: 6,
       });
       const iconImage = iconStyle.iconImage_;
       iconImage.addEventListener('change', function () {
-        iconStyle.setScale(2);
-        expect(iconStyle.getWidth()).to.eql(6);
-        expect(iconStyle.getHeight()).to.eql(8);
+        expect(() => iconStyle.setScale(2)).to.throwException();
         done();
       });
       iconStyle.load();
     });
-    it('setScale with array updates the width and height', function (done) {
+    it('setScale throws when configured with width and height', function (done) {
       const iconStyle = new Icon({
-        src: img,
+        src,
+        height: 8,
       });
       const iconImage = iconStyle.iconImage_;
       iconImage.addEventListener('change', function () {
-        iconStyle.setScale([3, 4]);
-        expect(iconStyle.getWidth()).to.eql(9);
-        expect(iconStyle.getHeight()).to.eql(16);
+        expect(() => iconStyle.setScale([3, 4])).to.throwException();
         done();
       });
       iconStyle.load();


### PR DESCRIPTION
Fixes #14575 
Supersedes #14601

Only calculate the scale from the provided `width` and `height` when the image size is known.