### PR TITLE
WebGL Points / mark the renderer as initially ready

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -135,8 +135,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       postProcesses: options.postProcesses,
     });
 
-    this.ready = false;
-
     this.sourceRevision_ = -1;
 
     this.verticesBuffer_ = new WebGLArrayBuffer(ARRAY_BUFFER, DYNAMIC_DRAW);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -288,7 +288,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
      * @type {number}
      * @private
      */
-    this.generateBuffersRun_ = 0;
+    this.lastSentId = 0;
 
     /**
      * @private
@@ -327,7 +327,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
             this.renderInstructions_ = new Float32Array(
               event.data.renderInstructions
             );
-            if (received.generateBuffersRun === this.generateBuffersRun_) {
+            if (received.id === this.lastSentId) {
               this.ready = true;
             }
           }
@@ -636,14 +636,13 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     /** @type {import('../../render/webgl/constants.js').WebGLWorkerGenerateBuffersMessage} */
     const message = {
-      id: 0,
+      id: ++this.lastSentId,
       type: WebGLWorkerMessageType.GENERATE_POINT_BUFFERS,
       renderInstructions: this.renderInstructions_.buffer,
       customAttributesCount: this.customAttributes.length,
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;
-    message['generateBuffersRun'] = ++this.generateBuffersRun_;
     this.ready = false;
     this.worker_.postMessage(message, [this.renderInstructions_.buffer]);
     this.renderInstructions_ = null;

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -480,7 +480,6 @@ describe('ol/Map', function () {
 
       it('triggers when all tiles and sources are loaded and faded in', function (done) {
         const layers = map.getLayers().getArray();
-        expect(layers[6].getRenderer().ready).to.be(false);
         map.once('rendercomplete', function () {
           expect(map.tileQueue_.getTilesLoading()).to.be(0);
           expect(layers[1].getSource().image_.getState()).to.be(
@@ -713,8 +712,6 @@ describe('ol/Map', function () {
     });
 
     it('is a reliable start-end sequence', function (done) {
-      const layers = map.getLayers().getArray();
-      expect(layers[6].getRenderer().ready).to.be(false);
       let loading = 0;
       map.on('loadstart', () => {
         map.getView().setZoom(0.1);

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -1,7 +1,9 @@
 import Feature from '../../../../../../src/ol/Feature.js';
 import GeoJSON from '../../../../../../src/ol/format/GeoJSON.js';
 import Map from '../../../../../../src/ol/Map.js';
+import OSM from '../../../../../../src/ol/source/OSM.js';
 import Point from '../../../../../../src/ol/geom/Point.js';
+import TileLayer from '../../../../../../src/ol/layer/Tile.js';
 import VectorLayer from '../../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../../src/ol/source/Vector.js';
 import View from '../../../../../../src/ol/View.js';
@@ -778,6 +780,49 @@ describe('ol/renderer/webgl/PointsLayer', function () {
           done(e);
         }
       });
+    });
+  });
+
+  describe('layer not visible initially', function () {
+    let map, layer;
+    beforeEach(function () {
+      layer = new WebGLPointsLayer({
+        source: new VectorSource(),
+        style: {
+          symbol: {
+            symbolType: 'circle',
+            size: 14,
+            color: 'red',
+          },
+        },
+        maxZoom: 8,
+      });
+      const visibleLayer = new TileLayer({
+        source: new OSM(),
+      });
+      map = new Map({
+        pixelRatio: 1,
+        target: createMapDiv(100, 100),
+        layers: [layer, visibleLayer],
+        view: new View({
+          center: [0, 0],
+          zoom: 10,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map);
+      layer.dispose();
+    });
+
+    it('loadstart and loadend events trigger normally', function (done) {
+      map.once('loadstart', () => {
+        map.once('loadend', () => {
+          done();
+        });
+      });
+      map.renderSync();
     });
   });
 


### PR DESCRIPTION
This simply aligns the WebGL points renderer with other renderers by having its `ready` property set to `true` initially. In the case where the renderer is initially not needed because e.g. the layer is not being rendered, then it will not prevent the `loadend` event of the map to be dispatched.

Also contains a tiny bit of boyscoutting.

Fixes https://github.com/openlayers/openlayers/issues/14596
