### PR TITLE
Clear size when target is detached from map

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1259,6 +1259,7 @@ class Map extends BaseObject {
       if (rootNode instanceof ShadowRoot) {
         this.resizeObserver_.unobserve(rootNode.host);
       }
+      this.setSize(undefined);
     }
 
     // target may be undefined, null, a string or an Element.

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1176,6 +1176,41 @@ describe('ol/Map', function () {
         expect(map.targetChangeHandlerKeys_).to.be.ok();
       });
     });
+
+    it('detach and re-attach', function (done) {
+      const target = map.getTargetElement();
+      map.setTarget(null);
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map.setTarget(target);
+      map.addLayer(
+        new VectorLayer({
+          source: new VectorSource({
+            features: [new Feature(new Point([0, 0]))],
+          }),
+        })
+      );
+      map.getView().setCenter([0, 0]);
+      map.getView().setZoom(0);
+      map.renderSync();
+      try {
+        expect(target.querySelector('canvas')).to.be.a(HTMLCanvasElement);
+        map.setTarget(null);
+        expect(target.querySelector('canvas')).to.be(null);
+        map.setTarget(target);
+        map.once('rendercomplete', () => {
+          try {
+            expect(target.querySelector('canvas')).to.be.a(HTMLCanvasElement);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+      } finally {
+        document.body.removeChild(target);
+      }
+    });
   });
 
   describe('create interactions', function () {


### PR DESCRIPTION
This pull request fixes a regression caused by #14305: When detaching a map from a `target` using `map.setTarget(null)` and re-attaching it later using `map.setTarget(target)`, no map will be visible. The reason is that when no target is attached, the logic expects the map's `size` to be unset.