### PR TITLE
Ensure exported KML text scale is not an array

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -2697,7 +2697,7 @@ function writeLabelStyle(node, style, objectStack) {
   if (fill) {
     properties['color'] = fill.getColor();
   }
-  const scale = style.getScale();
+  const scale = style.getScaleArray()[0];
   if (scale && scale !== 1) {
     properties['scale'] = scale;
   }


### PR DESCRIPTION
As noted in https://github.com/openlayers/openlayers/pull/14606#issuecomment-1484236532 if exporting a user specified text style to KML the exported scale must not be an array.
