### PR TITLE
Helper method to bind a texture

### DIFF
--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -178,11 +178,12 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
 
     let textureSlot = 0;
     while (textureSlot < tileTexture.textures.length) {
-      const textureProperty = 'TEXTURE' + textureSlot;
       const uniformName = `${Uniforms.TILE_TEXTURE_ARRAY}[${textureSlot}]`;
-      gl.activeTexture(gl[textureProperty]);
-      gl.bindTexture(gl.TEXTURE_2D, tileTexture.textures[textureSlot]);
-      gl.uniform1i(this.helper.getUniformLocation(uniformName), textureSlot);
+      this.helper.bindTexture(
+        tileTexture.textures[textureSlot],
+        textureSlot,
+        uniformName
+      );
       ++textureSlot;
     }
 
@@ -192,13 +193,8 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       ++paletteIndex
     ) {
       const paletteTexture = this.paletteTextures_[paletteIndex];
-      gl.activeTexture(gl['TEXTURE' + textureSlot]);
       const texture = paletteTexture.getTexture(gl);
-      gl.bindTexture(gl.TEXTURE_2D, texture);
-      gl.uniform1i(
-        this.helper.getUniformLocation(paletteTexture.name),
-        textureSlot
-      );
+      this.helper.bindTexture(texture, textureSlot, paletteTexture.name);
       ++textureSlot;
     }
 

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -578,6 +578,19 @@ class WebGLHelper extends Disposable {
   }
 
   /**
+   * Prepare a program to use a texture.
+   * @param {WebGLTexture} texture The texture.
+   * @param {number} slot The texture slot.
+   * @param {string} uniformName The corresponding uniform name.
+   */
+  bindTexture(texture, slot, uniformName) {
+    const gl = this.getGL();
+    gl.activeTexture(gl.TEXTURE0 + slot);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.uniform1i(this.getUniformLocation(uniformName), slot);
+  }
+
+  /**
    * Clear the render target & bind it for future draw operations.
    * This is similar to `prepareDraw`, only post processes will not be applied.
    * Note: the whole viewport will be drawn to the render target, regardless of its size.


### PR DESCRIPTION
This is one small change from #14491, adding a helper function that prepares a program to use a texture.

The current rendering tests cover this refactor.