### PR TITLE
Allow postProcesses to be passed to parent renderer

### DIFF
--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -132,6 +132,7 @@ export function getCacheKey(source, tileCoord) {
  * @property {Object<string, import("../../webgl/Helper").UniformValue>} [uniforms] Additional uniforms
  * made available to shaders.
  * @property {number} [cacheSize=512] The tile representation cache size.
+ * @property {Array<import('./Layer.js').PostProcessesOptions>} [postProcesses] Post-processes definitions.
  */
 
 /**
@@ -154,6 +155,7 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
   constructor(tileLayer, options) {
     super(tileLayer, {
       uniforms: options.uniforms,
+      postProcesses: options.postProcesses,
     });
 
     /**


### PR DESCRIPTION
This adds a `postProcesses` property to the base WebGL tile layer renderer.  This allows renderers that extend this to pass along a `postProcesses` array to the helper that gets created.  This is used in #14491 by the new flow layer renderer to disable the creation of the default post processing pass if none is given by the calling renderer.