### PR TITLE
Make Modify hitdetect mode work with user projection

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1184,6 +1184,11 @@ class Modify extends PointerInteraction {
       map.forEachFeatureAtPixel(
         pixel,
         (feature, layer, geometry) => {
+          if (geometry) {
+            geometry = new Point(
+              toUserCoordinate(geometry.getCoordinates(), projection)
+            );
+          }
           const geom = geometry || feature.getGeometry();
           if (
             geom.getType() === 'Point' &&
@@ -1191,7 +1196,7 @@ class Modify extends PointerInteraction {
             this.features_.getArray().includes(feature)
           ) {
             hitPointGeometry = /** @type {Point} */ (geom);
-            const coordinate = hitPointGeometry
+            const coordinate = /** @type {Point} */ (feature.getGeometry())
               .getFlatCoordinates()
               .slice(0, 2);
             nodes = [

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -19,6 +19,7 @@ import {MultiPoint} from '../../../../../src/ol/geom.js';
 import {
   clearUserProjection,
   setUserProjection,
+  useGeographic,
 } from '../../../../../src/ol/proj.js';
 import {
   click,
@@ -1155,9 +1156,47 @@ describe('ol.interaction.Modify', function () {
       map.renderSync();
       simulateEvent('pointermove', 10, -10, null, 0);
       expect(modify.vertexFeature_.get('features')[0]).to.eql(pointFeature);
-      expect(modify.vertexFeature_.get('geometries')[0]).to.eql(
-        pointFeature.getGeometry()
+      expect(
+        modify.vertexFeature_.get('geometries')[0].getCoordinates()
+      ).to.eql(pointFeature.getGeometry().getCoordinates());
+    });
+
+    it('works with hit detection of point features with userGeographic()', function () {
+      useGeographic();
+      const modify = new Modify({
+        hitDetection: layer,
+        source: source,
+      });
+      map.setView(
+        new View({
+          center: [16, 48],
+          zoom: map.getView().getZoom(),
+        })
       );
+      map.addInteraction(modify);
+      source.clear();
+      const pointFeature = new Feature(new Point([16, 48]));
+      source.addFeature(pointFeature);
+      layer.setStyle(
+        new Style({
+          image: new CircleStyle({
+            radius: 30,
+            fill: new Fill({
+              color: 'fuchsia',
+            }),
+          }),
+        })
+      );
+      map.renderSync();
+      simulateEvent('pointermove', 10, -10, null, 0);
+      simulateEvent('pointerdown', 10, -10, null, 0);
+      simulateEvent('pointerdrag', 0, 0, null, 0);
+      simulateEvent('pointerup', 0, 0, null, 0);
+      expect(modify.vertexFeature_.get('features')[0]).to.eql(pointFeature);
+      expect(
+        modify.vertexFeature_.get('geometries')[0].getCoordinates()
+      ).to.eql(pointFeature.getGeometry().getCoordinates());
+      clearUserProjection();
     });
 
     it('snaps to pointer by default', function () {


### PR DESCRIPTION
Previously, when configuring a Modify interaction with `hitDetect`, dragging would not work. This can easily be reproduced by adding `useGeographic(true)` to the `modify-icon-html` example.

This pull request adds a missing coordinate transform, and makes sure the modify node `geometry` has the coordinates of, instead of a reference to the modify candidate geometry. This is required to avoid misses due to coordinate transform floating point inaccuracies, which would avoid matching up the node with the r-tree.