### PR TITLE
Remove experimental description from getUserProjection() API method

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -54,7 +54,7 @@ import {warn} from './console.js';
  * @property {boolean} animate Animate.
  * @property {import("./transform.js").Transform} coordinateToPixelTransform CoordinateToPixelTransform.
  * @property {import("rbush").default} declutterTree DeclutterTree.
- * @property {null|import("./extent.js").Extent} extent Extent.
+ * @property {null|import("./extent.js").Extent} extent Extent (in view projection coordinates).
  * @property {import("./extent.js").Extent} [nextExtent] Next extent during an animation series.
  * @property {number} index Index.
  * @property {Array<import("./layer/Layer.js").State>} layerStatesArray LayerStatesArray.

--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -202,7 +202,7 @@ import {fromExtent as polygonFromExtent} from './geom/Polygon.js';
 
 /**
  * @typedef {Object} State
- * @property {import("./coordinate.js").Coordinate} center Center.
+ * @property {import("./coordinate.js").Coordinate} center Center (in view projection coordinates).
  * @property {import("./proj/Projection.js").default} projection Projection.
  * @property {number} resolution Resolution.
  * @property {import("./coordinate.js").Coordinate} [nextCenter] The next center during an animation series.
@@ -216,7 +216,7 @@ import {fromExtent as polygonFromExtent} from './geom/Polygon.js';
  * Like {@link import("./Map.js").FrameState}, but just `viewState` and `extent`.
  * @typedef {Object} ViewStateLayerStateExtent
  * @property {State} viewState View state.
- * @property {import("./extent.js").Extent} extent Extent.
+ * @property {import("./extent.js").Extent} extent Extent (in user projection coordinates).
  * @property {Array<import("./layer/Layer.js").State>} [layerStatesArray] Layer states.
  */
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -567,8 +567,6 @@ export function clearUserProjection() {
 
 /**
  * Get the projection for coordinates supplied from and returned by API methods.
- * Note that this method is not yet a part of the stable API.  Support for user
- * projections is not yet complete and should be considered experimental.
  * @return {Projection|null} The user projection (or null if not set).
  * @api
  */

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -549,7 +549,8 @@ let userProjection = null;
 
 /**
  * Set the projection for coordinates supplied from and returned by API methods.
- * This includes all API methods except for those interacting with tile grids.
+ * This includes all API methods except for those interacting with tile grids,
+ * plus {@link import("./Map.js").FrameState} and {@link import("./View.js").State}.
  * @param {ProjectionLike} projection The user projection.
  * @api
  */
@@ -575,8 +576,9 @@ export function getUserProjection() {
 }
 
 /**
- * Use geographic coordinates (WGS-84 datum) in API methods.  This includes all API
- * methods except for those interacting with tile grids.
+ * Use geographic coordinates (WGS-84 datum) in API methods.
+ * This includes all API methods except for those interacting with tile grids,
+ * plus {@link import("./Map.js").FrameState} and {@link import("./View.js").State}.
  * @api
  */
 export function useGeographic() {


### PR DESCRIPTION
This description was removed from other methods when they were added to the API so was presumably overlooked here.

In addition to tile grids user projections to not apply to coordinates in `frameState` and `viewState` which are also part of the API.  Should that be mentioned either here in or in the descriptions for those objects?