### PR TITLE
OSMXML: support reading geometry from ways

### DIFF
--- a/src/ol/format/OSMXML.js
+++ b/src/ol/format/OSMXML.js
@@ -79,10 +79,12 @@ class OSMXML extends XMLFeature {
       for (let j = 0; j < state.ways.length; j++) {
         const values = /** @type {Object} */ (state.ways[j]);
         /** @type {Array<number>} */
-        const flatCoordinates = [];
-        for (let i = 0, ii = values.ndrefs.length; i < ii; i++) {
-          const point = state.nodes[values.ndrefs[i]];
-          extend(flatCoordinates, point);
+        const flatCoordinates = values.flatCoordinates;
+        if (!flatCoordinates.length) {
+          for (let i = 0, ii = values.ndrefs.length; i < ii; i++) {
+            const point = state.nodes[values.ndrefs[i]];
+            extend(flatCoordinates, point);
+          }
         }
         let geometry;
         if (values.ndrefs[0] == values.ndrefs[values.ndrefs.length - 1]) {
@@ -165,6 +167,7 @@ function readWay(node, objectStack) {
     {
       id: id,
       ndrefs: [],
+      flatCoordinates: [],
       tags: {},
     },
     WAY_PARSERS,
@@ -182,6 +185,10 @@ function readWay(node, objectStack) {
 function readNd(node, objectStack) {
   const values = /** @type {Object} */ (objectStack[objectStack.length - 1]);
   values.ndrefs.push(node.getAttribute('ref'));
+  if (node.hasAttribute('lon') && node.hasAttribute('lat')) {
+    values.flatCoordinates.push(parseFloat(node.getAttribute('lon')));
+    values.flatCoordinates.push(parseFloat(node.getAttribute('lat')));
+  }
 }
 
 /**

--- a/test/browser/spec/ol/format/osmxml.test.js
+++ b/test/browser/spec/ol/format/osmxml.test.js
@@ -113,6 +113,28 @@ describe('ol.format.OSMXML', function () {
       ]);
     });
 
+    it('can read coordinates from ways', function () {
+      const text =
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<osm version="0.6" generator="my hand">' +
+        '  <way id="3">' +
+        '    <tag k="name" v="3"/>' +
+        '    <nd ref="1" lat="1" lon="2" />' +
+        '    <nd ref="2" lat="3" lon="4" />' +
+        '  </way>' +
+        '</osm>';
+      const fs = format.readFeatures(text);
+      expect(fs).to.have.length(1);
+      const line = fs[0];
+      expect(line).to.be.an(Feature);
+      const g = line.getGeometry();
+      expect(g).to.be.an(LineString);
+      expect(g.getCoordinates()).to.eql([
+        [2, 1],
+        [4, 3],
+      ]);
+    });
+
     it('can transform and read nodes', function () {
       const text =
         '<?xml version="1.0" encoding="UTF-8"?>' +


### PR DESCRIPTION
The output mode `out geom`  of Overpass API adds `lon`, `lat` to the `<nd>` elements of `<way>`.

Ref: https://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL#out

Example: https://overpass-api.de/api/interpreter?data=way(423692233);out+geom;