### PR TITLE
WebGL / add support for more types in style expressions

### DIFF
--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -3,67 +3,14 @@ layout: example.html
 title: WebGL points layer
 shortdesc: Using a WebGL-optimized layer to render a large quantities of points
 docs: >
-  This example shows how to use a `WebGLPointsLayer` to show a large amount of points on the map.
-  The layer is given a style in JSON format which allows a certain level of customization of the final reprensentation.
+  <p>
+    This example shows how to use a `WebGLPointsLayer` to show a large amount of points on the map.
+    The layer is given a style in JSON format which allows a certain level of customization of the final representation.
+  </p>
 
-  The following operators can be used:
-
-   * Reading operators:
-     * `['get', 'attributeName']` fetches a feature attribute (it will be prefixed by `a_` in the shader)
-       Note: those will be taken from the attributes provided to the renderer
-     * `['var', 'varName']` fetches a value from the style variables, or 0 if undefined
-     * `['time']` returns the time in seconds since the creation of the layer
-     * `['zoom']` returns the current zoom level
-     * `['resolution']` returns the current resolution
-
-   * Math operators:
-     * `['*', value1, value2]` multiplies `value1` by `value2`
-     * `['/', value1, value2]` divides `value1` by `value2`
-     * `['+', value1, value2]` adds `value1` and `value2`
-     * `['-', value1, value2]` subtracts `value2` from `value1`
-     * `['clamp', value, low, high]` clamps `value` between `low` and `high`
-     * `['%', value1, value2]` returns the result of `value1 % value2` (modulo)
-     * `['^', value1, value2]` returns the value of `value1` raised to the `value2` power
-
-   * Transform operators:
-     * `['case', condition1, output1, ...conditionN, outputN, fallback]` selects the first output whose corresponding
-       condition evaluates to `true`. If no match is found, returns the `fallback` value.
-       All conditions should be `boolean`, output and fallback can be any kind.
-     * `['match', input, match1, output1, ...matchN, outputN, fallback]` compares the `input` value against all
-       provided `matchX` values, returning the output associated with the first valid match. If no match is found,
-       returns the `fallback` value.
-       `input` and `matchX` values must all be of the same type, and can be `number` or `string`. `outputX` and
-       `fallback` values must be of the same type, and can be of any kind.
-     * `['interpolate', interpolation, input, stop1, output1, ...stopN, outputN]` returns a value by interpolating between
-       pairs of inputs and outputs; `interpolation` can either be `['linear']` or `['exponential', base]` where `base` is
-       the rate of increase from stop A to stop B (i.e. power to which the interpolation ratio is raised); a value
-       of 1 is equivalent to `['linear']`.
-       `input` and `stopX` values must all be of type `number`. `outputX` values can be `number` or `color` values.
-       Note: `input` will be clamped between `stop1` and `stopN`, meaning that all output values will be comprised
-       between `output1` and `outputN`.
-
-   * Logical operators:
-     * `['<', value1, value2]` returns `true` if `value1` is strictly lower than `value2`, or `false` otherwise.
-     * `['<=', value1, value2]` returns `true` if `value1` is lower than or equals `value2`, or `false` otherwise.
-     * `['>', value1, value2]` returns `true` if `value1` is strictly greater than `value2`, or `false` otherwise.
-     * `['>=', value1, value2]` returns `true` if `value1` is greater than or equals `value2`, or `false` otherwise.
-     * `['==', value1, value2]` returns `true` if `value1` equals `value2`, or `false` otherwise.
-     * `['!=', value1, value2]` returns `true` if `value1` does not equal `value2`, or `false` otherwise.
-     * `['!', value1]` returns `false` if `value1` is `true` or greater than `0`, or `true` otherwise.
-     * `['between', value1, value2, value3]` returns `true` if `value1` is contained between `value2` and `value3`
-       (inclusively), or `false` otherwise.
-
-   * Conversion operators:
-     * `['array', value1, ...valueN]` creates a numerical array from `number` values; please note that the amount of
-       values can currently only be 2, 3 or 4.
-     * `['color', red, green, blue, alpha]` creates a `color` value from `number` values; the `alpha` parameter is
-       optional; if not specified, it will be set to 1.
-       Note: `red`, `green` and `blue` components must be values between 0 and 255; `alpha` between 0 and 1.
-   Values can either be literals or another operator, as they will be evaluated recursively.
-   Literal values can be of the following types:
-    * `boolean`
-    * `number`
-    * `string`
+  <p>
+    Consult the <a href="/en/latest/apidoc/module-ol_style_expressions.html#~ExpressionValue">documentation on expressions</a> to know which operators to use and how.
+  </p>
 
 tags: "webgl, point, layer, feature"
 experimental: true

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -13,24 +13,20 @@ class WebGLLayer extends Layer {
   createRenderer() {
     return new WebGLVectorLayerRenderer(this, {
       fill: {
-        attributes: {
-          color: function (feature) {
-            const color = [...asArray(feature.get('COLOR') || '#eee')];
-            color[3] = 0.6;
-            return packColor(color);
-          },
+        color: function (feature) {
+          const color = [...asArray(feature.get('COLOR') || '#eee')];
+          color[3] = 0.6;
+          return packColor(color);
         },
       },
       stroke: {
-        attributes: {
-          color: function (feature) {
-            const color = [...asArray(feature.get('COLOR') || '#eee')];
-            color.forEach((_, i) => (color[i] = Math.round(color[i] * 0.75))); // darken slightly
-            return packColor(color);
-          },
-          width: function () {
-            return 1.5;
-          },
+        color: function (feature) {
+          const color = [...asArray(feature.get('COLOR') || '#eee')];
+          color.forEach((_, i) => (color[i] = Math.round(color[i] * 0.75))); // darken slightly
+          return packColor(color);
+        },
+        width: function () {
+          return 1.5;
         },
       },
     });

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -15,12 +15,9 @@ class WebGLLayer extends Layer {
       fill: {
         attributes: {
           color: function (feature) {
-            const color = asArray(feature.get('COLOR') || '#eee');
-            color[3] = 0.85;
+            const color = [...asArray(feature.get('COLOR') || '#eee')];
+            color[3] = 0.6;
             return packColor(color);
-          },
-          opacity: function () {
-            return 0.6;
           },
         },
       },
@@ -33,9 +30,6 @@ class WebGLLayer extends Layer {
           },
           width: function () {
             return 1.5;
-          },
-          opacity: function () {
-            return 1;
           },
         },
       },

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -7,7 +7,7 @@ import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import WebGLVectorLayerRenderer from '../src/ol/renderer/webgl/VectorLayer.js';
 import {asArray} from '../src/ol/color.js';
-import {packColor} from '../src/ol/renderer/webgl/shaders.js';
+import {packColor} from '../src/ol/webgl/styleparser.js';
 
 class WebGLLayer extends Layer {
   createRenderer() {

--- a/examples/webgl-vector-tiles.js
+++ b/examples/webgl-vector-tiles.js
@@ -21,7 +21,6 @@ class WebGLVectorTileLayer extends VectorTile {
             const color = asArray(style?.getFill()?.getColor() || '#eee');
             return packColor(color);
           },
-          opacity: () => 1,
         },
       },
       stroke: {
@@ -35,7 +34,6 @@ class WebGLVectorTileLayer extends VectorTile {
             const style = this.getStyle()(feature, 1)[0];
             return style?.getStroke()?.getWidth() || 0;
           },
-          opacity: () => 1,
         },
       },
       point: {

--- a/examples/webgl-vector-tiles.js
+++ b/examples/webgl-vector-tiles.js
@@ -6,7 +6,7 @@ import View from '../src/ol/View.js';
 import WebGLVectorTileLayerRenderer from '../src/ol/renderer/webgl/VectorTileLayer.js';
 import {Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
 import {asArray} from '../src/ol/color.js';
-import {packColor} from '../src/ol/renderer/webgl/shaders.js';
+import {packColor} from '../src/ol/webgl/styleparser.js';
 
 const key =
   'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ';

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -87,7 +87,7 @@ class WebGLPointsLayer extends Layer {
     this.parseResult_ = parseLiteralStyle(options.style);
 
     /**
-     * @type {Object<string, (string|number)>}
+     * @type {Object<string, (string|number|Array<number>|boolean)>}
      * @private
      */
     this.styleVariables_ = options.style.variables || {};

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -124,6 +124,7 @@ function parseStyle(style, bandCount) {
     stringLiteralsMap: {},
     functions: {},
     bandCount: bandCount,
+    style: style,
   };
 
   const pipeline = [];

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -202,13 +202,13 @@ function parseStyle(style, bandCount) {
   }
 
   for (let i = 0; i < numVariables; ++i) {
-    const variableName = context.variables[i];
-    if (!(variableName in style.variables)) {
-      throw new Error(`Missing '${variableName}' in style variables`);
+    const variable = context.variables[i];
+    if (!(variable.name in style.variables)) {
+      throw new Error(`Missing '${variable.name}' in style variables`);
     }
-    const uniformName = uniformNameForVariable(variableName);
+    const uniformName = uniformNameForVariable(variable.name);
     uniforms[uniformName] = function () {
-      let value = style.variables[variableName];
+      let value = style.variables[variable.name];
       if (typeof value === 'string') {
         value = getStringNumberEquivalent(context, value);
       }

--- a/src/ol/render/webgl/BatchRenderer.js
+++ b/src/ol/render/webgl/BatchRenderer.js
@@ -12,7 +12,9 @@ import {
  * @typedef {Object} CustomAttribute A description of a custom attribute to be passed on to the GPU, with a value different
  * for each feature.
  * @property {string} name Attribute name.
- * @property {function(import("../../Feature").FeatureLike):number} callback This callback computes the numerical value of the
+ * @property {number} [size] Amount of numerical values composing the attribute, either 1, 2, 3 or 4; in case size is > 1, the return value
+ * of the callback should be an array; if unspecified, assumed to be a single float value
+ * @property {function(import("../../Feature").FeatureLike):number|Array<number>} callback This callback computes the numerical value of the
  * attribute for a given feature.
  */
 
@@ -62,6 +64,16 @@ class AbstractBatchRenderer {
      * @protected
      */
     this.customAttributes = customAttributes;
+
+    /**
+     * Amount of numerical values taken by the custom attributes
+     * @type {number}
+     * @protected
+     */
+    this.customAttributesSize = this.customAttributes.reduce(
+      (prev, curr) => prev + (curr.size || 1),
+      0
+    );
   }
 
   /**
@@ -144,7 +156,7 @@ class AbstractBatchRenderer {
       type: messageType,
       renderInstructions: batch.renderInstructions.buffer,
       renderInstructionsTransform: batch.renderInstructionsTransform,
-      customAttributesCount: this.customAttributes.length,
+      customAttributesSize: this.customAttributesSize,
     };
     this.worker_.postMessage(message, [batch.renderInstructions.buffer]);
 
@@ -187,6 +199,29 @@ class AbstractBatchRenderer {
       };
 
     this.worker_.addEventListener('message', handleMessage);
+  }
+
+  /**
+   * @protected
+   * @param {import("./MixedGeometryBatch.js").GeometryBatch} batch
+   * @param {import("./MixedGeometryBatch.js").GeometryBatchItem} batchEntry
+   * @param {number} currentIndex
+   * @return {number} The amount of values pushed
+   */
+  pushCustomAttributesInRenderInstructions(batch, batchEntry, currentIndex) {
+    let shift = 0;
+    for (let k = 0, kk = this.customAttributes.length; k < kk; k++) {
+      const attr = this.customAttributes[k];
+      const value = attr.callback(batchEntry.feature);
+      batch.renderInstructions[currentIndex + shift++] = value[0] || value;
+      if (!attr.size || attr.size === 1) continue;
+      batch.renderInstructions[currentIndex + shift++] = value[1];
+      if (attr.size < 3) continue;
+      batch.renderInstructions[currentIndex + shift++] = value[2];
+      if (attr.size < 4) continue;
+      batch.renderInstructions[currentIndex + shift++] = value[3];
+    }
+    return shift;
   }
 }
 

--- a/src/ol/render/webgl/BatchRenderer.js
+++ b/src/ol/render/webgl/BatchRenderer.js
@@ -203,9 +203,9 @@ class AbstractBatchRenderer {
 
   /**
    * @protected
-   * @param {import("./MixedGeometryBatch.js").GeometryBatch} batch
-   * @param {import("./MixedGeometryBatch.js").GeometryBatchItem} batchEntry
-   * @param {number} currentIndex
+   * @param {import("./MixedGeometryBatch.js").GeometryBatch} batch Geometry batch
+   * @param {import("./MixedGeometryBatch.js").GeometryBatchItem} batchEntry Batch item
+   * @param {number} currentIndex Current index
    * @return {number} The amount of values pushed
    */
   pushCustomAttributesInRenderInstructions(batch, batchEntry, currentIndex) {
@@ -214,11 +214,17 @@ class AbstractBatchRenderer {
       const attr = this.customAttributes[k];
       const value = attr.callback(batchEntry.feature);
       batch.renderInstructions[currentIndex + shift++] = value[0] || value;
-      if (!attr.size || attr.size === 1) continue;
+      if (!attr.size || attr.size === 1) {
+        continue;
+      }
       batch.renderInstructions[currentIndex + shift++] = value[1];
-      if (attr.size < 3) continue;
+      if (attr.size < 3) {
+        continue;
+      }
       batch.renderInstructions[currentIndex + shift++] = value[2];
-      if (attr.size < 4) continue;
+      if (attr.size < 4) {
+        continue;
+      }
       batch.renderInstructions[currentIndex + shift++] = value[3];
     }
     return shift;

--- a/src/ol/render/webgl/LineStringBatchRenderer.js
+++ b/src/ol/render/webgl/LineStringBatchRenderer.js
@@ -48,7 +48,7 @@ class LineStringBatchRenderer extends AbstractBatchRenderer {
       customAttributes.map(function (attribute) {
         return {
           name: 'a_' + attribute.name,
-          size: 1,
+          size: attribute.size || 1,
           type: AttributeType.FLOAT,
         };
       })
@@ -68,7 +68,7 @@ class LineStringBatchRenderer extends AbstractBatchRenderer {
     // + 1 instruction per line (for vertices count)
     const totalInstructionsCount =
       2 * batch.verticesCount +
-      (1 + this.customAttributes.length) * batch.geometriesCount;
+      (1 + this.customAttributesSize) * batch.geometriesCount;
     if (
       !batch.renderInstructions ||
       batch.renderInstructions.length !== totalInstructionsCount
@@ -91,12 +91,11 @@ class LineStringBatchRenderer extends AbstractBatchRenderer {
           batch.renderInstructionsTransform,
           flatCoords
         );
-
-        // custom attributes
-        for (let k = 0, kk = this.customAttributes.length; k < kk; k++) {
-          const value = this.customAttributes[k].callback(batchEntry.feature);
-          batch.renderInstructions[renderIndex++] = value;
-        }
+        renderIndex += this.pushCustomAttributesInRenderInstructions(
+          batch,
+          batchEntry,
+          renderIndex
+        );
 
         // vertices count
         batch.renderInstructions[renderIndex++] = flatCoords.length / 2;

--- a/src/ol/render/webgl/PointBatchRenderer.js
+++ b/src/ol/render/webgl/PointBatchRenderer.js
@@ -43,7 +43,7 @@ class PointBatchRenderer extends AbstractBatchRenderer {
       customAttributes.map(function (attribute) {
         return {
           name: 'a_' + attribute.name,
-          size: 1,
+          size: attribute.size || 1,
           type: AttributeType.FLOAT,
         };
       })
@@ -61,7 +61,7 @@ class PointBatchRenderer extends AbstractBatchRenderer {
     // 2 instructions per vertex for position (x and y)
     // + 1 instruction per vertex per custom attributes
     const totalInstructionsCount =
-      (2 + this.customAttributes.length) * batch.geometriesCount;
+      (2 + this.customAttributesSize) * batch.geometriesCount;
     if (
       !batch.renderInstructions ||
       batch.renderInstructions.length !== totalInstructionsCount
@@ -81,12 +81,11 @@ class PointBatchRenderer extends AbstractBatchRenderer {
 
         batch.renderInstructions[renderIndex++] = tmpCoords[0];
         batch.renderInstructions[renderIndex++] = tmpCoords[1];
-
-        // pushing custom attributes
-        for (let j = 0, jj = this.customAttributes.length; j < jj; j++) {
-          const value = this.customAttributes[j].callback(batchEntry.feature);
-          batch.renderInstructions[renderIndex++] = value;
-        }
+        renderIndex += this.pushCustomAttributesInRenderInstructions(
+          batch,
+          batchEntry,
+          renderIndex
+        );
       }
     }
   }

--- a/src/ol/render/webgl/PolygonBatchRenderer.js
+++ b/src/ol/render/webgl/PolygonBatchRenderer.js
@@ -36,7 +36,7 @@ class PolygonBatchRenderer extends AbstractBatchRenderer {
       customAttributes.map(function (attribute) {
         return {
           name: 'a_' + attribute.name,
-          size: 1,
+          size: attribute.size || 1,
           type: AttributeType.FLOAT,
         };
       })
@@ -57,7 +57,7 @@ class PolygonBatchRenderer extends AbstractBatchRenderer {
     // + 1 instruction per ring (for vertices count in ring)
     const totalInstructionsCount =
       2 * batch.verticesCount +
-      (1 + this.customAttributes.length) * batch.geometriesCount +
+      (1 + this.customAttributesSize) * batch.geometriesCount +
       batch.ringsCount;
     if (
       !batch.renderInstructions ||
@@ -81,12 +81,11 @@ class PolygonBatchRenderer extends AbstractBatchRenderer {
           batch.renderInstructionsTransform,
           flatCoords
         );
-
-        // custom attributes
-        for (let k = 0, kk = this.customAttributes.length; k < kk; k++) {
-          const value = this.customAttributes[k].callback(batchEntry.feature);
-          batch.renderInstructions[renderIndex++] = value;
-        }
+        renderIndex += this.pushCustomAttributesInRenderInstructions(
+          batch,
+          batchEntry,
+          renderIndex
+        );
 
         // ring count
         batch.renderInstructions[renderIndex++] =

--- a/src/ol/render/webgl/constants.js
+++ b/src/ol/render/webgl/constants.js
@@ -20,7 +20,7 @@ export const WebGLWorkerMessageType = {
  * @property {number} id Message id; will be used both in request and response as a means of identification
  * @property {WebGLWorkerMessageType} type Message type
  * @property {ArrayBuffer} renderInstructions Polygon render instructions raw binary buffer.
- * @property {number} [customAttributesCount] Amount of custom attributes count in the polygon render instructions.
+ * @property {number} [customAttributesSize] Amount of custom attributes count in the polygon render instructions.
  * @property {ArrayBuffer} [vertexBuffer] Vertices array raw binary buffer (sent by the worker).
  * @property {ArrayBuffer} [indexBuffer] Indices array raw binary buffer (sent by the worker).
  * @property {import("../../transform").Transform} [renderInstructionsTransform] Transformation matrix used to project the instructions coordinates

--- a/src/ol/render/webgl/utils.js
+++ b/src/ol/render/webgl/utils.js
@@ -27,7 +27,7 @@ function writePointVertex(buffer, pos, x, y, index) {
  * @param {number} elementIndex Index from which render instructions will be read.
  * @param {Float32Array} vertexBuffer Buffer in the form of a typed array.
  * @param {Uint32Array} indexBuffer Buffer in the form of a typed array.
- * @param {number} customAttributesCount Amount of custom attributes for each element.
+ * @param {number} customAttributesSize Amount of custom attributes for each element.
  * @param {BufferPositions} [bufferPositions] Buffer write positions; if not specified, positions will be set at 0.
  * @return {BufferPositions} New buffer positions where to write next
  * @property {number} vertexPosition New position in the vertex buffer where future writes should start.
@@ -39,20 +39,20 @@ export function writePointFeatureToBuffers(
   elementIndex,
   vertexBuffer,
   indexBuffer,
-  customAttributesCount,
+  customAttributesSize,
   bufferPositions
 ) {
   // This is for x, y and index
   const baseVertexAttrsCount = 3;
   const baseInstructionsCount = 2;
-  const stride = baseVertexAttrsCount + customAttributesCount;
+  const stride = baseVertexAttrsCount + customAttributesSize;
 
   const x = instructions[elementIndex + 0];
   const y = instructions[elementIndex + 1];
 
   // read custom numerical attributes on the feature
   const customAttrs = tmpArray_;
-  customAttrs.length = customAttributesCount;
+  customAttrs.length = customAttributesSize;
   for (let i = 0; i < customAttrs.length; i++) {
     customAttrs[i] = instructions[elementIndex + baseInstructionsCount + i];
   }
@@ -255,7 +255,7 @@ export function writeLineSegmentToBuffers(
  * @param {number} polygonStartIndex Index of the polygon start point from which render instructions will be read.
  * @param {Array<number>} vertexArray Array containing vertices.
  * @param {Array<number>} indexArray Array containing indices.
- * @param {number} customAttributesCount Amount of custom attributes for each element.
+ * @param {number} customAttributesSize Amount of custom attributes for each element.
  * @return {number} Next polygon instructions index
  * @private
  */
@@ -264,16 +264,16 @@ export function writePolygonTrianglesToBuffers(
   polygonStartIndex,
   vertexArray,
   indexArray,
-  customAttributesCount
+  customAttributesSize
 ) {
   const instructionsPerVertex = 2; // x, y
-  const attributesPerVertex = 2 + customAttributesCount;
+  const attributesPerVertex = 2 + customAttributesSize;
   let instructionsIndex = polygonStartIndex;
   const customAttributes = instructions.slice(
     instructionsIndex,
-    instructionsIndex + customAttributesCount
+    instructionsIndex + customAttributesSize
   );
-  instructionsIndex += customAttributesCount;
+  instructionsIndex += customAttributesSize;
   const ringsCount = instructions[instructionsIndex++];
   let verticesCount = 0;
   const holes = new Array(ringsCount - 1);

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -639,7 +639,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       id: ++this.lastSentId,
       type: WebGLWorkerMessageType.GENERATE_POINT_BUFFERS,
       renderInstructions: this.renderInstructions_.buffer,
-      customAttributesCount: this.customAttributes.length,
+      customAttributesSize: this.customAttributes.length,
     };
     // additional properties will be sent back as-is by the worker
     message['projectionTransform'] = projectionTransform;
@@ -653,7 +653,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         id: 0,
         type: WebGLWorkerMessageType.GENERATE_POINT_BUFFERS,
         renderInstructions: this.hitRenderInstructions_.buffer,
-        customAttributesCount: 5 + this.customAttributes.length,
+        customAttributesSize: 5 + this.customAttributes.length,
       };
       hitMessage['projectionTransform'] = projectionTransform;
       hitMessage['hitDetection'] = true;

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -61,14 +61,6 @@ export const Uniforms = {
  */
 
 /**
- * @param {Object<import("./shaders.js").DefaultAttributes,CustomAttributeCallback>} obj Lookup of attribute getters.
- * @return {Array<import("../../render/webgl/BatchRenderer").CustomAttribute>} An array of attribute descriptors.
- */
-function toAttributesArray(obj) {
-  return Object.keys(obj).map((key) => ({name: key, callback: obj[key]}));
-}
-
-/**
  * @classdesc
  * Experimental WebGL vector renderer. Supports polygons, lines and points:
  *  * Polygons are broken down into triangles
@@ -122,57 +114,50 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
      */
     this.currentFrameStateTransform_ = createTransform();
 
-    const fillAttributes = {
-      color: function () {
-        return packColor('#ddd');
-      },
-      opacity: function () {
-        return 1;
-      },
-      ...(options.fill && options.fill.attributes),
-    };
-
-    const strokeAttributes = {
-      color: function () {
-        return packColor('#eee');
-      },
-      opacity: function () {
-        return 1;
-      },
-      width: function () {
-        return 1.5;
-      },
-      ...(options.stroke && options.stroke.attributes),
-    };
-
-    const pointAttributes = {
-      color: function () {
-        return packColor('#eee');
-      },
-      opacity: function () {
-        return 1;
-      },
-      ...(options.point && options.point.attributes),
-    };
-
     this.fillVertexShader_ =
       (options.fill && options.fill.vertexShader) || FILL_VERTEX_SHADER;
     this.fillFragmentShader_ =
       (options.fill && options.fill.fragmentShader) || FILL_FRAGMENT_SHADER;
-    this.fillAttributes_ = toAttributesArray(fillAttributes);
+    const fillAttributes = (options.fill && options.fill.attributes) || {};
+    this.fillAttributes_ = [
+      {
+        name: 'color',
+        dimension: 2,
+        callback: fillAttributes.color || (() => packColor('#eee')),
+      },
+    ];
 
     this.strokeVertexShader_ =
       (options.stroke && options.stroke.vertexShader) || STROKE_VERTEX_SHADER;
     this.strokeFragmentShader_ =
       (options.stroke && options.stroke.fragmentShader) ||
       STROKE_FRAGMENT_SHADER;
-    this.strokeAttributes_ = toAttributesArray(strokeAttributes);
+    const strokeAttributes =
+      (options.stroke && options.stroke.attributes) || {};
+    this.strokeAttributes_ = [
+      {
+        name: 'color',
+        dimension: 2,
+        callback: strokeAttributes.color || (() => packColor('#eee')),
+      },
+      {
+        name: 'width',
+        callback: strokeAttributes.width || (() => 1.5),
+      },
+    ];
 
     this.pointVertexShader_ =
       (options.point && options.point.vertexShader) || POINT_VERTEX_SHADER;
     this.pointFragmentShader_ =
       (options.point && options.point.fragmentShader) || POINT_FRAGMENT_SHADER;
-    this.pointAttributes_ = toAttributesArray(pointAttributes);
+    const pointAttributes = (options.point && options.point.attributes) || {};
+    this.pointAttributes_ = [
+      {
+        name: 'color',
+        dimension: 2,
+        callback: pointAttributes.color || (() => packColor('#eee')),
+      },
+    ];
 
     /**
      * @private

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -17,7 +17,6 @@ import {
   POINT_VERTEX_SHADER,
   STROKE_FRAGMENT_SHADER,
   STROKE_VERTEX_SHADER,
-  packColor,
 } from './shaders.js';
 import {buffer, createEmpty, equals, getWidth} from '../../extent.js';
 import {
@@ -28,6 +27,7 @@ import {
 } from '../../transform.js';
 import {create as createWebGLWorker} from '../../worker/webgl.js';
 import {listen, unlistenByKey} from '../../events.js';
+import {packColor} from '../../webgl/styleparser.js';
 
 export const Uniforms = {
   ...DefaultUniform,

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -20,8 +20,11 @@ import {
 } from './shaders.js';
 import {buffer, createEmpty, equals, getWidth} from '../../extent.js';
 import {
+  create as createMat4,
+  fromTransform as mat4FromTransform,
+} from '../../vec/mat4.js';
+import {
   create as createTransform,
-  makeInverse as makeInverseTransform,
   multiply as multiplyTransform,
   setFromArray as setFromTransform,
   translate as translateTransform,
@@ -29,10 +32,6 @@ import {
 import {create as createWebGLWorker} from '../../worker/webgl.js';
 import {listen, unlistenByKey} from '../../events.js';
 import {packColor} from '../../webgl/styleparser.js';
-import {
-  create as createMat4,
-  fromTransform as mat4FromTransform,
-} from '../../vec/mat4.js';
 
 export const Uniforms = {
   ...DefaultUniform,
@@ -41,7 +40,7 @@ export const Uniforms = {
 };
 
 /**
- * @typedef {function(import("../../Feature").default):number|[number,number]} AttributeCallback A callback computing
+ * @typedef {function(import("../../Feature").default):number|Array<number>} AttributeCallback A callback computing
  * the value of a custom attribute (different for each feature) to be passed on to the GPU.
  * Properties are available as 2nd arg for quicker access.
  */

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -34,7 +34,11 @@ import {packColor} from '../../webgl/styleparser.js';
  * @return {Array<import("../../render/webgl/BatchRenderer").CustomAttribute>} An array of attribute descriptors.
  */
 function toAttributesArray(obj) {
-  return Object.keys(obj).map((key) => ({name: key, callback: obj[key]}));
+  return Object.keys(obj).map((key) => ({
+    name: key,
+    size: key === 'color' ? 2 : 1,
+    callback: obj[key],
+  }));
 }
 
 /**
@@ -136,18 +140,12 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       color: function () {
         return packColor('#ddd');
       },
-      opacity: function () {
-        return 1;
-      },
       ...(options.fill && options.fill.attributes),
     };
 
     const strokeAttributes = {
       color: function () {
         return packColor('#eee');
-      },
-      opacity: function () {
-        return 1;
       },
       width: function () {
         return 1.5;
@@ -158,9 +156,6 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
     const pointAttributes = {
       color: function () {
         return packColor('#eee');
-      },
-      opacity: function () {
-        return 1;
       },
       ...(options.point && options.point.attributes),
     };

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -14,7 +14,6 @@ import {
   POINT_VERTEX_SHADER,
   STROKE_FRAGMENT_SHADER,
   STROKE_VERTEX_SHADER,
-  packColor,
 } from './shaders.js';
 import {
   create as createMat4,
@@ -28,6 +27,7 @@ import {
 } from '../../transform.js';
 import {create as createWebGLWorker} from '../../worker/webgl.js';
 import {getIntersection} from '../../extent.js';
+import {packColor} from '../../webgl/styleparser.js';
 
 /**
  * @param {Object<import("./shaders.js").DefaultAttributes,CustomAttributeCallback>} obj Lookup of attribute getters.

--- a/src/ol/renderer/webgl/shaders.js
+++ b/src/ol/renderer/webgl/shaders.js
@@ -3,31 +3,33 @@
  */
 import {asArray} from '../../color.js';
 
-/** @typedef {'color'|'opacity'|'width'} DefaultAttributes */
+/** @typedef {'color'|'width'} DefaultAttributes */
 
 /**
  * Packs red/green/blue channels of a color into a single float value; alpha is ignored.
  * This is how the color is expected to be computed.
  * @param {import("../../color.js").Color|string} color Color as array of numbers or string
- * @return {number} Float value containing the color
+ * @return {[number, number]} Vec2 array containing the color in compressed form
  */
 export function packColor(color) {
   const array = asArray(color);
-  const r = array[0] * 256 * 256;
-  const g = array[1] * 256;
-  const b = array[2];
-  return r + g + b;
+  const r = array[0] * 256;
+  const g = array[1];
+  const b = array[2] * 256;
+  const a = Math.round(array[3] * 255);
+  return [r + g, b + a];
 }
 
-const DECODE_COLOR_EXPRESSION = `vec3(
-  fract(floor(a_color / 256.0 / 256.0) / 256.0),
-  fract(floor(a_color / 256.0) / 256.0),
-  fract(a_color / 256.0)
-);`;
+const DECODE_COLOR_EXPRESSION = `vec4(
+  fract(a_color[1] / 256.0) * fract(floor(a_color[0] / 256.0) / 256.0),
+  fract(a_color[1] / 256.0) * fract(a_color[0] / 256.0),
+  fract(a_color[1] / 256.0) * fract(floor(a_color[1] / 256.0) / 256.0),
+  fract(a_color[1] / 256.0)
+)`;
 
 /**
  * Default polygon vertex shader.
- * Relies on the color and opacity attributes.
+ * Relies on the color attribute.
  * @type {string}
  */
 export const FILL_VERTEX_SHADER = `
@@ -38,15 +40,12 @@ export const FILL_VERTEX_SHADER = `
   #endif
   uniform mat4 u_projectionMatrix;
   attribute vec2 a_position;
-  attribute float a_color;
-  attribute float a_opacity;
-  varying vec3 v_color;
-  varying float v_opacity;
+  attribute vec2 a_color;
+  varying vec4 v_color;
 
   void main(void) {
     gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
-    v_color = ${DECODE_COLOR_EXPRESSION}
-    v_opacity = a_opacity;
+    v_color = ${DECODE_COLOR_EXPRESSION};
   }`;
 
 /**
@@ -65,8 +64,7 @@ export const FILL_FRAGMENT_SHADER = `
   uniform vec2 u_viewportSizePx;
   uniform float u_pixelRatio;
   uniform vec4 u_renderExtent;
-  varying vec3 v_color;
-  varying float v_opacity;
+  varying vec4 v_color;
 
   vec2 pxToWorld(vec2 pxPos) {
     vec2 screenPos = 2.0 * pxPos / u_viewportSizePx - 1.0;
@@ -87,12 +85,12 @@ export const FILL_FRAGMENT_SHADER = `
       discard;
     }
     #endif
-    gl_FragColor = vec4(v_color, 1.0) * v_opacity * u_globalAlpha;
+    gl_FragColor = v_color * u_globalAlpha;
   }`;
 
 /**
  * Default linestring vertex shader.
- * Relies on color, opacity and width attributes.
+ * Relies on color and width attributes.
  * @type {string}
  */
 export const STROKE_VERTEX_SHADER = `
@@ -106,15 +104,13 @@ export const STROKE_VERTEX_SHADER = `
   attribute vec2 a_segmentStart;
   attribute vec2 a_segmentEnd;
   attribute float a_parameters;
-  attribute float a_color;
-  attribute float a_opacity;
+  attribute vec2 a_color;
   attribute float a_width;
   varying vec2 v_segmentStart;
   varying vec2 v_segmentEnd;
   varying float v_angleStart;
   varying float v_angleEnd;
-  varying vec3 v_color;
-  varying float v_opacity;
+  varying vec4 v_color;
   varying float v_width;
 
   vec2 worldToPx(vec2 worldPos) {
@@ -155,8 +151,7 @@ export const STROKE_VERTEX_SHADER = `
     gl_Position = u_projectionMatrix * vec4(position, 0.0, 1.0) + pxToScreen(offsetPx);
     v_segmentStart = worldToPx(a_segmentStart);
     v_segmentEnd = worldToPx(a_segmentEnd);
-    v_color = ${DECODE_COLOR_EXPRESSION}
-    v_opacity = a_opacity;
+    v_color = ${DECODE_COLOR_EXPRESSION};
     v_width = a_width;
   }`;
 
@@ -180,8 +175,7 @@ export const STROKE_FRAGMENT_SHADER = `
   varying vec2 v_segmentEnd;
   varying float v_angleStart;
   varying float v_angleEnd;
-  varying vec3 v_color;
-  varying float v_opacity;
+  varying vec4 v_color;
   varying float v_width;
 
   vec2 pxToWorld(vec2 pxPos) {
@@ -212,13 +206,13 @@ export const STROKE_FRAGMENT_SHADER = `
       discard;
     }
     #endif
-    gl_FragColor = vec4(v_color, 1.0) * v_opacity * u_globalAlpha;
+    gl_FragColor = v_color * u_globalAlpha;
     gl_FragColor *= segmentDistanceField(v_currentPoint, v_segmentStart, v_segmentEnd, v_width);
   }`;
 
 /**
  * Default point vertex shader.
- * Relies on color and opacity attributes.
+ * Relies on color attribute.
  * @type {string}
  */
 export const POINT_VERTEX_SHADER = `
@@ -227,11 +221,9 @@ export const POINT_VERTEX_SHADER = `
   uniform mat4 u_offsetScaleMatrix;
   attribute vec2 a_position;
   attribute float a_index;
-  attribute float a_color;
-  attribute float a_opacity;
+  attribute vec2 a_color;
   varying vec2 v_texCoord;
-  varying vec3 v_color;
-  varying float v_opacity;
+  varying vec4 v_color;
 
   void main(void) {
     mat4 offsetMatrix = u_offsetScaleMatrix;
@@ -243,8 +235,7 @@ export const POINT_VERTEX_SHADER = `
     float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
     float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;
     v_texCoord = vec2(u, v);
-    v_color = ${DECODE_COLOR_EXPRESSION}
-    v_opacity = a_opacity;
+    v_color = ${DECODE_COLOR_EXPRESSION};
   }`;
 
 /**
@@ -255,9 +246,8 @@ export const POINT_FRAGMENT_SHADER = `
   precision mediump float;
   uniform float u_globalAlpha;
   uniform vec4 u_renderExtent;
-  varying vec3 v_color;
-  varying float v_opacity;
+  varying vec4 v_color;
 
   void main(void) {
-      gl_FragColor = vec4(v_color, 1.0) * v_opacity * u_globalAlpha;
+      gl_FragColor = v_color * u_globalAlpha;
   }`;

--- a/src/ol/renderer/webgl/shaders.js
+++ b/src/ol/renderer/webgl/shaders.js
@@ -1,24 +1,8 @@
 /**
  * @module ol/renderer/webgl/shaders
  */
-import {asArray} from '../../color.js';
 
 /** @typedef {'color'|'width'} DefaultAttributes */
-
-/**
- * Packs red/green/blue channels of a color into a single float value; alpha is ignored.
- * This is how the color is expected to be computed.
- * @param {import("../../color.js").Color|string} color Color as array of numbers or string
- * @return {[number, number]} Vec2 array containing the color in compressed form
- */
-export function packColor(color) {
-  const array = asArray(color);
-  const r = array[0] * 256;
-  const g = array[1];
-  const b = array[2] * 256;
-  const a = Math.round(array[3] * 255);
-  return [r + g, b + a];
-}
 
 const DECODE_COLOR_EXPRESSION = `vec4(
   fract(a_color[1] / 256.0) * fract(floor(a_color[0] / 256.0) / 256.0),

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -1038,16 +1038,7 @@ Operators['interpolate'] = {
     }
 
     // compute input/output types
-    let inputType = getValueType(args[1]);
-    for (let i = 2; i < args.length - 1; i += 2) {
-      inputType = inputType & getValueType(args[i]);
-    }
-    assertOfType(
-      ['interpolate', ...args],
-      inputType,
-      ValueTypes.NUMBER | ValueTypes.BOOLEAN,
-      'input'
-    );
+    const inputType = ValueTypes.NUMBER;
     const outputType =
       Operators['interpolate'].getReturnType(args) & expectedType;
     assertSingleType(['interpolate', ...args], outputType, 'output');
@@ -1091,6 +1082,8 @@ Operators['match'] = {
       ValueTypes.STRING | ValueTypes.NUMBER | ValueTypes.BOOLEAN,
       'input'
     );
+    inputType =
+      (ValueTypes.STRING | ValueTypes.NUMBER | ValueTypes.BOOLEAN) & inputType;
 
     const outputType = Operators['match'].getReturnType(args) & expectedType;
     assertSingleType(['match', ...args], outputType, 'output');

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -128,7 +128,7 @@ function getTypeFromHint(typeHint) {
       return ValueTypes.NUMBER;
     case 'boolean':
       return ValueTypes.BOOLEAN;
-    case 'number_array':
+    case 'number[]':
       return ValueTypes.NUMBER_ARRAY;
     default:
       throw new Error(`Unrecognized type hint: ${typeHint}`);

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -116,7 +116,7 @@ export const ValueTypes = {
 };
 
 /**
- * @param {string} typeHint
+ * @param {string} typeHint Type hint
  * @return {ValueTypes} Resulting value type (will be a single type)
  */
 function getTypeFromHint(typeHint) {
@@ -131,8 +131,9 @@ function getTypeFromHint(typeHint) {
       return ValueTypes.BOOLEAN;
     case 'number_array':
       return ValueTypes.NUMBER_ARRAY;
+    default:
+      throw new Error(`Unrecognized type hint: ${typeHint}`);
   }
-  throw new Error(`Unrecognized type hint: ${typeHint}`);
 }
 
 /**
@@ -373,7 +374,7 @@ export function expressionToGlsl(context, value, expectedType) {
 }
 
 function assertNumber(value) {
-  if (!(getValueType(value) & ValueTypes.NUMBER)) {
+  if ((getValueType(value) & ValueTypes.NUMBER) === 0) {
     throw new Error(
       `A numeric value was expected, got ${JSON.stringify(value)} instead`
     );
@@ -385,14 +386,14 @@ function assertNumbers(values) {
   }
 }
 function assertString(value) {
-  if (!(getValueType(value) & ValueTypes.STRING)) {
+  if ((getValueType(value) & ValueTypes.STRING) === 0) {
     throw new Error(
       `A string value was expected, got ${JSON.stringify(value)} instead`
     );
   }
 }
 function assertBoolean(value) {
-  if (!(getValueType(value) & ValueTypes.BOOLEAN)) {
+  if ((getValueType(value) & ValueTypes.BOOLEAN) === 0) {
     throw new Error(
       `A boolean value was expected, got ${JSON.stringify(value)} instead`
     );
@@ -538,7 +539,7 @@ export const PALETTE_TEXTURE_ARRAY = 'u_paletteTextures';
 
 // ['palette', index, colors]
 Operators['palette'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.COLOR;
   },
   toGlsl: function (context, args) {
@@ -596,7 +597,7 @@ Operators['palette'] = {
 const GET_BAND_VALUE_FUNC = 'getBandValue';
 
 Operators['band'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -639,7 +640,7 @@ Operators['band'] = {
 };
 
 Operators['time'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -649,7 +650,7 @@ Operators['time'] = {
 };
 
 Operators['zoom'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -659,7 +660,7 @@ Operators['zoom'] = {
 };
 
 Operators['resolution'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -695,7 +696,7 @@ Operators['*'] = {
 };
 
 Operators['/'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -709,7 +710,7 @@ Operators['/'] = {
 };
 
 Operators['+'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -720,7 +721,7 @@ Operators['+'] = {
 };
 
 Operators['-'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -734,7 +735,7 @@ Operators['-'] = {
 };
 
 Operators['clamp'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -747,7 +748,7 @@ Operators['clamp'] = {
 };
 
 Operators['%'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -761,7 +762,7 @@ Operators['%'] = {
 };
 
 Operators['^'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -775,7 +776,7 @@ Operators['^'] = {
 };
 
 Operators['abs'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -786,7 +787,7 @@ Operators['abs'] = {
 };
 
 Operators['floor'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -797,7 +798,7 @@ Operators['floor'] = {
 };
 
 Operators['round'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -808,7 +809,7 @@ Operators['round'] = {
 };
 
 Operators['ceil'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -819,7 +820,7 @@ Operators['ceil'] = {
 };
 
 Operators['sin'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -830,7 +831,7 @@ Operators['sin'] = {
 };
 
 Operators['cos'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -841,7 +842,7 @@ Operators['cos'] = {
 };
 
 Operators['atan'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER;
   },
   toGlsl: function (context, args) {
@@ -858,7 +859,7 @@ Operators['atan'] = {
 };
 
 Operators['>'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -872,7 +873,7 @@ Operators['>'] = {
 };
 
 Operators['>='] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -886,7 +887,7 @@ Operators['>='] = {
 };
 
 Operators['<'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -900,7 +901,7 @@ Operators['<'] = {
 };
 
 Operators['<='] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -915,7 +916,7 @@ Operators['<='] = {
 
 function getEqualOperator(operator) {
   return {
-    getReturnType: function (args) {
+    getReturnType: function () {
       return ValueTypes.BOOLEAN;
     },
     toGlsl: function (context, args) {
@@ -952,7 +953,7 @@ Operators['=='] = getEqualOperator('==');
 Operators['!='] = getEqualOperator('!=');
 
 Operators['!'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -964,7 +965,7 @@ Operators['!'] = {
 
 function getDecisionOperator(operator) {
   return {
-    getReturnType: function (args) {
+    getReturnType: function () {
       return ValueTypes.BOOLEAN;
     },
     toGlsl: function (context, args) {
@@ -972,8 +973,7 @@ function getDecisionOperator(operator) {
       for (let i = 0; i < args.length; i++) {
         assertBoolean(args[i]);
       }
-      let result = '';
-      result = args
+      let result = args
         .map((arg) => expressionToGlsl(context, arg, ValueTypes.BOOLEAN))
         .join(` ${operator} `);
       result = `(${result})`;
@@ -987,7 +987,7 @@ Operators['all'] = getDecisionOperator('&&');
 Operators['any'] = getDecisionOperator('||');
 
 Operators['between'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.BOOLEAN;
   },
   toGlsl: function (context, args) {
@@ -1001,7 +1001,7 @@ Operators['between'] = {
 };
 
 Operators['array'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.NUMBER_ARRAY;
   },
   toGlsl: function (context, args) {
@@ -1016,7 +1016,7 @@ Operators['array'] = {
 };
 
 Operators['color'] = {
-  getReturnType: function (args) {
+  getReturnType: function () {
     return ValueTypes.COLOR;
   },
   toGlsl: function (context, args) {

--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -21,10 +21,9 @@ import {asArray, fromString, isStringColor} from '../color.js';
  *     of bands, depending on the underlying data source and
  *     {@link import("../source/GeoTIFF.js").Options configuration}. `xOffset` and `yOffset` are optional
  *     and allow specifying pixel offsets for x and y. This is used for sampling data from neighboring pixels.
- *   * `['get', 'attributeName', typeHint]` fetches a feature attribute (it will be prefixed by `a_` in the shader)
- *     Note: those will be taken from the attributes provided to the renderer
- *     A type hint can optionally be specified, in case the resulting expression contains a type uncertainty which
- *     will make it invalid. Type hints can be one of: 'string', 'color', 'number', 'boolean', 'number_array'
+ *   * `['get', 'attributeName', typeHint]` fetches a feature property value, similar to `feature.get('attributeName')`
+ *     A type hint can optionally be specified, in case the resulting expression contains a type ambiguity which
+ *     will make it invalid. Type hints can be one of: 'string', 'color', 'number', 'boolean', 'number[]'
  *   * `['resolution']` returns the current resolution
  *   * `['time']` returns the time in seconds since the creation of the layer
  *   * `['var', 'varName']` fetches a value from the style variables; will throw an error if that variable is undefined
@@ -92,6 +91,7 @@ import {asArray, fromString, isStringColor} from '../color.js';
  * Literal values can be of the following types:
  * * `boolean`
  * * `number`
+ * * `number[]` (number arrays can only have a length of 2, 3 or 4)
  * * `string`
  * * {@link module:ol/color~Color}
  *

--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -15,7 +15,7 @@
  * @typedef {Object} BaseProps
  * @property {ExpressionValue} [filter] Filter expression. If it resolves to a number strictly greater than 0, the
  * point will be displayed. If undefined, all points will show.
- * @property {Object<string, number|number[]|string|boolean>} [variables] Style variables; each variable must hold a number.
+ * @property {Object<string, number | Array<number> | string | boolean>} [variables] Style variables; each variable must hold a number.
  * Note: **this object is meant to be mutated**: changes to the values will immediately be visible on the rendered features
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
  */

--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -15,7 +15,7 @@
  * @typedef {Object} BaseProps
  * @property {ExpressionValue} [filter] Filter expression. If it resolves to a number strictly greater than 0, the
  * point will be displayed. If undefined, all points will show.
- * @property {Object<string, number>} [variables] Style variables; each variable must hold a number.
+ * @property {Object<string, number|number[]|string|boolean>} [variables] Style variables; each variable must hold a number.
  * Note: **this object is meant to be mutated**: changes to the values will immediately be visible on the rendered features
  * @property {LiteralSymbolStyle} [symbol] Symbol representation.
  */

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -276,11 +276,15 @@ export class ShaderBuilder {
   }
 
   addVertexShaderFunction(code) {
-    if (this.vertexShaderFunctions.includes(code)) return;
+    if (this.vertexShaderFunctions.includes(code)) {
+      return;
+    }
     this.vertexShaderFunctions.push(code);
   }
   addFragmentShaderFunction(code) {
-    if (this.fragmentShaderFunctions.includes(code)) return;
+    if (this.fragmentShaderFunctions.includes(code)) {
+      return;
+    }
     this.fragmentShaderFunctions.push(code);
   }
 

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -117,6 +117,18 @@ export class ShaderBuilder {
      * @private
      */
     this.fillColorExpression = 'vec4(1.0)';
+
+    /**
+     * @type {Array<string>}
+     * @private
+     */
+    this.vertexShaderFunctions = [];
+
+    /**
+     * @type {Array<string>}
+     * @private
+     */
+    this.fragmentShaderFunctions = [];
   }
 
   /**
@@ -263,6 +275,15 @@ export class ShaderBuilder {
     return this;
   }
 
+  addVertexShaderFunction(code) {
+    if (this.vertexShaderFunctions.includes(code)) return;
+    this.vertexShaderFunctions.push(code);
+  }
+  addFragmentShaderFunction(code) {
+    if (this.fragmentShaderFunctions.includes(code)) return;
+    this.fragmentShaderFunctions.push(code);
+  }
+
   /**
    * Generates a symbol vertex shader from the builder parameters
    *
@@ -322,6 +343,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
+${this.vertexShaderFunctions.join('\n')}
 void main(void) {
   mat4 offsetMatrix = ${offsetMatrix};
   vec2 halfSize = ${this.symbolSizeExpression} * 0.5;
@@ -400,6 +422,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
+${this.fragmentShaderFunctions.join('\n')}
 void main(void) {
   if (${this.discardExpression}) { discard; }
   gl_FragColor = ${this.symbolColorExpression};
@@ -459,7 +482,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
-
+${this.vertexShaderFunctions.join('\n')}
 vec2 worldToPx(vec2 worldPos) {
   vec4 screenPos = u_projectionMatrix * vec4(worldPos, 0.0, 1.0);
   return (0.5 * screenPos.xy + 0.5) * u_viewportSizePx;
@@ -551,7 +574,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
-
+${this.fragmentShaderFunctions.join('\n')}
 vec2 pxToWorld(vec2 pxPos) {
   vec2 screenPos = 2.0 * pxPos / u_viewportSizePx - 1.0;
   return (u_screenToWorldMatrix * vec4(screenPos, 0.0, 1.0)).xy;
@@ -629,7 +652,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
-
+${this.vertexShaderFunctions.join('\n')}
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
 ${varyings
@@ -678,7 +701,7 @@ ${varyings
     return 'varying ' + varying.type + ' ' + varying.name + ';';
   })
   .join('\n')}
-
+${this.fragmentShaderFunctions.join('\n')}
 vec2 pxToWorld(vec2 pxPos) {
   vec2 screenPos = 2.0 * pxPos / u_viewportSizePx - 1.0;
   return (u_screenToWorldMatrix * vec4(screenPos, 0.0, 1.0)).xy;

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -36,7 +36,7 @@ export function getSymbolOpacityGlslFunction(type, sizeExpressionGlsl) {
 /**
  * Packs all components of a color into a two-floats array
  * @param {import("../color.js").Color|string} color Color as array of numbers or string
- * @return {[number, number]} Vec2 array containing the color in compressed form
+ * @return {Array<number>} Vec2 array containing the color in compressed form
  */
 export function packColor(color) {
   const array = asArray(color);
@@ -57,21 +57,22 @@ const UNPACK_COLOR_FN = `vec4 unpackColor(vec2 packedColor) {
 }`;
 
 /**
- * @param {ValueTypes} type
- * @return {1|2|3|4}
+ * @param {ValueTypes} type Value type
+ * @return {1|2|3|4} The amount of components for this value
  */
 function getGlslSizeFromType(type) {
   if (type === ValueTypes.COLOR) {
     return 2;
-  } else if (type === ValueTypes.NUMBER_ARRAY) {
+  }
+  if (type === ValueTypes.NUMBER_ARRAY) {
     return 4;
   }
   return 1;
 }
 
 /**
- * @param {ValueTypes}type
- * @return {'float'|'vec2'|'vec3'|'vec4'}
+ * @param {ValueTypes} type Value type
+ * @return {'float'|'vec2'|'vec3'|'vec4'} The corresponding GLSL type for this value
  */
 function getGlslTypeFromType(type) {
   const size = getGlslSizeFromType(type);
@@ -82,7 +83,6 @@ function getGlslTypeFromType(type) {
 }
 
 /**
- *
  * @param {import("../style/literal").LiteralStyle} style Style
  * @param {ShaderBuilder} builder Shader builder
  * @param {Object<string,import("../webgl/Helper").UniformValue>} uniforms Uniforms
@@ -318,7 +318,9 @@ export function parseLiteralStyle(style) {
     const uniformName = uniformNameForVariable(variable.name);
     builder.addUniform(`${getGlslTypeFromType(variable.type)} ${uniformName}`);
 
-    /** @return {any} */
+    /**
+     * @return {any} Current variable value
+     */
     const getValue = () => {
       if (!style.variables || style.variables[variable.name] === undefined) {
         throw new Error(

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -264,6 +264,7 @@ export function parseLiteralStyle(style) {
     attributes: [],
     stringLiteralsMap: {},
     functions: {},
+    style: style,
   };
 
   /**
@@ -275,6 +276,7 @@ export function parseLiteralStyle(style) {
     attributes: [],
     stringLiteralsMap: vertContext.stringLiteralsMap,
     functions: {},
+    style: style,
   };
 
   const builder = new ShaderBuilder();
@@ -318,26 +320,27 @@ export function parseLiteralStyle(style) {
     const uniformName = uniformNameForVariable(variable.name);
     builder.addUniform(`${getGlslTypeFromType(variable.type)} ${uniformName}`);
 
-    /**
-     * @return {any} Current variable value
-     */
-    const getValue = () => {
-      if (!style.variables || style.variables[variable.name] === undefined) {
-        throw new Error(
-          `The following variable is missing from the style: ${variable.name}`
-        );
-      }
-      return style.variables[variable.name];
-    };
     let callback;
     if (variable.type === ValueTypes.STRING) {
-      callback = () => getStringNumberEquivalent(vertContext, getValue());
+      callback = () =>
+        getStringNumberEquivalent(
+          vertContext,
+          /** @type {string} */ (style.variables[variable.name])
+        );
     } else if (variable.type === ValueTypes.COLOR) {
-      callback = () => packColor([...asArray(getValue() || '#eee')]);
+      callback = () =>
+        packColor([
+          ...asArray(
+            /** @type {string|Array<number>} */ (
+              style.variables[variable.name]
+            ) || '#eee'
+          ),
+        ]);
     } else if (variable.type === ValueTypes.BOOLEAN) {
-      callback = () => (getValue() ? 1.0 : 0.0);
+      callback = () =>
+        /** @type {boolean} */ (style.variables[variable.name]) ? 1.0 : 0.0;
     } else {
-      callback = getValue;
+      callback = () => /** @type {number} */ (style.variables[variable.name]);
     }
     uniforms[uniformName] = callback;
   });

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -57,6 +57,31 @@ const UNPACK_COLOR_FN = `vec4 unpackColor(vec2 packedColor) {
 }`;
 
 /**
+ * @param {ValueTypes} type
+ * @return {1|2|3|4}
+ */
+function getGlslSizeFromType(type) {
+  if (type === ValueTypes.COLOR) {
+    return 2;
+  } else if (type === ValueTypes.NUMBER_ARRAY) {
+    return 4;
+  }
+  return 1;
+}
+
+/**
+ * @param {ValueTypes}type
+ * @return {'float'|'vec2'|'vec3'|'vec4'}
+ */
+function getGlslTypeFromType(type) {
+  const size = getGlslSizeFromType(type);
+  if (size > 1) {
+    return /** @type {'vec2'|'vec3'|'vec4'} */ (`vec${size}`);
+  }
+  return 'float';
+}
+
+/**
  *
  * @param {import("../style/literal").LiteralStyle} style Style
  * @param {ShaderBuilder} builder Shader builder
@@ -289,35 +314,74 @@ export function parseLiteralStyle(style) {
   }
 
   // define one uniform per variable
-  fragContext.variables.forEach(function (varName) {
-    const uniformName = uniformNameForVariable(varName);
-    builder.addUniform(`float ${uniformName}`);
-    uniforms[uniformName] = function () {
-      if (!style.variables || style.variables[varName] === undefined) {
+  fragContext.variables.forEach(function (variable) {
+    const uniformName = uniformNameForVariable(variable.name);
+    builder.addUniform(`${getGlslTypeFromType(variable.type)} ${uniformName}`);
+
+    /** @return {any} */
+    const getValue = () => {
+      if (!style.variables || style.variables[variable.name] === undefined) {
         throw new Error(
-          `The following variable is missing from the style: ${varName}`
+          `The following variable is missing from the style: ${variable.name}`
         );
       }
-      let value = style.variables[varName];
-      if (typeof value === 'string') {
-        value = getStringNumberEquivalent(vertContext, value);
-      }
-      return value !== undefined ? value : -9999999; // to avoid matching with the first string literal
+      return style.variables[variable.name];
     };
+    let callback;
+    if (variable.type === ValueTypes.STRING) {
+      callback = () => getStringNumberEquivalent(vertContext, getValue());
+    } else if (variable.type === ValueTypes.COLOR) {
+      callback = () => packColor([...asArray(getValue() || '#eee')]);
+    } else if (variable.type === ValueTypes.BOOLEAN) {
+      callback = () => (getValue() ? 1.0 : 0.0);
+    } else {
+      callback = getValue;
+    }
+    uniforms[uniformName] = callback;
   });
 
   // for each feature attribute used in the fragment shader, define a varying that will be used to pass data
   // from the vertex to the fragment shader, as well as an attribute in the vertex shader (if not already present)
-  fragContext.attributes.forEach(function (attrName) {
-    if (!vertContext.attributes.includes(attrName)) {
-      vertContext.attributes.push(attrName);
+  fragContext.attributes.forEach(function (attribute) {
+    if (!vertContext.attributes.find((a) => a.name === attribute.name)) {
+      vertContext.attributes.push(attribute);
     }
-    builder.addVarying(`v_${attrName}`, 'float', `a_${attrName}`);
+    let type = getGlslTypeFromType(attribute.type);
+    let expression = `a_${attribute.name}`;
+    if (attribute.type === ValueTypes.COLOR) {
+      type = 'vec4';
+      expression = `unpackColor(${expression})`;
+      builder.addVertexShaderFunction(UNPACK_COLOR_FN);
+    }
+    builder.addVarying(`v_${attribute.name}`, type, expression);
   });
 
   // for each feature attribute used in the vertex shader, define an attribute in the vertex shader.
-  vertContext.attributes.forEach(function (attrName) {
-    builder.addAttribute(`float a_${attrName}`);
+  vertContext.attributes.forEach(function (attribute) {
+    builder.addAttribute(
+      `${getGlslTypeFromType(attribute.type)} a_${attribute.name}`
+    );
+  });
+
+  const attributes = vertContext.attributes.map(function (attribute) {
+    let callback;
+    if (attribute.type === ValueTypes.STRING) {
+      callback = (feature) =>
+        getStringNumberEquivalent(vertContext, feature.get(attribute.name));
+    } else if (attribute.type === ValueTypes.COLOR) {
+      callback = (feature) =>
+        packColor([...asArray(feature.get(attribute.name) || '#eee')]);
+    } else if (attribute.type === ValueTypes.BOOLEAN) {
+      callback = (feature) => (feature.get(attribute.name) ? 1.0 : 0.0);
+    } else {
+      callback = (feature) => feature.get(attribute.name);
+    }
+
+    return {
+      name: attribute.name,
+      size: getGlslSizeFromType(attribute.type),
+      callback,
+    };
   });
 
   return {
@@ -325,18 +389,7 @@ export function parseLiteralStyle(style) {
     hasSymbol,
     hasStroke,
     hasFill,
-    attributes: vertContext.attributes.map(function (attributeName) {
-      return {
-        name: attributeName,
-        callback: function (feature, props) {
-          let value = props[attributeName];
-          if (typeof value === 'string') {
-            value = getStringNumberEquivalent(vertContext, value);
-          }
-          return value !== undefined ? value : -9999999; // to avoid matching with the first string literal
-        },
-      };
-    }),
+    attributes: attributes,
     uniforms: uniforms,
   };
 }

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -9,6 +9,7 @@ import {
   getStringNumberEquivalent,
   uniformNameForVariable,
 } from '../style/expressions.js';
+import {asArray} from '../color.js';
 
 /**
  * @param {import('../style/literal.js').SymbolType} type Symbol type
@@ -31,6 +32,29 @@ export function getSymbolOpacityGlslFunction(type, sizeExpressionGlsl) {
       throw new Error(`Unexpected symbol type: ${type}`);
   }
 }
+
+/**
+ * Packs all components of a color into a two-floats array
+ * @param {import("../color.js").Color|string} color Color as array of numbers or string
+ * @return {[number, number]} Vec2 array containing the color in compressed form
+ */
+export function packColor(color) {
+  const array = asArray(color);
+  const r = array[0] * 256;
+  const g = array[1];
+  const b = array[2] * 256;
+  const a = Math.round(array[3] * 255);
+  return [r + g, b + a];
+}
+
+const UNPACK_COLOR_FN = `vec4 unpackColor(vec2 packedColor) {
+  return fract(packedColor[1] / 256.0) * vec4(
+    fract(floor(packedColor[0] / 256.0) / 256.0),
+    fract(packedColor[0] / 256.0),
+    fract(floor(packedColor[1] / 256.0) / 256.0),
+    1.0
+  );
+}`;
 
 /**
  *

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -24,7 +24,7 @@ worker.onmessage = (event) => {
       const baseVertexAttrsCount = 3;
       const baseInstructionsCount = 2;
 
-      const customAttrsCount = received.customAttributesCount;
+      const customAttrsCount = received.customAttributesSize;
       const instructionsCount = baseInstructionsCount + customAttrsCount;
       const renderInstructions = new Float32Array(received.renderInstructions);
 
@@ -68,7 +68,7 @@ worker.onmessage = (event) => {
       const vertices = [];
       const indices = [];
 
-      const customAttrsCount = received.customAttributesCount;
+      const customAttrsCount = received.customAttributesSize;
       const instructionsPerVertex = 2;
 
       const renderInstructions = new Float32Array(received.renderInstructions);
@@ -135,7 +135,7 @@ worker.onmessage = (event) => {
       const vertices = [];
       const indices = [];
 
-      const customAttrsCount = received.customAttributesCount;
+      const customAttrsCount = received.customAttributesSize;
       const renderInstructions = new Float32Array(received.renderInstructions);
 
       let currentInstructionsIndex = 0;

--- a/test/browser/spec/ol/render/webgl/BatchRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/BatchRenderer.test.js
@@ -48,8 +48,16 @@ describe('Batch renderers', function () {
     attributes = [
       {
         name: 'test',
-        callback: function (feature, properties) {
+        size: 1,
+        callback: function (feature) {
           return feature.get('test');
+        },
+      },
+      {
+        name: 'testVec',
+        size: 3,
+        callback: function (feature) {
+          return feature.get('test2');
         },
       },
     ];
@@ -58,14 +66,17 @@ describe('Batch renderers', function () {
     mixedBatch.addFeatures([
       new Feature({
         test: 1000,
+        test2: [22, 33, 44],
         geometry: new Point([10, 20]),
       }),
       new Feature({
         test: 2000,
+        test2: [44, 55, 66],
         geometry: new Point([30, 40]),
       }),
       new Feature({
         test: 3000,
+        test2: [66, 77, 88],
         geometry: new Polygon([
           [
             [10, 10],
@@ -78,6 +89,7 @@ describe('Batch renderers', function () {
       }),
       new Feature({
         test: 4000,
+        test2: [88, 99, 0],
         geometry: new LineString([
           [100, 200],
           [300, 400],
@@ -103,6 +115,7 @@ describe('Batch renderers', function () {
           {name: 'a_position', size: 2, type: FLOAT},
           {name: 'a_index', size: 1, type: FLOAT},
           {name: 'a_test', size: 1, type: FLOAT},
+          {name: 'a_testVec', size: 3, type: FLOAT},
         ]);
       });
     });
@@ -129,7 +142,7 @@ describe('Batch renderers', function () {
       });
       it('generates render instructions and updates buffers from the worker response', function () {
         expect(Array.from(mixedBatch.pointBatch.renderInstructions)).to.eql([
-          2, 2, 1000, 6, 6, 2000,
+          2, 2, 1000, 22, 33, 44, 6, 6, 2000, 44, 55, 66,
         ]);
       });
       it('updates buffers', function () {
@@ -187,6 +200,7 @@ describe('Batch renderers', function () {
           {name: 'a_segmentEnd', size: 2, type: FLOAT},
           {name: 'a_parameters', size: 1, type: FLOAT},
           {name: 'a_test', size: 1, type: FLOAT},
+          {name: 'a_testVec', size: 3, type: FLOAT},
         ]);
       });
     });
@@ -216,8 +230,8 @@ describe('Batch renderers', function () {
         expect(
           Array.from(mixedBatch.lineStringBatch.renderInstructions)
         ).to.eql([
-          3000, 5, 2, 0, 4, 0, 6, 2, 4, 6, 2, 0, 4000, 3, 20, 38, 60, 78, 100,
-          118,
+          3000, 66, 77, 88, 5, 2, 0, 4, 0, 6, 2, 4, 6, 2, 0, 4000, 88, 99, 0, 3,
+          20, 38, 60, 78, 100, 118,
         ]);
       });
       it('updates buffers', function () {
@@ -250,6 +264,7 @@ describe('Batch renderers', function () {
         expect(batchRenderer.attributes).to.eql([
           {name: 'a_position', size: 2, type: FLOAT},
           {name: 'a_test', size: 1, type: FLOAT},
+          {name: 'a_testVec', size: 3, type: FLOAT},
         ]);
       });
     });
@@ -277,7 +292,7 @@ describe('Batch renderers', function () {
       });
       it('generates render instructions and updates buffers from the worker response', function () {
         expect(Array.from(mixedBatch.polygonBatch.renderInstructions)).to.eql([
-          3000, 1, 5, 2, 0, 4, 0, 6, 2, 4, 6, 2, 0,
+          3000, 66, 77, 88, 1, 5, 2, 0, 4, 0, 6, 2, 4, 6, 2, 0,
         ]);
       });
       it('updates buffers', function () {

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -1,7 +1,12 @@
+import Feature from '../../../../../../src/ol/Feature.js';
+import LineString from '../../../../../../src/ol/geom/LineString.js';
 import LineStringBatchRenderer from '../../../../../../src/ol/render/webgl/LineStringBatchRenderer.js';
 import Map from '../../../../../../src/ol/Map.js';
+import Point from '../../../../../../src/ol/geom/Point.js';
 import PointBatchRenderer from '../../../../../../src/ol/render/webgl/PointBatchRenderer.js';
+import Polygon from '../../../../../../src/ol/geom/Polygon.js';
 import PolygonBatchRenderer from '../../../../../../src/ol/render/webgl/PolygonBatchRenderer.js';
+import VectorEventType from '../../../../../../src/ol/source/VectorEventType.js';
 import VectorLayer from '../../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../../src/ol/source/Vector.js';
 import View from '../../../../../../src/ol/View.js';
@@ -12,13 +17,8 @@ import {
   get as getProjection,
 } from '../../../../../../src/ol/proj.js';
 import {create} from '../../../../../../src/ol/transform.js';
-import Feature from '../../../../../../src/ol/Feature.js';
-import {packColor} from '../../../../../../src/ol/webgl/styleparser.js';
-import Polygon from '../../../../../../src/ol/geom/Polygon.js';
-import Point from '../../../../../../src/ol/geom/Point.js';
-import LineString from '../../../../../../src/ol/geom/LineString.js';
 import {getUid} from '../../../../../../src/ol/util.js';
-import VectorEventType from '../../../../../../src/ol/source/VectorEventType.js';
+import {packColor} from '../../../../../../src/ol/webgl/styleparser.js';
 
 describe('ol/renderer/webgl/VectorLayer', function () {
   /** @type {import("../../../../../../src/ol/renderer/webgl/VectorLayer.js").default} */

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -1,0 +1,528 @@
+import LineStringBatchRenderer from '../../../../../../src/ol/render/webgl/LineStringBatchRenderer.js';
+import Map from '../../../../../../src/ol/Map.js';
+import PointBatchRenderer from '../../../../../../src/ol/render/webgl/PointBatchRenderer.js';
+import PolygonBatchRenderer from '../../../../../../src/ol/render/webgl/PolygonBatchRenderer.js';
+import VectorLayer from '../../../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../../../src/ol/source/Vector.js';
+import View from '../../../../../../src/ol/View.js';
+import WebGLHelper from '../../../../../../src/ol/webgl/Helper.js';
+import WebGLVectorLayerRenderer from '../../../../../../src/ol/renderer/webgl/VectorLayer.js';
+import {
+  Projection,
+  get as getProjection,
+} from '../../../../../../src/ol/proj.js';
+import {create} from '../../../../../../src/ol/transform.js';
+import Feature from '../../../../../../src/ol/Feature.js';
+import {packColor} from '../../../../../../src/ol/webgl/styleparser.js';
+import Polygon from '../../../../../../src/ol/geom/Polygon.js';
+import Point from '../../../../../../src/ol/geom/Point.js';
+import LineString from '../../../../../../src/ol/geom/LineString.js';
+import {getUid} from '../../../../../../src/ol/util.js';
+import VectorEventType from '../../../../../../src/ol/source/VectorEventType.js';
+
+describe('ol/renderer/webgl/VectorLayer', function () {
+  /** @type {import("../../../../../../src/ol/renderer/webgl/VectorLayer.js").default} */
+  let renderer;
+  /** @type {VectorLayer} */
+  let vectorLayer;
+  /** @type {VectorSource} */
+  let vectorSource;
+  /** @type {import('../../../../../../src/ol/Map.js').FrameState} */
+  let frameState;
+  /** @type {Map} */
+  let map;
+
+  /** @type {Feature} */
+  let feature1;
+  /** @type {Feature} */
+  let feature2;
+  /** @type {Feature} */
+  let feature3;
+
+  beforeEach(function () {
+    feature1 = new Feature({id: '01', geometry: new Point([1, 2])});
+    feature2 = new Feature({
+      id: '02',
+      geometry: new Polygon([
+        [
+          [1, 2],
+          [3, 4],
+          [5, 6],
+          [1, 2],
+        ],
+      ]),
+    });
+    feature3 = new Feature({
+      id: '03',
+      geometry: new LineString([
+        [1, 2],
+        [3, 4],
+        [5, 6],
+        [1, 2],
+      ]),
+    });
+    vectorSource = new VectorSource({
+      features: [feature1, feature2, feature3],
+    });
+    vectorLayer = new VectorLayer({
+      source: vectorSource,
+    });
+    renderer = new WebGLVectorLayerRenderer(vectorLayer, {
+      uniforms: {
+        u_returnOne: () => 1,
+      },
+      attributes: [
+        {
+          name: 'myAttr',
+          size: 1,
+          callback: () => 10,
+        },
+      ],
+      point: {
+        color: () => packColor('green'),
+      },
+      fill: {
+        color: () => packColor('blue'),
+      },
+      stroke: {
+        color: () => packColor('red'),
+        width: () => 2.5,
+      },
+    });
+
+    const proj = new Projection({
+      code: 'custom',
+      units: 'pixels',
+      extent: [-128, -128, 128, 128],
+    });
+    frameState = {
+      layerStatesArray: [vectorLayer.getLayerState()],
+      layerIndex: 0,
+      extent: [-31, 1, 31, 31],
+      pixelRatio: 1,
+      pixelToCoordinateTransform: create(),
+      postRenderFunctions: [],
+      time: Date.now(),
+      viewHints: [],
+      viewState: {
+        center: [0, 16],
+        resolution: 0.25,
+        rotation: 0,
+        projection: proj,
+      },
+      size: [200, 100],
+      renderTargets: {},
+    };
+
+    map = new Map({
+      view: new View(),
+    });
+    vectorLayer.set('map', map, true);
+  });
+
+  afterEach(function () {
+    vectorLayer.dispose();
+    renderer.dispose();
+    map.dispose();
+  });
+
+  it('creates a new instance', function () {
+    expect(renderer).to.be.a(WebGLVectorLayerRenderer);
+  });
+
+  it('do not create renderers initially', function () {
+    expect(renderer.polygonRenderer_).to.be(null);
+    expect(renderer.pointRenderer_).to.be(null);
+    expect(renderer.lineStringRenderer_).to.be(null);
+  });
+
+  describe('#afterHelperCreated', () => {
+    beforeEach(() => {
+      renderer.helper = new WebGLHelper();
+      renderer.afterHelperCreated(frameState);
+    });
+
+    it('creates renderers', () => {
+      expect(renderer.polygonRenderer_).to.be.a(PolygonBatchRenderer);
+      expect(renderer.pointRenderer_).to.be.a(PointBatchRenderer);
+      expect(renderer.lineStringRenderer_).to.be.a(LineStringBatchRenderer);
+    });
+    it('passes custom attributes to renderers', () => {
+      expect(renderer.polygonRenderer_.attributes[2]).to.eql({
+        name: 'a_myAttr',
+        size: 1,
+        type: 5126,
+      });
+      expect(renderer.pointRenderer_.attributes[3]).to.eql({
+        name: 'a_myAttr',
+        size: 1,
+        type: 5126,
+      });
+      expect(renderer.lineStringRenderer_.attributes[5]).to.eql({
+        name: 'a_myAttr',
+        size: 1,
+        type: 5126,
+      });
+    });
+  });
+
+  describe('#reset', () => {
+    beforeEach(() => {
+      // first call prepareFrame to initialize the helper
+      renderer.prepareFrame(frameState);
+    });
+
+    describe('changing uniforms and attributes', () => {
+      const changedUniforms = {u_returnTwo: () => 2};
+      beforeEach(() => {
+        sinon.spy(renderer.helper, 'setUniforms');
+
+        renderer.reset({
+          uniforms: changedUniforms,
+          attributes: [
+            {
+              name: 'otherAttr',
+              size: 2,
+              callback: () => [100, 200],
+            },
+          ],
+          point: {},
+          fill: {},
+          stroke: {
+            color: () => packColor('red'),
+          },
+        });
+      });
+      it('recreates renderers with the default attributes as well as the custom ones', () => {
+        const polygonAttrs = renderer.polygonRenderer_.attributes.map(
+          (a) => a.name
+        );
+        const pointAttrs = renderer.pointRenderer_.attributes.map(
+          (a) => a.name
+        );
+        const lineStringAttrs = renderer.lineStringRenderer_.attributes.map(
+          (a) => a.name
+        );
+        expect(polygonAttrs).to.eql(['a_position', 'a_color', 'a_otherAttr']);
+        expect(pointAttrs).to.eql([
+          'a_position',
+          'a_index',
+          'a_color',
+          'a_otherAttr',
+        ]);
+        expect(lineStringAttrs).to.eql([
+          'a_segmentStart',
+          'a_segmentEnd',
+          'a_parameters',
+          'a_color',
+          'a_width',
+          'a_otherAttr',
+        ]);
+        expect(renderer.polygonRenderer_.attributes[2]).to.eql({
+          name: 'a_otherAttr',
+          size: 2,
+          type: 5126,
+        });
+      });
+      it('calls setUniforms on the helper with the new uniforms', () => {
+        expect(renderer.helper.setUniforms.calledWith(changedUniforms)).to.be(
+          true
+        );
+      });
+    });
+
+    describe('provide custom shaders instead of default ones', () => {
+      beforeEach(() => {
+        sinon.spy(renderer.helper, 'setUniforms');
+
+        renderer.reset({
+          attributes: [
+            {
+              name: 'otherAttr',
+              size: 2,
+              callback: () => [100, 200],
+            },
+            {
+              name: 'otherAttr2',
+              size: 4,
+              callback: () => [1, 2, 3, 4],
+            },
+          ],
+          point: {
+            vertexShader: 'void main(void) {}',
+            fragmentShader: 'void main(void) {}',
+          },
+          fill: {
+            vertexShader: 'void main(void) {}',
+            fragmentShader: 'void main(void) {}',
+          },
+          stroke: {
+            vertexShader: 'void main(void) {}',
+            fragmentShader: 'void main(void) {}',
+          },
+        });
+      });
+      it('recreates renderers with the only provided attributes', () => {
+        const polygonAttrs = renderer.polygonRenderer_.attributes.map(
+          (a) => a.name
+        );
+        const pointAttrs = renderer.pointRenderer_.attributes.map(
+          (a) => a.name
+        );
+        const lineStringAttrs = renderer.lineStringRenderer_.attributes.map(
+          (a) => a.name
+        );
+        expect(polygonAttrs).to.eql([
+          'a_position',
+          'a_otherAttr',
+          'a_otherAttr2',
+        ]);
+        expect(pointAttrs).to.eql([
+          'a_position',
+          'a_index',
+          'a_otherAttr',
+          'a_otherAttr2',
+        ]);
+        expect(lineStringAttrs).to.eql([
+          'a_segmentStart',
+          'a_segmentEnd',
+          'a_parameters',
+          'a_otherAttr',
+          'a_otherAttr2',
+        ]);
+        expect(renderer.polygonRenderer_.attributes[1]).to.eql({
+          name: 'a_otherAttr',
+          size: 2,
+          type: 5126,
+        });
+        expect(renderer.polygonRenderer_.attributes[2]).to.eql({
+          name: 'a_otherAttr2',
+          size: 4,
+          type: 5126,
+        });
+      });
+    });
+  });
+
+  describe('#renderFrame', () => {
+    beforeEach(async () => {});
+  });
+
+  describe('source changes', () => {
+    beforeEach(() => {
+      sinon.spy(renderer.batch_, 'addFeature');
+      sinon.spy(renderer.batch_, 'removeFeature');
+      sinon.spy(renderer.batch_, 'changeFeature');
+      sinon.spy(renderer.batch_, 'clear');
+    });
+    describe('initial state', () => {
+      it('batch contains all features', () => {
+        const polygonIds = Object.keys(renderer.batch_.polygonBatch.entries);
+        const lineStringIds = Object.keys(
+          renderer.batch_.lineStringBatch.entries
+        );
+        const pointIds = Object.keys(renderer.batch_.pointBatch.entries);
+        expect(polygonIds).to.eql([getUid(feature2)]);
+        expect(lineStringIds).to.eql([getUid(feature2), getUid(feature3)]);
+        expect(pointIds).to.eql([getUid(feature1)]);
+      });
+    });
+    describe('on feature added', () => {
+      it('calls batch.addFeature', () => {
+        const feature4 = new Feature({id: '04', geometry: new Point([1, 2])});
+        vectorSource.addFeature(feature4);
+        expect(renderer.batch_.addFeature.calledWith(feature4)).to.be(true);
+      });
+    });
+    describe('on feature changed', () => {
+      it('calls batch.changeFeature', () => {
+        feature1.set('message', 'hello world');
+        expect(renderer.batch_.changeFeature.calledWith(feature1)).to.be(true);
+      });
+    });
+    describe('on feature deleted', () => {
+      it('calls batch.removeFeature', () => {
+        vectorSource.removeFeature(feature2);
+        expect(renderer.batch_.removeFeature.calledWith(feature2)).to.be(true);
+      });
+    });
+    describe('on source clear', () => {
+      it('calls batch.clear', () => {
+        vectorSource.clear();
+        expect(renderer.batch_.clear.calledOnce).to.be(true);
+      });
+    });
+  });
+
+  describe('#prepareFrame', () => {
+    let toRender;
+    beforeEach(() => {
+      sinon.spy(vectorSource, 'loadFeatures');
+      toRender = renderer.prepareFrame(frameState);
+    });
+    it('requires rendering', () => {
+      expect(toRender).to.eql(true);
+    });
+    it('loads the data', () => {
+      expect(vectorSource.loadFeatures.calledOnce).to.eql(true);
+    });
+    describe('new frame without change', () => {
+      beforeEach(() => {
+        toRender = renderer.prepareFrame(frameState);
+      });
+      it('requires rendering', () => {
+        expect(toRender).to.eql(true);
+      });
+      it('does not load the data again', () => {
+        expect(vectorSource.loadFeatures.calledTwice).to.eql(false);
+      });
+    });
+    describe('on source change', () => {
+      beforeEach(() => {
+        vectorSource.changed();
+        toRender = renderer.prepareFrame(frameState);
+      });
+      it('requires rendering', () => {
+        expect(toRender).to.eql(true);
+      });
+      it('loads the data again', () => {
+        expect(vectorSource.loadFeatures.calledTwice).to.eql(true);
+      });
+    });
+    describe('on view change', () => {
+      beforeEach(() => {
+        frameState.extent = [0, 10, 0, 10];
+        toRender = renderer.prepareFrame(frameState);
+      });
+      it('requires rendering', () => {
+        expect(toRender).to.eql(true);
+      });
+      it('loads the data again', () => {
+        expect(vectorSource.loadFeatures.calledTwice).to.eql(true);
+      });
+    });
+  });
+
+  describe('#renderFrame', () => {
+    beforeEach(() => {
+      // call once without tracking in order to initialize helper
+      renderer.prepareFrame(frameState);
+      renderer.renderFrame(frameState);
+
+      sinon.spy(renderer.helper, 'setUniformFloatValue');
+      sinon.spy(renderer.helper, 'setUniformFloatVec4');
+      sinon.spy(renderer.helper, 'setUniformMatrixValue');
+      sinon.spy(renderer.helper, 'prepareDraw');
+      sinon.spy(renderer.helper, 'finalizeDraw');
+      sinon.spy(renderer.pointRenderer_, 'preRender');
+      sinon.spy(renderer.pointRenderer_, 'render');
+      sinon.spy(renderer.lineStringRenderer_, 'preRender');
+      sinon.spy(renderer.lineStringRenderer_, 'render');
+      sinon.spy(renderer.polygonRenderer_, 'preRender');
+      sinon.spy(renderer.polygonRenderer_, 'render');
+
+      // this is required to keep a "snapshot" of the input matrix
+      // (since the same object is reused for various calls)
+      renderer.helper.setUniformMatrixValue = new Proxy(
+        renderer.helper.setUniformMatrixValue,
+        {
+          apply(target, thisArg, [uniform, value]) {
+            return target.call(thisArg, uniform, [...value]);
+          },
+        }
+      );
+
+      renderer.renderFrame(frameState);
+    });
+    it('sets PROJECTION matrix uniform once for each geometry type', () => {
+      const calls = renderer.helper.setUniformMatrixValue
+        .getCalls()
+        .filter((c) => c.args[0] === 'u_projectionMatrix');
+      expect(calls.length).to.be(3);
+      expect(calls[0].args).to.eql([
+        'u_projectionMatrix',
+        // 0.04   0     0     0      combination of:
+        // 0      0.08  0     0        translate( 0 , -16 )  ->  subtract view center
+        // 0      0     1     0        scale( 2 / ( 0.25 * 200px ) , 2 / ( 0.25 * 100px ) )  ->  divide by resolution and viewport size
+        // 0     -1.28  0     1
+        [0.04, 0, 0, 0, 0, 0.08, 0, 0, 0, 0, 1, 0, 0, -1.28, 0, 1],
+      ]);
+    });
+    it('calls preRender and render once for each renderer', () => {
+      expect(renderer.pointRenderer_.preRender.callCount).to.be(1);
+      expect(renderer.pointRenderer_.render.callCount).to.be(1);
+      expect(renderer.lineStringRenderer_.preRender.callCount).to.be(1);
+      expect(renderer.lineStringRenderer_.render.callCount).to.be(1);
+      expect(renderer.polygonRenderer_.preRender.callCount).to.be(1);
+      expect(renderer.polygonRenderer_.render.callCount).to.be(1);
+    });
+    it('calls helper.prepareDraw once', () => {
+      expect(renderer.helper.prepareDraw.calledOnce).to.eql(true);
+    });
+    it('calls helper.finalizeDraw once', () => {
+      expect(renderer.helper.finalizeDraw.calledOnce).to.be(true);
+    });
+
+    describe('with horizontal wrapping', () => {
+      beforeEach(() => {
+        vectorSource = new VectorSource({
+          features: [],
+          wrapX: true,
+        });
+        vectorLayer.setSource(vectorSource);
+        frameState.viewState.projection = getProjection('EPSG:3857');
+        // spanning 3 worlds
+        frameState.extent = [
+          -20037508.34 * 1.5,
+          -10000,
+          20037508.34 * 1.5,
+          10000,
+        ];
+        renderer.pointRenderer_.preRender.resetHistory();
+        renderer.pointRenderer_.render.resetHistory();
+        renderer.lineStringRenderer_.preRender.resetHistory();
+        renderer.lineStringRenderer_.render.resetHistory();
+        renderer.polygonRenderer_.preRender.resetHistory();
+        renderer.polygonRenderer_.render.resetHistory();
+        renderer.renderFrame(frameState);
+      });
+      it('calls preRender and render three times for each renderer', () => {
+        expect(renderer.pointRenderer_.preRender.callCount).to.be(3);
+        expect(renderer.pointRenderer_.render.callCount).to.be(3);
+        expect(renderer.lineStringRenderer_.preRender.callCount).to.be(3);
+        expect(renderer.lineStringRenderer_.render.callCount).to.be(3);
+        expect(renderer.polygonRenderer_.preRender.callCount).to.be(3);
+        expect(renderer.polygonRenderer_.render.callCount).to.be(3);
+      });
+    });
+  });
+
+  describe('#dispose', () => {
+    beforeEach(() => {
+      sinon.spy(renderer.worker_, 'terminate');
+      sinon.spy(vectorSource, 'removeEventListener');
+      renderer.dispose();
+    });
+    it('disposes of the webgl worker', () => {
+      expect(renderer.worker_.terminate.callCount).to.be(1);
+    });
+    it('unlistens to source events', () => {
+      expect(
+        vectorSource.removeEventListener.calledWith(VectorEventType.ADDFEATURE)
+      ).to.be(true);
+      expect(
+        vectorSource.removeEventListener.calledWith(
+          VectorEventType.CHANGEFEATURE
+        )
+      ).to.be(true);
+      expect(
+        vectorSource.removeEventListener.calledWith(
+          VectorEventType.REMOVEFEATURE
+        )
+      ).to.be(true);
+      expect(
+        vectorSource.removeEventListener.calledWith(VectorEventType.CLEAR)
+      ).to.be(true);
+    });
+  });
+});

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -117,17 +117,17 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
       expect(renderer.lineStringRenderer_).to.be.a(LineStringBatchRenderer);
     });
     it('use options provided initially', () => {
-      expect(renderer.polygonRenderer_.attributes[3]).to.eql({
+      expect(renderer.polygonRenderer_.attributes[2]).to.eql({
         name: 'a_returnOne',
         size: 1,
         type: 5126,
       });
-      expect(renderer.pointRenderer_.attributes[4]).to.eql({
+      expect(renderer.pointRenderer_.attributes[3]).to.eql({
         name: 'a_returnOne',
         size: 1,
         type: 5126,
       });
-      expect(renderer.lineStringRenderer_.attributes[6]).to.eql({
+      expect(renderer.lineStringRenderer_.attributes[5]).to.eql({
         name: 'a_returnOne',
         size: 1,
         type: 5126,
@@ -161,17 +161,17 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
       });
     });
     it('recreates renderers with the new options', () => {
-      expect(renderer.polygonRenderer_.attributes[3]).to.eql({
+      expect(renderer.polygonRenderer_.attributes[2]).to.eql({
         name: 'a_returnTwo',
         size: 1,
         type: 5126,
       });
-      expect(renderer.pointRenderer_.attributes[4]).to.eql({
+      expect(renderer.pointRenderer_.attributes[3]).to.eql({
         name: 'a_returnTwo',
         size: 1,
         type: 5126,
       });
-      expect(renderer.lineStringRenderer_.attributes[6]).to.eql({
+      expect(renderer.lineStringRenderer_.attributes[5]).to.eql({
         name: 'a_returnTwo',
         size: 1,
         type: 5126,

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -198,6 +198,44 @@ describe('ol/style/expressions', function () {
         ValueTypes.COLOR
       );
     });
+    it('correctly analyzes get operator return type with hint', function () {
+      expect(getValueType(['get', 'myAttr', 'number'])).to.eql(
+        ValueTypes.NUMBER
+      );
+      expect(getValueType(['get', 'myAttr', 'string'])).to.eql(
+        ValueTypes.STRING
+      );
+      expect(getValueType(['get', 'myAttr', 'boolean'])).to.eql(
+        ValueTypes.BOOLEAN
+      );
+      expect(getValueType(['get', 'myAttr', 'number_array'])).to.eql(
+        ValueTypes.NUMBER_ARRAY
+      );
+      expect(getValueType(['get', 'myAttr', 'color'])).to.eql(ValueTypes.COLOR);
+    });
+    it('correctly analyzes var operator return type with hint', function () {
+      expect(getValueType(['var', 'myAttr', 'number'])).to.eql(
+        ValueTypes.NUMBER
+      );
+      expect(getValueType(['var', 'myAttr', 'string'])).to.eql(
+        ValueTypes.STRING
+      );
+      expect(getValueType(['var', 'myAttr', 'boolean'])).to.eql(
+        ValueTypes.BOOLEAN
+      );
+      expect(getValueType(['var', 'myAttr', 'number_array'])).to.eql(
+        ValueTypes.NUMBER_ARRAY
+      );
+      expect(getValueType(['var', 'myAttr', 'color'])).to.eql(ValueTypes.COLOR);
+    });
+    it('throws on invalid hint', function () {
+      expect(() => getValueType(['get', 'myAttr', 'weird-type'])).to.throwError(
+        /Unrecognized type hint/
+      );
+      expect(() => getValueType(['var', 'myAttr', 'weird-type'])).to.throwError(
+        /Unrecognized type hint/
+      );
+    });
   });
 
   describe('expressionToGlsl', function () {

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -45,12 +45,12 @@ describe('ol/style/expressions', function () {
   });
 
   describe('colorToGlsl', function () {
-    it('normalizes color and outputs numbers with dot separators', function () {
+    it('normalizes color and outputs numbers with dot separators, including premultiplied alpha', function () {
       expect(colorToGlsl([100, 0, 255])).to.eql(
         'vec4(0.39215686274509803, 0.0, 1.0, 1.0)'
       );
-      expect(colorToGlsl([100, 0, 255, 1])).to.eql(
-        'vec4(0.39215686274509803, 0.0, 1.0, 1.0)'
+      expect(colorToGlsl([100, 0, 255, 0.7])).to.eql(
+        'vec4(0.2745098039215686, 0.0, 0.7, 0.7)'
       );
     });
     it('handles colors in string format', function () {
@@ -60,7 +60,7 @@ describe('ol/style/expressions', function () {
         'vec4(0.39215686274509803, 0.0, 1.0, 1.0)'
       );
       expect(colorToGlsl('rgba(100, 0, 255, 0.3)')).to.eql(
-        'vec4(0.39215686274509803, 0.0, 1.0, 0.3)'
+        'vec4(0.11764705882352941, 0.0, 0.3, 0.3)'
       );
     });
   });
@@ -303,7 +303,7 @@ describe('ol/style/expressions', function () {
       ).to.eql('vec4(a_attr4, 1.0, 2.0, 3.0)');
       expect(
         expressionToGlsl(context, ['color', ['get', 'attr4'], 1, 2, 0.5])
-      ).to.eql('vec4(a_attr4 / 255.0, 1.0 / 255.0, 2.0 / 255.0, 0.5)');
+      ).to.eql('(0.5 * vec4(a_attr4 / 255.0, 1.0 / 255.0, 2.0 / 255.0, 1.0))');
       expect(expressionToGlsl(context, ['band', 1])).to.eql(
         'getBandValue(1.0, 0.0, 0.0)'
       );
@@ -1131,7 +1131,7 @@ describe('ol/style/expressions', function () {
         ['match', ['get', 'year'], 2000, 'green', '#ffe52c'],
       ];
       expect(expressionToGlsl(context, expression, ValueTypes.COLOR)).to.eql(
-        'mix(vec4(1.0, 1.0, 0.0, 0.5), (a_year == 2000.0 ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : vec4(1.0, 0.8980392156862745, 0.17254901960784313, 1.0)), pow(clamp((pow((mod((u_time + mix(0.0, 8.0, pow(clamp((a_year - 1850.0) / (2015.0 - 1850.0), 0.0, 1.0), 1.0))), 8.0) / 8.0), 0.5) - 0.0) / (1.0 - 0.0), 0.0, 1.0), 1.0))'
+        'mix(vec4(0.5, 0.5, 0.0, 0.5), (a_year == 2000.0 ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : vec4(1.0, 0.8980392156862745, 0.17254901960784313, 1.0)), pow(clamp((pow((mod((u_time + mix(0.0, 8.0, pow(clamp((a_year - 1850.0) / (2015.0 - 1850.0), 0.0, 1.0), 1.0))), 8.0) / 8.0), 0.5) - 0.0) / (1.0 - 0.0), 0.0, 1.0), 1.0))'
       );
     });
 

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -209,7 +209,7 @@ describe('ol/style/expressions', function () {
       expect(getValueType(['get', 'myAttr', 'boolean'])).to.eql(
         ValueTypes.BOOLEAN
       );
-      expect(getValueType(['get', 'myAttr', 'number_array'])).to.eql(
+      expect(getValueType(['get', 'myAttr', 'number[]'])).to.eql(
         ValueTypes.NUMBER_ARRAY
       );
       expect(getValueType(['get', 'myAttr', 'color'])).to.eql(ValueTypes.COLOR);

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -227,6 +227,13 @@ describe('ol/style/expressions', function () {
       expect(expressionToGlsl(context, ['*', 1, 2, 3, 4])).to.eql(
         '(1.0 * 2.0 * 3.0 * 4.0)'
       );
+      expect(
+        expressionToGlsl(
+          context,
+          ['*', [255, 127.5, 0, 0.5], 'red'],
+          ValueTypes.ANY
+        )
+      ).to.eql('(vec4(0.5, 0.25, 0.0, 0.5) * vec4(1.0, 0.0, 0.0, 1.0))');
 
       expect(
         expressionToGlsl(context, ['+', ['*', ['get', 'size'], 0.001], 12])

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -842,6 +842,17 @@ describe('ol/style/expressions', function () {
         '(a_attr2 == 0.0 ? vec4(0.0, 0.0, 1.0, 1.0) : (a_attr2 == 1.0 ? vec4(1.0, 1.0, 2.0, 2.0) : (a_attr2 == 2.0 ? vec4(2.0, 2.0, 3.0, 3.0) : vec4(3.0, 3.0, 4.0, 4.0))))'
       );
     });
+
+    it('only expects string, number or boolean as input', (done) => {
+      // match input is only expressed through get operator and values which can be strings or colors
+      // the call shouldn't throw because match does not allow color as input (so the final input type is string)
+      expressionToGlsl(
+        context,
+        ['match', ['get', 'attr3'], 'red', [6, 0], 'green', [3, 0], [0, 0]],
+        ValueTypes.ANY
+      );
+      done();
+    });
   });
 
   describe('interpolate operator', function () {
@@ -1096,6 +1107,25 @@ describe('ol/style/expressions', function () {
       ).to.eql(
         'mix(mix(-10.0, 0.0, pow(clamp((a_attr - 1000.0) / (2000.0 - 1000.0), 0.0, 1.0), 0.5)), 10.0, pow(clamp((a_attr - 2000.0) / (5000.0 - 2000.0), 0.0, 1.0), 0.5))'
       );
+    });
+
+    it('only expects number as input', (done) => {
+      // interpolation input is only expressed through get and var operators, which means that it is unspecified on its own
+      // the call shouldn't throw because interpolation only accepts numerical input
+      expressionToGlsl(
+        context,
+        [
+          'interpolate',
+          ['linear'],
+          ['get', 'attr'],
+          1000,
+          ['var', 'value'],
+          2000,
+          3000,
+        ],
+        ValueTypes.ANY
+      );
+      done();
     });
   });
 

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -31,6 +31,7 @@ varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 varying float v_opacity;
 varying vec3 v_test;
+
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
   vec2 halfSize = vec2(6.0) * 0.5;
@@ -87,6 +88,7 @@ attribute vec2 a_myAttr;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 
+
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
   vec2 halfSize = vec2(6.0) * 0.5;
@@ -141,6 +143,7 @@ attribute float a_index;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 
+
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix * u_offsetRotateMatrix;
   vec2 halfSize = vec2(6.0) * 0.5;
@@ -191,6 +194,7 @@ attribute vec4 a_hitColor;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 varying vec4 v_hitColor;
+
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
   vec2 halfSize = vec2(1.0) * 0.5;
@@ -242,6 +246,7 @@ attribute float a_index;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+
 
 void main(void) {
   mat4 offsetMatrix = u_offsetScaleMatrix;
@@ -295,6 +300,7 @@ varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 varying float v_opacity;
 varying vec3 v_test;
+
 void main(void) {
   if (false) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
@@ -321,6 +327,7 @@ uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 
+
 void main(void) {
   if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
@@ -340,6 +347,7 @@ uniform float u_resolution;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
 varying vec4 v_hitColor;
+
 void main(void) {
   if (false) { discard; }
   gl_FragColor = vec4(1.0);
@@ -801,6 +809,34 @@ void main(void) {
   gl_FragColor = vec4(1.0) * u_globalAlpha;
   if (gl_FragColor.a < 0.1) { discard; } gl_FragColor = v_hitColor;
 }`);
+    });
+  });
+
+  describe('addVertexShaderFunction', () => {
+    const FN1 = `vec4 getRed() { return vec4(1.0, 0.0, 0.0, 1.0); }`;
+    let builder;
+    beforeEach(() => {
+      builder = new ShaderBuilder();
+      builder.addVertexShaderFunction(FN1);
+    });
+    it('adds the function in all vertex shaders', () => {
+      expect(builder.getFillVertexShader()).to.contain(FN1);
+      expect(builder.getStrokeVertexShader()).to.contain(FN1);
+      expect(builder.getSymbolVertexShader()).to.contain(FN1);
+    });
+  });
+
+  describe('addFragmentShaderFunction', () => {
+    const FN2 = `vec2 getUp() { return [1.0, 1.0]; }`;
+    let builder;
+    beforeEach(() => {
+      builder = new ShaderBuilder();
+      builder.addFragmentShaderFunction(FN2);
+    });
+    it('adds the function in all vertex shaders', () => {
+      expect(builder.getFillFragmentShader()).to.contain(FN2);
+      expect(builder.getStrokeFragmentShader()).to.contain(FN2);
+      expect(builder.getSymbolFragmentShader()).to.contain(FN2);
     });
   });
 });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -1,10 +1,10 @@
+import Feature from '../../../../../src/ol/Feature.js';
+import {asArray} from '../../../../../src/ol/color.js';
 import {
   packColor,
   parseLiteralStyle,
 } from '../../../../../src/ol/webgl/styleparser.js';
 import {uniformNameForVariable} from '../../../../../src/ol/style/expressions.js';
-import {asArray} from '../../../../../src/ol/color.js';
-import Feature from '../../../../../src/ol/Feature.js';
 
 describe('ol.webgl.styleparser', function () {
   describe('parseLiteralStyle', function () {

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -113,46 +113,6 @@ describe('ol.webgl.styleparser', function () {
       expect(result.uniforms[uniformName]()).to.be.greaterThan(0);
     });
 
-    it('throws when a variable is requested but not present in the style', function (done) {
-      const varName = 'mySize';
-      const uniformName = uniformNameForVariable(varName);
-
-      const result = parseLiteralStyle({
-        variables: {},
-        symbol: {
-          symbolType: 'square',
-          size: ['var', varName, 'number_array'],
-          color: 'red',
-        },
-      });
-
-      try {
-        result.uniforms[uniformName]();
-      } catch (e) {
-        done();
-      }
-      done(true);
-    });
-
-    it('throws when a variable is requested but the style does not have a variables dict', function (done) {
-      const variableName = 'mySize';
-      const uniformName = uniformNameForVariable(variableName);
-      const result = parseLiteralStyle({
-        symbol: {
-          symbolType: 'square',
-          size: ['var', variableName, 'number_array'],
-          color: 'red',
-        },
-      });
-
-      try {
-        result.uniforms[uniformName]();
-      } catch (e) {
-        done();
-      }
-      done(true);
-    });
-
     it('reads when symbol, stroke or fill styles are present', function () {
       const result = parseLiteralStyle({
         variables: {
@@ -292,6 +252,9 @@ describe('ol.webgl.styleparser', function () {
         const varName = 'ratio';
         const uniformName = uniformNameForVariable(varName);
         const result = parseLiteralStyle({
+          variables: {
+            [varName]: 0.5,
+          },
           symbol: {
             symbolType: 'square',
             size: 6,
@@ -529,7 +492,7 @@ describe('ol.webgl.styleparser', function () {
           symbol: {
             symbolType: 'square',
             color: ['var', 'color'],
-            size: ['var', 'iconSize', 'number_array'],
+            size: ['var', 'iconSize'],
           },
         });
       });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -396,7 +396,7 @@ describe('ol.webgl.styleparser', function () {
           symbol: {
             symbolType: 'square',
             color: ['get', 'color'],
-            size: ['get', 'iconSize', 'number_array'],
+            size: ['get', 'iconSize', 'number[]'],
           },
         });
       });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -1,5 +1,9 @@
-import {parseLiteralStyle} from '../../../../../src/ol/webgl/styleparser.js';
+import {
+  packColor,
+  parseLiteralStyle,
+} from '../../../../../src/ol/webgl/styleparser.js';
 import {uniformNameForVariable} from '../../../../../src/ol/style/expressions.js';
+import {asArray} from '../../../../../src/ol/color.js';
 
 describe('ol.webgl.styleparser', function () {
   describe('parseLiteralStyle', function () {
@@ -404,6 +408,13 @@ describe('ol.webgl.styleparser', function () {
         expect(result.attributes[0].name).to.eql('intensity');
         expect(result.uniforms).to.have.property('u_var_scale');
       });
+    });
+  });
+
+  describe('packColor', () => {
+    it('compresses all the components of a color into a [number, number] array', () => {
+      expect(packColor(asArray('red'))).to.eql([65280, 255]);
+      expect(packColor(asArray('rgba(0, 255, 255, 0.5)'))).to.eql([255, 65408]);
     });
   });
 });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -240,7 +240,7 @@ describe('ol.webgl.styleparser', function () {
           },
         ]);
         expect(result.builder.symbolColorExpression).to.eql(
-          'vec4(vec4(1.0, 0.5, 0.25, 0.25).rgb, vec4(1.0, 0.5, 0.25, 0.25).a * 1.0 * 1.0)'
+          'vec4(vec4(0.25, 0.125, 0.0625, 0.25).rgb, vec4(0.25, 0.125, 0.0625, 0.25).a * 1.0 * 1.0)'
         );
         expect(result.builder.symbolSizeExpression).to.eql('vec2(a_attr1)');
         expect(result.builder.symbolOffsetExpression).to.eql(

--- a/test/browser/spec/ol/worker/webgl.test.js
+++ b/test/browser/spec/ol/worker/webgl.test.js
@@ -27,7 +27,7 @@ describe('ol/worker/webgl', function () {
         const message = {
           type: WebGLWorkerMessageType.GENERATE_POINT_BUFFERS,
           renderInstructions,
-          customAttributesCount: 1,
+          customAttributesSize: 1,
           testInt: 101,
           testString: 'abcd',
           id,
@@ -74,7 +74,7 @@ describe('ol/worker/webgl', function () {
         const message = {
           type: WebGLWorkerMessageType.GENERATE_LINE_STRING_BUFFERS,
           renderInstructions,
-          customAttributesCount: 1,
+          customAttributesSize: 1,
           testInt: 101,
           testString: 'abcd',
           id,
@@ -128,7 +128,7 @@ describe('ol/worker/webgl', function () {
         const message = {
           type: WebGLWorkerMessageType.GENERATE_POLYGON_BUFFERS,
           renderInstructions,
-          customAttributesCount: 1,
+          customAttributesSize: 1,
           testInt: 101,
           testString: 'abcd',
           id,

--- a/test/rendering/cases/webgl-vectortile/main.js
+++ b/test/rendering/cases/webgl-vectortile/main.js
@@ -6,7 +6,7 @@ import View from '../../../../src/ol/View.js';
 import WebGLVectorTileLayerRenderer from '../../../../src/ol/renderer/webgl/VectorTileLayer.js';
 import {asArray} from '../../../../src/ol/color.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
-import {packColor} from '../../../../src/ol/renderer/webgl/shaders.js';
+import {packColor} from '../../../../src/ol/webgl/styleparser.js';
 
 class WebGLVectorTileLayer extends VectorTile {
   createRenderer() {

--- a/test/rendering/cases/webgl-vectortile/main.js
+++ b/test/rendering/cases/webgl-vectortile/main.js
@@ -15,13 +15,15 @@ class WebGLVectorTileLayer extends VectorTile {
       fill: {
         attributes: {
           color: () => packColor(asArray('#eee')),
-          opacity: () => 1,
         },
       },
       stroke: {
         attributes: {
-          color: () => packColor(asArray('#888')),
-          opacity: () => 0.5,
+          color: () => {
+            const color = [...asArray('#888')];
+            color[3] = 0.5;
+            return packColor(color);
+          },
           width: () => 1,
         },
       },


### PR DESCRIPTION
This PR expands the style expressions system to allow:

* multiplying colors:
  ```js
  color: ['*', 'red', 'rgba(255, 255, 255, 0.3)'] // gives a translucent red
  ```
* reading colors or arrays from attributes and variables
  ```js
  color: ['get', 'COLOR'], // reads the attribute value and computes a color out of it
  ```
  ```js
  size: ['var', 'iconSize', 'number_array'] // a type hint can be provided to disambiguate in the case where either
                                            // a number or a number_array is expected
  ```
* the `WebGLVectorLayerRenderer` class has been reworked quite a bit to provide a simpler API and better handle custom attributes; I also wrote test for most of it, which was lacking. Note that there's still pending work on the vector tile equivalent, both APIs are not really consistent and might change again once we introduce `WebGLVectorLayer` and `WebGLVectorTileLayer` classes

Also contains some fixes relating to alpha premultiplication and slightly better error messages when parsing a style.

As an illustration, the `webgl-vector-layer` example has been reworked to rely on the following style:
```js
const style = {
  'stroke-color': ['*', ['get', 'COLOR'], [220, 220, 220]],
  'stroke-width': 1.5,
  'fill-color': ['*', ['get', 'COLOR'], [255, 255, 255, 0.6]],
};
```