### PR TITLE
Use MapTiler Coordinates API to find proj4 transforms without `+nadgrids` for `fromEPSGCode()`

### DIFF
--- a/examples/cog-projection.html
+++ b/examples/cog-projection.html
@@ -1,0 +1,12 @@
+---
+layout: example.html
+title: COG with Projection Lookup
+shortdesc: Rendering a COG over another layer in a different projection.
+docs: >
+  Example of using `fromEPSGCode()` to enable a COG to be rendered over another layer in a different projection.
+tags: "cog, projection, proj4js, maptiler"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
+---
+<div id="map" class="map"></div>

--- a/examples/cog-projection.js
+++ b/examples/cog-projection.js
@@ -1,0 +1,56 @@
+import GeoTIFF from '../src/ol/source/GeoTIFF.js';
+import Map from '../src/ol/Map.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import XYZ from '../src/ol/source/XYZ.js';
+import proj4 from 'proj4';
+import {
+  epsgLookupMapTiler,
+  fromEPSGCode,
+  register,
+  setEPSGLookup,
+} from '../src/ol/proj/proj4.js';
+
+const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
+const attributions =
+  '<a href="https://www.maptiler.com/copyright/" target="_blank">&copy; MapTiler</a> ' +
+  '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
+
+register(proj4);
+setEPSGLookup(epsgLookupMapTiler(key));
+
+const cogSource = new GeoTIFF({
+  sources: [
+    {
+      url: 'https://mikenunn.net/data/MiniScale_(std_with_grid)_R23.tif',
+      nodata: 0,
+    },
+  ],
+});
+
+cogSource.setAttributions(
+  'Contains OS data © Crown Copyright and database right ' +
+    new Date().getFullYear()
+);
+
+const map = new Map({
+  target: 'map',
+  layers: [
+    new TileLayer({
+      source: new XYZ({
+        attributions: attributions,
+        url:
+          'https://api.maptiler.com/tiles/satellite/{z}/{x}/{y}.jpg?key=' + key,
+        maxZoom: 20,
+        crossOrigin: '',
+      }),
+    }),
+    new TileLayer({
+      source: cogSource,
+    }),
+  ],
+  view: cogSource
+    .getView()
+    .then((viewConfig) =>
+      fromEPSGCode(viewConfig.projection.getCode()).then(() => viewConfig)
+    ),
+});

--- a/examples/cog-projection.js
+++ b/examples/cog-projection.js
@@ -43,9 +43,12 @@ const map = new Map({
         maxZoom: 20,
         crossOrigin: '',
       }),
+      style: {exposure: 0.2},
     }),
     new TileLayer({
       source: cogSource,
+      opacity: 0.7,
+      style: {gamma: 0.7},
     }),
   ],
   view: cogSource

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -156,3 +156,69 @@ export async function fromEPSGCode(code) {
 
   return get(epsgCode);
 }
+
+/**
+ * Generate an EPSG lookup function which uses the MapTiler Coordinates API to find projection
+ * definitions which do not require proj4 to be configured to handle `+nadgrids` parameters.
+ * Call {@link module:ol/proj/proj4.setEPSGLookup} use the function for lookups
+ * `setEPSGLookup(epsgLookupMapTiler('{YOUR_MAPTILER_API_KEY_HERE}'))`.
+ *
+ * @param {string} key MapTiler API key.  Get your own API key at https://www.maptiler.com/cloud/.
+ * @return {function(number):Promise<string>} The EPSG lookup function.
+ * @api
+ */
+export function epsgLookupMapTiler(key) {
+  return async function (code) {
+    const response = await fetch(
+      `https://api.maptiler.com/coordinates/search/code:${code}.json?transformations=true&exports=true&key=${key}`
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Unexpected response from maptiler.com: ${response.status}`
+      );
+    }
+    return response.json().then((json) => {
+      const results = json['results'];
+      if (results?.length > 0) {
+        const result = results.filter(
+          (r) => r['id']?.['authority'] === 'EPSG' && r['id']?.['code'] === code
+        )[0];
+        if (result) {
+          const transforms = result['transformations'];
+          if (transforms?.length > 0) {
+            // use default transform if it does not require grids
+            const defaultTransform = result['default_transformation'];
+            if (
+              transforms.filter(
+                (t) =>
+                  t['id']?.['authority'] === defaultTransform?.['authority'] &&
+                  t['id']?.['code'] === defaultTransform?.['code'] &&
+                  t['grids']?.length === 0
+              ).length > 0
+            ) {
+              return result['exports']?.['proj4'];
+            }
+            // otherwise use most accurate alternative without grids
+            const transform = transforms
+              .filter(
+                (t) =>
+                  t['grids']?.length === 0 &&
+                  t['target_crs']?.['authority'] === 'EPSG' &&
+                  t['target_crs']?.['code'] === 4326 &&
+                  t['deprecated'] === false &&
+                  t['usable'] === true
+              )
+              .sort((t1, t2) => t1['accuracy'] - t2['accuracy'])[0]?.[
+              'exports'
+            ]?.['proj4'];
+            if (transform) {
+              return transform;
+            }
+          }
+          // fallback to default
+          return result['exports']?.['proj4'];
+        }
+      }
+    });
+  };
+}


### PR DESCRIPTION
Fixes #14691 
Add `epsgLookupMapTiler` function using MapTiler Coordinates API to find proj4 transforms without `+nadgrids` which can be handled more easily "on demand".

Add an example of using `fromEPSGCode()` via a GeoTIFF source view options.
https://deploy-preview-14692--ol-site.netlify.app/en/latest/examples/cog-projection.html