### PR TITLE
Do not restrict image reprojection extent width for global projections

### DIFF
--- a/src/ol/reproj/Triangulation.js
+++ b/src/ol/reproj/Triangulation.js
@@ -126,7 +126,7 @@ class Triangulation {
       this.sourceProj_.canWrapX() &&
       !!maxSourceExtent &&
       !!this.sourceProj_.getExtent() &&
-      getWidth(maxSourceExtent) == getWidth(this.sourceProj_.getExtent());
+      getWidth(maxSourceExtent) >= getWidth(this.sourceProj_.getExtent());
 
     /**
      * @type {?number}

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -3,12 +3,12 @@ import ImageState from '../../../../../src/ol/ImageState.js';
 import ImageWMS from '../../../../../src/ol/source/ImageWMS.js';
 import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';
+import {fromLonLat, get as getProjection} from '../../../../../src/ol/proj.js';
 import {
   getForViewAndSize,
   getHeight,
   getWidth,
 } from '../../../../../src/ol/extent.js';
-import {get as getProjection} from '../../../../../src/ol/proj.js';
 
 describe('ol/source/ImageWMS', function () {
   let extent, pixelRatio, options, optionsReproj, projection, resolution;
@@ -488,6 +488,79 @@ describe('ol/source/ImageWMS', function () {
         done();
       });
       source.refresh();
+    });
+  });
+
+  describe('reprojection', function () {
+    let map, source;
+    const queryData = [];
+    beforeEach(function () {
+      const options = {
+        params: {
+          LAYERS: 'layer',
+        },
+        ratio: 1,
+        url: 'http://example.com/wms',
+        projection: 'EPSG:4326',
+      };
+      source = new ImageWMS(options);
+      source.setImageLoadFunction(function (image, src) {
+        queryData.push(new URL(src).searchParams);
+        image.state = ImageState.LOADED;
+        source.loading = false;
+      });
+      const target = document.createElement('div');
+      target.style.width = '256px';
+      target.style.height = '256px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        layers: [
+          new Image({
+            source: source,
+          }),
+        ],
+        view: new View({
+          zoom: 0,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      document.body.removeChild(map.getTargetElement());
+      map.setTarget(null);
+      queryData.length = 0;
+      getProjection('EPSG:3857').setGlobal(true);
+      getProjection('EPSG:4326').setGlobal(true);
+    });
+
+    it('loads wrapped extents when both projections are global', function (done) {
+      map.once('rendercomplete', function () {
+        expect(queryData.length).to.be(1);
+        expect(queryData[0].get('BBOX')).to.be('-85.078125,181,85.078125,541');
+        expect(queryData[0].get('WIDTH')).to.be('256');
+        expect(queryData[0].get('HEIGHT')).to.be('121');
+        done();
+      });
+      map.getView().setCenter(fromLonLat([361, 0]));
+    });
+
+    it('does not load outside extent when view projection is not global', function (done) {
+      getProjection('EPSG:3857').setGlobal(false);
+      map.once('rendercomplete', function () {
+        expect(queryData.length).to.be(0);
+        done();
+      });
+      map.getView().setCenter(fromLonLat([361, 0]));
+    });
+
+    it('does not load outside extent when source projection is not global', function (done) {
+      getProjection('EPSG:4326').setGlobal(false);
+      map.once('rendercomplete', function () {
+        expect(queryData.length).to.be(0);
+        done();
+      });
+      map.getView().setCenter(fromLonLat([361, 0]));
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/14705#issuecomment-1522416020

Image wrapping is not directly supported by OpenLayers but works if the server supports wrapped coordinates.  Reprojection is currently assuming there is no wrapping and restricting the extent to projection extents and therefore not handling the image produced by the server.  While restricting the x axis is needed in non-global projections and restricting the y axis is essential in all cases to avoid going beyond the poles, there is no need to limit the x coordinates of global projections beyond those of the view extent, or the layer extent if one is specified.
