### PR TITLE
Update Maptiler topo map to latest version

### DIFF
--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -3,7 +3,7 @@ import olms from 'ol-mapbox-style';
 
 olms(
   'map',
-  'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB'
+  'https://api.maptiler.com/maps/topo-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB'
 ).then(function (map) {
   map.addControl(new FullScreen());
 });

--- a/examples/offscreen-canvas.worker.js
+++ b/examples/offscreen-canvas.worker.js
@@ -45,7 +45,7 @@ function getFont(font) {
 
 function loadStyles() {
   const styleUrl =
-    'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB';
+    'https://api.maptiler.com/maps/topo-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB';
 
   fetch(styleUrl)
     .then((data) => data.json())

--- a/site/src/main.js
+++ b/site/src/main.js
@@ -85,7 +85,7 @@ map.addControl(new FullScreen());
 
 apply(
   map,
-  'https://api.maptiler.com/maps/topo/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB'
+  'https://api.maptiler.com/maps/topo-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB'
 );
 
 container.onmouseover = function () {


### PR DESCRIPTION
This pull request updates the Maptiler topo map to the latest version (v2). This is necessary because in the previous version, the used hillshade tiles are not available for all zoom levels any more, which can be seen in the small map on https://openlayers.org/.