### PR TITLE
Add example of flat style

### DIFF
--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -252,7 +252,7 @@ class BaseVectorLayer extends Layer {
    * `setStyle()` without arguments to reset to the default style. See
    * [the ol/style/Style module]{@link module:ol/style/Style~Style} for information on the default style.
    *
-   * If your layer has a static style, you can use [flat style](@link module:ol/style/flat~FlatStyle) object
+   * If your layer has a static style, you can use [flat style]{@link module:ol/style/flat~FlatStyle} object
    * literals instead of using the `Style` and symbolizer constructors (`Fill`, `Stroke`, etc.):
    * ```js
    * vectorLayer.setStyle({

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -252,9 +252,15 @@ class BaseVectorLayer extends Layer {
    * `setStyle()` without arguments to reset to the default style. See
    * [the ol/style/Style module]{@link module:ol/style/Style~Style} for information on the default style.
    *
-   * If your layer has a static style, you can use "flat" style object literals instead of
-   * using the `Style` and symbolizer constructors (`Fill`, `Stroke`, etc.).  See the documentation
-   * for the [flat style types]{@link module:ol/style/flat~FlatStyle} to see what properties are supported.
+   * If your layer has a static style, you can use [flat style](@link module:ol/style/flat~FlatStyle) object
+   * literals instead of using the `Style` and symbolizer constructors (`Fill`, `Stroke`, etc.):
+   * ```js
+   * vectorLayer.setStyle({
+   *   "fill-color": "yellow",
+   *   "stroke-color": "black",
+   *   "stroke-width": 4
+   * })
+   * ```
    *
    * @param {import("../style/Style.js").StyleLike|import("../style/flat.js").FlatStyleLike|null} [style] Layer style.
    * @api


### PR DESCRIPTION
- references #14733 
- provides a minimal example of flat [flat styles](https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html).
