### PR TITLE
Handle user projection in Translate interaction

### DIFF
--- a/src/ol/geom/Circle.js
+++ b/src/ol/geom/Circle.js
@@ -4,7 +4,7 @@
 import SimpleGeometry from './SimpleGeometry.js';
 import {createOrUpdate, forEachCorner, intersects} from '../extent.js';
 import {deflateCoordinate} from './flat/deflate.js';
-import {rotate, translate} from './flat/transform.js';
+import {rotate} from './flat/transform.js';
 
 /**
  * @classdesc
@@ -234,22 +234,6 @@ class Circle extends SimpleGeometry {
     const stride = this.getStride();
     this.setCenter(
       rotate(center, 0, center.length, stride, angle, anchor, center)
-    );
-    this.changed();
-  }
-
-  /**
-   * Translate the geometry.  This modifies the geometry coordinates in place.  If
-   * instead you want a new geometry, first `clone()` this geometry.
-   * @param {number} deltaX Delta X.
-   * @param {number} deltaY Delta Y.
-   * @api
-   */
-  translate(deltaX, deltaY) {
-    const center = this.getCenter();
-    const stride = this.getStride();
-    this.setCenter(
-      translate(center, 0, center.length, stride, deltaX, deltaY, center)
     );
     this.changed();
   }


### PR DESCRIPTION
Fixes #14666

A basic fix which handles all geometry types but may result in non `[cx + r, cy]` compliant Circle geometry if a geographic user projection Circle geometry is translated across a non-parallel view projection such as transverse mercator.  Problems caused by the Circle `setCenter` method not working in non-compliant geometries are avoided by removing the unneeded override of the Circle `translate` method and using flat coordinates (although these will still need fixing for the Modify interaction to work correctly in a similar situation).
