### PR TITLE
Accept custom templates with only `{x}`, `{y}` and `{z}` placeholders for Zoomify

### DIFF
--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -93,6 +93,7 @@ export class CustomTile extends ImageTile {
  * `http://my.zoomify.info/IMAGE.TIF/`. A URL template must include
  * `{TileGroup}`, `{x}`, `{y}`, and `{z}` placeholders, e.g.
  * `http://my.zoomify.info/IMAGE.TIF/{TileGroup}/{z}-{x}-{y}.jpg`.
+ * Custom templates with only the `{x}`, `{y}`, and `{z}` placeholders are accepted.
  * Internet Imaging Protocol (IIP) with JTL extension can be also used with
  * `{tileIndex}` and `{z}` placeholders, e.g.
  * `http://my.zoomify.info?FIF=IMAGE.TIF&JTL={z},{tileIndex}`.
@@ -191,7 +192,11 @@ class Zoomify extends TileImage {
     });
 
     let url = options.url;
-    if (url && !url.includes('{TileGroup}') && !url.includes('{tileIndex}')) {
+    if (
+      url &&
+      !(url.includes('{x}') && url.includes('{y}') && url.includes('{z}')) &&
+      !url.includes('{tileIndex}')
+    ) {
       url += '{TileGroup}/{z}-{x}-{y}.jpg';
     }
     const urls = expandUrl(url);

--- a/test/browser/spec/ol/source/Zoomify.test.js
+++ b/test/browser/spec/ol/source/Zoomify.test.js
@@ -295,6 +295,30 @@ describe('ol/source/Zoomify', function () {
         'spec/ol/source/images/zoomify?JTL=1,3'
       );
     });
+    it('creates an expected tileUrlFunction with custom template', function () {
+      const source = new Zoomify({
+        url: 'spec/ol/source/images/zoomify/{z}/{x}/{y}.jpg',
+        size: size,
+      });
+      const tileUrlFunction = source.getTileUrlFunction();
+      // zoomlevel 0
+      expect(tileUrlFunction([0, 0, 0])).to.eql(
+        'spec/ol/source/images/zoomify/0/0/0.jpg'
+      );
+      // zoomlevel 1
+      expect(tileUrlFunction([1, 0, 0])).to.eql(
+        'spec/ol/source/images/zoomify/1/0/0.jpg'
+      );
+      expect(tileUrlFunction([1, 1, 0])).to.eql(
+        'spec/ol/source/images/zoomify/1/1/0.jpg'
+      );
+      expect(tileUrlFunction([1, 0, 1])).to.eql(
+        'spec/ol/source/images/zoomify/1/0/1.jpg'
+      );
+      expect(tileUrlFunction([1, 1, 1])).to.eql(
+        'spec/ol/source/images/zoomify/1/1/1.jpg'
+      );
+    });
 
     it('creates an expected tileUrlFunction without template', function () {
       const source = new Zoomify({


### PR DESCRIPTION
Fixes #14758