### PR TITLE
Ensure circle coordinates are always [cx, cy, cx + r, cy]

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -260,11 +260,25 @@ class Geometry extends BaseObject {
    * The geometry is modified in place.
    * If you do not want the geometry modified in place, first `clone()` it and
    * then use this function on the clone.
-   * @abstract
    * @param {import("../proj.js").TransformFunction} transformFn Transform function.
    * Called with a flat array of geometry coordinates.
+   * @api
    */
   applyTransform(transformFn) {
+    this.applyTransformInternal(transformFn);
+  }
+
+  /**
+   * Apply a transform function to the coordinates of the geometry.
+   * The geometry is modified in place.
+   * If you do not want the geometry modified in place, first `clone()` it and
+   * then use this function on the clone.
+   * @abstract
+   * @param {import("../proj.js").TransformFunction} transformFn Transform function.
+   * @param {import("../proj/Projection.js").default} [sourceProj] Source projection.
+   * @param {import("../proj/Projection.js").default} [destProj] Destination projection.
+   */
+  applyTransformInternal(transformFn, sourceProj, destProj) {
     abstract();
   }
 
@@ -339,7 +353,11 @@ class Geometry extends BaseObject {
             );
           }
         : getTransform(sourceProj, destination);
-    this.applyTransform(transformFn);
+    this.applyTransformInternal(
+      transformFn,
+      sourceProj,
+      getProjection(destination)
+    );
     return this;
   }
 }

--- a/src/ol/geom/GeometryCollection.js
+++ b/src/ol/geom/GeometryCollection.js
@@ -294,12 +294,13 @@ class GeometryCollection extends Geometry {
    * then use this function on the clone.
    * @param {import("../proj.js").TransformFunction} transformFn Transform function.
    * Called with a flat array of geometry coordinates.
-   * @api
+   * @param {import("../proj/Projection.js").default} [sourceProj] Source projection.
+   * @param {import("../proj/Projection.js").default} [destProj] Destination projection.
    */
-  applyTransform(transformFn) {
+  applyTransformInternal(transformFn, sourceProj, destProj) {
     const geometries = this.geometries_;
     for (let i = 0, ii = geometries.length; i < ii; ++i) {
-      geometries[i].applyTransform(transformFn);
+      geometries[i].applyTransformInternal(transformFn, sourceProj, destProj);
     }
     this.changed();
   }

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -201,9 +201,10 @@ class SimpleGeometry extends Geometry {
    * then use this function on the clone.
    * @param {import("../proj.js").TransformFunction} transformFn Transform function.
    * Called with a flat array of geometry coordinates.
-   * @api
+   * @param {import("../proj/Projection.js").default} [sourceProj] Source projection.
+   * @param {import("../proj/Projection.js").default} [destProj] Destination projection.
    */
-  applyTransform(transformFn) {
+  applyTransformInternal(transformFn, sourceProj, destProj) {
     if (this.flatCoordinates) {
       transformFn(this.flatCoordinates, this.flatCoordinates, this.stride);
       this.changed();


### PR DESCRIPTION
This pull request fixes the way `transform()` and `applyTransform()` work on `Circle` geometries. The internal representation of a circle geometry is two points, one being the point's center `[cx, cy]`, and the other being a point "right" of the center, by the amount of the circle's radius, i.e. `[cx + r, cy]`. Previously, the `transform()` and `applyTransform()` functions caused this contract to break.

Addresses https://github.com/openlayers/openlayers/pull/14744#discussion_r1193215641.