### PR TITLE
Miscellaneous rich text documentation fixes

### DIFF
--- a/examples/vector-labels-justify-text.html
+++ b/examples/vector-labels-justify-text.html
@@ -7,6 +7,6 @@ docs: >
   By default, the text is justified according to the `textAlign` option.
   However, this option justifies also the label itself according to `textAlign` setting.
   To decouple the label placement from text placement (within the label box) use `justify`.
-tags: "vector, openstreetmap, label, rich-text"
+tags: "vector, openstreetmap, label"
 ---
 <div id="map" class="map"></div>

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -44,7 +44,7 @@ const DEFAULT_FILL_COLOR = '#333';
  * contain line breaks (`\n`). For rich text provide an array of text/font tuples. A tuple consists of the text to
  * render and the font to use (or `''` to use the text style's font). A line break has to be a separate tuple (i.e. `'\n', ''`).
  * **Example:** `['foo', 'bold 10px sans-serif', ' bar', 'italic 10px sans-serif', ' baz', '']` will yield "**foo** *bar* baz".
- * **Note:** Rich text is not supported for the immediate rendering API.
+ * **Note:** Rich text is not supported for `placement: 'line'` or the immediate rendering API.
  * @property {CanvasTextAlign} [textAlign] Text alignment. Possible values: `'left'`, `'right'`, `'center'`, `'end'` or `'start'`.
  * Default is `'center'` for `placement: 'point'`. For `placement: 'line'`, the default is to let the renderer choose a
  * placement where `maxAngle` is not exceeded.

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -53,7 +53,7 @@ import Text from './Text.js';
  * contain line breaks (`\n`). For rich text provide an array of text/font tuples. A tuple consists of the text to
  * render and the font to use (or `''` to use the text style's font). A line break has to be a separate tuple (i.e. `'\n', ''`).
  * **Example:** `['foo', 'bold 10px sans-serif', ' bar', 'italic 10px sans-serif', ' baz', '']` will yield "**foo** *bar* baz".
- * **Note:** Rich text is not supported for the immediate rendering API.
+ * **Note:** Rich text is not supported for `'text-placement': 'line'` or the immediate rendering API.
  * @property {string} [text-font] Font style as CSS `font` value, see:
  * https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/font. Default is `'10px sans-serif'`
  * @property {number} [text-max-angle=Math.PI/4] When `text-placement` is set to `'line'`, allow a maximum angle between adjacent characters.
@@ -69,12 +69,12 @@ import Text from './Text.js';
  * @property {boolean} [text-rotate-with-view=false] Whether to rotate the text with the view.
  * @property {number} [text-rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {CanvasTextAlign} [text-align] Text alignment. Possible values: `'left'`, `'right'`, `'center'`, `'end'` or `'start'`.
- * Default is `'center'` for `text-placement: 'point'`. For `text-placement: 'line'`, the default is to let the renderer choose a
+ * Default is `'center'` for `'text-placement': 'point'`. For `'text-placement': 'line'`, the default is to let the renderer choose a
  * placement where `text-max-angle` is not exceeded.
  * @property {import('./Text.js').TextJustify} [text-justify] Text justification within the text box.
  * If not set, text is justified towards the `textAlign` anchor.
  * Otherwise, use options `'left'`, `'center'`, or `'right'` to justify the text within the text box.
- * **Note:** `text-justify` is ignored for immediate rendering and also for `text-placement: 'line'`.
+ * **Note:** `text-justify` is ignored for immediate rendering and also for `'text-placement': 'line'`.
  * @property {CanvasTextBaseline} [text-baseline='middle'] Text base line. Possible values: `'bottom'`, `'top'`, `'middle'`, `'alphabetic'`,
  * `'hanging'`, `'ideographic'`.
  * @property {Array<number>} [text-padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of


### PR DESCRIPTION
Document that rich text is not supported for `placement: 'line'` (and use quotes in `'text-placement': 'line'` as required by JavaScript elsewhere in docs).  Remove inappropriate tag from example which does not use rich text.
