### PR TITLE
Fix ufos example with type hint

### DIFF
--- a/examples/icon-sprite-webgl.js
+++ b/examples/icon-sprite-webgl.js
@@ -42,7 +42,7 @@ const style = {
   filter: [
     'any',
     ['==', ['var', 'filterShape'], 'all'],
-    ['==', ['var', 'filterShape'], ['get', 'shape']],
+    ['==', ['var', 'filterShape'], ['get', 'shape', 'string']],
   ],
   symbol: {
     symbolType: 'image',


### PR DESCRIPTION
https://openlayers.org/en/latest/examples/icon-sprite-webgl.html no longer works with 7.4.0 because of a required type hint.