### PR TITLE
Add support for 'in' and 'sqrt' operators in expressions

### DIFF
--- a/src/ol/style/expressions.js
+++ b/src/ol/style/expressions.js
@@ -44,6 +44,7 @@ import {asArray, fromString, isStringColor} from '../color.js';
  *   * `['sin', value1]` returns the sine of `value1`
  *   * `['cos', value1]` returns the cosine of `value1`
  *   * `['atan', value1, value2]` returns `atan2(value1, value2)`. If `value2` is not provided, returns `atan(value1)`
+ *   * `['sqrt', value1]` returns the square root of `value1`
  *
  * * Transform operators:
  *   * `['case', condition1, output1, ...conditionN, outputN, fallback]` selects the first output whose corresponding
@@ -878,6 +879,17 @@ Operators['atan'] = {
           args[1]
         )})`
       : `atan(${expressionToGlsl(context, args[0])})`;
+  },
+};
+
+Operators['sqrt'] = {
+  getReturnType: function () {
+    return ValueTypes.NUMBER;
+  },
+  toGlsl: function (context, args) {
+    assertArgsCount(args, 1);
+    assertNumbers(args);
+    return `sqrt(${expressionToGlsl(context, args[0])})`;
   },
 };
 

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -389,6 +389,14 @@ export function parseLiteralStyle(style) {
     };
   });
 
+  // add functions that were collected in the parsing contexts
+  for (const functionName in vertContext.functions) {
+    builder.addVertexShaderFunction(vertContext.functions[functionName]);
+  }
+  for (const functionName in fragContext.functions) {
+    builder.addFragmentShaderFunction(fragContext.functions[functionName]);
+  }
+
   return {
     builder: builder,
     hasSymbol,

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -29,18 +29,8 @@ describe('ol/style/expressions', function () {
       expect(arrayToGlsl([3, 4])).to.eql('vec2(3.0, 4.0)');
     });
     it('throws on invalid lengths', function () {
-      let thrown = false;
-      try {
-        arrayToGlsl([3]);
-      } catch (e) {
-        thrown = true;
-      }
-      try {
-        arrayToGlsl([3, 2, 1, 0, -1]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() => arrayToGlsl([3])).to.throwException();
+      expect(() => arrayToGlsl([3, 2, 1, 0, -1])).to.throwException();
     });
   });
 
@@ -123,22 +113,12 @@ describe('ol/style/expressions', function () {
       expect(getValueType(true)).to.eql(ValueTypes.BOOLEAN);
     });
 
-    it('throws on an unsupported type (object)', function (done) {
-      try {
-        getValueType(new Object());
-      } catch (e) {
-        done();
-      }
-      done(true);
+    it('throws on an unsupported type (object)', function () {
+      expect(() => getValueType(new Object())).to.throwException();
     });
 
-    it('throws on an unsupported type (mixed array)', function (done) {
-      try {
-        getValueType([1, true, 'aa']);
-      } catch (e) {
-        done();
-      }
-      done(true);
+    it('throws on an unsupported type (mixed array)', function () {
+      expect(() => getValueType([1, true, 'aa'])).to.throwException();
     });
 
     it('correctly analyzes operator return types', function () {
@@ -373,137 +353,65 @@ describe('ol/style/expressions', function () {
     });
 
     it('throws on unsupported types for operators', function () {
-      let thrown = false;
-      try {
-        expressionToGlsl(context, ['var', 1234]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['var', 1234])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['any', ['var', 'aa'], 10]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['any', ['var', 'aa'], 10])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['all', ['var', 'aa'], 10]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['all', ['var', 'aa'], 10])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['<', 0, 'aa']);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['<', 0, 'aa'])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['+', true, ['get', 'attr']]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['+', true, ['get', 'attr']])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['color', 1, 2, 'red']);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['color', 1, 2, 'red'])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['array', 1, '2', 3]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['array', 1, '2', 3])
+      ).to.throwException();
     });
 
     it('throws with the wrong number of arguments', function () {
-      let thrown = false;
-      try {
-        expressionToGlsl(context, ['var', 1234, 456]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['var', 1234, 456])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['all', ['var', true], ['get', true], true]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['all', ['var', true], ['get', true], true])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['any', ['var', true]]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['any', ['var', true]])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['<', 4]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() => expressionToGlsl(context, ['<', 4])).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['+']);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() => expressionToGlsl(context, ['+'])).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['array', 1]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() => expressionToGlsl(context, ['array', 1])).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['color', 1, 2, 3, 4, 5]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['color', 1, 2, 3, 4, 5])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['sqrt', 1, 2]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['sqrt', 1, 2])
+      ).to.throwException();
     });
 
     it('throws on invalid expressions', function () {
-      let thrown = false;
-      try {
-        expressionToGlsl(context, null);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() => expressionToGlsl(context, null)).to.throwException();
     });
 
     it('throws when using a variable not defined in the style', () => {
@@ -563,19 +471,15 @@ describe('ol/style/expressions', function () {
     });
 
     it('throws if no single output type could be inferred', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['case', false, 'red', true, 'yellow', 'green'],
           ValueTypes.COLOR
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(false);
+        )
+      ).not.to.throwException();
 
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'case',
           true,
@@ -583,60 +487,38 @@ describe('ol/style/expressions', function () {
           true,
           'yellow',
           'green',
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['case', true, 'red', false, 'yellow', 'green'],
           ValueTypes.NUMBER
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        )
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['case', true, 'red', false, 'yellow', 'not_a_color'],
           ValueTypes.COLOR
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        )
+      ).to.throwException();
     });
 
     it('throws if invalid argument count', function () {
-      let thrown = false;
-      try {
-        expressionToGlsl(context, ['case', true, 0, false, 1]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['case', true, 0, false, 1])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['case', true, 0]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['case', true, 0])
+      ).to.throwException();
 
-      try {
-        expressionToGlsl(context, ['case', false]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['case', false])
+      ).to.throwException();
     });
 
     it('correctly parses the expression (colors)', function () {
@@ -732,19 +614,15 @@ describe('ol/style/expressions', function () {
     });
 
     it('throws if no single output type could be inferred', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'green'],
           ValueTypes.COLOR
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(false);
+        )
+      ).not.to.throwException();
 
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'match',
           ['get', 'attr'],
@@ -753,28 +631,20 @@ describe('ol/style/expressions', function () {
           1,
           'yellow',
           'green',
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'green'],
           ValueTypes.NUMBER
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        )
+      ).to.throwException();
     });
 
     it('throws if invalid argument count', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'match',
           ['get', 'attr'],
@@ -782,26 +652,16 @@ describe('ol/style/expressions', function () {
           true,
           false,
           false,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
-        expressionToGlsl(context, ['match', ['get', 'attr'], 0, true]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['match', ['get', 'attr'], 0, true])
+      ).to.throwException();
 
-      try {
-        expressionToGlsl(context, ['match', ['get', 'attr'], 0]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+      expect(() =>
+        expressionToGlsl(context, ['match', ['get', 'attr'], 0])
+      ).to.throwException();
     });
 
     it('correctly parses the expression (colors)', function () {
@@ -869,15 +729,16 @@ describe('ol/style/expressions', function () {
       );
     });
 
-    it('only expects string, number or boolean as input', (done) => {
+    it('only expects string, number or boolean as input', () => {
       // match input is only expressed through get operator and values which can be strings or colors
       // the call shouldn't throw because match does not allow color as input (so the final input type is string)
-      expressionToGlsl(
-        context,
-        ['match', ['get', 'attr3'], 'red', [6, 0], 'green', [3, 0], [0, 0]],
-        ValueTypes.ANY
-      );
-      done();
+      expect(() =>
+        expressionToGlsl(
+          context,
+          ['match', ['get', 'attr3'], 'red', [6, 0], 'green', [3, 0], [0, 0]],
+          ValueTypes.ANY
+        )
+      ).not.to.throwException();
     });
   });
 
@@ -935,19 +796,15 @@ describe('ol/style/expressions', function () {
     });
 
     it('throws if no single output type could be inferred', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           ['interpolate', ['linear'], ['get', 'attr'], 1000, -10, 2000, 10],
           ValueTypes.COLOR
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        )
+      ).to.throwException();
 
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           ['linear'],
@@ -956,14 +813,10 @@ describe('ol/style/expressions', function () {
           [1, 2, 3],
           1,
           222,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           [
@@ -976,29 +829,21 @@ describe('ol/style/expressions', function () {
             [0, 0, 0, 4],
           ],
           ValueTypes.NUMBER
-        );
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        )
+      ).to.throwException();
     });
 
     it('throws if invalid argument count', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           ['linear'],
           ['get', 'attr'],
           1000,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           ['linear'],
@@ -1008,16 +853,12 @@ describe('ol/style/expressions', function () {
           2000,
           10,
           5000,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
     });
 
     it('throws if an invalid interpolation type is given', function () {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           'linear',
@@ -1026,14 +867,10 @@ describe('ol/style/expressions', function () {
           0,
           2000,
           1,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           ['exponential'],
@@ -1042,14 +879,10 @@ describe('ol/style/expressions', function () {
           -10,
           2000,
           1,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
 
-      thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(context, [
           'interpolate',
           ['not_a_type'],
@@ -1058,11 +891,8 @@ describe('ol/style/expressions', function () {
           -10,
           2000,
           1,
-        ]);
-      } catch (e) {
-        thrown = true;
-      }
-      expect(thrown).to.be(true);
+        ])
+      ).to.throwException();
     });
 
     it('correctly parses the expression (colors, linear)', function () {
@@ -1140,23 +970,24 @@ describe('ol/style/expressions', function () {
       );
     });
 
-    it('only expects number as input', (done) => {
+    it('only expects number as input', () => {
       // interpolation input is only expressed through get and var operators, which means that it is unspecified on its own
       // the call shouldn't throw because interpolation only accepts numerical input
-      expressionToGlsl(
-        context,
-        [
-          'interpolate',
-          ['linear'],
-          ['get', 'attr'],
-          1000,
-          ['var', 'value'],
-          2000,
-          3000,
-        ],
-        ValueTypes.ANY
-      );
-      done();
+      expect(() =>
+        expressionToGlsl(
+          context,
+          [
+            'interpolate',
+            ['linear'],
+            ['get', 'attr'],
+            1000,
+            ['var', 'value'],
+            2000,
+            3000,
+          ],
+          ValueTypes.ANY
+        )
+      ).not.to.throwException();
     });
   });
 
@@ -1530,8 +1361,7 @@ describe('ol/style/expressions', function () {
     });
 
     it('throws when an attribute is used with conflicting types', () => {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           [
@@ -1544,16 +1374,12 @@ describe('ol/style/expressions', function () {
             'red',
           ],
           ValueTypes.COLOR
-        );
-      } catch {
-        thrown = true;
-      }
-      expect(thrown).to.eql(true);
+        )
+      ).to.throwException();
     });
 
     it('throws when a variable is used with conflicting types', () => {
-      let thrown = false;
-      try {
+      expect(() =>
         expressionToGlsl(
           context,
           [
@@ -1566,11 +1392,8 @@ describe('ol/style/expressions', function () {
             'red',
           ],
           ValueTypes.COLOR
-        );
-      } catch {
-        thrown = true;
-      }
-      expect(thrown).to.eql(true);
+        )
+      ).to.throwException();
     });
 
     it('throws if a variable is used with the wrong type', () => {

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -361,28 +361,6 @@ describe('ol/style/expressions', function () {
       expect(expressionToGlsl(context, ['get', 'myAttr'])).to.eql('v_myAttr');
     });
 
-    it('correctly adapts output for fragment shaders', function () {
-      expressionToGlsl(context, ['get', 'myAttr']);
-      expressionToGlsl(context, ['var', 'myVar']);
-      expressionToGlsl(context, [
-        'clamp',
-        ['get', 'attr2'],
-        ['get', 'attr2'],
-        ['get', 'myAttr'],
-      ]);
-      expressionToGlsl(context, ['*', ['get', 'attr2'], ['var', 'myVar']]);
-      expressionToGlsl(context, ['*', ['get', 'attr3'], ['var', 'myVar2']]);
-      expect(context.attributes).to.eql([
-        {name: 'myAttr', type: ValueTypes.NUMBER},
-        {name: 'attr2', type: ValueTypes.NUMBER},
-        {name: 'attr3', type: ValueTypes.NUMBER},
-      ]);
-      expect(context.variables).to.eql([
-        {name: 'myVar', type: ValueTypes.NUMBER},
-        {name: 'myVar2', type: ValueTypes.NUMBER},
-      ]);
-    });
-
     it('gives precedence to the string type unless asked otherwise', function () {
       expect(expressionToGlsl(context, 'lightgreen', ValueTypes.ANY)).to.eql(
         '0.0'
@@ -1368,6 +1346,30 @@ describe('ol/style/expressions', function () {
           name: 'color',
           type: ValueTypes.COLOR,
         },
+      ]);
+    });
+
+    it('get and var operators, numbers', function () {
+      context.style.variables['myVar'] = 123;
+      context.style.variables['myVar2'] = 456;
+      expressionToGlsl(context, ['get', 'myAttr']);
+      expressionToGlsl(context, ['var', 'myVar']);
+      expressionToGlsl(context, [
+        'clamp',
+        ['get', 'attr2'],
+        ['get', 'attr2'],
+        ['get', 'myAttr'],
+      ]);
+      expressionToGlsl(context, ['*', ['get', 'attr2'], ['var', 'myVar']]);
+      expressionToGlsl(context, ['*', ['get', 'attr3'], ['var', 'myVar2']]);
+      expect(context.attributes).to.eql([
+        {name: 'myAttr', type: ValueTypes.NUMBER},
+        {name: 'attr2', type: ValueTypes.NUMBER},
+        {name: 'attr3', type: ValueTypes.NUMBER},
+      ]);
+      expect(context.variables).to.eql([
+        {name: 'myVar', type: ValueTypes.NUMBER},
+        {name: 'myVar2', type: ValueTypes.NUMBER},
       ]);
     });
 

--- a/test/browser/spec/ol/style/expressions.test.js
+++ b/test/browser/spec/ol/style/expressions.test.js
@@ -299,6 +299,8 @@ describe('ol/style/expressions', function () {
       expect(expressionToGlsl(context, ['atan', 1, 0.5])).to.eql(
         'atan(1.0, 0.5)'
       );
+      expect(expressionToGlsl(context, ['sqrt', 100])).to.eql('sqrt(100.0)');
+
       expect(expressionToGlsl(context, ['>', 10, ['get', 'attr4']])).to.eql(
         '(10.0 > a_attr4)'
       );
@@ -480,6 +482,14 @@ describe('ol/style/expressions', function () {
       thrown = false;
       try {
         expressionToGlsl(context, ['color', 1, 2, 3, 4, 5]);
+      } catch (e) {
+        thrown = true;
+      }
+      expect(thrown).to.be(true);
+
+      thrown = false;
+      try {
+        expressionToGlsl(context, ['sqrt', 1, 2]);
       } catch (e) {
         thrown = true;
       }

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -548,7 +548,11 @@ describe('ol.webgl.styleparser', function () {
     it('adds shader functions in the vertex and fragment shaders', () => {
       const result = parseLiteralStyle({
         ['stroke-width']: 2,
-        filter: ['in', ['get', 'type'], ['road', 'path', 'street']],
+        filter: [
+          'in',
+          ['get', 'type'],
+          ['literal', ['road', 'path', 'street']],
+        ],
       });
 
       expect(result.builder.vertexShaderFunctions_).to.eql([]);

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -543,4 +543,23 @@ describe('ol.webgl.styleparser', function () {
       expect(packColor(asArray('rgba(0, 255, 255, 0.5)'))).to.eql([255, 65408]);
     });
   });
+
+  describe('shader functions', () => {
+    it('adds shader functions in the vertex and fragment shaders', () => {
+      const result = parseLiteralStyle({
+        ['stroke-width']: 2,
+        filter: ['in', ['get', 'type'], ['road', 'path', 'street']],
+      });
+
+      expect(result.builder.vertexShaderFunctions_).to.eql([]);
+      expect(result.builder.fragmentShaderFunctions_).to.contain(
+        `bool operator_in_0(float inputValue) {
+  if (inputValue == 0.0) { return true; }
+  if (inputValue == 1.0) { return true; }
+  if (inputValue == 2.0) { return true; }
+  return false;
+}`
+      );
+    });
+  });
 });


### PR DESCRIPTION
This PR implements two new operators taken from the MapBox style spec:
* [`in`](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#in) takes two arguments: a "needle" and a "haystack", and will return true if the haystack contains the needle; currently has the following limitations:
  * cannot be used to check the presence of a substring in a string
  * **only supports array literals as haystack**:
    * for instance, this is valid since it can be identified as a number array:  
    `['in', ['get', 'factor'], [2, 5, 10]]`  
    * this will fail because a string array can either be an array literal or an expression:  
    `['in', ['get', 'type'], ['road', 'path', 'street']]`  
    * to disambiguate a string array literal, [use the `literal` operator](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#types-literal):
    `['in', ['get', 'type'], ['literal', ['road', 'path', 'street']]]`  
    * lastly, this will throw an error since dynamic haystacks are not yet supported:  
    `['in', ['get', 'type'], ['var', 'supportedTypes']]`  

* [`sqrt`](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/#sqrt): self explanatory

The current limitations on the `in` operator will be really hard to work around with the current system. On the other hand, the approach introduced in #14780 will give much more flexibility and should help remove this limitations. As a result I figured I would not invest too much efforts in the current system, and the `in` operator as it is should already be very helpful for static filtering.

Addresses https://github.com/openlayers/openlayers/issues/11765, https://github.com/openlayers/openlayers/issues/11308, https://github.com/openlayers/openlayers/issues/13739

Replaces https://github.com/openlayers/openlayers/pull/11839