### PR TITLE
Rework webgl points hit detection

### DIFF
--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -185,44 +185,8 @@ class Heatmap extends BaseVector {
           },
         },
       ],
+      hitDetectionEnabled: true,
       vertexShader: `
-        precision mediump float;
-        uniform mat4 u_projectionMatrix;
-        uniform mat4 u_offsetScaleMatrix;
-        uniform float u_size;
-        attribute vec2 a_position;
-        attribute float a_index;
-        attribute float a_weight;
-
-        varying vec2 v_texCoord;
-        varying float v_weight;
-
-        void main(void) {
-          mat4 offsetMatrix = u_offsetScaleMatrix;
-          float offsetX = a_index == 0.0 || a_index == 3.0 ? -u_size / 2.0 : u_size / 2.0;
-          float offsetY = a_index == 0.0 || a_index == 1.0 ? -u_size / 2.0 : u_size / 2.0;
-          vec4 offsets = offsetMatrix * vec4(offsetX, offsetY, 0.0, 0.0);
-          gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0) + offsets;
-          float u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
-          float v = a_index == 0.0 || a_index == 1.0 ? 0.0 : 1.0;
-          v_texCoord = vec2(u, v);
-          v_weight = a_weight;
-        }`,
-      fragmentShader: `
-        precision mediump float;
-        uniform float u_blurSlope;
-
-        varying vec2 v_texCoord;
-        varying float v_weight;
-
-        void main(void) {
-          vec2 texCoord = v_texCoord * 2.0 - vec2(1.0, 1.0);
-          float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;
-          float value = (1.0 - sqrt(sqRadius)) * u_blurSlope;
-          float alpha = smoothstep(0.0, 1.0, value) * v_weight;
-          gl_FragColor = vec4(alpha, alpha, alpha, alpha);
-        }`,
-      hitVertexShader: `
         precision mediump float;
         uniform mat4 u_projectionMatrix;
         uniform mat4 u_offsetScaleMatrix;
@@ -248,9 +212,10 @@ class Heatmap extends BaseVector {
           v_hitColor = a_hitColor;
           v_weight = a_weight;
         }`,
-      hitFragmentShader: `
+      fragmentShader: `
         precision mediump float;
         uniform float u_blurSlope;
+        uniform mediump int u_hitDetection;
 
         varying vec2 v_texCoord;
         varying float v_weight;
@@ -261,12 +226,14 @@ class Heatmap extends BaseVector {
           float sqRadius = texCoord.x * texCoord.x + texCoord.y * texCoord.y;
           float value = (1.0 - sqrt(sqRadius)) * u_blurSlope;
           float alpha = smoothstep(0.0, 1.0, value) * v_weight;
-          if (alpha < 0.05) {
-            discard;
+          gl_FragColor = vec4(alpha, alpha, alpha, alpha);
+          if (u_hitDetection > 0) {
+            if (alpha < 0.05) {
+              discard;
+            }
+            gl_FragColor = v_hitColor;
           }
-
-          gl_FragColor = v_hitColor;
-        }`,
+      }`,
       uniforms: {
         u_size: () => {
           return (this.get(Property.RADIUS) + this.get(Property.BLUR)) * 2;

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -109,12 +109,7 @@ class WebGLPointsLayer extends Layer {
     return new WebGLPointsLayerRenderer(this, {
       vertexShader: this.parseResult_.builder.getSymbolVertexShader(),
       fragmentShader: this.parseResult_.builder.getSymbolFragmentShader(),
-      hitVertexShader:
-        !this.hitDetectionDisabled_ &&
-        this.parseResult_.builder.getSymbolVertexShader(true),
-      hitFragmentShader:
-        !this.hitDetectionDisabled_ &&
-        this.parseResult_.builder.getSymbolFragmentShader(true),
+      hitDetectionEnabled: !this.hitDetectionDisabled_,
       uniforms: this.parseResult_.uniforms,
       attributes:
         /** @type {Array<import('../renderer/webgl/PointsLayer.js').CustomAttribute>} */ (

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -162,7 +162,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
      * @type {boolean}
      * @private
      */
-    this.hitDetectionEnabled_ = !!options.hitDetectionEnabled;
+    this.hitDetectionEnabled_ = options.hitDetectionEnabled ?? true;
 
     const customAttributes = options.attributes
       ? options.attributes.map(function (attribute) {

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -51,6 +51,7 @@ export const DefaultUniform = {
   RESOLUTION: 'u_resolution',
   VIEWPORT_SIZE_PX: 'u_viewportSizePx',
   PIXEL_RATIO: 'u_pixelRatio',
+  HIT_DETECTION: 'u_hitDetection',
 };
 
 /**

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -715,6 +715,15 @@ class WebGLHelper extends Disposable {
   }
 
   /**
+   * Sets the `u_hitDetection` uniform.
+   * @param {boolean} enabled Whether to enable the hit detection code path
+   */
+  applyHitDetectionUniform(enabled) {
+    const loc = this.getUniformLocation(DefaultUniform.HIT_DETECTION);
+    this.getGL().uniform1i(loc, enabled ? 1 : 0);
+  }
+
+  /**
    * Sets the custom uniforms based on what was given in the constructor. This is called internally in `prepareDraw`.
    * @param {import("../Map.js").FrameState} frameState Frame state.
    */
@@ -991,7 +1000,7 @@ class WebGLHelper extends Disposable {
    */
   enableAttributeArray_(attribName, size, type, stride, offset) {
     const location = this.getAttributeLocation(attribName);
-    // the attribute has not been found in the shaders; do not enable it
+    // the attribute has not been found in the shaders or is not used; do not enable it
     if (location < 0) {
       return;
     }

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -629,7 +629,6 @@ ${this.uniforms_
     return 'uniform ' + uniform + ';';
   })
   .join('\n')}
-attribute vec4 a_hitColor;
 varying vec4 v_hitColor;
 ${this.varyings_
   .map(function (varying) {

--- a/test/browser/spec/ol/layer/Heatmap.test.js
+++ b/test/browser/spec/ol/layer/Heatmap.test.js
@@ -96,7 +96,7 @@ describe('ol/layer/Heatmap', function () {
 
       const renderer = layer.getRenderer();
       renderer.worker_.addEventListener('message', function (event) {
-        if (!renderer.hitRenderInstructions_) {
+        if (!renderer.renderInstructions_) {
           return;
         }
         map.renderSync();

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -23,12 +23,16 @@ uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
+
 
 attribute vec2 a_position;
 attribute float a_index;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -61,6 +65,7 @@ void main(void) {
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
   v_quadCoord = vec2(u, v);
+  v_hitColor = a_hitColor;
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
@@ -81,12 +86,16 @@ uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
+
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 
 
 void main(void) {
@@ -118,6 +127,7 @@ void main(void) {
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
   v_quadCoord = vec2(u, v);
+  v_hitColor = a_hitColor;
 
 }`);
     });
@@ -136,12 +146,16 @@ uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
+
 
 attribute vec2 a_position;
 attribute float a_index;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 
 
 void main(void) {
@@ -173,6 +187,7 @@ void main(void) {
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
   v_quadCoord = vec2(u, v);
+  v_hitColor = a_hitColor;
 
 }`);
     });
@@ -190,12 +205,16 @@ uniform mat4 u_offsetRotateMatrix;
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
+
 
 attribute vec2 a_position;
 attribute float a_index;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 
 
 void main(void) {
@@ -227,6 +246,7 @@ void main(void) {
   u = a_index == 0.0 || a_index == 3.0 ? 0.0 : 1.0;
   v = a_index == 2.0 || a_index == 3.0 ? 0.0 : 1.0;
   v_quadCoord = vec2(u, v);
+  v_hitColor = a_hitColor;
 
 }`);
     });
@@ -245,9 +265,11 @@ void main(void) {
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -255,7 +277,10 @@ void main(void) {
   if (false) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
-
+  if (u_hitDetection > 0) {
+    if (gl_FragColor.a < 0.1) { discard; };
+    gl_FragColor = v_hitColor;
+  }
 }`);
     });
     it('generates a symbol fragment shader (with uniforms)', function () {
@@ -272,17 +297,22 @@ void main(void) {
 uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
+uniform mediump int u_hitDetection;
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
+varying vec4 v_hitColor;
 
 
 void main(void) {
   if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   gl_FragColor.rgb *= gl_FragColor.a;
-
+  if (u_hitDetection > 0) {
+    if (gl_FragColor.a < 0.1) { discard; };
+    gl_FragColor = v_hitColor;
+  }
 }`);
     });
   });
@@ -311,18 +341,22 @@ uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
 uniform vec4 u_renderExtent;
+uniform mediump int u_hitDetection;
+
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
 attribute vec2 a_segmentStart;
 attribute vec2 a_segmentEnd;
 attribute float a_parameters;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_segmentStart;
 varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -366,6 +400,7 @@ void main(void) {
   v_segmentStart = worldToPx(a_segmentStart);
   v_segmentEnd = worldToPx(a_segmentEnd);
   v_width = lineWidth;
+  v_hitColor = a_hitColor;
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
@@ -397,12 +432,15 @@ uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
 uniform vec4 u_renderExtent;
+uniform mediump int u_hitDetection;
+
 uniform float u_myUniform;
 varying vec2 v_segmentStart;
 varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -437,7 +475,10 @@ void main(void) {
   if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0) * u_globalAlpha;
   gl_FragColor *= segmentDistanceField(v_currentPoint, v_segmentStart, v_segmentEnd, v_width);
-
+  if (u_hitDetection > 0) {
+    if (gl_FragColor.a < 0.1) { discard; };
+    gl_FragColor = v_hitColor;
+  }
 }`);
     });
   });
@@ -466,9 +507,13 @@ uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
 uniform vec4 u_renderExtent;
+uniform mediump int u_hitDetection;
+
 uniform float u_myUniform;
 attribute vec2 a_position;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -504,7 +549,10 @@ uniform float u_time;
 uniform float u_zoom;
 uniform float u_resolution;
 uniform vec4 u_renderExtent;
+uniform mediump int u_hitDetection;
+
 uniform float u_myUniform;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -529,7 +577,10 @@ void main(void) {
   #endif
   if (u_myUniform > 0.5) { discard; }
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0) * u_globalAlpha;
-
+  if (u_hitDetection > 0) {
+    if (gl_FragColor.a < 0.1) { discard; };
+    gl_FragColor = v_hitColor;
+  }
 }`);
     });
   });


### PR DESCRIPTION
Together with @jahow we are in the process of refactoring/implementing hit detection in all the WebGL renderers.
This PR is the first step, focused on refactoring the existing WebGL points hit detection mechanism by simplifying and optimizing it.

Before this PR, plain and hit detection rendering had redundant code paths: 2 array buffers, 2 vertex shaders, 2 fragment shaders, 2 test cases... This made it difficult to maintain and also consummed more resource than striclty necessary.

With this PR we introduce a unified approach for WebGL points rendering, driven by a single uniform.
