### PR TITLE
Add option-based support for options.target in ZoomSlider

### DIFF
--- a/src/ol/control/ZoomSlider.js
+++ b/src/ol/control/ZoomSlider.js
@@ -27,6 +27,8 @@ const Direction = {
  * @property {number} [duration=200] Animation duration in milliseconds.
  * @property {function(import("../MapEvent.js").default):void} [render] Function called when the control
  * should be re-rendered. This is called in a `requestAnimationFrame` callback.
+ * @property {HTMLElement|string} [target] Specify a target if you want the control to be
+ * rendered outside of the map's viewport.
  */
 
 /**
@@ -47,6 +49,7 @@ class ZoomSlider extends Control {
     options = options ? options : {};
 
     super({
+      target: options.target,
       element: document.createElement('div'),
       render: options.render,
     });


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
It was already possible to call `setTarget()` on the ZoomSlider object later on, but having it in the constructor allows compatibility with `Option`'s native `options.target`, as it is already supported natively.