### PR TITLE
send 'loadend' event on layer image load failure

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -152,7 +152,7 @@ class LayerRenderer extends Observable {
    */
   handleImageChange_(event) {
     const image = /** @type {import("../Image.js").default} */ (event.target);
-    if (image.getState() === ImageState.LOADED) {
+    if (image.getState() === ImageState.LOADED || image.getState() === ImageState.ERROR) {
       this.renderIfReadyAndVisible();
     }
   }

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -152,7 +152,10 @@ class LayerRenderer extends Observable {
    */
   handleImageChange_(event) {
     const image = /** @type {import("../Image.js").default} */ (event.target);
-    if (image.getState() === ImageState.LOADED || image.getState() === ImageState.ERROR) {
+    if (
+      image.getState() === ImageState.LOADED ||
+      image.getState() === ImageState.ERROR
+    ) {
       this.renderIfReadyAndVisible();
     }
   }


### PR DESCRIPTION
Before this fix the map's 'loadend' event was never fired when an error loading a WMS image occured.

The check whether the map finished loaded happens in Map.renderFrame_. That method gets triggered every time something relevant changes in a layer, e.g. when a WMS image finishes loading. But what was missing was the triggering of the rendering when the loading of a WMS image fails.

fixes #14808

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
