### PR TITLE
Optionally show or hide Bing 'placeholder' tiles

### DIFF
--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -3,7 +3,9 @@ layout: example.html
 title: Bing Maps
 shortdesc: Example of a Bing Maps layer.
 docs: >
-  <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles indicating that. Zoom the map beyond level 19 to see the "placeholder" tiles. If you want OpenLayers to display stretched tiles in place of "placeholder" tiles beyond zoom level 19 then set <code>maxZoom</code> to <code>19</code> in the options passed to <code>ol/source/BingMaps</code>.</p>
+  <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles by default for `Aerial` and `OrdnanceSurvey` styles. If you want OpenLayers to display
+    stretched tiles in place of "placeholder" tiles at zoom levels where Bing Maps does not have tiles available then set
+    <code>placeHolderTiles</code> to <code>false</code> in the options passed to <code>ol/source/BingMaps</code>.</p>
 tags: "bing, bing-maps"
 cloak:
   - key: AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -20,9 +20,7 @@ for (i = 0, ii = styles.length; i < ii; ++i) {
       source: new BingMaps({
         key: 'AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN',
         imagerySet: styles[i],
-        // use maxZoom 19 to see stretched tiles instead of the BingMaps
-        // "no photos at this zoom level" tiles
-        // maxZoom: 19
+        // placeHolderTiles: false, // Optional. Prevents showing of BingMaps placeholder tiles
       }),
     })
   );

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -68,6 +68,8 @@ const TOS_ATTRIBUTION =
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
+ * @property {boolean} placeHolderTiles Whether to show BingMaps placeholder tiles when zoomed past the maximum level provided in an area. When `false`, requests beyond
+ * the maximum zoom level will return no tile. When `true`, the placeholder tile will be returned.
  */
 
 /**
@@ -164,6 +166,12 @@ class BingMaps extends TileImage {
      */
     this.imagerySet_ = options.imagerySet;
 
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.placeHolderTiles_ = options.placeHolderTiles;
+
     const url =
       'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/' +
       this.imagerySet_ +
@@ -233,6 +241,7 @@ class BingMaps extends TileImage {
 
     const culture = this.culture_;
     const hidpi = this.hidpi_;
+    const placeHolderTiles = this.placeHolderTiles_;
     this.tileUrlFunction = createFromTileUrlFunctions(
       resource.imageUrlSubdomains.map(function (subdomain) {
         /** @type {import('../tilecoord.js').TileCoord} */
@@ -261,7 +270,17 @@ class BingMaps extends TileImage {
             if (hidpi) {
               url += '&dpi=d1&device=mobile';
             }
-            return url.replace('{quadkey}', quadKey(quadKeyTileCoord));
+            url = url.replace('{quadkey}', quadKey(quadKeyTileCoord));
+            const uri = new URL(url);
+            const params = uri.searchParams;
+            if (placeHolderTiles === true && params.has('n')) {
+              params.delete('n');
+              url = uri.toString();
+            } else if (placeHolderTiles === false && !params.has('n')) {
+              params.append('n', 'z');
+              url = uri.toString();
+            }
+            return url;
           }
         );
       })


### PR DESCRIPTION
Fixes #14541 

These are defaulted on or off for different styles as described in the issue by using the presence of the `n=z` url param to hide or show these placeholder tiles. This PR adds an optional parameter allowing users to decide whether to show these tiles or, alternatively, overzoom the best available resolution. If the parameter is not set, the default behavior for the style is used. 