### PR TITLE
Optionally show or hide Bing 'placeholder' tiles

### DIFF
--- a/examples/bing-maps.html
+++ b/examples/bing-maps.html
@@ -3,7 +3,9 @@ layout: example.html
 title: Bing Maps
 shortdesc: Example of a Bing Maps layer.
 docs: >
-  <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles indicating that. Zoom the map beyond level 19 to see the "placeholder" tiles. If you want OpenLayers to display stretched tiles in place of "placeholder" tiles beyond zoom level 19 then set <code>maxZoom</code> to <code>19</code> in the options passed to <code>ol/source/BingMaps</code>.</p>
+  <p>When the Bing Maps tile service doesn't have tiles for a given resolution and region it returns "placeholder" tiles by default for `Aerial` and `OrdnanceSurvey' styles. If you want OpenLayers to display
+    stretched tiles in place of "placeholder" tiles at zoom levels where Bing Maps does not have tiles available then set
+    <code>placeholderTiles</code> to <code>false</code> in the options passed to <code>ol/source/BingMaps</code>.</p>
 tags: "bing, bing-maps"
 cloak:
   - key: AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN

--- a/examples/bing-maps.js
+++ b/examples/bing-maps.js
@@ -20,9 +20,7 @@ for (i = 0, ii = styles.length; i < ii; ++i) {
       source: new BingMaps({
         key: 'AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN',
         imagerySet: styles[i],
-        // use maxZoom 19 to see stretched tiles instead of the BingMaps
-        // "no photos at this zoom level" tiles
-        // maxZoom: 19
+        // placeholderTiles: false, // Optional. Prevents showing of BingMaps placeholder tiles
       }),
     })
   );

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -266,21 +266,20 @@ class BingMaps extends TileImage {
               tileCoord[2],
               quadKeyTileCoord
             );
-            let url = imageUrl;
+            const url = new URL(
+              imageUrl.replace('{quadkey}', quadKey(quadKeyTileCoord))
+            );
+            const params = url.searchParams;
             if (hidpi) {
-              url += '&dpi=d1&device=mobile';
+              params.set('dpi', 'd1');
+              params.set('device', 'mobile');
             }
-            url = url.replace('{quadkey}', quadKey(quadKeyTileCoord));
-            const uri = new URL(url);
-            const params = uri.searchParams;
-            if (placeholderTiles === true && params.has('n')) {
+            if (placeholderTiles === true) {
               params.delete('n');
-              url = uri.toString();
-            } else if (placeholderTiles === false && !params.has('n')) {
-              params.append('n', 'z');
-              url = uri.toString();
+            } else if (placeholderTiles === false) {
+              params.set('n', 'z');
             }
-            return url;
+            return url.toString();
           }
         );
       })

--- a/test/browser/spec/ol/source/BingMaps.test.js
+++ b/test/browser/spec/ol/source/BingMaps.test.js
@@ -29,6 +29,8 @@ describe('ol/source/BingMaps', function () {
       source = new BingMaps({
         imagerySet: 'AerialWithLabelsOnDemand',
         key: '',
+        placeholderTiles: false,
+        hidpi: true,
       });
 
       const client = new XMLHttpRequest();
@@ -102,6 +104,11 @@ describe('ol/source/BingMaps', function () {
         projection
       );
       expect(tileUrl.match(regex)[1]).to.equal(quadKey([6, 33, 22]));
+
+      const url = new URL(tileUrl);
+      expect(url.searchParams.get('dpi')).to.equal('d1');
+      expect(url.searchParams.get('device')).to.equal('mobile');
+      expect(url.searchParams.get('n')).to.equal('z');
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/14541

Placeholder tiles are shown by default for different styles as described in the issue. The behavior is controlled by the presence of the `n=z` url param. This PR adds an optional parameter allowing users to decide whether to show these tiles or, alternatively, overzoom the best available resolution. If the parameter is not set, the default behavior for the style is used.

This is a fairly big improvement from the method of using maxzoom to hide placeholder tiles mentioned in the example because Bing's zoom level coverage differs across the globe, so while a maxzoom of x works to hide the tiles in the US, a different one is required in, eg, Spain.