### PR TITLE
WebGL / Support styles with only fill, stroke or symbol, better defaults

### DIFF
--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -348,3 +348,18 @@ function getImage(flatStyle) {
 
   return;
 }
+
+/**
+ * @return {import('./flat.js').FlatStyle} The default flat style.
+ */
+export function createDefaultStyle() {
+  return {
+    'fill-color': 'rgba(255,255,255,0.4)',
+    'stroke-color': '#3399CC',
+    'stroke-width': 1.25,
+    'circle-radius': 5,
+    'circle-fill-color': 'rgba(255,255,255,0.4)',
+    'circle-stroke-width': 1.25,
+    'circle-stroke-color': '#3399CC',
+  };
+}

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -61,6 +61,12 @@ export class ShaderBuilder {
     this.varyings_ = [];
 
     /**
+     * @type {boolean}
+     * @private
+     */
+    this.hasSymbol_ = false;
+
+    /**
      * @type {string}
      * @private
      */
@@ -103,6 +109,12 @@ export class ShaderBuilder {
     this.symbolRotateWithView_ = false;
 
     /**
+     * @type {boolean}
+     * @private
+     */
+    this.hasStroke_ = false;
+
+    /**
      * @type {string}
      * @private
      */
@@ -113,6 +125,12 @@ export class ShaderBuilder {
      * @private
      */
     this.strokeColorExpression_ = 'vec4(1.0)';
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.hasFill_ = false;
 
     /**
      * @type {string}
@@ -180,6 +198,7 @@ export class ShaderBuilder {
    * @return {ShaderBuilder} the builder object
    */
   setSymbolSizeExpression(expression) {
+    this.hasSymbol_ = true;
     this.symbolSizeExpression_ = expression;
     return this;
   }
@@ -200,7 +219,6 @@ export class ShaderBuilder {
    * Sets an expression to compute the offset of the symbol from the point center.
    * This expression can use all the uniforms and attributes available
    * in the vertex shader, and should evaluate to a `vec2` value.
-   * Note: will only be used for point geometry shaders.
    * @param {string} expression Offset expression
    * @return {ShaderBuilder} the builder object
    */
@@ -217,6 +235,7 @@ export class ShaderBuilder {
    * @return {ShaderBuilder} the builder object
    */
   setSymbolColorExpression(expression) {
+    this.hasSymbol_ = true;
     this.symbolColorExpression_ = expression;
     return this;
   }
@@ -263,16 +282,19 @@ export class ShaderBuilder {
    * @return {ShaderBuilder} the builder object
    */
   setStrokeWidthExpression(expression) {
+    this.hasStroke_ = true;
     this.strokeWidthExpression_ = expression;
     return this;
   }
 
   setStrokeColorExpression(expression) {
+    this.hasStroke_ = true;
     this.strokeColorExpression_ = expression;
     return this;
   }
 
   setFillColorExpression(expression) {
+    this.hasFill_ = true;
     this.fillColorExpression_ = expression;
     return this;
   }
@@ -302,9 +324,13 @@ export class ShaderBuilder {
    * The following varyings are hardcoded and gives the coordinate of the pixel both in the quad and on the texture:
    * `vec2 v_quadCoord`, `vec2 v_texCoord`, `vec4 v_hitColor`.
    *
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no size or color specified
    */
   getSymbolVertexShader() {
+    if (!this.hasSymbol_) {
+      return null;
+    }
+
     const offsetMatrix = this.symbolRotateWithView_
       ? 'u_offsetScaleMatrix * u_offsetRotateMatrix'
       : 'u_offsetScaleMatrix';
@@ -384,9 +410,13 @@ ${this.varyings_
    * Expects the following varyings to be transmitted by the vertex shader:
    * `vec2 v_quadCoord`, `vec2 v_texCoord`, `vec4 v_hitColor`.
    *
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no size or color specified
    */
   getSymbolFragmentShader() {
+    if (!this.hasSymbol_) {
+      return null;
+    }
+
     return `precision mediump float;
 uniform float u_time;
 uniform float u_zoom;
@@ -419,9 +449,13 @@ void main(void) {
 
   /**
    * Generates a stroke vertex shader from the builder parameters
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no size or color specified
    */
   getStrokeVertexShader() {
+    if (!this.hasStroke_) {
+      return null;
+    }
+
     return `#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else
@@ -508,9 +542,13 @@ ${this.varyings_
   /**
    * Generates a stroke fragment shader from the builder parameters
    *
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no size or color specified
    */
   getStrokeFragmentShader() {
+    if (!this.hasStroke_) {
+      return null;
+    }
+
     return `#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else
@@ -575,9 +613,13 @@ void main(void) {
   /**
    * Generates a fill vertex shader from the builder parameters
    *
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no color specified
    */
   getFillVertexShader() {
+    if (!this.hasFill_) {
+      return null;
+    }
+
     return `#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else
@@ -615,9 +657,13 @@ ${this.varyings_
 
   /**
    * Generates a fill fragment shader from the builder parameters
-   * @return {string} The full shader as a string.
+   * @return {string|null} The full shader as a string; null if no color specified
    */
   getFillFragmentShader() {
+    if (!this.hasFill_) {
+      return null;
+    }
+
     return `#ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
 #else

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -204,6 +204,13 @@ export class ShaderBuilder {
   }
 
   /**
+   * @return {string} The current symbol size expression
+   */
+  getSymbolSizeExpression() {
+    return this.symbolSizeExpression_;
+  }
+
+  /**
    * Sets an expression to compute the rotation of the shape.
    * This expression can use all the uniforms and attributes available
    * in the vertex shader, and should evaluate to a `float` value in radians.
@@ -238,6 +245,13 @@ export class ShaderBuilder {
     this.hasSymbol_ = true;
     this.symbolColorExpression_ = expression;
     return this;
+  }
+
+  /**
+   * @return {string} The current symbol color expression
+   */
+  getSymbolColorExpression() {
+    return this.symbolColorExpression_;
   }
 
   /**
@@ -287,12 +301,20 @@ export class ShaderBuilder {
     return this;
   }
 
+  /**
+   * @param {string} expression Stroke color expression, evaluate to `vec4`
+   * @return {ShaderBuilder} the builder object
+   */
   setStrokeColorExpression(expression) {
     this.hasStroke_ = true;
     this.strokeColorExpression_ = expression;
     return this;
   }
 
+  /**
+   * @param {string} expression Fill color expression, evaluate to `vec4`
+   * @return {ShaderBuilder} the builder object
+   */
   setFillColorExpression(expression) {
     this.hasFill_ = true;
     this.fillColorExpression_ = expression;

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -2,6 +2,8 @@
  * Class for generating shaders from literal style objects
  * @module ol/webgl/ShaderBuilder
  */
+import {colorToGlsl, numberToGlsl} from '../style/expressions.js';
+import {createDefaultStyle} from '../style/flat.js';
 
 const BASE_UNIFORMS = `uniform mat4 u_projectionMatrix;
 uniform mat4 u_screenToWorldMatrix;
@@ -14,6 +16,8 @@ uniform float u_resolution;
 uniform vec4 u_renderExtent;
 uniform mediump int u_hitDetection;
 `;
+
+const DEFAULT_STYLE = createDefaultStyle();
 
 /**
  * @typedef {Object} VaryingDescription
@@ -70,7 +74,9 @@ export class ShaderBuilder {
      * @type {string}
      * @private
      */
-    this.symbolSizeExpression_ = 'vec2(1.0)';
+    this.symbolSizeExpression_ = `vec2(${numberToGlsl(
+      DEFAULT_STYLE['circle-radius']
+    )})`;
 
     /**
      * @type {string}
@@ -88,7 +94,9 @@ export class ShaderBuilder {
      * @type {string}
      * @private
      */
-    this.symbolColorExpression_ = 'vec4(1.0)';
+    this.symbolColorExpression_ = colorToGlsl(
+      /** @type {string} */ (DEFAULT_STYLE['circle-fill-color'])
+    );
 
     /**
      * @type {string}
@@ -118,13 +126,15 @@ export class ShaderBuilder {
      * @type {string}
      * @private
      */
-    this.strokeWidthExpression_ = '1.0';
+    this.strokeWidthExpression_ = numberToGlsl(DEFAULT_STYLE['stroke-width']);
 
     /**
      * @type {string}
      * @private
      */
-    this.strokeColorExpression_ = 'vec4(1.0)';
+    this.strokeColorExpression_ = colorToGlsl(
+      /** @type {string} */ (DEFAULT_STYLE['stroke-color'])
+    );
 
     /**
      * @type {boolean}
@@ -136,7 +146,9 @@ export class ShaderBuilder {
      * @type {string}
      * @private
      */
-    this.fillColorExpression_ = 'vec4(1.0)';
+    this.fillColorExpression_ = colorToGlsl(
+      /** @type {string} */ (DEFAULT_STYLE['fill-color'])
+    );
 
     /**
      * @type {Array<string>}

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -218,39 +218,35 @@ describe('VectorStyleRenderer', () => {
         expect(buffers.invertVerticesTransform).to.eql(
           makeInverseTransform(createTransform(), SAMPLE_TRANSFORM)
         );
-        expect(buffers.polygonIndicesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.polygonIndicesBuffer.getType()).to.be(
-          ELEMENT_ARRAY_BUFFER
-        );
-        expect(buffers.polygonIndicesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.polygonVerticesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.polygonVerticesBuffer.getType()).to.be(ARRAY_BUFFER);
-        expect(buffers.polygonVerticesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.polygonVerticesBuffer.getArray().slice(0, 6)).to.eql([
+        expect(buffers.polygonBuffers[0]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.polygonBuffers[0].getType()).to.be(ELEMENT_ARRAY_BUFFER);
+        expect(buffers.polygonBuffers[0].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.polygonBuffers[1]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.polygonBuffers[1].getType()).to.be(ARRAY_BUFFER);
+        expect(buffers.polygonBuffers[1].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.polygonBuffers[1].getArray().slice(0, 6)).to.eql([
           -45, -47.5, 3000, 10, 20, 30,
         ]);
 
-        expect(buffers.lineStringIndicesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.lineStringIndicesBuffer.getType()).to.be(
+        expect(buffers.lineStringBuffers[0]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.lineStringBuffers[0].getType()).to.be(
           ELEMENT_ARRAY_BUFFER
         );
-        expect(buffers.lineStringIndicesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.lineStringVerticesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.lineStringVerticesBuffer.getType()).to.be(ARRAY_BUFFER);
-        expect(buffers.lineStringVerticesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.lineStringVerticesBuffer.getArray().slice(0, 9)).to.eql([
+        expect(buffers.lineStringBuffers[0].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.lineStringBuffers[1]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.lineStringBuffers[1].getType()).to.be(ARRAY_BUFFER);
+        expect(buffers.lineStringBuffers[1].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.lineStringBuffers[1].getArray().slice(0, 9)).to.eql([
           -45, -47.5, -40, -47.5, 58900000, 3000, 10, 20, 30,
         ]);
 
-        expect(buffers.pointIndicesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.pointIndicesBuffer.getType()).to.be(
-          ELEMENT_ARRAY_BUFFER
-        );
-        expect(buffers.pointIndicesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.pointVerticesBuffer).to.be.an(WebGLArrayBuffer);
-        expect(buffers.pointVerticesBuffer.getType()).to.be(ARRAY_BUFFER);
-        expect(buffers.pointVerticesBuffer.getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.pointVerticesBuffer.getArray().slice(0, 7)).to.eql([
+        expect(buffers.pointBuffers[0]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.pointBuffers[0].getType()).to.be(ELEMENT_ARRAY_BUFFER);
+        expect(buffers.pointBuffers[0].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.pointBuffers[1]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.pointBuffers[1].getType()).to.be(ARRAY_BUFFER);
+        expect(buffers.pointBuffers[1].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.pointBuffers[1].getArray().slice(0, 7)).to.eql([
           -45, -45, 0, 1000, 10, 20, 30,
         ]);
       });
@@ -262,9 +258,9 @@ describe('VectorStyleRenderer', () => {
           geometryBatch,
           SAMPLE_TRANSFORM
         );
-        sinon.spy(helper, 'useProgram');
         sinon.spy(helper, 'bindBuffer');
         sinon.spy(helper, 'enableAttributes');
+        sinon.spy(helper, 'useProgram');
         sinon.spy(helper, 'drawElements');
         preRenderCb = sinon.spy();
         vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
@@ -283,22 +279,22 @@ describe('VectorStyleRenderer', () => {
       });
       it('binds buffers for all geometry types', function () {
         expect(helper.bindBuffer.callCount).to.be(6);
-        expect(
-          helper.bindBuffer.calledWith(buffers.polygonIndicesBuffer)
-        ).to.be(true);
-        expect(
-          helper.bindBuffer.calledWith(buffers.polygonVerticesBuffer)
-        ).to.be(true);
-        expect(
-          helper.bindBuffer.calledWith(buffers.lineStringIndicesBuffer)
-        ).to.be(true);
-        expect(
-          helper.bindBuffer.calledWith(buffers.lineStringVerticesBuffer)
-        ).to.be(true);
-        expect(helper.bindBuffer.calledWith(buffers.pointIndicesBuffer)).to.be(
+        expect(helper.bindBuffer.calledWith(buffers.polygonBuffers[0])).to.be(
           true
         );
-        expect(helper.bindBuffer.calledWith(buffers.pointVerticesBuffer)).to.be(
+        expect(helper.bindBuffer.calledWith(buffers.polygonBuffers[1])).to.be(
+          true
+        );
+        expect(
+          helper.bindBuffer.calledWith(buffers.lineStringBuffers[0])
+        ).to.be(true);
+        expect(
+          helper.bindBuffer.calledWith(buffers.lineStringBuffers[1])
+        ).to.be(true);
+        expect(helper.bindBuffer.calledWith(buffers.pointBuffers[0])).to.be(
+          true
+        );
+        expect(helper.bindBuffer.calledWith(buffers.pointBuffers[1])).to.be(
           true
         );
       });
@@ -321,17 +317,137 @@ describe('VectorStyleRenderer', () => {
         expect(helper.drawElements.callCount).to.be(3);
         expect(helper.drawElements.firstCall.args).to.eql([
           0,
-          buffers.polygonIndicesBuffer.getSize(),
+          buffers.polygonBuffers[0].getSize(),
         ]);
         expect(helper.drawElements.secondCall.args).to.eql([
           0,
-          buffers.lineStringIndicesBuffer.getSize(),
+          buffers.lineStringBuffers[0].getSize(),
         ]);
         expect(helper.drawElements.thirdCall.args).to.eql([
           0,
-          buffers.pointIndicesBuffer.getSize(),
+          buffers.pointBuffers[0].getSize(),
         ]);
       });
+    });
+  });
+  describe('rendering only fill', () => {
+    let buffers, preRenderCb;
+    beforeEach(async () => {
+      const fillOnlyShaders = {...SAMPLE_SHADERS};
+      delete fillOnlyShaders.stroke;
+      delete fillOnlyShaders.symbol;
+      sinon.spy(helper, 'flushBufferData');
+      sinon.spy(helper, 'enableAttributes');
+      sinon.spy(helper, 'useProgram');
+      sinon.spy(helper, 'drawElements');
+      vectorStyleRenderer = new VectorStyleRenderer(fillOnlyShaders, helper);
+      buffers = await vectorStyleRenderer.generateBuffers(
+        geometryBatch,
+        SAMPLE_TRANSFORM
+      );
+      preRenderCb = sinon.spy();
+      vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
+    });
+    it('only loads buffer data for one geometry type', function () {
+      expect(helper.flushBufferData.callCount).to.be(2);
+    });
+    it('only does one render', function () {
+      expect(preRenderCb.callCount).to.be(1);
+    });
+    it('only does the polygon render pass', function () {
+      expect(helper.enableAttributes.callCount).to.be(1);
+      expect(helper.enableAttributes.firstCall.firstArg).to.be(
+        vectorStyleRenderer.polygonAttributesDesc_
+      );
+      expect(helper.useProgram.callCount).to.be(1);
+      expect(helper.useProgram.firstCall.firstArg).to.be(
+        vectorStyleRenderer.fillProgram_
+      );
+      expect(helper.drawElements.callCount).to.be(1);
+      expect(helper.drawElements.firstCall.args).to.eql([
+        0,
+        buffers.polygonBuffers[0].getSize(),
+      ]);
+    });
+  });
+  describe('rendering only stroke', () => {
+    let buffers, preRenderCb;
+    beforeEach(async () => {
+      const strokeOnlyShaders = {...SAMPLE_SHADERS};
+      delete strokeOnlyShaders.fill;
+      delete strokeOnlyShaders.symbol;
+      sinon.spy(helper, 'flushBufferData');
+      sinon.spy(helper, 'enableAttributes');
+      sinon.spy(helper, 'useProgram');
+      sinon.spy(helper, 'drawElements');
+      vectorStyleRenderer = new VectorStyleRenderer(strokeOnlyShaders, helper);
+      buffers = await vectorStyleRenderer.generateBuffers(
+        geometryBatch,
+        SAMPLE_TRANSFORM
+      );
+      preRenderCb = sinon.spy();
+      vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
+    });
+    it('only loads buffer data for one geometry type', function () {
+      expect(helper.flushBufferData.callCount).to.be(2);
+    });
+    it('only does one render', function () {
+      expect(preRenderCb.callCount).to.be(1);
+    });
+    it('only does the line string render pass', function () {
+      expect(helper.enableAttributes.callCount).to.be(1);
+      expect(helper.enableAttributes.firstCall.firstArg).to.be(
+        vectorStyleRenderer.lineStringAttributesDesc_
+      );
+      expect(helper.useProgram.callCount).to.be(1);
+      expect(helper.useProgram.firstCall.firstArg).to.be(
+        vectorStyleRenderer.strokeProgram_
+      );
+      expect(helper.drawElements.callCount).to.be(1);
+      expect(helper.drawElements.firstCall.args).to.eql([
+        0,
+        buffers.lineStringBuffers[0].getSize(),
+      ]);
+    });
+  });
+  describe('rendering only symbol', () => {
+    let buffers, preRenderCb;
+    beforeEach(async () => {
+      const symbolOnlyShaders = {...SAMPLE_SHADERS};
+      delete symbolOnlyShaders.fill;
+      delete symbolOnlyShaders.stroke;
+      sinon.spy(helper, 'flushBufferData');
+      sinon.spy(helper, 'enableAttributes');
+      sinon.spy(helper, 'useProgram');
+      sinon.spy(helper, 'drawElements');
+      vectorStyleRenderer = new VectorStyleRenderer(symbolOnlyShaders, helper);
+      buffers = await vectorStyleRenderer.generateBuffers(
+        geometryBatch,
+        SAMPLE_TRANSFORM
+      );
+      preRenderCb = sinon.spy();
+      vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
+    });
+    it('only loads buffer data for one geometry type', function () {
+      expect(helper.flushBufferData.callCount).to.be(2);
+    });
+    it('only does one render', function () {
+      expect(preRenderCb.callCount).to.be(1);
+    });
+    it('only does the point render pass', function () {
+      expect(helper.enableAttributes.callCount).to.be(1);
+      expect(helper.enableAttributes.firstCall.firstArg).to.be(
+        vectorStyleRenderer.pointAttributesDesc_
+      );
+      expect(helper.useProgram.callCount).to.be(1);
+      expect(helper.useProgram.firstCall.firstArg).to.be(
+        vectorStyleRenderer.symbolProgram_
+      );
+      expect(helper.drawElements.callCount).to.be(1);
+      expect(helper.drawElements.firstCall.args).to.eql([
+        0,
+        buffers.pointBuffers[0].getSize(),
+      ]);
     });
   });
 });

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -20,6 +20,9 @@ import {getUid} from '../../../../../../src/ol/util.js';
 const SAMPLE_STYLE = {
   ['fill-color']: ['get', 'color'],
   ['stroke-width']: 2,
+  symbol: {
+    size: 3,
+  },
 };
 
 const SAMPLE_STYLE2 = {

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -18,6 +18,9 @@ import {createXYZ} from '../../../../../../src/ol/tilegrid.js';
 const SAMPLE_STYLE = {
   ['fill-color']: ['get', 'color'],
   ['stroke-width']: 2,
+  symbol: {
+    size: 3,
+  },
 };
 
 const SAMPLE_STYLE2 = {

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -250,6 +250,14 @@ void main(void) {
 
 }`);
     });
+
+    it('returns null if no color or size specified', function () {
+      const builder = new ShaderBuilder();
+      builder.setSymbolRotationExpression('1.0');
+      builder.setSymbolOffsetExpression('vec2(1.0)');
+      builder.setSymbolRotateWithView('0.0');
+      expect(builder.getSymbolVertexShader()).to.be(null);
+    });
   });
   describe('getSymbolFragmentShader', function () {
     it('generates a symbol fragment shader (with varying)', function () {
@@ -314,6 +322,14 @@ void main(void) {
     gl_FragColor = v_hitColor;
   }
 }`);
+    });
+
+    it('returns null if no color or size specified', function () {
+      const builder = new ShaderBuilder();
+      builder.setSymbolRotationExpression('1.0');
+      builder.setSymbolOffsetExpression('vec2(1.0)');
+      builder.setSymbolRotateWithView('0.0');
+      expect(builder.getSymbolFragmentShader()).to.be(null);
     });
   });
   describe('getStrokeVertexShader', function () {
@@ -405,6 +421,11 @@ void main(void) {
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
     });
+
+    it('returns null if no color or size specified', function () {
+      const builder = new ShaderBuilder();
+      expect(builder.getStrokeVertexShader()).to.be(null);
+    });
   });
   describe('getStrokeFragmentShader', function () {
     it('generates a stroke fragment shader (with varying, attribute and uniform)', function () {
@@ -481,6 +502,11 @@ void main(void) {
   }
 }`);
     });
+
+    it('returns null if no color or size specified', function () {
+      const builder = new ShaderBuilder();
+      expect(builder.getStrokeFragmentShader()).to.be(null);
+    });
   });
   describe('getFillVertexShader', function () {
     it('generates a fill vertex shader (with varying, attribute and uniform)', function () {
@@ -522,6 +548,11 @@ void main(void) {
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
+    });
+
+    it('returns null if no color specified', function () {
+      const builder = new ShaderBuilder();
+      expect(builder.getFillVertexShader()).to.be(null);
     });
   });
   describe('getFillFragmentShader', function () {
@@ -583,6 +614,11 @@ void main(void) {
   }
 }`);
     });
+
+    it('returns null if no color specified', function () {
+      const builder = new ShaderBuilder();
+      expect(builder.getFillFragmentShader()).to.be(null);
+    });
   });
 
   describe('addVertexShaderFunction', () => {
@@ -591,6 +627,9 @@ void main(void) {
     beforeEach(() => {
       builder = new ShaderBuilder();
       builder.addVertexShaderFunction(FN1);
+      builder.setFillColorExpression('vec4(1.0)');
+      builder.setStrokeColorExpression('vec4(1.0)');
+      builder.setSymbolColorExpression('vec4(1.0)');
     });
     it('adds the function in all vertex shaders', () => {
       expect(builder.getFillVertexShader()).to.contain(FN1);
@@ -605,6 +644,9 @@ void main(void) {
     beforeEach(() => {
       builder = new ShaderBuilder();
       builder.addFragmentShaderFunction(FN2);
+      builder.setFillColorExpression('vec4(1.0)');
+      builder.setStrokeColorExpression('vec4(1.0)');
+      builder.setSymbolColorExpression('vec4(1.0)');
     });
     it('adds the function in all vertex shaders', () => {
       expect(builder.getFillFragmentShader()).to.contain(FN2);

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -45,16 +45,11 @@ describe('ol.webgl.styleparser', function () {
         },
       ]);
       expect(result.builder.symbolColorExpression_).to.eql(
-        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0)'
+        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5) * vec4(1.0, 1.0, 1.0, 1.0)'
       );
       expect(result.builder.symbolSizeExpression_).to.eql(
         `vec2(mix(4.0, 8.0, clamp((a_population - ${lowerUniformName}) / (${higherUniformName} - ${lowerUniformName}), 0.0, 1.0)))`
       );
-      expect(result.builder.symbolOffsetExpression_).to.eql('vec2(0.0, 0.0)');
-      expect(result.builder.texCoordExpression_).to.eql(
-        'vec4(0.0, 0.0, 1.0, 1.0)'
-      );
-      expect(result.builder.symbolRotateWithView_).to.eql(false);
       expect(Object.keys(result.attributes).length).to.eql(1);
       expect(result.attributes).to.have.property('population');
       expect(result.uniforms).to.have.property(lowerUniformName);
@@ -80,17 +75,12 @@ describe('ol.webgl.styleparser', function () {
         },
       ]);
       expect(result.builder.symbolColorExpression_).to.eql(
-        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 1.0 * 1.0)'
+        'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 1.0) * vec4(1.0, 1.0, 1.0, 1.0)'
       );
       expect(result.builder.symbolSizeExpression_).to.eql('vec2(6.0)');
-      expect(result.builder.symbolOffsetExpression_).to.eql('vec2(0.0, 0.0)');
-      expect(result.builder.texCoordExpression_).to.eql(
-        'vec4(0.0, 0.0, 1.0, 1.0)'
-      );
       expect(result.builder.discardExpression_).to.eql(
         '!(v_attr0 >= 0.0 && v_attr0 <= 10.0)'
       );
-      expect(result.builder.symbolRotateWithView_).to.eql(false);
       expect(Object.keys(result.attributes).length).to.eql(1);
       expect(result.attributes).to.have.property('attr0');
     });
@@ -113,37 +103,6 @@ describe('ol.webgl.styleparser', function () {
       expect(result.uniforms[uniformName]()).to.be.greaterThan(0);
     });
 
-    it('reads when symbol, stroke or fill styles are present', function () {
-      const result = parseLiteralStyle({
-        variables: {
-          mySize: 'abcdef',
-        },
-        symbol: {
-          symbolType: 'square',
-          size: 1,
-          color: 'red',
-        },
-        ['stroke-width']: 1,
-        ['fill-color']: 'blue',
-      });
-
-      expect(result.hasSymbol).to.be(true);
-      expect(result.hasStroke).to.be(true);
-      expect(result.hasFill).to.be(true);
-    });
-
-    it('reads when symbol, stroke or fill styles are absent', function () {
-      const result = parseLiteralStyle({
-        variables: {
-          mySize: 'abcdef',
-        },
-      });
-
-      expect(result.hasSymbol).to.be(false);
-      expect(result.hasStroke).to.be(false);
-      expect(result.hasFill).to.be(false);
-    });
-
     describe('symbol style', function () {
       it('without expressions', function () {
         const result = parseLiteralStyle({
@@ -159,14 +118,10 @@ describe('ol.webgl.styleparser', function () {
         expect(result.builder.attributes_).to.eql([]);
         expect(result.builder.varyings_).to.eql([]);
         expect(result.builder.symbolColorExpression_).to.eql(
-          'vec4(vec4(1.0, 0.0, 0.0, 1.0).rgb, vec4(1.0, 0.0, 0.0, 1.0).a * 1.0 * 1.0)'
+          'vec4(vec4(1.0, 0.0, 0.0, 1.0).rgb, vec4(1.0, 0.0, 0.0, 1.0).a * 1.0) * vec4(1.0, 1.0, 1.0, 1.0)'
         );
         expect(result.builder.symbolSizeExpression_).to.eql(
           'vec2(vec2(4.0, 8.0))'
-        );
-        expect(result.builder.symbolOffsetExpression_).to.eql('vec2(0.0, 0.0)');
-        expect(result.builder.texCoordExpression_).to.eql(
-          'vec4(0.0, 0.0, 1.0, 1.0)'
         );
         expect(result.builder.symbolRotateWithView_).to.eql(true);
         expect(result.attributes).to.eql([]);
@@ -205,7 +160,7 @@ describe('ol.webgl.styleparser', function () {
           },
         ]);
         expect(result.builder.symbolColorExpression_).to.eql(
-          'vec4(vec4(0.25, 0.125, 0.0625, 0.25).rgb, vec4(0.25, 0.125, 0.0625, 0.25).a * 1.0 * 1.0)'
+          'vec4(vec4(0.25, 0.125, 0.0625, 0.25).rgb, vec4(0.25, 0.125, 0.0625, 0.25).a * 1.0) * vec4(1.0, 1.0, 1.0, 1.0)'
         );
         expect(result.builder.symbolSizeExpression_).to.eql('vec2(a_attr1)');
         expect(result.builder.symbolOffsetExpression_).to.eql(
@@ -236,13 +191,9 @@ describe('ol.webgl.styleparser', function () {
         expect(result.builder.attributes_).to.eql([]);
         expect(result.builder.varyings_).to.eql([]);
         expect(result.builder.symbolColorExpression_).to.eql(
-          'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5 * 1.0) * texture2D(u_texture, v_texCoord)'
+          'vec4(vec4(0.2, 0.4, 0.6, 1.0).rgb, vec4(0.2, 0.4, 0.6, 1.0).a * 0.5) * texture2D(u_texture, v_texCoord)'
         );
         expect(result.builder.symbolSizeExpression_).to.eql('vec2(6.0)');
-        expect(result.builder.symbolOffsetExpression_).to.eql('vec2(0.0, 0.0)');
-        expect(result.builder.texCoordExpression_).to.eql(
-          'vec4(0.0, 0.0, 1.0, 1.0)'
-        );
         expect(result.builder.symbolRotateWithView_).to.eql(false);
         expect(result.attributes).to.eql([]);
         expect(result.uniforms).to.have.property('u_texture');
@@ -273,14 +224,9 @@ describe('ol.webgl.styleparser', function () {
         expect(result.builder.attributes_).to.eql([]);
         expect(result.builder.varyings_).to.eql([]);
         expect(result.builder.symbolColorExpression_).to.eql(
-          `vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), clamp((${uniformName} - 0.0) / (1.0 - 0.0), 0.0, 1.0)).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), clamp((${uniformName} - 0.0) / (1.0 - 0.0), 0.0, 1.0)).a * 1.0 * 1.0)`
+          `vec4(mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), clamp((u_var_ratio - 0.0) / (1.0 - 0.0), 0.0, 1.0)).rgb, mix(vec4(1.0, 1.0, 0.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), clamp((u_var_ratio - 0.0) / (1.0 - 0.0), 0.0, 1.0)).a * 1.0) * vec4(1.0, 1.0, 1.0, 1.0)`
         );
         expect(result.builder.symbolSizeExpression_).to.eql('vec2(6.0)');
-        expect(result.builder.symbolOffsetExpression_).to.eql('vec2(0.0, 0.0)');
-        expect(result.builder.texCoordExpression_).to.eql(
-          'vec4(0.0, 0.0, 1.0, 1.0)'
-        );
-        expect(result.builder.symbolRotateWithView_).to.eql(false);
         expect(result.attributes).to.eql([]);
         expect(result.uniforms).to.have.property(uniformName);
       });
@@ -504,8 +450,8 @@ describe('ol.webgl.styleparser', function () {
       });
       it('adds uniforms to the shader builder', () => {
         expect(parseResult.builder.uniforms_).to.eql([
-          'vec4 u_var_iconSize',
           'vec2 u_var_color',
+          'vec4 u_var_iconSize',
           'float u_var_lineType',
           'float u_var_lineWidth',
           'vec2 u_var_fillColor',
@@ -514,8 +460,8 @@ describe('ol.webgl.styleparser', function () {
       });
       it('returns uniforms in the result', () => {
         expect(Object.keys(parseResult.uniforms)).to.eql([
-          'u_var_iconSize',
           'u_var_color',
+          'u_var_iconSize',
           'u_var_lineType',
           'u_var_lineWidth',
           'u_var_fillColor',


### PR DESCRIPTION
This PR reworks the WebGL style processing to allow partial styles, e.g. only stroke or fill. Now the ShaderBuilder will output `null` when asking for a shader if not enough parameters were provided for that shader (typically, at least color or size).

Default style parameters used by the WebGL renderers have also been centralized and made mostly consistent with the default vector style of OpenLayers. To do that a `createDefaultStyle()` function was introduced in the `ol/style/flat.js` module to provide a sensible place for default values; ideally this could be used in the future for any vector renderer.

Mostly inspired by #14690