### PR TITLE
Avoid missing tiles for Raster source using Tile layers or sources

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -587,9 +587,12 @@ class RasterSource extends ImageSource {
      */
     this.layers_ = createLayers(options.sources);
 
-    const changed = this.changed.bind(this);
     for (let i = 0, ii = this.layers_.length; i < ii; ++i) {
-      this.layers_[i].addEventListener(EventType.CHANGE, changed);
+      this.layers_[i].addEventListener(EventType.CHANGE, () => {
+        if (this.requestedFrameState_) {
+          this.processSources_();
+        }
+      });
     }
 
     /** @type {boolean} */
@@ -869,15 +872,16 @@ class RasterSource extends ImageSource {
     }
     context.putImageData(output, 0, 0);
 
-    this.changed();
+    if (frameState.animate) {
+      requestAnimationFrame(this.changed.bind(this));
+    } else {
+      this.changed();
+    }
     this.renderedRevision_ = this.getRevision();
 
     this.dispatchEvent(
       new RasterSourceEvent(RasterEventType.AFTEROPERATIONS, frameState, data)
     );
-    if (frameState.animate) {
-      requestAnimationFrame(this.changed.bind(this));
-    }
   }
 
   /**

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -587,12 +587,9 @@ class RasterSource extends ImageSource {
      */
     this.layers_ = createLayers(options.sources);
 
+    const changed = this.changed.bind(this);
     for (let i = 0, ii = this.layers_.length; i < ii; ++i) {
-      this.layers_[i].addEventListener(EventType.CHANGE, () => {
-        if (this.requestedFrameState_) {
-          this.processSources_();
-        }
-      });
+      this.layers_[i].addEventListener(EventType.CHANGE, changed);
     }
 
     /** @type {boolean} */
@@ -771,6 +768,8 @@ class RasterSource extends ImageSource {
       return null;
     }
 
+    this.tileQueue_.loadMoreTiles(16, 16);
+
     resolution = this.findNearestResolution(resolution);
     const frameState = this.updateFrameState_(extent, resolution, projection);
     this.requestedFrameState_ = frameState;
@@ -793,8 +792,6 @@ class RasterSource extends ImageSource {
     ) {
       this.processSources_();
     }
-
-    frameState.tileQueue.loadMoreTiles(16, 16);
 
     if (frameState.animate) {
       requestAnimationFrame(this.changed.bind(this));


### PR DESCRIPTION
This pull request fixes an issue with the Raster source, which can be seen in the map at the top of https://openlayers.org/: Sometimes not all tiles of the hillshade are displayed. To see this bug, simple reload the website several times - it will reveal itself eventually.

A second chunk of this change removes an unnecessary `layer.changed()` call, when we're waiting for an animation of dependent sources to finish.