### PR TITLE
Mark image as changed in the next animation frame

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -601,7 +601,7 @@ class RasterSource extends ImageSource {
      */
     this.tileQueue_ = new TileQueue(function () {
       return 1;
-    }, this.changed.bind(this));
+    }, changed);
 
     /**
      * The most recently requested frame state.
@@ -869,11 +869,7 @@ class RasterSource extends ImageSource {
     }
     context.putImageData(output, 0, 0);
 
-    if (frameState.animate) {
-      requestAnimationFrame(this.changed.bind(this));
-    } else {
-      this.changed();
-    }
+    requestAnimationFrame(this.changed.bind(this));
     this.renderedRevision_ = this.getRevision();
 
     this.dispatchEvent(


### PR DESCRIPTION
#14853 improved the situation regarding missing tiles for raster sources, and was a step in the right direction. With the additional change here, I think the issue is finally fixed.