### PR TITLE
Fix VectorImageLayer opacity

### DIFF
--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -107,7 +107,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
       vectorRenderer.useContainer(null, null);
       const context = vectorRenderer.context;
       const layerState = frameState.layerStatesArray[frameState.layerIndex];
-      context.globalAlpha = layerState.opacity;
+      this.globalAlpha = layerState.opacity;
       const imageLayerState = Object.assign({}, layerState, {opacity: 1});
       const imageFrameState = /** @type {import("../../Map.js").FrameState} */ (
         Object.assign({}, frameState, {

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -107,7 +107,6 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
       vectorRenderer.useContainer(null, null);
       const context = vectorRenderer.context;
       const layerState = frameState.layerStatesArray[frameState.layerIndex];
-      this.globalAlpha = layerState.opacity;
       const imageLayerState = Object.assign({}, layerState, {opacity: 1});
       const imageFrameState = /** @type {import("../../Map.js").FrameState} */ (
         Object.assign({}, frameState, {


### PR DESCRIPTION
Fixing the issue Issue #14866:
At the point context.globalAlpha was set, the context is the context of vectorRenderer, not global context for the whole render.