### PR TITLE
Remove marked warning

### DIFF
--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -29,7 +29,8 @@ function getPackageInfo() {
 
 handlebars.registerHelper(
   'md',
-  (str) => new handlebars.SafeString(marked(str))
+  (str) =>
+    new handlebars.SafeString(marked(str, {headerIds: false, mangle: false}))
 );
 
 /**


### PR DESCRIPTION
This pull request removes `marked`'s warning about changed meaning of the `headerIds` and `mangle` options.