### PR TITLE
Use `touch-action: none;` for elements in viewport

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -111,7 +111,7 @@
   all: unset;
 }
 
-.ol-viewport * {
+.ol-viewport {
   touch-action: none;
 }
 

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -111,6 +111,10 @@
   all: unset;
 }
 
+.ol-viewport * {
+  touch-action: none;
+}
+
 .ol-selectable {
   -webkit-touch-callout: default;
   -webkit-user-select: text;


### PR DESCRIPTION
Fixes #13495
Fixes #14893

Prevents touch actions on elements within the viewport scaling the page (but not actions on the viewport itself if interactions are disabled as in #13545).
