### PR TITLE
Avoid line dash flicker in Measure examples

### DIFF
--- a/examples/measure-style.js
+++ b/examples/measure-style.js
@@ -161,11 +161,12 @@ const modify = new Modify({source: source, style: modifyStyle});
 let tipPoint;
 
 function styleFunction(feature, segments, drawType, tip) {
-  const styles = [style];
+  const styles = [];
   const geometry = feature.getGeometry();
   const type = geometry.getType();
   let point, label, line;
-  if (!drawType || drawType === type) {
+  if (!drawType || drawType === type || type === 'Point') {
+    styles.push(style);
     if (type === 'Polygon') {
       point = geometry.getInteriorPoint();
       label = formatArea(geometry);

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -145,30 +145,37 @@ const formatArea = function (polygon) {
   return output;
 };
 
+const style = new Style({
+  fill: new Fill({
+    color: 'rgba(255, 255, 255, 0.2)',
+  }),
+  stroke: new Stroke({
+    color: 'rgba(0, 0, 0, 0.5)',
+    lineDash: [10, 10],
+    width: 2,
+  }),
+  image: new CircleStyle({
+    radius: 5,
+    stroke: new Stroke({
+      color: 'rgba(0, 0, 0, 0.7)',
+    }),
+    fill: new Fill({
+      color: 'rgba(255, 255, 255, 0.2)',
+    }),
+  }),
+});
+
 function addInteraction() {
   const type = typeSelect.value == 'area' ? 'Polygon' : 'LineString';
   draw = new Draw({
     source: source,
     type: type,
-    style: new Style({
-      fill: new Fill({
-        color: 'rgba(255, 255, 255, 0.2)',
-      }),
-      stroke: new Stroke({
-        color: 'rgba(0, 0, 0, 0.5)',
-        lineDash: [10, 10],
-        width: 2,
-      }),
-      image: new CircleStyle({
-        radius: 5,
-        stroke: new Stroke({
-          color: 'rgba(0, 0, 0, 0.7)',
-        }),
-        fill: new Fill({
-          color: 'rgba(255, 255, 255, 0.2)',
-        }),
-      }),
-    }),
+    style: function (feature) {
+      const geometryType = feature.getGeometry().getType();
+      if (geometryType === type || geometryType === 'Point') {
+        return style;
+      }
+    },
   });
   map.addInteraction(draw);
 


### PR DESCRIPTION
When a polygon is drawn clockwise the outline stroke line dash matches the offset of the sketch line stroke line dash, but if drawn counter clockwise the offsets to not match and cause a flickering effect when drawing.  This can be avoided as when drawing a polygon for measurement the sketch line does not need to be styled.
