### PR TITLE
Call requestAnimationFrame in the appropriate place

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -794,13 +794,10 @@ class RasterSource extends ImageSource {
 
     if (
       !this.renderedImageCanvas_ ||
-      this.getRevision() !== this.renderedRevision_
+      this.getRevision() !== this.renderedRevision_ ||
+      frameState.animate
     ) {
       this.changed();
-    }
-
-    if (frameState.animate) {
-      requestAnimationFrame(this.changed.bind(this));
     }
 
     return canvas;
@@ -825,7 +822,7 @@ class RasterSource extends ImageSource {
       if (imageData) {
         imageDatas[i] = imageData;
       } else {
-        return resolve;
+        return new Promise((resolve) => requestAnimationFrame(() => resolve));
       }
     }
 


### PR DESCRIPTION
This is a follow-up on #14856, and fixes one remaining issue with the raster source's workflow of handling the response from the worker.