### PR TITLE
Fix infinite tile rendering loop and incomplete images in Raster source

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -601,7 +601,7 @@ class RasterSource extends ImageSource {
      */
     this.tileQueue_ = new TileQueue(function () {
       return 1;
-    }, this.changed.bind(this));
+    }, this.processSources_.bind(this));
 
     /**
      * The most recently requested frame state.


### PR DESCRIPTION
This pull request fixes an infinite rendering loop that was introduced with #14856, by reverting the changes from that pull request. I did an in-depth investigation of the problem with incomplete images when tiled sources are used for a Raster source, and I found a way to fix it: by calling `processSources_()` instead of `changed()` in the tile queue's loaded callback.