### PR TITLE
Add typedef, use underscore for private methods

### DIFF
--- a/src/ol/interaction/DblClickDragZoom.js
+++ b/src/ol/interaction/DblClickDragZoom.js
@@ -59,6 +59,12 @@ class DblClickDragZoom extends Interaction {
     this.handlingDoubleDownSequence_ = false;
 
     /**
+     * @type {?}
+     * @private
+     */
+    this.doubleTapTimeoutId_ = undefined;
+
+    /**
      * @type {!Object<string, PointerEvent>}
      * @private
      */
@@ -104,7 +110,7 @@ class DblClickDragZoom extends Interaction {
           stopEvent = this.stopDown(handled);
         } else {
           stopEvent = this.stopDown(false);
-          this.waitForDblTap();
+          this.waitForDblTap_();
         }
       }
     }
@@ -210,8 +216,9 @@ class DblClickDragZoom extends Interaction {
 
   /**
    * Wait the second double finger tap.
+   * @private
    */
-  waitForDblTap() {
+  waitForDblTap_() {
     if (this.doubleTapTimeoutId_ !== undefined) {
       // double-click
       clearTimeout(this.doubleTapTimeoutId_);
@@ -219,7 +226,7 @@ class DblClickDragZoom extends Interaction {
     } else {
       this.handlingDoubleDownSequence_ = true;
       this.doubleTapTimeoutId_ = setTimeout(
-        this.endInteraction.bind(this),
+        this.endInteraction_.bind(this),
         250
       );
     }
@@ -228,7 +235,7 @@ class DblClickDragZoom extends Interaction {
   /**
    * @private
    */
-  endInteraction() {
+  endInteraction_() {
     this.handlingDoubleDownSequence_ = false;
     this.doubleTapTimeoutId_ = undefined;
   }

--- a/src/ol/interaction/DblClickDragZoom.js
+++ b/src/ol/interaction/DblClickDragZoom.js
@@ -59,7 +59,7 @@ class DblClickDragZoom extends Interaction {
     this.handlingDoubleDownSequence_ = false;
 
     /**
-     * @type {?}
+     * @type {ReturnType<typeof setTimeout>}
      * @private
      */
     this.doubleTapTimeoutId_ = undefined;


### PR DESCRIPTION
It seems wrong that a property does not have a typedef and that private methods do not use underscore.  I am not familiar with Angular but I suspected the former is causing the issue in https://stackoverflow.com/q/76728961/10118270  As in `ol/interaction/MouseWheelZoom` a timeout id is declared as `{?}`.