### PR TITLE
WebGL helper improvements

### DIFF
--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -123,6 +123,10 @@ describe('VectorStyleRenderer', () => {
       }),
     ]);
   });
+  afterEach(() => {
+    helper.dispose();
+  });
+
   describe('constructor using style', () => {
     beforeEach(() => {
       vectorStyleRenderer = new VectorStyleRenderer(SAMPLE_STYLE, helper);

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -168,6 +168,7 @@ describe('ol/renderer/webgl/VectorLayer', function () {
       renderer.afterHelperCreated(frameState);
     });
     afterEach(() => {
+      renderer.helper.dispose();
       spy.restore();
     });
 

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -145,6 +145,7 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
       renderer.afterHelperCreated(frameState);
     });
     afterEach(() => {
+      renderer.helper.dispose();
       spy.restore();
     });
 


### PR DESCRIPTION
I think because getting the appropriate WebGL context from a canvas implies a little overhead, it is better to store the context instead of the canvas, like we also do for 2d contexts.

I also added missing `dispose()` calls on the helper in the WebGL tests.