### PR TITLE
More WebGL TileHelper cleanup

### DIFF
--- a/test/browser/spec/ol/webgl/TileGeometry.test.js
+++ b/test/browser/spec/ol/webgl/TileGeometry.test.js
@@ -45,6 +45,9 @@ describe('ol/webgl/TileGeometry', function () {
       styleRenderers
     );
   });
+  this.afterEach(() => {
+    helper.dispose();
+  });
 
   describe('tile provided initially', () => {
     it('assigns the given tile', () => {


### PR DESCRIPTION
This adds another `afterEach()` hook to clean up WebGL helpers, which I had missed in #14929.