### PR TITLE
Update TileJSON source url

### DIFF
--- a/examples/custom-interactions.html
+++ b/examples/custom-interactions.html
@@ -6,8 +6,5 @@ docs: >
   This example demonstrates creating a custom interaction by subclassing `ol/interaction/Pointer`.
   Note that the built in interaction `ol/interaction/Translate` might be a better option for moving features.
 tags: "drag, feature, vector, editing, custom, interaction"
-cloak:
-  - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ
-    value: Your Mapbox access token from https://mapbox.com/ here
 ---
 <div id="map" class="map"></div>

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -129,17 +129,13 @@ const polygonFeature = new Feature(
   ])
 );
 
-const key =
-  'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ';
-
 const map = new Map({
   interactions: defaultInteractions().extend([new Drag()]),
   layers: [
     new TileLayer({
       source: new TileJSON({
-        url:
-          'https://a.tiles.mapbox.com/v4/aj.1x1-degrees.json?secure&access_token=' +
-          key,
+        url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+        crossOrigin: '',
       }),
     }),
     new VectorLayer({

--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -2,11 +2,11 @@ import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {LineString, Point, Polygon} from '../src/ol/geom.js';
+import {OGCMapTile, Vector as VectorSource} from '../src/ol/source.js';
 import {
   Pointer as PointerInteraction,
   defaults as defaultInteractions,
 } from '../src/ol/interaction.js';
-import {TileJSON, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 class Drag extends PointerInteraction {
@@ -133,8 +133,8 @@ const map = new Map({
   interactions: defaultInteractions().extend([new Drag()]),
   layers: [
     new TileLayer({
-      source: new TileJSON({
-        url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+      source: new OGCMapTile({
+        url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad',
         crossOrigin: '',
       }),
     }),

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -1,10 +1,9 @@
 import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Icon, Style} from '../src/ol/style.js';
+import {OGCMapTile, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {fromLonLat} from '../src/ol/proj.js';
 
@@ -84,8 +83,8 @@ const vectorLayer = new VectorLayer({
 });
 
 const rasterLayer = new TileLayer({
-  source: new TileJSON({
-    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+  source: new OGCMapTile({
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad',
     crossOrigin: '',
   }),
 });

--- a/examples/icon-color.js
+++ b/examples/icon-color.js
@@ -85,7 +85,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
     crossOrigin: '',
   }),
 });

--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -54,7 +54,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
     crossOrigin: '',
   }),
 });

--- a/examples/icon-scale.js
+++ b/examples/icon-scale.js
@@ -1,10 +1,9 @@
 import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Circle, Fill, Icon, Stroke, Style, Text} from '../src/ol/style.js';
+import {OGCMapTile, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const iconFeature = new Feature({
@@ -53,8 +52,8 @@ const vectorLayer = new VectorLayer({
 });
 
 const rasterLayer = new TileLayer({
-  source: new TileJSON({
-    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+  source: new OGCMapTile({
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad',
     crossOrigin: '',
   }),
 });

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -36,7 +36,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
     crossOrigin: '',
   }),
 });

--- a/examples/icon.js
+++ b/examples/icon.js
@@ -2,10 +2,9 @@ import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Overlay from '../src/ol/Overlay.js';
 import Point from '../src/ol/geom/Point.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Icon, Style} from '../src/ol/style.js';
+import {OGCMapTile, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const iconFeature = new Feature({
@@ -35,8 +34,8 @@ const vectorLayer = new VectorLayer({
 });
 
 const rasterLayer = new TileLayer({
-  source: new TileJSON({
-    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+  source: new OGCMapTile({
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad',
     crossOrigin: '',
   }),
 });

--- a/examples/modify-icon.js
+++ b/examples/modify-icon.js
@@ -1,11 +1,10 @@
 import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
-import TileJSON from '../src/ol/source/TileJSON.js';
-import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Icon, Style} from '../src/ol/style.js';
 import {Modify} from '../src/ol/interaction.js';
+import {OGCMapTile, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const iconFeature = new Feature({
@@ -35,8 +34,8 @@ const vectorLayer = new VectorLayer({
 });
 
 const rasterLayer = new TileLayer({
-  source: new TileJSON({
-    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
+  source: new OGCMapTile({
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad',
     crossOrigin: '',
   }),
 });

--- a/examples/modify-icon.js
+++ b/examples/modify-icon.js
@@ -36,7 +36,7 @@ const vectorLayer = new VectorLayer({
 
 const rasterLayer = new TileLayer({
   source: new TileJSON({
-    url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+    url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
     crossOrigin: '',
   }),
 });

--- a/examples/tilejson.js
+++ b/examples/tilejson.js
@@ -7,7 +7,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new TileJSON({
-        url: 'https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json?secure=1',
+        url: 'https://maps.gnosis.earth/ogcapi/collections/NaturalEarth:raster:HYP_HR_SR_OB_DR/map/tiles/WebMercatorQuad?f=tilejson',
         crossOrigin: 'anonymous',
       }),
     }),

--- a/src/ol/source.js
+++ b/src/ol/source.js
@@ -17,6 +17,8 @@ export {default as ImageCanvas} from './source/ImageCanvas.js';
 export {default as ImageMapGuide} from './source/ImageMapGuide.js';
 export {default as ImageStatic} from './source/ImageStatic.js';
 export {default as ImageWMS} from './source/ImageWMS.js';
+export {default as OGCMapTile} from './source/OGCMapTile.js';
+export {default as OGCVectorTile} from './source/OGCVectorTile.js';
 export {default as OSM} from './source/OSM.js';
 export {default as Raster} from './source/Raster.js';
 export {default as Source} from './source/Source.js';


### PR DESCRIPTION
`https://a.tiles.mapbox.com/v3/aj.1x1-degrees.json` used in several examples is no longer working and the alternative v4 version needs an API key which is inconvenient in CodeSandbox when it is only needed to provide a background context to what the example is demonstrating.  An alternative to is directly reference the TileJSON endpoint of an OGC Web Mercator raster source which does not require an API key.