### PR TITLE
Apply dashed line hit detection to all geometry types

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -6,6 +6,10 @@
 
 The `start` and `end` behavior previously was equivalent to `right` and `left`. Now it takes the text direction into account, so it will mean `left` and `right` for left-to-right text.
 
+#### Consistent hit detection of dashed lines
+
+MultiLineString stroke, and Polygon, MultiPolygon and Circle geometry outlines are now hit detected along their entire length by `ol/Map` methods (`forEachFeatureAtPixel`, `getFeaturesAtPixel`, `hasFeatureAtPixel`) even if the line is dashed.  This is consistent with LineString stroke and the `getFeatures` methods of `ol/layer/Vector` and `ol/layer/VectorTile`.
+
 ### 7.2.0
 
 #### Rendered resolutions of `ol/source/Raster`

--- a/src/ol/render/canvas/LineStringBuilder.js
+++ b/src/ol/render/canvas/LineStringBuilder.js
@@ -106,8 +106,8 @@ class CanvasLineStringBuilder extends CanvasBuilder {
         state.lineCap,
         state.lineJoin,
         state.miterLimit,
-        state.lineDash,
-        state.lineDashOffset,
+        defaultLineDash,
+        defaultLineDashOffset,
       ],
       beginPathInstruction
     );

--- a/src/ol/render/canvas/PolygonBuilder.js
+++ b/src/ol/render/canvas/PolygonBuilder.js
@@ -8,7 +8,11 @@ import CanvasInstruction, {
   fillInstruction,
   strokeInstruction,
 } from './Instruction.js';
-import {defaultFillStyle} from '../canvas.js';
+import {
+  defaultFillStyle,
+  defaultLineDash,
+  defaultLineDashOffset,
+} from '../canvas.js';
 import {snap} from '../../geom/flat/simplify.js';
 
 class CanvasPolygonBuilder extends CanvasBuilder {
@@ -101,8 +105,8 @@ class CanvasPolygonBuilder extends CanvasBuilder {
         state.lineCap,
         state.lineJoin,
         state.miterLimit,
-        state.lineDash,
-        state.lineDashOffset,
+        defaultLineDash,
+        defaultLineDashOffset,
       ]);
     }
     const flatCoordinates = circleGeometry.getFlatCoordinates();
@@ -157,8 +161,8 @@ class CanvasPolygonBuilder extends CanvasBuilder {
         state.lineCap,
         state.lineJoin,
         state.miterLimit,
-        state.lineDash,
-        state.lineDashOffset,
+        defaultLineDash,
+        defaultLineDashOffset,
       ]);
     }
     const ends = polygonGeometry.getEnds();
@@ -200,8 +204,8 @@ class CanvasPolygonBuilder extends CanvasBuilder {
         state.lineCap,
         state.lineJoin,
         state.miterLimit,
-        state.lineDash,
-        state.lineDashOffset,
+        defaultLineDash,
+        defaultLineDashOffset,
       ]);
     }
     const endss = multiPolygonGeometry.getEndss();

--- a/test/browser/spec/ol/renderer/map.test.js
+++ b/test/browser/spec/ol/renderer/map.test.js
@@ -7,10 +7,14 @@ import VectorSource from '../../../../../src/ol/source/Vector.js';
 import View from '../../../../../src/ol/View.js';
 import {Circle, Fill, Stroke, Style} from '../../../../../src/ol/style.js';
 import {
+  Circle as CircleGeometry,
   GeometryCollection,
   LineString,
+  MultiLineString,
   MultiPoint,
+  MultiPolygon,
   Point,
+  Polygon,
 } from '../../../../../src/ol/geom.js';
 import {Projection} from '../../../../../src/ol/proj.js';
 import {fromExtent} from '../../../../../src/ol/geom/Polygon.js';
@@ -92,11 +96,9 @@ describe('ol.renderer.Map', function () {
     });
 
     it('hits lines even if they are dashed', function () {
-      const geometry = new LineString([
-        [-1e6, 0],
-        [1e6, 0],
-      ]);
-      const feature = new Feature(geometry);
+      map.getView().setResolution(1);
+      let geometry, hit;
+      const feature = new Feature();
       const layer = new VectorLayer({
         source: new VectorSource({
           features: [feature],
@@ -110,16 +112,93 @@ describe('ol.renderer.Map', function () {
         }),
       });
       map.addLayer(layer);
-      map.renderSync();
-      const hit = map.forEachFeatureAtPixel(
-        [50, 50],
-        (feature, layer, geometry) => ({
-          feature,
-          layer,
-          geometry,
-        })
-      );
 
+      geometry = new LineString([
+        [-20, 0],
+        [20, 0],
+      ]);
+      feature.setGeometry(geometry);
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      geometry = new MultiLineString([
+        [
+          [-20, 0],
+          [20, 0],
+        ],
+      ]);
+      feature.setGeometry(geometry);
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      geometry = new Polygon([
+        [
+          [-20, 0],
+          [20, 0],
+          [20, -20],
+          [-20, -20],
+          [-20, 0],
+        ],
+      ]);
+      feature.setGeometry(geometry);
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      geometry = new MultiPolygon([
+        [
+          [
+            [-20, 0],
+            [20, 0],
+            [20, -20],
+            [-20, -20],
+            [-20, 0],
+          ],
+        ],
+      ]);
+      feature.setGeometry(geometry);
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      geometry = new CircleGeometry([0, -40 / Math.PI], 40 / Math.PI);
+      feature.setGeometry(geometry);
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
       expect(hit).to.be.ok();
       expect(hit.feature).to.be(feature);
       expect(hit.layer).to.be(layer);


### PR DESCRIPTION
Fixes #14936

Previously only LineString geometry was hit detected between dashes. A MultiLineString with similar coordinates would not (although using the previous test for LineString would have not have noticed that as it was hitting the rounded end of a dash).

This applies the same logic to LineString and MultiLineString, plus Polygon, MutiPolygon and Circle geometry outlines, and sets the test resolution and geometry coordinates to match the dash intervals to ensure a meaningful test with hits midway between dashes.

Vector layer hit detection already had this behaviour, so map and vector layer hit detection will now be consistent.
