### PR TITLE
Hit detect transparent fill and backgroundFill in Text styles

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next version
 
+#### Hit detection with Text fill
+
+Hit detection of fill for Text styles is now consistent with that for Circle and RegularShape styles. Transparent `fill` and `backgroundFill` is detected, with no hit detection over unfilled shapes. To get the previous behavior in Text styles where a transparent fill may have been used to avoid the default fill specify `fill: null`. If using FlatStyle notation specify `'text-fill-color': null`.
+
 #### Fixed `textAlign` with `placement: 'line'`
 
 The `start` and `end` behavior previously was equivalent to `right` and `left`. Now it takes the text direction into account, so it will mean `left` and `right` for left-to-right text.

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -93,7 +93,7 @@ export const defaultFont = '10px sans-serif';
 
 /**
  * @const
- * @type {import("../colorlike.js").ColorLike}
+ * @type {string}
  */
 export const defaultFillStyle = '#000';
 

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -337,7 +337,6 @@ class CanvasTextBuilder extends CanvasBuilder {
         );
         if (textState.backgroundFill) {
           this.updateFillStyle(this.state, this.createFill);
-          this.hitDetectionInstructions.push(this.createFill(this.state));
         }
         if (textState.backgroundStroke) {
           this.updateStrokeStyle(this.state, this.applyStroke);
@@ -405,6 +404,12 @@ class CanvasTextBuilder extends CanvasBuilder {
         geometryWidths,
       ]);
       const scale = 1 / pixelRatio;
+      // Set default fill for hit detection background
+      const currentFillStyle = this.state.fillStyle;
+      if (textState.backgroundFill) {
+        this.state.fillStyle = defaultFillStyle;
+        this.hitDetectionInstructions.push(this.createFill(this.state));
+      }
       this.hitDetectionInstructions.push([
         CanvasInstruction.DRAW_IMAGE,
         begin,
@@ -433,6 +438,11 @@ class CanvasTextBuilder extends CanvasBuilder {
         this.textOffsetY_,
         geometryWidths,
       ]);
+      // Reset previous fill
+      if (textState.backgroundFill) {
+        this.state.fillStyle = currentFillStyle;
+        this.hitDetectionInstructions.push(this.createFill(this.state));
+      }
 
       this.endGeometry(feature);
     }

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -95,6 +95,7 @@ class CanvasTextBuilder extends CanvasBuilder {
      * @type {!Object<string, import("../canvas.js").FillState>}
      */
     this.fillStates = {};
+    this.fillStates[defaultFillStyle] = {fillStyle: defaultFillStyle};
 
     /**
      * @private
@@ -427,7 +428,7 @@ class CanvasTextBuilder extends CanvasBuilder {
         this.text_,
         this.textKey_,
         this.strokeKey_,
-        this.fillKey_,
+        this.fillKey_ ? defaultFillStyle : this.fillKey_,
         this.textOffsetX_,
         this.textOffsetY_,
         geometryWidths,
@@ -524,7 +525,7 @@ class CanvasTextBuilder extends CanvasBuilder {
       end,
       baseline,
       textState.overflow,
-      fillKey,
+      fillKey ? defaultFillStyle : fillKey,
       textState.maxAngle,
       1,
       offsetY,

--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -54,7 +54,7 @@ const DEFAULT_FILL_COLOR = '#333';
  * **Note:** `justify` is ignored for immediate rendering and also for `placement: 'line'`.
  * @property {CanvasTextBaseline} [textBaseline='middle'] Text base line. Possible values: `'bottom'`, `'top'`, `'middle'`, `'alphabetic'`,
  * `'hanging'`, `'ideographic'`.
- * @property {import("./Fill.js").default} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333).
+ * @property {import("./Fill.js").default|null} [fill] Fill style. If none is provided, we'll use a dark fill-style (#333). Specify `null` for no fill.
  * @property {import("./Stroke.js").default} [stroke] Stroke style.
  * @property {import("./Fill.js").default} [backgroundFill] Fill style for the text background when `placement` is
  * `'point'`. Default is no fill.

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -79,7 +79,7 @@ import Text from './Text.js';
  * `'hanging'`, `'ideographic'`.
  * @property {Array<number>} [text-padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
- * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-fill-color] The fill color.
+ * @property {import("../color.js").Color|import("../colorlike.js").ColorLike|null} [text-fill-color] The fill color. Specify `null` for no fill.
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-background-fill-color] The fill color.
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-stroke-color] The stroke color.
  * @property {CanvasLineCap} [text-stroke-line-cap='round'] Line cap style: `butt`, `round`, or `square`.
@@ -207,12 +207,12 @@ export function toStyle(flatStyle) {
 /**
  * @param {FlatStyle} flatStyle The flat style.
  * @param {string} prefix The property prefix.
- * @return {Fill|undefined} The fill (if any).
+ * @return {Fill|null|undefined} The fill (if any).
  */
 function getFill(flatStyle, prefix) {
   const color = flatStyle[prefix + 'fill-color'];
   if (!color) {
-    return;
+    return color;
   }
 
   return new Fill({color: color});

--- a/test/browser/spec/ol/renderer/map.test.js
+++ b/test/browser/spec/ol/renderer/map.test.js
@@ -205,6 +205,174 @@ describe('ol.renderer.Map', function () {
       expect(hit.geometry).to.be(geometry);
     });
 
+    it('hits Text stroke, transparent fill and background fill', function () {
+      let hit;
+      const geometry = new Point([0, 0]);
+      const feature = new Feature(geometry);
+      const layer = new VectorLayer({
+        source: new VectorSource({
+          features: [feature],
+        }),
+      });
+      map.addLayer(layer);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 20,
+        'text-stroke-color': 'black',
+        'text-fill-color': null,
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 1,
+        'text-stroke-color': 'black',
+        'text-fill-color': null,
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be(undefined);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 1,
+        'text-stroke-color': 'black',
+        'text-fill-color': 'transparent',
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 1,
+        'text-stroke-color': 'black',
+        'text-fill-color': null,
+        'text-background-fill-color': 'transparent',
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+    });
+
+    it('hits line placement Text stroke and transparent fill', function () {
+      let hit;
+      const geometry = new LineString([
+        [-1e6, 0],
+        [1e6, 0],
+      ]);
+      const feature = new Feature(geometry);
+      const layer = new VectorLayer({
+        source: new VectorSource({
+          features: [feature],
+        }),
+      });
+      map.addLayer(layer);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 20,
+        'text-stroke-color': 'black',
+        'text-fill-color': null,
+        'text-placement': 'line',
+        'text-overflow': true,
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 1,
+        'text-stroke-color': 'black',
+        'text-fill-color': null,
+        'text-placement': 'line',
+        'text-overflow': true,
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be(undefined);
+
+      layer.setStyle({
+        'text-value': 'X',
+        'text-font': 'bold 100px sans-serif',
+        'text-baseline': 'top',
+        'text-offset-y': -50,
+        'text-stroke-width': 1,
+        'text-stroke-color': 'black',
+        'text-fill-color': 'transparent',
+        'text-placement': 'line',
+        'text-overflow': true,
+      });
+      map.renderSync();
+      hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
+        feature,
+        layer,
+        geometry,
+      }));
+      expect(hit).to.be.ok();
+      expect(hit.feature).to.be(feature);
+      expect(hit.layer).to.be(layer);
+      expect(hit.geometry).to.be(geometry);
+    });
+
     it('prioritizes closer features when no direct hit is found', function () {
       map.getView().setResolution(1);
       map.addLayer(


### PR DESCRIPTION
Makes Text fill and backgroundFill hit detection consistent with RegularShape fill as discussed in https://github.com/openlayers/openlayers/issues/14924#issuecomment-1646569165