### PR TITLE
Don't overwrite browser zoom shortcuts

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -219,6 +219,21 @@ export const platformModifierKeyOnly = function (mapBrowserEvent) {
 };
 
 /**
+ * Return `true` if the platform-modifier-key (the meta-key on Mac,
+ * ctrl-key otherwise) is pressed.
+ *
+ * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+ * @return {boolean} True if the platform modifier key is pressed.
+ * @api
+ */
+export const platformModifierKey = function (mapBrowserEvent) {
+  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
+    mapBrowserEvent.originalEvent
+  );
+  return MAC ? originalEvent.metaKey : originalEvent.ctrlKey;
+};
+
+/**
  * Return `true` if only the shift-key is pressed, `false` otherwise (e.g. when
  * additionally the alt-key is pressed).
  *

--- a/src/ol/interaction/KeyboardZoom.js
+++ b/src/ol/interaction/KeyboardZoom.js
@@ -3,15 +3,17 @@
  */
 import EventType from '../events/EventType.js';
 import Interaction, {zoomByDelta} from './Interaction.js';
-import {targetNotEditable} from '../events/condition.js';
+import {platformModifierKey, targetNotEditable} from '../events/condition.js';
 
 /**
  * @typedef {Object} Options
  * @property {number} [duration=100] Animation duration in milliseconds.
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes an {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
- * boolean to indicate whether that event should be handled. Default is
- * {@link module:ol/events/condition.targetNotEditable}.
+ * boolean to indicate whether that event should be handled. The default condition is
+ * that {@link module:ol/events/condition.targetNotEditable} is fulfilled and that
+ * the platform modifier key isn't pressed
+ * (!{@link module:ol/events/condition.platformModifierKey}).
  * @property {number} [delta=1] The zoom level delta on each key press.
  */
 
@@ -41,7 +43,14 @@ class KeyboardZoom extends Interaction {
      * @private
      * @type {import("../events/condition.js").Condition}
      */
-    this.condition_ = options.condition ? options.condition : targetNotEditable;
+    this.condition_ = options.condition
+      ? options.condition
+      : function (mapBrowserEvent) {
+          return (
+            !platformModifierKey(mapBrowserEvent) &&
+            targetNotEditable(mapBrowserEvent)
+          );
+        };
 
     /**
      * @private

--- a/test/browser/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/browser/spec/ol/interaction/keyboardzoom.test.js
@@ -57,5 +57,20 @@ describe('ol.interaction.KeyboardZoom', function () {
       map.handleMapBrowserEvent(event);
       expect(spy.called).to.be(false);
     });
+
+    it('does nothing if ctrl key is pressed at the same time', function () {
+      const view = map.getView();
+      const spy = sinon.spy(view, 'animateInternal');
+      const event = new MapBrowserEvent('keydown', map, {
+        type: 'keydown',
+        target: map.getTargetElement(),
+        preventDefault: Event.prototype.preventDefault,
+      });
+
+      event.originalEvent.key = '+';
+      event.originalEvent.ctrlKey = true;
+      map.handleMapBrowserEvent(event);
+      expect(spy.called).to.be(false);
+    });
   });
 });


### PR DESCRIPTION
Some browsers enable the user to set the zoomlevel of the website using `Ctrl` and `+` or `-`. The default version of `KeyboardZoom` catches these keydown events and adjusts the map zoomlevel. There might be a situation where a user wants to increase or decrease the size of e.g. the controls as well. They are not able to do this via shortcuts because they are handled by OpenLayers. To get around this, I suggest that the default `KeyboardZoom` should only adjust the zoom level if `+` or `-` was pressed without `Ctrl` being pressed at the same time. This way, the event is raised to the browser if `Ctrl` was pressed, too.
