### PR TITLE
fix Style RenderFunction type

### DIFF
--- a/src/ol/style/Style.js
+++ b/src/ol/style/Style.js
@@ -36,7 +36,7 @@ import {assert} from '../asserts.js';
  * 1. The pixel coordinates of the geometry in GeoJSON notation.
  * 2. The {@link module:ol/render~State} of the layer renderer.
  *
- * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>),import("../render.js").State): void} RenderFunction
+ * @typedef {function((import("../coordinate.js").Coordinate|Array<import("../coordinate.js").Coordinate>|Array<Array<import("../coordinate.js").Coordinate>>|Array<Array<Array<import("../coordinate.js").Coordinate>>>),import("../render.js").State): void} RenderFunction
  */
 
 /**


### PR DESCRIPTION
When rendering a `MultiPolygon`, it should be a coordinate data structure of a three-level nested array