### PR TITLE
Cannot create polygon from empty extent

### DIFF
--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -5,7 +5,7 @@ import LinearRing from './LinearRing.js';
 import Point from './Point.js';
 import SimpleGeometry from './SimpleGeometry.js';
 import {arrayMaxSquaredDelta, assignClosestArrayPoint} from './flat/closest.js';
-import {closestSquaredDistanceXY, getCenter} from '../extent.js';
+import {closestSquaredDistanceXY, getCenter, isEmpty} from '../extent.js';
 import {deflateCoordinatesArray} from './flat/deflate.js';
 import {extend} from '../array.js';
 import {getInteriorPointOfArray} from './flat/interiorpoint.js';
@@ -438,6 +438,9 @@ export function circular(center, radius, n, sphereRadius) {
  * @api
  */
 export function fromExtent(extent) {
+  if (isEmpty(extent)) {
+    throw new Error('Cannot create polygon from empty extent');
+  }
   const minX = extent[0];
   const minY = extent[1];
   const maxX = extent[2];

--- a/test/node/ol/geom/Polygon.test.js
+++ b/test/node/ol/geom/Polygon.test.js
@@ -5,7 +5,11 @@ import Polygon, {
   fromExtent,
 } from '../../../../src/ol/geom/Polygon.js';
 import expect from '../../expect.js';
-import {boundingExtent, isEmpty} from '../../../../src/ol/extent.js';
+import {
+  boundingExtent,
+  createEmpty,
+  isEmpty,
+} from '../../../../src/ol/extent.js';
 
 describe('ol/geom/Polygon.js', function () {
   it('cannot be constructed with a null geometry', function () {
@@ -692,6 +696,12 @@ describe('ol/geom/Polygon.js', function () {
       expect(flatCoordinates).to.eql([1, 2, 1, 5, 3, 5, 3, 2, 1, 2]);
       const orientedFlatCoordinates = polygon.getOrientedFlatCoordinates();
       expect(orientedFlatCoordinates).to.eql([1, 2, 1, 5, 3, 5, 3, 2, 1, 2]);
+    });
+
+    it('throws on empty extent', function () {
+      expect(function () {
+        fromExtent(createEmpty());
+      }).to.throwException();
     });
   });
 


### PR DESCRIPTION
Fixes #14961

Assert that the extent supplied to `ol/geom/Polygon#fromExtent` is not empty.


