### PR TITLE
Fix test for keyboard zoom on a Mac

### DIFF
--- a/test/browser/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/browser/spec/ol/interaction/keyboardzoom.test.js
@@ -2,6 +2,7 @@ import Event from '../../../../../src/ol/events/Event.js';
 import Map from '../../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../../src/ol/View.js';
+import {MAC} from '../../../../../src/ol/has.js';
 
 describe('ol.interaction.KeyboardZoom', function () {
   let map;
@@ -58,7 +59,7 @@ describe('ol.interaction.KeyboardZoom', function () {
       expect(spy.called).to.be(false);
     });
 
-    it('does nothing if ctrl key is pressed at the same time', function () {
+    it('does nothing if platform modifier key is pressed at the same time', function () {
       const view = map.getView();
       const spy = sinon.spy(view, 'animateInternal');
       const event = new MapBrowserEvent('keydown', map, {
@@ -68,7 +69,11 @@ describe('ol.interaction.KeyboardZoom', function () {
       });
 
       event.originalEvent.key = '+';
-      event.originalEvent.ctrlKey = true;
+      if (MAC) {
+        event.originalEvent.metaKey = true;
+      } else {
+        event.originalEvent.ctrlKey = true;
+      }
       map.handleMapBrowserEvent(event);
       expect(spy.called).to.be(false);
     });


### PR DESCRIPTION
The test always failed because the `Ctrl` key isn't considered on a Mac.