### PR TITLE
WebGLTile: Properly render semi-transparent tiles

### DIFF
--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -50,6 +50,17 @@ export function ascending(a, b) {
 }
 
 /**
+ * Compare function sorting arrays in descending order.  Safe to use for numeric values.
+ * @param {*} a The first object to be compared.
+ * @param {*} b The second object to be compared.
+ * @return {number} A negative number, zero, or a positive number as the first
+ *     argument is greater than, equal to, or less than the second.
+ */
+export function descending(a, b) {
+  return a < b ? 1 : a > b ? -1 : 0;
+}
+
+/**
  * {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution} can use a function
  * of this type to determine which nearest resolution to use.
  *

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -274,10 +274,6 @@ function parseStyle(style, bandCount) {
 
       ${pipeline.join('\n')}
 
-      if (color.a == 0.0) {
-        discard;
-      }
-
       gl_FragColor = color;
       gl_FragColor.rgb *= gl_FragColor.a;
       gl_FragColor *= ${Uniforms.TRANSITION_ALPHA};

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -551,8 +551,9 @@ class WebGLHelper extends Disposable {
    * subsequent draw calls.
    * @param {import("../Map.js").FrameState} frameState current frame state
    * @param {boolean} [disableAlphaBlend] If true, no alpha blending will happen.
+   * @param {boolean} [enableDepth] If true, enables depth testing.
    */
-  prepareDraw(frameState, disableAlphaBlend) {
+  prepareDraw(frameState, disableAlphaBlend, enableDepth) {
     const gl = this.gl_;
     const canvas = this.getCanvas();
     const size = frameState.size;
@@ -576,10 +577,18 @@ class WebGLHelper extends Disposable {
     gl.bindTexture(gl.TEXTURE_2D, null);
 
     gl.clearColor(0.0, 0.0, 0.0, 0.0);
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.depthRange(0.0, 1.0);
+    gl.clearDepth(1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, disableAlphaBlend ? gl.ZERO : gl.ONE_MINUS_SRC_ALPHA);
+    if (enableDepth) {
+      gl.enable(gl.DEPTH_TEST);
+      gl.depthFunc(gl.LESS);
+    } else {
+      gl.disable(gl.DEPTH_TEST);
+    }
   }
 
   /**
@@ -602,18 +611,33 @@ class WebGLHelper extends Disposable {
    * @param {import("../Map.js").FrameState} frameState current frame state
    * @param {import("./RenderTarget.js").default} renderTarget Render target to draw to
    * @param {boolean} [disableAlphaBlend] If true, no alpha blending will happen.
+   * @param {boolean} [enableDepth] If true, enables depth testing.
    */
-  prepareDrawToRenderTarget(frameState, renderTarget, disableAlphaBlend) {
+  prepareDrawToRenderTarget(
+    frameState,
+    renderTarget,
+    disableAlphaBlend,
+    enableDepth
+  ) {
     const gl = this.gl_;
     const size = renderTarget.getSize();
 
     gl.bindFramebuffer(gl.FRAMEBUFFER, renderTarget.getFramebuffer());
+    gl.bindRenderbuffer(gl.RENDERBUFFER, renderTarget.getDepthbuffer());
     gl.viewport(0, 0, size[0], size[1]);
     gl.bindTexture(gl.TEXTURE_2D, renderTarget.getTexture());
     gl.clearColor(0.0, 0.0, 0.0, 0.0);
-    gl.clear(gl.COLOR_BUFFER_BIT);
+    gl.depthRange(0.0, 1.0);
+    gl.clearDepth(1.0);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, disableAlphaBlend ? gl.ZERO : gl.ONE_MINUS_SRC_ALPHA);
+    if (enableDepth) {
+      gl.enable(gl.DEPTH_TEST);
+      gl.depthFunc(gl.LESS);
+    } else {
+      gl.disable(gl.DEPTH_TEST);
+    }
   }
 
   /**

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -585,7 +585,7 @@ class WebGLHelper extends Disposable {
     gl.blendFunc(gl.ONE, disableAlphaBlend ? gl.ZERO : gl.ONE_MINUS_SRC_ALPHA);
     if (enableDepth) {
       gl.enable(gl.DEPTH_TEST);
-      gl.depthFunc(gl.LESS);
+      gl.depthFunc(gl.LEQUAL);
     } else {
       gl.disable(gl.DEPTH_TEST);
     }
@@ -634,7 +634,7 @@ class WebGLHelper extends Disposable {
     gl.blendFunc(gl.ONE, disableAlphaBlend ? gl.ZERO : gl.ONE_MINUS_SRC_ALPHA);
     if (enableDepth) {
       gl.enable(gl.DEPTH_TEST);
-      gl.depthFunc(gl.LESS);
+      gl.depthFunc(gl.LEQUAL);
     } else {
       gl.disable(gl.DEPTH_TEST);
     }

--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -114,6 +114,7 @@ class WebGLPostProcessingPass {
     this.renderTargetTextureSize_ = null;
 
     this.frameBuffer_ = gl.createFramebuffer();
+    this.depthBuffer_ = gl.createRenderbuffer();
 
     // compile the program for the frame buffer
     // TODO: make compilation errors show up
@@ -201,6 +202,7 @@ class WebGLPostProcessingPass {
 
     // rendering goes to my buffer
     gl.bindFramebuffer(gl.FRAMEBUFFER, this.getFrameBuffer());
+    gl.bindRenderbuffer(gl.RENDERBUFFER, this.getDepthBuffer());
     gl.viewport(0, 0, textureSize[0], textureSize[1]);
 
     // if size has changed: adjust canvas & render target texture
@@ -243,6 +245,19 @@ class WebGLPostProcessingPass {
         this.renderTargetTexture_,
         0
       );
+
+      gl.renderbufferStorage(
+        gl.RENDERBUFFER,
+        gl.DEPTH_COMPONENT16,
+        textureSize[0],
+        textureSize[1]
+      );
+      gl.framebufferRenderbuffer(
+        gl.FRAMEBUFFER,
+        gl.DEPTH_ATTACHMENT,
+        gl.RENDERBUFFER,
+        this.depthBuffer_
+      );
     }
   }
 
@@ -273,7 +288,8 @@ class WebGLPostProcessingPass {
         const attributes = gl.getContextAttributes();
         if (attributes && attributes.preserveDrawingBuffer) {
           gl.clearColor(0.0, 0.0, 0.0, 0.0);
-          gl.clear(gl.COLOR_BUFFER_BIT);
+          gl.clearDepth(1.0);
+          gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
         }
 
         frameState.renderTargets[canvasId] = true;
@@ -319,6 +335,14 @@ class WebGLPostProcessingPass {
    */
   getFrameBuffer() {
     return this.frameBuffer_;
+  }
+
+  /**
+   * @return {WebGLRenderbuffer} Depth buffer
+   * @api
+   */
+  getDepthBuffer() {
+    return this.depthBuffer_;
   }
 
   /**

--- a/src/ol/webgl/PostProcessingPass.js
+++ b/src/ol/webgl/PostProcessingPass.js
@@ -296,6 +296,7 @@ class WebGLPostProcessingPass {
       }
     }
 
+    gl.disable(gl.DEPTH_TEST);
     gl.enable(gl.BLEND);
     gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);

--- a/src/ol/webgl/RenderTarget.js
+++ b/src/ol/webgl/RenderTarget.js
@@ -39,6 +39,12 @@ class WebGLRenderTarget {
     this.framebuffer_ = gl.createFramebuffer();
 
     /**
+     * @private
+     * @type {WebGLRenderbuffer}
+     */
+    this.depthbuffer_ = gl.createRenderbuffer();
+
+    /**
      * @type {Array<number>}
      * @private
      */
@@ -162,6 +168,13 @@ class WebGLRenderTarget {
   }
 
   /**
+   * @return {WebGLRenderbuffer} Depth buffer of the render target
+   */
+  getDepthbuffer() {
+    return this.depthbuffer_;
+  }
+
+  /**
    * @private
    */
   updateSize_() {
@@ -178,6 +191,20 @@ class WebGLRenderTarget {
       gl.TEXTURE_2D,
       this.texture_,
       0
+    );
+
+    gl.bindRenderbuffer(gl.RENDERBUFFER, this.depthbuffer_);
+    gl.renderbufferStorage(
+      gl.RENDERBUFFER,
+      gl.DEPTH_COMPONENT16,
+      size[0],
+      size[1]
+    );
+    gl.framebufferRenderbuffer(
+      gl.FRAMEBUFFER,
+      gl.DEPTH_ATTACHMENT,
+      gl.RENDERBUFFER,
+      this.depthbuffer_
     );
 
     this.data_ = new Uint8Array(size[0] * size[1] * 4);

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -335,9 +335,6 @@ describe('ol/layer/WebGLTile', function () {
         }
         vec4 color = texture2D(u_tileTextures[0], v_textureCoord);
         color = vec4(u_var_r / 255.0, u_var_g / 255.0, u_var_b / 255.0, 1.0);
-        if (color.a == 0.0) {
-          discard;
-        }
         gl_FragColor = color;
         gl_FragColor.rgb *= gl_FragColor.a;
         gl_FragColor *= u_transitionAlpha;
@@ -449,9 +446,6 @@ describe('ol/layer/WebGLTile', function () {
         }
         vec4 color = texture2D(u_tileTextures[0], v_textureCoord);
         color = vec4((getBandValue(4.0, 0.0, 0.0) / 3000.0), (getBandValue(1.0, 0.0, 0.0) / 3000.0), (getBandValue(2.0, 0.0, 0.0) / 3000.0), 1.0);
-        if (color.a == 0.0) {
-          discard;
-        }
         gl_FragColor = color;
         gl_FragColor.rgb *= gl_FragColor.a;
         gl_FragColor *= u_transitionAlpha;


### PR DESCRIPTION
When using the WebGL raster tile renderer with semi-transparent tiles (e.g. overlay layers), I noticed that the tiles aren't properly getting clipped by the other zoom layers, like happens on the canvas renderer: (Sample used: https://gist.github.com/puckipedia/a2a191a6684c5d9d238eed4f78133756)

<details>
<summary>Video of the situation before this PR</summary>

https://github.com/openlayers/openlayers/assets/488734/bfb2dc91-9d86-4619-a241-b0b02d6f0de6
</details>

Not only the layers involved in the fade, but also lower zoom levels, are visible, causing a bunch of visual noise that is not necessary.

This pull request solves that in a bit of a heavy-handed way: It adds proper depth testing to the WebGL helper, as well as the WebGL tile renderer:

<details>
<summary>Video of the situation after this PR</summary>

https://github.com/openlayers/openlayers/assets/488734/b628fb39-4da9-4e81-b2db-0b78e56243b0
</details>

As you can see, compared to the original situation, there's always at most two tiles being blended.

The PR first introduces the depth buffer to the `PostProcessingPass` and `RenderTarget`, as well as allowing enabling depth testing (with the default OpenGL settings) to the WebGL `Helper` . This tries to avoid any conflict with existing code using the helper, and as such is entirely opt-in. If depth isn't enabled, the depth renderbuffer will be entirely ignored.

463b5b59b7d4302be7ac113ff2989b7f2658552e then adjusts the renderer to render from the highest zoom level to the lowest, making use of the depth buffer to clip any lower zoom levels to only render where higher zoom level tiles haven't been rendered. Afterwards, it renders all the tiles with an alpha lower than 1, which allows them to blend with the existing tiles. This is necessary to preserve proper transparency behavior. 
