### PR TITLE
Reflect that Stamen styles are hosted by Stadia Maps 

### DIFF
--- a/examples/animated-gif.js
+++ b/examples/animated-gif.js
@@ -3,7 +3,7 @@ import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
 import View from '../src/ol/View.js';
 import {Icon, Style} from '../src/ol/style.js';
-import {Stamen, Vector as VectorSource} from '../src/ol/source.js';
+import {StadiaMaps, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 
 const iconFeature = new Feature({
@@ -19,8 +19,8 @@ const vectorLayer = new VectorLayer({
 });
 
 const rasterLayer = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/color-manipulation.js
+++ b/examples/color-manipulation.js
@@ -1,7 +1,7 @@
 import ImageLayer from '../src/ol/layer/Image.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import {Raster as RasterSource, Stamen} from '../src/ol/source.js';
+import {Raster as RasterSource, StadiaMaps} from '../src/ol/source.js';
 
 /**
  * Color manipulation functions below are adapted from
@@ -101,8 +101,8 @@ function xyz2rgb(x) {
 
 const raster = new RasterSource({
   sources: [
-    new Stamen({
-      layer: 'watercolor',
+    new StadiaMaps({
+      layer: 'stamen_watercolor',
     }),
   ],
   operation: function (pixels, data) {

--- a/examples/d3.js
+++ b/examples/d3.js
@@ -1,5 +1,5 @@
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import View from '../src/ol/View.js';
 import {Layer, Tile as TileLayer} from '../src/ol/layer.js';
 import {fromLonLat, toLonLat} from '../src/ol/proj.js';
@@ -72,8 +72,8 @@ class CanvasLayer extends Layer {
 const map = new Map({
   layers: [
     new TileLayer({
-      source: new Stamen({
-        layer: 'watercolor',
+      source: new StadiaMaps({
+        layer: 'stamen_watercolor',
       }),
     }),
   ],

--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -9,7 +9,7 @@ import {
   Style,
   Text,
 } from '../src/ol/style.js';
-import {Cluster, Stamen, Vector as VectorSource} from '../src/ol/source.js';
+import {Cluster, StadiaMaps, Vector as VectorSource} from '../src/ol/source.js';
 import {
   Select,
   defaults as defaultInteractions,
@@ -137,8 +137,8 @@ vector = new VectorLayer({
 });
 
 const raster = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -1,7 +1,7 @@
 import KML from '../src/ol/format/KML.js';
 import Map from '../src/ol/Map.js';
 import Polygon from '../src/ol/geom/Polygon.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Fill, Icon, Stroke, Style} from '../src/ol/style.js';
@@ -68,8 +68,8 @@ const vector = new VectorLayer({
 });
 
 const raster = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/filter-points-webgl.js
+++ b/examples/filter-points-webgl.js
@@ -1,7 +1,7 @@
 import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
 import WebGLPointsLayer from '../src/ol/layer/WebGLPoints.js';
@@ -107,8 +107,8 @@ client.send();
 const map = new Map({
   layers: [
     new TileLayer({
-      source: new Stamen({
-        layer: 'toner',
+      source: new StadiaMaps({
+        layer: 'stamen_toner',
       }),
     }),
     new WebGLPointsLayer({

--- a/examples/flight-animation.js
+++ b/examples/flight-animation.js
@@ -1,7 +1,7 @@
 import Feature from '../src/ol/Feature.js';
 import LineString from '../src/ol/geom/LineString.js';
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Stroke, Style} from '../src/ol/style.js';
@@ -10,8 +10,8 @@ import {getVectorContext} from '../src/ol/render.js';
 import {getWidth} from '../src/ol/extent.js';
 
 const tileLayer = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/heatmap-earthquakes.js
+++ b/examples/heatmap-earthquakes.js
@@ -1,6 +1,6 @@
 import KML from '../src/ol/format/KML.js';
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Heatmap as HeatmapLayer, Tile as TileLayer} from '../src/ol/layer.js';
@@ -28,8 +28,8 @@ const vector = new HeatmapLayer({
 });
 
 const raster = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/icon-negative.js
+++ b/examples/icon-negative.js
@@ -2,7 +2,7 @@ import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import Point from '../src/ol/geom/Point.js';
 import Select from '../src/ol/interaction/Select.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Icon, Style} from '../src/ol/style.js';
@@ -26,7 +26,7 @@ iconFeature.set('style', createStyle('data/icon.png', undefined));
 const map = new Map({
   layers: [
     new TileLayer({
-      source: new Stamen({layer: 'watercolor'}),
+      source: new StadiaMaps({layer: 'stamen_watercolor'}),
     }),
     new VectorLayer({
       style: function (feature) {

--- a/examples/immediate-geographic.js
+++ b/examples/immediate-geographic.js
@@ -1,4 +1,4 @@
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import {Circle, Fill, Style} from '../src/ol/style.js';
 import {Map, View} from '../src/ol/index.js';
@@ -10,8 +10,8 @@ import {useGeographic} from '../src/ol/proj.js';
 useGeographic();
 
 const layer = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/kml-earthquakes.js
+++ b/examples/kml-earthquakes.js
@@ -1,6 +1,6 @@
 import KML from '../src/ol/format/KML.js';
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Circle as CircleStyle, Fill, Stroke, Style} from '../src/ol/style.js';
@@ -44,8 +44,8 @@ const vector = new VectorLayer({
 });
 
 const raster = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/kml-timezones.js
+++ b/examples/kml-timezones.js
@@ -1,6 +1,6 @@
 import KML from '../src/ol/format/KML.js';
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import {Fill, Stroke, Style} from '../src/ol/style.js';
@@ -68,8 +68,8 @@ vector.getSource().on('featuresloadend', function (evt) {
 });
 
 const raster = new TileLayer({
-  source: new Stamen({
-    layer: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/layer-clipping-vector.js
+++ b/examples/layer-clipping-vector.js
@@ -2,16 +2,16 @@ import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {Fill, Style} from '../src/ol/style.js';
-import {OSM, Stamen, Vector as VectorSource} from '../src/ol/source.js';
+import {OSM, StadiaMaps, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer, Vector as VectorLayer} from '../src/ol/layer.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import {getVectorContext} from '../src/ol/render.js';
 
 //A distinct className is required to use another canvas for the background
 const background = new TileLayer({
-  className: 'stamen',
-  source: new Stamen({
-    layer: 'toner',
+  className: 'toner',
+  source: new StadiaMaps({
+    layer: 'stamen_toner',
   }),
 });
 

--- a/examples/stadia-maps.html
+++ b/examples/stadia-maps.html
@@ -1,0 +1,9 @@
+---
+layout: example.html
+title: Stadia Maps (Retina Tiles)
+shortdesc: Example of retina/HiDPI layers with a Stadia Maps tile source.
+docs: >
+  Example showing the Alidade Smooth Dark theme from Stadia Maps, using the retina (HiDPI) tiles.
+tags: "stadia-maps, retina, dark, hidpi"
+---
+<div id="map" class="map"></div>

--- a/examples/stadia-maps.js
+++ b/examples/stadia-maps.js
@@ -10,20 +10,15 @@ const map = new Map({
     // web deployments. See https://docs.stadiamaps.com/authentication/ for details.
     new TileLayer({
       source: new StadiaMaps({
-        layer: 'stamen_watercolor',
-        // apiKey: 'OPTIONAL'
-      }),
-    }),
-    new TileLayer({
-      source: new StadiaMaps({
-        layer: 'stamen_terrain_labels',
+        layer: 'alidade_smooth_dark',
+        retina: true,
         // apiKey: 'OPTIONAL'
       }),
     }),
   ],
   target: 'map',
   view: new View({
-    center: fromLonLat([-122.416667, 37.783333]),
-    zoom: 12,
+    center: fromLonLat([24.750645, 59.444351]),
+    zoom: 14,
   }),
 });

--- a/examples/stamen.html
+++ b/examples/stamen.html
@@ -1,9 +1,9 @@
 ---
 layout: example.html
-title: Stamen Tiles
-shortdesc: Example of a Stamen tile source.
+title: Stadia Maps (Stamen Tile Layer Composition)
+shortdesc: Example of composing layers with a Stadia Maps tile source.
 docs: >
-  Two layers are composed: the watercolor base layer with the terrain labels.
-tags: "stamen, watercolor, terrain-labels, two-layers"
+  Two layer groups are composed: the watercolor base layer with the terrain labels from Stamen.
+tags: "stamen, watercolor, terrain-labels, two-layers, stadia-maps"
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-time.js
+++ b/examples/wms-time.js
@@ -1,5 +1,5 @@
 import Map from '../src/ol/Map.js';
-import Stamen from '../src/ol/source/Stamen.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import TileWMS from '../src/ol/source/TileWMS.js';
 import View from '../src/ol/View.js';
@@ -17,8 +17,8 @@ let animationId = null;
 
 const layers = [
   new TileLayer({
-    source: new Stamen({
-      layer: 'terrain',
+    source: new StadiaMaps({
+      layer: 'stamen_terrain',
     }),
   }),
   new TileLayer({

--- a/site/src/index.hbs
+++ b/site/src/index.hbs
@@ -31,7 +31,7 @@ head:
     <div class='col-sm-6'>
       <h3>Tiled Layers</h3>
       <img src='/theme/img/tiled-layers.png' width="102" height="84" class='thumb' alt="tiled layers">
-      <p>Pull tiles from OSM, Bing, MapBox, Stamen, and any other XYZ source you can find.  OGC mapping services and untiled layers also supported.</p>
+      <p>Pull tiles from OSM, Bing, MapBox, Stadia Maps, and any other XYZ source you can find.  OGC mapping services and untiled layers also supported.</p>
     </div>
     <div class='col-sm-6'>
       <h3>Vector Layers</h3>

--- a/src/ol/source.js
+++ b/src/ol/source.js
@@ -22,7 +22,7 @@ export {default as OGCVectorTile} from './source/OGCVectorTile.js';
 export {default as OSM} from './source/OSM.js';
 export {default as Raster} from './source/Raster.js';
 export {default as Source} from './source/Source.js';
-export {default as Stamen} from './source/Stamen.js';
+export {default as StadiaMaps} from './source/StadiaMaps.js';
 export {default as Tile} from './source/Tile.js';
 export {default as TileArcGISRest} from './source/TileArcGISRest.js';
 export {default as TileDebug} from './source/TileDebug.js';

--- a/src/ol/source/StadiaMaps.js
+++ b/src/ol/source/StadiaMaps.js
@@ -1,5 +1,5 @@
 /**
- * @module ol/source/Stamen
+ * @module ol/source/StadiaMaps
  */
 
 import XYZ from './XYZ.js';
@@ -7,80 +7,102 @@ import {ATTRIBUTION as OSM_ATTRIBUTION} from './OSM.js';
 
 /**
  * @const
- * @type {Array<string>}
+ * @type string
  */
-const ATTRIBUTIONS = [
-  'Map tiles by <a href="https://stamen.com/" target="_blank">Stamen Design</a>, ' +
-    'under <a href="https://creativecommons.org/licenses/by/3.0/" target="_blank">CC BY' +
-    ' 3.0</a>.',
-  OSM_ATTRIBUTION,
-];
+const STADIA_ATTRIBUTION = '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>';
+
+/**
+ * @const
+ * @type string
+ */
+const OMT_ATTRIBUTION = '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>';
+
+/**
+ * @const
+ * @type string
+ */
+const STAMEN_ATTRIBUTION = '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>';
 
 /**
  * @type {Object<string, {extension: string, opaque: boolean}>}
  */
 const LayerConfig = {
-  'terrain': {
+  'stamen_terrain': {
     extension: 'png',
     opaque: true,
   },
-  'terrain-background': {
+  'stamen_terrain_background': {
     extension: 'png',
     opaque: true,
   },
-  'terrain-labels': {
+  'stamen_terrain_labels': {
     extension: 'png',
     opaque: false,
   },
-  'terrain-lines': {
+  'stamen_terrain_lines': {
     extension: 'png',
     opaque: false,
   },
-  'toner-background': {
+  'stamen_toner_background': {
     extension: 'png',
     opaque: true,
   },
-  'toner': {
+  'stamen_toner': {
     extension: 'png',
     opaque: true,
   },
-  'toner-hybrid': {
+  'stamen_toner_labels': {
     extension: 'png',
     opaque: false,
   },
-  'toner-labels': {
+  'stamen_toner_lines': {
     extension: 'png',
     opaque: false,
   },
-  'toner-lines': {
-    extension: 'png',
-    opaque: false,
-  },
-  'toner-lite': {
+  'stamen_toner_lite': {
     extension: 'png',
     opaque: true,
   },
-  'watercolor': {
+  'stamen_watercolor': {
     extension: 'jpg',
+    opaque: true,
+  },
+  'alidade_smooth': {
+    extension: 'png',
+    opaque: true,
+  },
+  'alidade_smooth_dark': {
+    extension: 'png',
+    opaque: true,
+  },
+  'stadia_outdoors': {
+    extension: 'png',
+    opaque: true,
+  },
+  'osm_bright': {
+    extension: 'png',
     opaque: true,
   },
 };
 
 /**
- * @type {Object<string, {minZoom: number, maxZoom: number}>}
+ * @type {Object<string, {minZoom: number, maxZoom: number, retina: boolean}>}
  */
 const ProviderConfig = {
-  'terrain': {
+  'stamen_terrain': {
     minZoom: 0,
     maxZoom: 18,
+    retina: true,
   },
-  'toner': {
+  'stamen_toner': {
     minZoom: 0,
     maxZoom: 20,
+    retina: true,
   },
-  'watercolor': {
-    minZoom: 0,
+  'stamen_watercolor': {
+    minZoom: 1,
     maxZoom: 18,
+    retina: false,
   },
 };
 
@@ -89,7 +111,7 @@ const ProviderConfig = {
  * @property {number} [cacheSize] Initial tile cache size. Will auto-grow to hold at least the number of tiles in the viewport.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
  * linear interpolation is used when resampling.  Set to false to use the nearest neighbor instead.
- * @property {string} layer Layer name.
+ * @property {string} layer Layer name. Valid values: `alidade_smooth`, `alidade_smooth_dark`, `stadia_outdoors`, `stamen_terrain`, `stamen_terrain_background`, `stamen_terrain_labels`, `stamen_terrain_lines`, `stamen_toner_background`, `stamen_toner`, `stamen_toner_labels`, `stamen_toner_lines`, `stamen_toner_lite`, `stamen_watercolor`, and `osm_bright`.
  * @property {number} [minZoom] Minimum zoom.
  * @property {number} [maxZoom] Maximum zoom.
  * @property {number} [reprojectionErrorThreshold=0.5] Maximum allowed reprojection error (in pixels).
@@ -108,50 +130,72 @@ const ProviderConfig = {
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
+ * @property {string} apiKey Stadia Maps API key. Not required for localhost or most public web deployments. See https://docs.stadiamaps.com/authentication/ for details.
+ * @property {boolean} retina Use retina tiles (if available; not available for Stamen Watercolor).
  */
 
 /**
  * @classdesc
- * Layer source for the Stamen tile server.
+ * Layer source for the Stadia Maps tile server.
  * @api
  */
-class Stamen extends XYZ {
+class StadiaMaps extends XYZ {
   /**
-   * @param {Options} options Stamen options.
+   * @param {Options} options StadiaMaps options.
    */
   constructor(options) {
     const i = options.layer.indexOf('-');
     const provider = i == -1 ? options.layer : options.layer.slice(0, i);
-    const providerConfig = ProviderConfig[provider];
+    const providerConfig = ProviderConfig[provider] || {
+      'minZoom': 0,
+      'maxZoom': 20,
+      'retina': true,
+    };
 
     const layerConfig = LayerConfig[options.layer];
+    const query = options.apiKey ? '?api_key=' + options.apiKey : '';
+    const retina = providerConfig.retina && options.retina ? '@2x' : '';
 
     const url =
       options.url !== undefined
         ? options.url
-        : 'https://stamen-tiles-{a-d}.a.ssl.fastly.net/' +
+        : 'https://tiles.stadiamaps.com/tiles/' +
           options.layer +
-          '/{z}/{x}/{y}.' +
-          layerConfig.extension;
+          '/{z}/{x}/{y}' +
+          retina +
+          '.' +
+          layerConfig.extension +
+          query;
+
+    const attributions = [STADIA_ATTRIBUTION, OMT_ATTRIBUTION, OSM_ATTRIBUTION];
+
+    if (options.layer.startsWith('stamen_')) {
+      attributions.splice(1, 0, STAMEN_ATTRIBUTION);
+    }
 
     super({
-      attributions: ATTRIBUTIONS,
+      attributions: attributions,
       cacheSize: options.cacheSize,
       crossOrigin: 'anonymous',
       interpolate: options.interpolate,
       maxZoom:
-        options.maxZoom != undefined ? options.maxZoom : providerConfig.maxZoom,
+        options.maxZoom !== undefined
+          ? options.maxZoom
+          : providerConfig.maxZoom,
       minZoom:
-        options.minZoom != undefined ? options.minZoom : providerConfig.minZoom,
+        options.minZoom !== undefined
+          ? options.minZoom
+          : providerConfig.minZoom,
       opaque: layerConfig.opaque,
       reprojectionErrorThreshold: options.reprojectionErrorThreshold,
       tileLoadFunction: options.tileLoadFunction,
       transition: options.transition,
       url: url,
+      tilePixelRatio: retina ? 2 : 1,
       wrapX: options.wrapX,
       zDirection: options.zDirection,
     });
   }
 }
 
-export default Stamen;
+export default StadiaMaps;

--- a/src/ol/source/StadiaMaps.js
+++ b/src/ol/source/StadiaMaps.js
@@ -9,19 +9,22 @@ import {ATTRIBUTION as OSM_ATTRIBUTION} from './OSM.js';
  * @const
  * @type string
  */
-const STADIA_ATTRIBUTION = '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>';
+const STADIA_ATTRIBUTION =
+  '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>';
 
 /**
  * @const
  * @type string
  */
-const OMT_ATTRIBUTION = '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>';
+const OMT_ATTRIBUTION =
+  '&copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a>';
 
 /**
  * @const
  * @type string
  */
-const STAMEN_ATTRIBUTION = '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>';
+const STAMEN_ATTRIBUTION =
+  '&copy; <a href="https://stamen.com/" target="_blank">Stamen Design</a>';
 
 /**
  * @type {Object<string, {extension: string, opaque: boolean}>}

--- a/test/browser/spec/ol/source/StadiaMaps.test.js
+++ b/test/browser/spec/ol/source/StadiaMaps.test.js
@@ -1,18 +1,18 @@
-import Stamen from '../../../../../src/ol/source/Stamen.js';
+import StadiaMaps from '../../../../../src/ol/source/StadiaMaps.js';
 
-describe('ol.source.Stamen', function () {
+describe('ol.source.StadiaMaps', function () {
   describe('constructor', function () {
     it('can be constructed with a custom minZoom', function () {
-      const source = new Stamen({
-        layer: 'watercolor',
+      const source = new StadiaMaps({
+        layer: 'stamen_watercolor',
         minZoom: 10,
       });
       expect(source.getTileGrid().getMinZoom()).to.be(10);
     });
 
     it('can be constructed with a custom maxZoom', function () {
-      const source = new Stamen({
-        layer: 'watercolor',
+      const source = new StadiaMaps({
+        layer: 'stamen_watercolor',
         maxZoom: 8,
       });
       expect(source.getTileGrid().getMaxZoom()).to.be(8);


### PR DESCRIPTION
Closes #14963, and additionally adds all other styles available from Stadia Maps + an example.
