### PR TITLE
Use none to avoid hit detection of text fills

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,7 +4,55 @@
 
 #### Hit detection with Text fill
 
-Hit detection of fill for Text styles is now consistent with that for Circle and RegularShape styles. Transparent `fill` and `backgroundFill` is detected, with no hit detection over unfilled shapes. To get the previous behavior in Text styles where a transparent fill may have been used to avoid the default fill specify `fill: null`. If using FlatStyle notation specify `'text-fill-color': 'none'`.
+Previously, text labels with transparent fills were not hit detected.  Now, you can control whether a transparent fill in a text label is hit detected or not.
+
+To create a text style with a transparent fill that will be hit detected, simply exclude the `fill` or use a fill with `'transparent'` as the color.
+```js
+// transparent fill, will be hit detected
+const style = Style({
+  text: new Text({
+    fill: new Fill({
+      color: 'transparent',
+    }),
+    stroke: new Stroke({
+      color: 'red',
+      width: 2,
+    }),
+  }),
+});
+```
+Or, if using the flat literal style syntax:
+```js
+// transparent fill, will be hit detected
+const style = {
+  'text-fill-color': 'transparent',
+  'text-stroke-color': 'red',
+  'text-stroke-width': 2,
+}
+```
+
+By contrast, if you want a transparent fill that will not be hit detected, do the following:
+```js
+// absent fill, will not be hit detected
+const style = Style({
+  text: new Text({
+    fill: null,
+    stroke: new Stroke({
+      color: 'red',
+      width: 2,
+    }),
+  }),
+});
+```
+Or, if using the flat literal style syntax:
+```js
+// absent fill, will not be hit detected
+const style = {
+  'text-fill-color': 'none',
+  'text-stroke-color': 'red',
+  'text-stroke-width': 2,
+}
+```
 
 #### Fixed `textAlign` with `placement: 'line'`
 

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,7 +4,7 @@
 
 #### Hit detection with Text fill
 
-Hit detection of fill for Text styles is now consistent with that for Circle and RegularShape styles. Transparent `fill` and `backgroundFill` is detected, with no hit detection over unfilled shapes. To get the previous behavior in Text styles where a transparent fill may have been used to avoid the default fill specify `fill: null`. If using FlatStyle notation specify `'text-fill-color': null`.
+Hit detection of fill for Text styles is now consistent with that for Circle and RegularShape styles. Transparent `fill` and `backgroundFill` is detected, with no hit detection over unfilled shapes. To get the previous behavior in Text styles where a transparent fill may have been used to avoid the default fill specify `fill: null`. If using FlatStyle notation specify `'text-fill-color': 'none'`.
 
 #### Fixed `textAlign` with `placement: 'line'`
 

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -79,7 +79,7 @@ import Text from './Text.js';
  * `'hanging'`, `'ideographic'`.
  * @property {Array<number>} [text-padding=[0, 0, 0, 0]] Padding in pixels around the text for decluttering and background. The order of
  * values in the array is `[top, right, bottom, left]`.
- * @property {import("../color.js").Color|import("../colorlike.js").ColorLike|null} [text-fill-color] The fill color. Specify `null` for no fill.
+ * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-fill-color] The fill color. Specify `'none'` to avoid hit detection on the fill.
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-background-fill-color] The fill color.
  * @property {import("../color.js").Color|import("../colorlike.js").ColorLike} [text-stroke-color] The stroke color.
  * @property {CanvasLineCap} [text-stroke-line-cap='round'] Line cap style: `butt`, `round`, or `square`.
@@ -212,7 +212,10 @@ export function toStyle(flatStyle) {
 function getFill(flatStyle, prefix) {
   const color = flatStyle[prefix + 'fill-color'];
   if (!color) {
-    return color;
+    return;
+  }
+  if (color === 'none') {
+    return null;
   }
 
   return new Fill({color: color});

--- a/test/browser/spec/ol/renderer/Map.test.js
+++ b/test/browser/spec/ol/renderer/Map.test.js
@@ -19,7 +19,7 @@ import {
 import {Projection} from '../../../../../src/ol/proj.js';
 import {fromExtent} from '../../../../../src/ol/geom/Polygon.js';
 
-describe('ol.renderer.Map', function () {
+describe('ol/renderer/Map.js', function () {
   describe('constructor', function () {
     it('createst an instance', function () {
       const map = new Map({});
@@ -435,7 +435,7 @@ describe('ol.renderer.Map', function () {
         'text-offset-y': -50,
         'text-stroke-width': 20,
         'text-stroke-color': 'black',
-        'text-fill-color': null,
+        'text-fill-color': 'none',
       });
       map.renderSync();
       hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
@@ -455,7 +455,7 @@ describe('ol.renderer.Map', function () {
         'text-offset-y': -50,
         'text-stroke-width': 1,
         'text-stroke-color': 'black',
-        'text-fill-color': null,
+        'text-fill-color': 'none',
       });
       map.renderSync();
       hit = map.forEachFeatureAtPixel([50, 50], (feature, layer, geometry) => ({
@@ -492,7 +492,7 @@ describe('ol.renderer.Map', function () {
         'text-offset-y': -50,
         'text-stroke-width': 1,
         'text-stroke-color': 'black',
-        'text-fill-color': null,
+        'text-fill-color': 'none',
         'text-background-fill-color': 'transparent',
       });
       map.renderSync();
@@ -528,7 +528,7 @@ describe('ol.renderer.Map', function () {
         'text-offset-y': -50,
         'text-stroke-width': 20,
         'text-stroke-color': 'black',
-        'text-fill-color': null,
+        'text-fill-color': 'none',
         'text-placement': 'line',
         'text-overflow': true,
       });
@@ -550,7 +550,7 @@ describe('ol.renderer.Map', function () {
         'text-offset-y': -50,
         'text-stroke-width': 1,
         'text-stroke-color': 'black',
-        'text-fill-color': null,
+        'text-fill-color': 'none',
         'text-placement': 'line',
         'text-overflow': true,
       });


### PR DESCRIPTION
Following up on https://github.com/openlayers/openlayers/pull/14943#issuecomment-1672441870, this changes syntax for avoiding hit detection on text fills when using the flat literal syntax.

We're adding support for expressions in styles in #14780.  Currently, the types supported by expressions do not include `null` or `undefined`.  We may need to add support for this, but I'm going to avoid it until there is a compelling case.

Instead of `'text-fill-color': null`, this change makes it so `'text-fill-color': 'none'` will results in a text where the fill is not hit detected.