### PR TITLE
Direct access to object properties

### DIFF
--- a/src/ol/Object.js
+++ b/src/ol/Object.js
@@ -159,6 +159,14 @@ class BaseObject extends Observable {
   }
 
   /**
+   * Get an object of all property names and values.
+   * @return {Object<string, *>?} Object.
+   */
+  getPropertiesInternal() {
+    return this.values_;
+  }
+
+  /**
    * @return {boolean} The object has properties.
    */
   hasProperties() {

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -266,6 +266,15 @@ class RenderFeature {
   }
 
   /**
+   * Get an object of all property names and values.  This has the same behavior as getProperties,
+   * but is here to conform with the {@link module:ol/Feature~Feature} interface.
+   * @return {Object<string, *>?} Object.
+   */
+  getPropertiesInternal() {
+    return this.properties_;
+  }
+
+  /**
    * @return {number} Stride.
    */
   getStride() {

--- a/test/node/ol/Feature.test.js
+++ b/test/node/ol/Feature.test.js
@@ -84,6 +84,31 @@ describe('ol/Feature.js', function () {
     });
   });
 
+  describe('getPropertiesInternal()', () => {
+    it('returns the feature properties and geometry', () => {
+      const point = new Point([15, 30]);
+      const feature = new Feature({
+        foo: 'bar',
+        ten: 10,
+        geometry: point,
+      });
+
+      const attributes = feature.getPropertiesInternal();
+
+      const keys = Object.keys(attributes);
+      expect(keys.sort()).to.eql(['foo', 'geometry', 'ten']);
+
+      expect(attributes.foo).to.be('bar');
+      expect(attributes.geometry).to.be(point);
+      expect(attributes.ten).to.be(10);
+    });
+
+    it('is null by default', () => {
+      const feature = new Feature();
+      expect(feature.getPropertiesInternal()).to.be(null);
+    });
+  });
+
   describe('#getGeometry()', function () {
     const point = new Point([15, 30]);
 

--- a/test/node/ol/render/Feature.test.js
+++ b/test/node/ol/render/Feature.test.js
@@ -13,7 +13,7 @@ import {
 } from '../../../../src/ol/geom.js';
 
 describe('ol/render/Feature', function () {
-  describe('ol/render/Feature.toGeometry()', function () {
+  describe('toGeometry()', function () {
     it('creates a Point', function () {
       const geometry = new Point([0, 0]);
       const renderFeature = new RenderFeature(
@@ -154,7 +154,25 @@ describe('ol/render/Feature', function () {
     });
   });
 
-  describe('ol/render/Feature.toFeature()', function () {
+  describe('getPropertiesInternal()', () => {
+    it('returns the properties', () => {
+      const id = 'asdf';
+      const properties = {test: '123'};
+      const geometry = new Point([0, 0]);
+      const feature = new RenderFeature(
+        geometry.getType(),
+        geometry.getFlatCoordinates().slice(),
+        [],
+        properties,
+        id
+      );
+
+      const got = feature.getPropertiesInternal();
+      expect(got).to.eql(properties);
+    });
+  });
+
+  describe('toFeature()', function () {
     it('creates a Feature<Point>', function () {
       const id = 'asdf';
       const properties = {test: '123'};


### PR DESCRIPTION
This adds a method for directly accessing properties without creating a copy.  Intended for internal use only (e.g. during rendering).

Extracted from #14780.