### PR TITLE
Doc updates

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -621,8 +621,8 @@ exports.publish = function (taffyData, opts, tutorials) {
     generate('Global', [{kind: 'globalobj'}], globalUrl);
   }
 
-  // index page displays information from package.json and lists files
-  const files = find({kind: 'file'});
+  // the file type doclets come from @fileoverview tags in comment blocks with an @api tag
+  const fileOverviews = find({kind: 'file'});
 
   view.navigationItems = view.nav.reduce(function (dict, item) {
     dict[item.longname] = item;
@@ -642,7 +642,7 @@ exports.publish = function (taffyData, opts, tutorials) {
         readme: opts.readme,
         longname: opts.mainpagetitle ? opts.mainpagetitle : 'Main Page',
       },
-    ].concat(files),
+    ],
     indexUrl
   );
 
@@ -666,6 +666,15 @@ exports.publish = function (taffyData, opts, tutorials) {
 
       const myModules = helper.find(modules, {longname: longname});
       if (myModules.length) {
+        // assign any file overview description as the module description
+        myModules.forEach((moduleDoclet) => {
+          fileOverviews.forEach((fileDoclet) => {
+            if (fileDoclet.memberof !== moduleDoclet.longname) {
+              return;
+            }
+            moduleDoclet.description = fileDoclet.description;
+          });
+        });
         generate(
           'Module: ' + myModules[0].name,
           myModules,

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -411,6 +411,9 @@ span.type-signature.static {
 .main table .name {
   width: 110px;
 }
+.main table .name code {
+  white-space: nowrap;
+}
 .main table .type {
   color: #aaa;
   font-size: 12px;

--- a/config/jsdoc/api/template/tmpl/properties.tmpl
+++ b/config/jsdoc/api/template/tmpl/properties.tmpl
@@ -47,14 +47,6 @@
 
 		<th>Type</th>
 
-		<?js if (props.hasAttributes) {?>
-		<th>Argument</th>
-		<?js } ?>
-
-		<?js if (props.hasDefault) {?>
-		<th>Default</th>
-		<?js } ?>
-
 		<th class="last">Description</th>
 	</tr>
 	</thead>
@@ -73,33 +65,19 @@
 
             <td class="type">
             <?js if (prop.type && prop.type.names) {?>
-                <?js= self.partial('type.tmpl', prop.type.names) ?>
+                <?js= self.partial('type.tmpl', prop.type.names) + (prop.optional && typeof prop.defaultvalue === 'undefined' && !prop.type.names.includes('undefined') ? ' | undefined' : '') ?>
+                <?js if (typeof prop.defaultvalue !== 'undefined') { ?>
+                    (defaults to <?js= self.htmlsafe(prop.defaultvalue) ?>)
+                <?js } ?>
             <?js } ?>
             </td>
 
-            <?js if (props.hasAttributes) {?>
-                <td class="attributes">
-                <?js if (prop.optional) { ?>
-                    &lt;optional><br>
+            <td class="description last">
+                <?js= prop.description ?>
+                <?js if (prop.subprops) { ?>
+                    <h6>Properties</h6><?js= self.partial('properties.tmpl', prop.subprops) ?>
                 <?js } ?>
-
-                <?js if (prop.nullable) { ?>
-                    &lt;nullable><br>
-                <?js } ?>
-                </td>
-            <?js } ?>
-
-            <?js if (props.hasDefault) {?>
-                <td class="default">
-                <?js if (typeof prop.defaultvalue !== 'undefined') { ?>
-                    <?js= self.htmlsafe(prop.defaultvalue) ?>
-                <?js } ?>
-                </td>
-            <?js } ?>
-
-            <td class="description last"><?js= prop.description ?><?js if (prop.subprops) { ?>
-                <h6>Properties</h6><?js= self.partial('properties.tmpl', prop.subprops) ?>
-            <?js } ?></td>
+            </td>
         </tr>
 
 	<?js }); ?>

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "generate-types": "tsc --project config/tsconfig-build.json --declaration --declarationMap --emitDeclarationOnly --outdir build/ol",
     "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build && node tasks/serialize-workers.cjs && node tasks/set-version.js",
     "typecheck": "tsc --pretty",
-    "apidoc-debug": "shx rm -rf build/apidoc && node --inspect-brk=9229 ./node_modules/jsdoc/jsdoc.js -R config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc",
-    "apidoc": "shx rm -rf build/apidoc && jsdoc -R config/jsdoc/api/index.md -c config/jsdoc/api/conf.json -P package.json -d build/apidoc"
+    "apidoc-debug": "shx rm -rf build/apidoc && node --inspect-brk=9229 ./node_modules/jsdoc/jsdoc.js --readme config/jsdoc/api/index.md --configure config/jsdoc/api/conf.json --package package.json --destination build/apidoc",
+    "apidoc": "shx rm -rf build/apidoc && jsdoc --readme config/jsdoc/api/index.md --configure config/jsdoc/api/conf.json --package package.json --destination build/apidoc"
   },
   "type": "module",
   "repository": {

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -11,6 +11,19 @@ import Style from './Style.js';
 import Text from './Text.js';
 
 /**
+ * @api
+ * @fileoverview Vector layers can be styled with an object literal containing properties for
+ * stroke, fill, image, and text styles.  The types below can be composed into a single object.
+ * For example, a style with both stroke and fill properties could look like this:
+ *
+ *     const style = {
+ *       'stroke-color': 'yellow',
+ *       'stroke-width': 1.5,
+ *       'fill-color': 'orange',
+ *     };
+ */
+
+/**
  * For static styling, the [layer.setStyle()]{@link module:ol/layer/Vector~VectorLayer#setStyle} method
  * can be called with an object literal that has fill, stroke, text, icon, regular shape, and/or circle properties.
  * @api


### PR DESCRIPTION
Currently, comments with `@fileoverview` (or `@file`) get ignored (they end up `undocumented: true` due to the api plugin).  If a comment with `@fileoverview` is given an `@api` tag, the comment is included inline in the index page ([we concatenate](https://github.com/openlayers/openlayers/blob/f68564107019688658f6387a067f61124ec7fdf7/config/jsdoc/api/template/publish.js#L624-L647) all `file` type tags with the index docs).

Since we don't currently use the `@fileoverview` and `@api` tag combo anywhere, I repurposed this to serve as a way to add a description for a module.

In this branch, I've also updated the templates so the table for typedefs looks more like the table for constructor options.

I've updated the [docs for the `ol/style/flat.js` module](https://deploy-preview-14999--ol-site.netlify.app/en/latest/apidoc/module-ol_style_flat) to demonstrate the change.  Here is an animation of the before/after change (after has the module description, example, and typedef table changes).

![doc-change](https://github.com/openlayers/openlayers/assets/41094/5287a7af-e9d9-4e61-81c8-f2954595f451)
