### PR TITLE
Do not override `caption-side` in featureInfo styles

### DIFF
--- a/site/src/theme/site.css
+++ b/site/src/theme/site.css
@@ -525,3 +525,7 @@ div.code-toolbar>.toolbar button:before {
     max-width: 1140px;
   }
 }
+
+table.featureInfo {
+  caption-side: initial;
+}


### PR DESCRIPTION
Fixes #14988

https://deploy-preview-15002--ol-site.netlify.app/en/latest/examples/getfeatureinfo-tile.html