### PR TITLE
Styling with logical operators and type assertions

### DIFF
--- a/examples/geojson-vt.js
+++ b/examples/geojson-vt.js
@@ -4,7 +4,6 @@ import Projection from '../src/ol/proj/Projection.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
 import View from '../src/ol/View.js';
-import {Fill, Style} from '../src/ol/style.js';
 
 // Converts geojson-vt data to GeoJSON
 const replacer = function (key, value) {
@@ -45,18 +44,10 @@ const replacer = function (key, value) {
   };
 };
 
-const style = new Style({
-  fill: new Fill({
-    color: '#eeeeee',
-  }),
-});
-
 const layer = new VectorTileLayer({
   background: '#1a2b39',
-  style: function (feature) {
-    const color = feature.get('COLOR') || '#eeeeee';
-    style.getFill().setColor(color);
-    return style;
+  style: {
+    'fill-color': ['string', ['get', 'COLOR'], '#eee'],
   },
 });
 

--- a/examples/hitdetect-vector.js
+++ b/examples/hitdetect-vector.js
@@ -3,13 +3,6 @@ import Map from '../src/ol/Map.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
-
-const style = new Style({
-  fill: new Fill({
-    color: '#eeeeee',
-  }),
-});
 
 const vectorLayer = new VectorLayer({
   background: '#1a2b39',
@@ -17,10 +10,8 @@ const vectorLayer = new VectorLayer({
     url: 'https://openlayers.org/data/vector/ecoregions.json',
     format: new GeoJSON(),
   }),
-  style: function (feature) {
-    const color = feature.get('COLOR_NNH') || '#eeeeee';
-    style.getFill().setColor(color);
-    return style;
+  style: {
+    'fill-color': ['string', ['get', 'COLOR_NNH'], '#eee'],
   },
 });
 
@@ -33,17 +24,13 @@ const map = new Map({
   }),
 });
 
-const highlightStyle = new Style({
-  stroke: new Stroke({
-    color: 'rgba(255, 255, 255, 0.7)',
-    width: 2,
-  }),
-});
-
 const featureOverlay = new VectorLayer({
   source: new VectorSource(),
   map: map,
-  style: highlightStyle,
+  style: {
+    'stroke-color': 'rgba(255, 255, 255, 0.7)',
+    'stroke-width': 2,
+  },
 });
 
 let highlight;

--- a/examples/image-vector-layer.js
+++ b/examples/image-vector-layer.js
@@ -4,13 +4,6 @@ import VectorImageLayer from '../src/ol/layer/VectorImage.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
-
-const style = new Style({
-  fill: new Fill({
-    color: '#eeeeee',
-  }),
-});
 
 const vectorLayer = new VectorImageLayer({
   background: '#1a2b39',
@@ -19,10 +12,8 @@ const vectorLayer = new VectorImageLayer({
     url: 'https://openlayers.org/data/vector/ecoregions.json',
     format: new GeoJSON(),
   }),
-  style: function (feature) {
-    const color = feature.get('COLOR') || '#eeeeee';
-    style.getFill().setColor(color);
-    return style;
+  style: {
+    'fill-color': ['string', ['get', 'COLOR'], '#eee'],
   },
 });
 
@@ -38,12 +29,10 @@ const map = new Map({
 const featureOverlay = new VectorLayer({
   source: new VectorSource(),
   map: map,
-  style: new Style({
-    stroke: new Stroke({
-      color: 'rgba(255, 255, 255, 0.7)',
-      width: 2,
-    }),
-  }),
+  style: {
+    'stroke-color': 'rgba(255, 255, 255, 0.7)',
+    'stroke-width': 2,
+  },
 });
 
 let highlight;

--- a/examples/layer-z-index.js
+++ b/examples/layer-z-index.js
@@ -4,45 +4,37 @@ import Point from '../src/ol/geom/Point.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
-import {Fill, RegularShape, Stroke, Style} from '../src/ol/style.js';
-
-const stroke = new Stroke({color: 'black', width: 1});
 
 const styles = {
-  'square': new Style({
-    image: new RegularShape({
-      fill: new Fill({color: 'blue'}),
-      stroke: stroke,
-      points: 4,
-      radius: 80,
-      angle: Math.PI / 4,
-    }),
-  }),
-  'triangle': new Style({
-    image: new RegularShape({
-      fill: new Fill({color: 'red'}),
-      stroke: stroke,
-      points: 3,
-      radius: 80,
-      rotation: Math.PI / 4,
-      angle: 0,
-    }),
-  }),
-  'star': new Style({
-    image: new RegularShape({
-      fill: new Fill({color: 'green'}),
-      stroke: stroke,
-      points: 5,
-      radius: 80,
-      radius2: 4,
-      angle: 0,
-    }),
-  }),
+  square: {
+    'shape-points': 4,
+    'shape-radius': 80,
+    'shape-angle': Math.PI / 4,
+    'shape-stroke-color': 'black',
+    'shape-stroke-width': 1,
+    'shape-fill-color': 'blue',
+  },
+  triangle: {
+    'shape-points': 3,
+    'shape-radius': 80,
+    'shape-rotation': Math.PI / 4,
+    'shape-stroke-color': 'black',
+    'shape-stroke-width': 1,
+    'shape-fill-color': 'red',
+  },
+  star: {
+    'shape-points': 5,
+    'shape-radius': 80,
+    'shape-radius2': 40,
+    'shape-rotation': Math.PI / 4,
+    'shape-stroke-color': 'black',
+    'shape-stroke-width': 1,
+    'shape-fill-color': 'green',
+  },
 };
 
 function createLayer(coordinates, style, zIndex) {
   const feature = new Feature(new Point(coordinates));
-  feature.setStyle(style);
 
   const source = new VectorSource({
     features: [feature],
@@ -50,15 +42,16 @@ function createLayer(coordinates, style, zIndex) {
 
   const vectorLayer = new VectorLayer({
     source: source,
+    style,
   });
   vectorLayer.setZIndex(zIndex);
 
   return vectorLayer;
 }
 
-const layer0 = createLayer([40, 40], styles['star']);
-const layer1 = createLayer([0, 0], styles['square'], 1);
-const layer2 = createLayer([0, 40], styles['triangle'], 0);
+const layer0 = createLayer([40, 40], styles.star);
+const layer1 = createLayer([0, 0], styles.square, 1);
+const layer2 = createLayer([0, 40], styles.triangle, 0);
 
 const layers = [];
 layers.push(layer1);

--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -3,58 +3,60 @@ import TopoJSON from '../src/ol/format/TopoJSON.js';
 import VectorTileLayer from '../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
 import View from '../src/ol/View.js';
-import {Fill, Stroke, Style} from '../src/ol/style.js';
 import {fromLonLat} from '../src/ol/proj.js';
 
 const key = 'uZNs91nMR-muUTP99MyBSg';
 
-const roadStyleCache = {};
-const roadColor = {
-  'major_road': '#776',
-  'minor_road': '#ccb',
-  'highway': '#f39',
-};
-const buildingStyle = new Style({
-  fill: new Fill({
-    color: '#666',
-    opacity: 0.4,
-  }),
-  stroke: new Stroke({
-    color: '#444',
-    width: 1,
-  }),
-});
-const waterStyle = new Style({
-  fill: new Fill({
-    color: '#9db9e8',
-  }),
-});
-const roadStyle = function (feature) {
-  const kind = feature.get('kind');
-  const railway = feature.get('railway');
-  const sort_key = feature.get('sort_key');
-  const styleKey = kind + '/' + railway + '/' + sort_key;
-  let style = roadStyleCache[styleKey];
-  if (!style) {
-    let color, width;
-    if (railway) {
-      color = '#7de';
-      width = 1;
-    } else {
-      color = roadColor[kind];
-      width = kind == 'highway' ? 1.5 : 1;
-    }
-    style = new Style({
-      stroke: new Stroke({
-        color: color,
-        width: width,
-      }),
-      zIndex: sort_key,
-    });
-    roadStyleCache[styleKey] = style;
-  }
-  return style;
-};
+const rules = [
+  {
+    filter: ['==', ['get', 'layer'], 'water'],
+    style: {
+      'fill-color': '#9db9e8',
+    },
+  },
+  {
+    else: true,
+    filter: ['all', ['==', ['get', 'layer'], 'roads'], ['get', 'railway']],
+    style: {
+      'stroke-color': '#7de',
+      'stroke-width': 1,
+      'z-index': ['number', ['get', 'sort_key'], 0],
+    },
+  },
+  {
+    else: true,
+    filter: ['==', ['get', 'layer'], 'roads'],
+    style: {
+      'stroke-color': [
+        'match',
+        ['get', 'kind'],
+        'major_road',
+        '#776',
+        'minor_road',
+        '#ccb',
+        'highway',
+        '#f39',
+        'none',
+      ],
+      'stroke-width': ['match', ['get', 'kind'], 'highway', 1.5, 1],
+      'z-index': ['number', ['get', 'sort_key'], 0],
+    },
+  },
+  {
+    else: true,
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'buildings'],
+      ['<', ['resolution'], 10],
+    ],
+    style: {
+      'fill-color': '#6666',
+      'stroke-color': '#4446',
+      'stroke-width': 1,
+      'z-index': ['number', ['get', 'sort_key'], 0],
+    },
+  },
+];
 
 const map = new Map({
   layers: [
@@ -72,18 +74,7 @@ const map = new Map({
           'https://tile.nextzen.org/tilezen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=' +
           key,
       }),
-      style: function (feature, resolution) {
-        switch (feature.get('layer')) {
-          case 'water':
-            return waterStyle;
-          case 'roads':
-            return roadStyle(feature);
-          case 'buildings':
-            return resolution < 10 ? buildingStyle : null;
-          default:
-            return null;
-        }
-      },
+      style: rules,
     }),
   ],
   target: 'map',

--- a/examples/sphere-mollweide.js
+++ b/examples/sphere-mollweide.js
@@ -6,7 +6,6 @@ import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
 import proj4 from 'proj4';
-import {Fill, Style} from '../src/ol/style.js';
 import {register} from '../src/ol/proj/proj4.js';
 
 proj4.defs(
@@ -27,12 +26,6 @@ const sphereMollweideProjection = new Projection({
   worldExtent: [-179, -89.99, 179, 89.99],
 });
 
-const style = new Style({
-  fill: new Fill({
-    color: '#eeeeee',
-  }),
-});
-
 const map = new Map({
   keyboardEventTarget: document,
   layers: [
@@ -41,10 +34,8 @@ const map = new Map({
         url: 'https://openlayers.org/data/vector/ecoregions.json',
         format: new GeoJSON(),
       }),
-      style: function (feature) {
-        const color = feature.get('COLOR_BIO') || '#eeeeee';
-        style.getFill().setColor(color);
-        return style;
+      style: {
+        'fill-color': ['string', ['get', 'COLOR_BIO'], '#eee'],
       },
     }),
     new Graticule(),

--- a/examples/vector-layer.js
+++ b/examples/vector-layer.js
@@ -10,20 +10,9 @@ const vectorLayer = new VectorLayer({
     url: 'https://openlayers.org/data/vector/ecoregions.json',
     format: new GeoJSON(),
   }),
-  style: [
-    {
-      // if features have a COLOR property, use that in the style
-      filter: ['get', 'COLOR'],
-      style: {
-        'fill-color': ['get', 'COLOR'],
-      },
-    },
-    {
-      // otherwise, use this style
-      else: true,
-      style: {'fill-color': '#eee'},
-    },
-  ],
+  style: {
+    'fill-color': ['string', ['get', 'COLOR'], '#eee'],
+  },
 });
 
 const map = new Map({

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -181,8 +181,13 @@ export function parse(encoded, context) {
  * @type {Object<string, string>}
  */
 export const Ops = {
+  Number: 'number',
+  String: 'string',
   Get: 'get',
   Var: 'var',
+  Any: 'any',
+  All: 'all',
+  Not: '!',
   Resolution: 'resolution',
   Equal: '==',
   NotEqual: '!=',
@@ -216,9 +221,14 @@ export const Ops = {
  * @type {Object<string, Parser>}
  */
 const parsers = {
+  [Ops.Number]: createParser(withArgs(1, Infinity, AnyType), NumberType),
+  [Ops.String]: createParser(withArgs(1, Infinity, AnyType), StringType),
   [Ops.Get]: createParser(withGetArgs, AnyType),
   [Ops.Var]: createParser(withVarArgs, AnyType),
   [Ops.Resolution]: createParser(withNoArgs, NumberType),
+  [Ops.Any]: createParser(withArgs(2, Infinity, BooleanType), BooleanType),
+  [Ops.All]: createParser(withArgs(2, Infinity, BooleanType), BooleanType),
+  [Ops.Not]: createParser(withArgs(1, 1, BooleanType), BooleanType),
   [Ops.Equal]: createParser(withArgs(2, 2, AnyType), BooleanType),
   [Ops.NotEqual]: createParser(withArgs(2, 2, AnyType), BooleanType),
   [Ops.GreaterThan]: createParser(withArgs(2, 2, AnyType), BooleanType),

--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -179,7 +179,11 @@ export function buildRuleSet(rules, context) {
       }
       someMatched = true;
       for (const styleEvaluator of compiledRules[i].styles) {
-        styles.push(styleEvaluator(context));
+        const style = styleEvaluator(context);
+        if (!style) {
+          continue;
+        }
+        styles.push(style);
       }
     }
 
@@ -206,20 +210,40 @@ export function buildStyle(flatStyle, context) {
 
   const style = new Style();
   return function (context) {
+    let empty = true;
     if (evaluateFill) {
-      style.setFill(evaluateFill(context));
+      const fill = evaluateFill(context);
+      if (fill) {
+        empty = false;
+      }
+      style.setFill(fill);
     }
     if (evaluateStroke) {
-      style.setStroke(evaluateStroke(context));
+      const stroke = evaluateStroke(context);
+      if (stroke) {
+        empty = false;
+      }
+      style.setStroke(stroke);
     }
     if (evaluateText) {
-      style.setText(evaluateText(context));
+      const text = evaluateText(context);
+      if (text) {
+        empty = false;
+      }
+      style.setText(text);
     }
     if (evaluateImage) {
-      style.setImage(evaluateImage(context));
+      const image = evaluateImage(context);
+      if (image) {
+        empty = false;
+      }
+      style.setImage(image);
     }
     if (evaluateZIndex) {
       style.setZIndex(evaluateZIndex(context));
+    }
+    if (empty) {
+      return null;
     }
     return style;
   };
@@ -315,12 +339,16 @@ function buildStroke(flatStyle, prefix, context) {
 
   const stroke = new Stroke();
   return function (context) {
-    if (evaluateWidth) {
-      stroke.setWidth(evaluateWidth(context));
+    if (evaluateColor) {
+      const color = evaluateColor(context);
+      if (color === 'none') {
+        return null;
+      }
+      stroke.setColor(color);
     }
 
-    if (evaluateColor) {
-      stroke.setColor(evaluateColor(context));
+    if (evaluateWidth) {
+      stroke.setWidth(evaluateWidth(context));
     }
 
     if (evaluateLineCap) {

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -38,6 +38,90 @@ describe('ol/expr/cpu.js', () => {
         expected: false,
       },
       {
+        name: 'number assertion',
+        type: NumberType,
+        expression: ['number', 'not', 'a', 'number', 42, false],
+        expected: 42,
+      },
+      {
+        name: 'string assertion',
+        type: StringType,
+        expression: ['string', 42, 'chicken', false],
+        expected: 'chicken',
+      },
+      {
+        name: 'resolution',
+        type: NumberType,
+        expression: ['resolution'],
+        context: {
+          resolution: 10,
+        },
+        expected: 10,
+      },
+      {
+        name: 'resolution (comparison)',
+        type: BooleanType,
+        expression: ['>', ['resolution'], 10],
+        context: {
+          resolution: 11,
+        },
+        expected: true,
+      },
+      {
+        name: 'any (true)',
+        type: BooleanType,
+        expression: ['any', ['get', 'nope'], ['get', 'yep'], ['get', 'nope']],
+        context: {
+          properties: {nope: false, yep: true},
+        },
+        expected: true,
+      },
+      {
+        name: 'any (false)',
+        type: BooleanType,
+        expression: ['any', ['get', 'nope'], false, ['!', ['get', 'yep']]],
+        context: {
+          properties: {nope: false, yep: true},
+        },
+        expected: false,
+      },
+      {
+        name: 'all (true)',
+        type: BooleanType,
+        expression: ['all', ['get', 'yep'], true, ['!', ['get', 'nope']]],
+        context: {
+          properties: {yep: true, nope: false},
+        },
+        expected: true,
+      },
+      {
+        name: 'all (false)',
+        type: BooleanType,
+        expression: ['all', ['!', ['get', 'nope']], ['get', 'yep'], false],
+        context: {
+          properties: {nope: false, yep: true},
+        },
+        expected: false,
+      },
+      {
+        name: 'not (true)',
+        type: BooleanType,
+        expression: ['!', ['get', 'nope']],
+        context: {
+          properties: {nope: false, yep: true},
+        },
+        expected: true,
+      },
+      {
+        name: 'not (false)',
+        type: BooleanType,
+        expression: ['!', ['get', 'yep']],
+        context: {
+          properties: {nope: false, yep: true},
+        },
+        expected: false,
+      },
+      {
         name: 'equal comparison (true)',
         type: BooleanType,
         expression: ['==', ['get', 'number'], 42],


### PR DESCRIPTION
Building on #14780, this adds support for additional expression operators: `any`, `all`, `!`, `resolution`, `string`, and `number`.  The logical operators (`any`, `all`, `!`) and type assertions (`string`, `number`) behave like those in the [Mapbox style spec](https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/).  We should be able to add support for `zoom` instead of (or in addition to) `resolution`, but I haven't done that yet (sticking with the existing style function interface).

I've updated a few examples.  I'll leave a comment inline about a few specific issues.