### PR TITLE
Fix return type of Layer#renderFrame

### DIFF
--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -69,8 +69,8 @@ class LayerRenderer extends Observable {
    * Render the layer.
    * @abstract
    * @param {import("../Map.js").FrameState} frameState Frame state.
-   * @param {HTMLElement} target Target that may be used to render content to.
-   * @return {HTMLElement} The rendered element.
+   * @param {HTMLElement|null} target Target that may be used to render content to.
+   * @return {HTMLElement|null} The rendered element.
    */
   renderFrame(frameState, target) {
     return abstract();


### PR DESCRIPTION
Fixes #15004

VectorLayer#renderFrame would return null, but it wasn't annotated until #14984