### PR TITLE
Fix word repetition in example descriptions

### DIFF
--- a/examples/wms-image.html
+++ b/examples/wms-image.html
@@ -3,7 +3,7 @@ layout: example.html
 title: Single Image WMS
 shortdesc: Example of a single image WMS layer.
 docs: >
-  WMS can be used as an Image layer, as shown here, or as a Tile layer, as shown in the [Tiled WMS example](wms-tiled.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
+  WMS can be used as an Image layer, as shown here, or as a Tile layer, as shown in the [Tiled WMS](wms-tiled.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
 tags: "wms, image"
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-tiled.html
+++ b/examples/wms-tiled.html
@@ -3,7 +3,7 @@ layout: example.html
 title: Tiled WMS
 shortdesc: Example of a tiled WMS layer.
 docs: >
-  WMS can be used as a Tile layer, as shown here, or as an Image layer, as shown in the [Single Image WMS example](wms-image.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
+  WMS can be used as a Tile layer, as shown here, or as an Image layer, as shown in the [Single Image WMS](wms-image.html) example. Tiles can be cached, so the browser will not re-fetch data for areas that were viewed already. But there may be problems with repeated labels for WMS servers that are not aware of tiles, in which case single image WMS will produce better cartography.
 tags: "wms, tile, tilelayer"
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
Change "example example" to "example" in WMS example descriptions
