### PR TITLE
Move inlineDynamicImports options to output

### DIFF
--- a/tasks/serialize-workers.cjs
+++ b/tasks/serialize-workers.cjs
@@ -43,7 +43,9 @@ async function build(input, {minify = true} = {}) {
   const bundle = await rollup.rollup({
     input,
     plugins,
-    inlineDynamicImports: true,
+    output: {
+      inlineDynamicImports: true,
+    },
   });
   const {output} = await bundle.generate({format: 'es'});
 


### PR DESCRIPTION
After the recent rollup update, we should update the configuration for building workers to move the `inlineDynamicImports` option from the root of the config to the `output` section.

This removes a deprecation warning when running `npm run build-package`.