### PR TITLE
Bump version to 8.0.0-dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ol",
-  "version": "7.5.1-dev",
+  "version": "8.0.0-dev",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ol",
-      "version": "7.5.1-dev",
+      "version": "8.0.0-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
         "earcut": "^2.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ol",
-  "version": "7.5.1-dev",
+  "version": "8.0.0-dev",
   "description": "OpenLayers mapping library",
   "keywords": [
     "map",


### PR DESCRIPTION
Since we have already rolled in breaking changes, it makes sense to bump the version for our `dev` tagged releases.