### PR TITLE
Fix various typos

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -128,8 +128,8 @@ Here is a quick guide to help you migrate to the new style format:
   * if using an array for the `symbol.size` property, use a combination of `shape-radius` and `shape-scale`
 * for `symbolType: 'square'`:
   * set `shape-points` to `4`
-  * set `shape-radius1` to half ot the `symbol.size` value
-  * set `shape-radius2` to half ot the `symbol.size` value multiplied by `Math.sqrt(2)`
+  * set `shape-radius1` to half of the `symbol.size` value
+  * set `shape-radius2` to half of the `symbol.size` value multiplied by `Math.sqrt(2)`
   * if using an array for the `symbol.size` property, use a combination of `shape-radius1`, `shape-radius2` and `shape-scale`
   * set `shape-fill-color` to the `symbol.color` value
 * for `symbolType: 'image'`:
@@ -301,7 +301,7 @@ const source = new DataTileSource({
 
 #### Fixed coordinate dimension handling in `ol/proj`'s `addCoordinateTransforms`
 
-The `forward` and `inverse` functions passed to `addCooordinateTransforms` now receive a coordinate with all dimensions of the original coordinate, not just two. If you previosly had coordinates with more than two dimensions and added a transform like
+The `forward` and `inverse` functions passed to `addCooordinateTransforms` now receive a coordinate with all dimensions of the original coordinate, not just two. If you previously had coordinates with more than two dimensions and added a transform like
 ```js
 addCoordinateTransforms(
     'EPSG:4326',
@@ -484,7 +484,7 @@ new Layer({
 ```
 
 Please note that this may incur a significant performance loss when dealing with many layers and/or
-targetting mobile devices.
+targeting mobile devices.
 
 ##### Removal of `TOUCH` constant from `ol/has`
 

--- a/examples/external-map.html
+++ b/examples/external-map.html
@@ -1,9 +1,9 @@
 ---
 layout: example.html
 title: External map
-shortdesc: Move a map to a seperate window.
+shortdesc: Move a map to a separate window.
 docs: >
-  Move a map to a seperate window.
+  Move a map to a separate window.
 tags: "external, window"
 sources:
   - path: resources/external-map-map.html

--- a/examples/feature-move-animation.js
+++ b/examples/feature-move-animation.js
@@ -40,7 +40,7 @@ const map = new Map({
   ],
 });
 
-// The polyline string is read from a JSON similiar to those returned
+// The polyline string is read from a JSON similar to those returned
 // by directions APIs such as Openrouteservice and Mapbox.
 fetch('data/polyline/route.json').then(function (response) {
   response.json().then(function (result) {

--- a/examples/offscreen-canvas.js
+++ b/examples/offscreen-canvas.js
@@ -140,7 +140,7 @@ worker.addEventListener('message', (message) => {
     // Worker requested a new render frame
     map.render();
   } else if (canvas && message.data.action === 'rendered') {
-    // Worker provies a new render frame
+    // Worker provides a new render frame
     requestAnimationFrame(function () {
       const imageData = message.data.imageData;
       canvas.width = imageData.width;

--- a/examples/webpack/config.mjs
+++ b/examples/webpack/config.mjs
@@ -84,7 +84,7 @@ export default {
       https: false,
     },
     alias: {
-      // allow imports from 'ol/module' instead of specifiying the source path
+      // allow imports from 'ol/module' instead of specifying the source path
       ol: path.join(root, 'src', 'ol'),
     },
   },

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -60,7 +60,7 @@ handlebars.registerHelper('indent', (text, options) => {
  */
 function sortObjectByKey(obj) {
   return Object.keys(obj)
-    .sort() // sort twice to get predictable, case insensitve order
+    .sort() // sort twice to get predictable, case insensitive order
     .sort((a, b) => a.localeCompare(b, 'en', {sensitivity: 'base'}))
     .reduce((idx, tag) => {
       idx[tag] = obj[tag];

--- a/site/src/3rd-party/index.hbs
+++ b/site/src/3rd-party/index.hbs
@@ -67,7 +67,7 @@ layout: default.hbs
       </tr>
       <tr>
         <td><a href="https://github.com/Viglino/ol-ext">OL-Ext</a></td>
-        <td>Miscellanous classes and functions for OpenLayers.</td>
+        <td>Miscellaneous classes and functions for OpenLayers.</td>
         <td><a href="https://github.com/Viglino">Jean-Marc Viglino</a></td>
       </tr>
       <tr>

--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -304,7 +304,7 @@ export function decodeFallback(image, src) {
 
 /**
  * Loads an image and decodes it to an `ImageBitmap` if `createImageBitmap()` is supported. Returns
- * the laoded image otherwise.
+ * the loaded image otherwise.
  * @param {HTMLImageElement} image Image, not yet loaded.
  * @param {string} [src] `src` attribute of the image. Optional, not required if already present.
  * @return {Promise<ImageBitmap|HTMLImageElement>} Promise resolving to an `ImageBitmap` or an

--- a/src/ol/interaction/DblClickDragZoom.js
+++ b/src/ol/interaction/DblClickDragZoom.js
@@ -15,7 +15,7 @@ import MapBrowserEventType from '../MapBrowserEventType.js';
 
 /**
  * @classdesc
- * Allows the user to zoom the map by double tap/clik then drag up/down
+ * Allows the user to zoom the map by double tap/click then drag up/down
  * with one finger/left mouse.
  * @api
  */

--- a/tasks/publish.sh
+++ b/tasks/publish.sh
@@ -33,7 +33,7 @@ display_usage() {
 
   The tag must be pushed to ${REMOTE} before the release can be published.
 
-  Additional args afer <version> will be passed to "npm publish" (e.g. "--tag beta").
+  Additional args after <version> will be passed to "npm publish" (e.g. "--tag beta").
 
 EOF
 }

--- a/test/browser/spec/ol/format/gml.test.js
+++ b/test/browser/spec/ol/format/gml.test.js
@@ -1840,7 +1840,7 @@ describe('ol.format.GML3', function () {
       expect(features[0].values_['name']).to.have.length(2);
     });
 
-    it('parses mutliple simple elements to strings', function () {
+    it('parses multiple simple elements to strings', function () {
       expect(features[0].values_['name'][0]).to.be.a('string');
     });
 
@@ -2277,7 +2277,7 @@ describe('ol.format.GML32', function () {
         format = new GML32({srsName: 'CRS:84', curve: true});
         const serialized = format.writeGeometryNode(g);
         // Conversion back to GML is not lossless, because we don't know
-        // the mapping of original LineString segements to the OpenLayers
+        // the mapping of original LineString segments to the OpenLayers
         // LineString geometry's coordinates.
         const expected =
           '<gml:Curve xmlns:gml="http://www.opengis.net/gml/3.2" ' +
@@ -3002,7 +3002,7 @@ describe('ol.format.GML32', function () {
       expect(features[0].values_['attributeB']).to.have.length(2);
     });
 
-    it('parses mutliple complex elements to an array of objects', function () {
+    it('parses multiple complex elements to an array of objects', function () {
       expect(features[0].values_['attributeA'][0]).to.be.a('object');
     });
 

--- a/test/browser/spec/ol/format/ows.test.js
+++ b/test/browser/spec/ol/format/ows.test.js
@@ -59,7 +59,7 @@ describe('ol.format.OWS 1.1', function () {
         'xmlns:xlink="http://www.w3.org/1999/xlink" >' +
         '<ows:ServiceIdentification>' +
         '<ows:Title>Web Map Tile Service</ows:Title>' +
-        '<ows:Abstract>Service that contrains the map access interface ' +
+        '<ows:Abstract>Service that constrains the map access interface ' +
         'to some TileMatrixSets</ows:Abstract>' +
         '<ows:Keywords>' +
         '<ows:Keyword>tile</ows:Keyword>' +
@@ -79,7 +79,7 @@ describe('ol.format.OWS 1.1', function () {
     const serviceIdentification = obj.ServiceIdentification;
     expect(serviceIdentification).to.be.ok();
     expect(serviceIdentification.Abstract).to.eql(
-      'Service that contains the map access interface to some TileMatrixSets'
+      'Service that constrains the map access interface to some TileMatrixSets'
     );
     expect(serviceIdentification.AccessConstraints).to.eql('none');
     expect(serviceIdentification.Fees).to.eql('none');

--- a/test/browser/spec/ol/format/ows.test.js
+++ b/test/browser/spec/ol/format/ows.test.js
@@ -79,7 +79,7 @@ describe('ol.format.OWS 1.1', function () {
     const serviceIdentification = obj.ServiceIdentification;
     expect(serviceIdentification).to.be.ok();
     expect(serviceIdentification.Abstract).to.eql(
-      'Service that contrains the map access interface to some TileMatrixSets'
+      'Service that contains the map access interface to some TileMatrixSets'
     );
     expect(serviceIdentification.AccessConstraints).to.eql('none');
     expect(serviceIdentification.Fees).to.eql('none');

--- a/test/browser/spec/ol/format/wmts/capabilities_epsg4326_with_boundingbox.xml
+++ b/test/browser/spec/ol/format/wmts/capabilities_epsg4326_with_boundingbox.xml
@@ -14,7 +14,7 @@
     </ows:Keywords>
     <ows:ServiceType>OGC WMTS</ows:ServiceType>
     <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
-    <ows:AccessConstraints>Proper attribution is required for any usage. The attribution shall follow the example of the demo map at https://maps.eox.at in the lower right corner including the respective links e.g. "Terrain { Data © OpenStreetMap contributers and others, Rendering © EOX }" with links to http://www.openstreetmap.org/copyright, https://maps.eox.at/#data, and https://eox.at. Additional restrictions may apply for individual layers as indicated in the respective abstract.</ows:AccessConstraints>
+    <ows:AccessConstraints>Proper attribution is required for any usage. The attribution shall follow the example of the demo map at https://maps.eox.at in the lower right corner including the respective links e.g. "Terrain { Data © OpenStreetMap contributors and others, Rendering © EOX }" with links to http://www.openstreetmap.org/copyright, https://maps.eox.at/#data, and https://eox.at. Additional restrictions may apply for individual layers as indicated in the respective abstract.</ows:AccessConstraints>
   </ows:ServiceIdentification>
   <ows:ServiceProvider>
     <ows:ProviderName>EOX</ows:ProviderName>

--- a/test/browser/spec/ol/format/wmts/ogcsample.xml
+++ b/test/browser/spec/ol/format/wmts/ogcsample.xml
@@ -2,7 +2,7 @@
 <Capabilities version="1.0.0" xmlns="http://www.opengis.net/wmts/1.0" xmlns:gml="http://www.opengis.net/gml" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0.0/wmtsGetCapabilities_response.xsd">
 	<ows:ServiceIdentification>
 		<ows:Title>Web Map Tile Service</ows:Title>
-		<ows:Abstract>Service that contrains the map
+		<ows:Abstract>Service that constrains the map
 access interface to some TileMatrixSets</ows:Abstract>
 		<ows:Keywords>
 			<ows:Keyword>tile</ows:Keyword>

--- a/test/browser/spec/ol/style/text.test.js
+++ b/test/browser/spec/ol/style/text.test.js
@@ -16,7 +16,7 @@ describe('ol.style.Text', function () {
       expect(style.getFill().getColor()).to.be('#123456');
     });
 
-    it('can always be resetted to no color', function () {
+    it('can always be reset to no color', function () {
       const style = new Text();
       style.getFill().setColor();
       expect(style.getFill().getColor()).to.be(undefined);


### PR DESCRIPTION
Found via `codespell -q 3 -S "./node_modules" -L coordinatess,nd`