### PR TITLE
Make BingMaps source 'placeholderTiles' optional

### DIFF
--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -69,7 +69,7 @@ const TOS_ATTRIBUTION =
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
  * @property {boolean} [placeholderTiles] Whether to show BingMaps placeholder tiles when zoomed past the maximum level provided in an area. When `false`, requests beyond
- * the maximum zoom level will return no tile. When `true`, the placeholder tile will be returned. When no set, the default behaviour of the imagery set takes place,
+ * the maximum zoom level will return no tile. When `true`, the placeholder tile will be returned. When not set, the default behaviour of the imagery set takes place,
  * which is unique for each imagery set in BingMaps.
  */
 

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -68,8 +68,9 @@ const TOS_ATTRIBUTION =
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
- * @property {boolean} placeholderTiles Whether to show BingMaps placeholder tiles when zoomed past the maximum level provided in an area. When `false`, requests beyond
- * the maximum zoom level will return no tile. When `true`, the placeholder tile will be returned.
+ * @property {boolean} [placeholderTiles] Whether to show BingMaps placeholder tiles when zoomed past the maximum level provided in an area. When `false`, requests beyond
+ * the maximum zoom level will return no tile. When `true`, the placeholder tile will be returned. When no set, the default behaviour of the imagery set takes place,
+ * which is unique for each imagery set in BingMaps.
  */
 
 /**
@@ -168,7 +169,7 @@ class BingMaps extends TileImage {
 
     /**
      * @private
-     * @type {boolean}
+     * @type {boolean|undefined}
      */
     this.placeholderTiles_ = options.placeholderTiles;
 


### PR DESCRIPTION
Fixes #15026 

Makes the `placeholderTiles` option of the BingMaps source object optional.

This fix is just about fixing the type definition to make the option optional.  Without it, the option is forced to be defined as boolean when used in a TypeScript project.