### PR TITLE
Wait until font loading has finished

### DIFF
--- a/test/rendering/cases/layer-vectortile-icon-label/main.js
+++ b/test/rendering/cases/layer-vectortile-icon-label/main.js
@@ -16,7 +16,10 @@ new Map({
   }),
 });
 
-render({
-  message: 'Vector tile layer declutters image with text correctly',
-  tolerance: 0.01,
-});
+setTimeout(() => {
+  // wait until fonts are loaded
+  render({
+    message: 'Vector tile layer declutters image with text correctly',
+    tolerance: 0.01,
+  });
+}, 500);


### PR DESCRIPTION
This pull request fixes an ephemeral issue with the layer-vectortile-icon-label rendering test: Sometimes the test fails because the map uses the fallback font until the desired font has finished loading.