### PR TITLE
Detect static image loaders by arguments length

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -37,7 +37,8 @@ import {toPromise} from './functions.js';
 
 /**
  * Loader function used for image sources. Receives extent, resolution and pixel ratio as arguments.
- * The function returns an {@link import("./DataTile.js").ImageLike image}, an
+ * For images that cover any extent and resolution (static images), the loader function should not accept
+ * any arguments. The function returns an {@link import("./DataTile.js").ImageLike image}, an
  * {@link import("./Image.js").ImageObject image object}, or a promise for the same.
  * For loaders that generate images, the promise should not resolve until the image is loaded.
  * If the returned image does not match the extent, resolution or pixel ratio passed to the loader,

--- a/src/ol/source/Image.js
+++ b/src/ol/source/Image.js
@@ -172,6 +172,12 @@ class ImageSource extends Source {
      * @type {number}
      */
     this.wantedResolution_;
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.static_ = options.loader ? options.loader.length === 0 : false;
   }
 
   /**
@@ -263,18 +269,19 @@ class ImageSource extends Source {
     if (this.loader) {
       const requestExtent = getRequestExtent(extent, resolution, pixelRatio, 1);
       const requestResolution = this.findNearestResolution(resolution);
-      if (this.image) {
-        if (
-          ((this.wantedExtent_ &&
+      if (
+        this.image &&
+        (this.static_ ||
+          (((this.wantedExtent_ &&
             containsExtent(this.wantedExtent_, requestExtent)) ||
             containsExtent(this.image.getExtent(), requestExtent)) &&
-          ((this.wantedResolution_ &&
-            fromResolutionLike(this.wantedResolution_) === requestResolution) ||
-            fromResolutionLike(this.image.getResolution()) ===
-              requestResolution)
-        ) {
-          return this.image;
-        }
+            ((this.wantedResolution_ &&
+              fromResolutionLike(this.wantedResolution_) ===
+                requestResolution) ||
+              fromResolutionLike(this.image.getResolution()) ===
+                requestResolution)))
+      ) {
+        return this.image;
       }
       this.wantedExtent_ = requestExtent;
       this.wantedResolution_ = requestResolution;

--- a/test/browser/spec/ol/source/Image.test.js
+++ b/test/browser/spec/ol/source/Image.test.js
@@ -1,0 +1,22 @@
+import ImageSource from '../../../../../src/ol/source/Image.js';
+
+describe('ol/source/Image', function () {
+  describe('constructor', function () {
+    it('does not set the static_ flag when no loader is configured', function () {
+      const source = new ImageSource({});
+      expect(source.static_).to.be(false);
+    });
+    it('does not set the static_ flag when loader accepts arguments', function () {
+      const source = new ImageSource({
+        loader: function (extent, resolution, projection) {},
+      });
+      expect(source.static_).to.be(false);
+    });
+    it('sets the static_ flag when loader accepts no arguments', function () {
+      const source = new ImageSource({
+        loader: function () {},
+      });
+      expect(source.static_).to.be(true);
+    });
+  });
+});


### PR DESCRIPTION
This pull request fixes the [problem](https://github.com/openlayers/openlayers/issues/14788#issuecomment-1686883178) that static images get re-requested on every extent or resolution change.

To detect a static image loader (i.e. a loader that returns an image which is valid for any extent and resolution), the Image source now checks for the length of the loader function.