### PR TITLE
Set correct maxZoom in OSM Vector Tiles example

### DIFF
--- a/examples/osm-vector-tiles.js
+++ b/examples/osm-vector-tiles.js
@@ -69,7 +69,7 @@ const map = new Map({
           layerName: 'layer',
           layers: ['water', 'roads', 'buildings'],
         }),
-        maxZoom: 19,
+        maxZoom: 16,
         url:
           'https://tile.nextzen.org/tilezen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=' +
           key,


### PR DESCRIPTION
The source is not serving tiles above zoom level 16, consequently blurred interim tiles are seen with higher view zoom levels instead of sharp render tiles based on tiles served at the correct maxZoom.