### PR TITLE
Remove ol/style/Icon's imgSize property

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -69,6 +69,14 @@ const staticOptions = {
 ```
 Try to get rid of such an unintended use, or replace the `imageSize` option with an extent calculation like the above.
 
+##### Removal of `ol/style/Icon`'s `imgSize` property
+
+The `imgSize` property is no longer needed. If you had it configured, simply remove it.
+
+##### Removal of the `icon-img-size` flat style property
+
+This property is no longer needed and can simply be removed.
+
 ##### Change of the symbol style format in `ol/layer/WebGLPointsLayer`
 
 The `WebGLPointsLayer` class used to rely on a custom style format that was made specifically for this layer and which looked like this:

--- a/examples/animated-gif.js
+++ b/examples/animated-gif.js
@@ -43,7 +43,6 @@ gif.frames(
         new Style({
           image: new Icon({
             img: ctx.canvas,
-            imgSize: [frame.width, frame.height],
             opacity: 0.8,
           }),
         })

--- a/examples/earthquake-custom-symbol.js
+++ b/examples/earthquake-custom-symbol.js
@@ -48,7 +48,6 @@ const styleFunction = function (feature) {
     style = new Style({
       image: new Icon({
         img: canvas,
-        imgSize: [size, size],
         rotation: 1.2,
       }),
     });

--- a/src/ol/render/canvas/ImageBuilder.js
+++ b/src/ol/render/canvas/ImageBuilder.js
@@ -16,13 +16,13 @@ class CanvasImageBuilder extends CanvasBuilder {
 
     /**
      * @private
-     * @type {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement}
+     * @type {import('../../DataTile.js').ImageLike}
      */
     this.hitDetectionImage_ = null;
 
     /**
      * @private
-     * @type {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement}
+     * @type {import('../../DataTile.js').ImageLike}
      */
     this.image_ = null;
 

--- a/src/ol/render/canvas/Immediate.js
+++ b/src/ol/render/canvas/Immediate.js
@@ -142,7 +142,7 @@ class CanvasImmediateRenderer extends VectorContext {
 
     /**
      * @private
-     * @type {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement}
+     * @type {import('../../DataTile.js').ImageLike}
      */
     this.image_ = null;
 

--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -101,7 +101,6 @@ export function createHitDetectionImageData(
         style.setImage(
           new Icon({
             img: img,
-            imgSize: imgSize,
             anchor: image.getAnchor(),
             anchorXUnits: 'pixels',
             anchorYUnits: 'pixels',

--- a/src/ol/style/Image.js
+++ b/src/ol/style/Image.js
@@ -162,7 +162,7 @@ class ImageStyle {
    * Get the image element for the symbolizer.
    * @abstract
    * @param {number} pixelRatio Pixel ratio.
-   * @return {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement} Image element.
+   * @return {import('../DataTile.js').ImageLike} Image element.
    */
   getImage(pixelRatio) {
     return abstract();
@@ -170,7 +170,7 @@ class ImageStyle {
 
   /**
    * @abstract
-   * @return {HTMLCanvasElement|HTMLVideoElement|HTMLImageElement} Image element.
+   * @return {import('../DataTile.js').ImageLike} Image element.
    */
   getHitDetectionImage() {
     return abstract();

--- a/src/ol/style/literal.js
+++ b/src/ol/style/literal.js
@@ -33,11 +33,7 @@
 /**
  * @typedef {Object} IconProps
  * @property {string} [icon-src] Image source URI.
- * @property {HTMLImageElement|HTMLCanvasElement} [icon-img] Image object for the icon. If the `icon-src` option is not provided then the
- * provided image must already be loaded. And in that case, it is required
- * to provide the size of the image, with the `icon-img-size` option.
- * @property {import("../size.js").Size} [icon-img-size] Image size in pixels. Only required if `icon-img` is set and `icon-src` is not.
- * The provided size needs to match the actual size of the image.
+ * @property {HTMLImageElement|HTMLCanvasElement} [icon-img] Image object for the icon. Required if the `icon-src` option is not provided.
  * @property {Array<number>|ExpressionValue} [icon-anchor=[0.5, 0.5]] Anchor. Default value is the icon center.
  * @property {import("./Icon.js").IconOrigin} [icon-anchor-origin='top-left'] Origin of the anchor: `bottom-left`, `bottom-right`,
  * `top-left` or `top-right`.

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -475,8 +475,19 @@ function parseIconProperties(
     builder.addUniform(`vec2 u_texture${textureId}_size`);
   } else {
     image = style['icon-img'];
-    const imgSize = style['icon-img-size'];
-    size = arrayToGlsl(imgSize);
+    if (image instanceof HTMLImageElement) {
+      if (image.complete && image.width && image.height) {
+        size = arrayToGlsl([image.width, image.height]);
+      } else {
+        // the size is provided asynchronously using a uniform
+        uniforms[`u_texture${textureId}_size`] = () => {
+          return image.complete ? [image.width, image.height] : [0, 0];
+        };
+        size = `u_texture${textureId}_size`;
+      }
+    } else {
+      size = arrayToGlsl([image.width, image.height]);
+    }
   }
   uniforms[`u_texture${textureId}`] = image;
   builder

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -2,14 +2,14 @@ import Icon from '../../../../../src/ol/style/Icon.js';
 import IconImage, {
   get as getIconImage,
 } from '../../../../../src/ol/style/IconImage.js';
+import ImageState from '../../../../../src/ol/ImageState.js';
 import {getUid} from '../../../../../src/ol/util.js';
 import {shared as iconImageCache} from '../../../../../src/ol/style/IconImageCache.js';
 
 describe('ol.style.Icon', function () {
   const size = [36, 48];
   const src =
-    'data:image/gif;base64,' +
-    'R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
+    'data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=';
 
   beforeEach(function () {
     iconImageCache.clear();
@@ -19,24 +19,8 @@ describe('ol.style.Icon', function () {
       const canvas = document.createElement('canvas');
       new Icon({
         img: canvas,
-        imgSize: size,
       });
-      expect(getIconImage(canvas, getUid(canvas), size, '').getImage()).to.eql(
-        canvas
-      );
-    });
-
-    it('imgSize overrides img.width and img.height', function (done) {
-      const style = new Icon({
-        src: src,
-        imgSize: size,
-      });
-      const iconImage = style.iconImage_;
-      iconImage.addEventListener('change', function () {
-        expect([iconImage.image_.width, iconImage.image_.height]).to.eql(size);
-        done();
-      });
-      style.load();
+      expect(getIconImage(canvas, getUid(canvas)).getImage()).to.eql(canvas);
     });
   });
 
@@ -60,7 +44,6 @@ describe('ol.style.Icon', function () {
         color: '#319FD3',
         crossOrigin: 'Anonymous',
         img: canvas,
-        imgSize: size,
         offset: [1, 2],
         offsetOrigin: 'bottom-left',
         opacity: 0.5,
@@ -80,7 +63,6 @@ describe('ol.style.Icon', function () {
       expect(original.anchorYUnits_).to.eql(clone.anchorYUnits_);
       expect(original.crossOrigin_).to.eql(clone.crossOrigin_);
       expect(original.getColor()).to.eql(clone.getColor());
-      expect(original.imgSize_).to.eql(clone.imgSize_);
       expect(original.offset_).to.eql(clone.offset_);
       expect(original.offsetOrigin_).to.eql(clone.offsetOrigin_);
       expect(original.getScale()).to.eql(clone.getScale());
@@ -102,10 +84,8 @@ describe('ol.style.Icon', function () {
       expect(original.getSrc()).to.be(clone.getSrc());
     });
     it('copies all values with src without shared IconImageCache', function (done) {
-      const imgSize = [11, 13];
       const original = new Icon({
         src: src,
-        imgSize: imgSize.slice(),
       });
       iconImageCache.clear();
 
@@ -123,8 +103,6 @@ describe('ol.style.Icon', function () {
       ]).then(function () {
         expect(original.getSrc()).to.be(clone.getSrc());
         expect(original.iconImage_).to.not.be(clone.iconImage_);
-        expect(original.getImage(1).width).to.be(imgSize[0]);
-        expect(original.getImage(1).height).to.be(imgSize[1]);
         expect(original.getImage(1).width).to.be(clone.getImage(1).width);
         expect(original.getImage(1).height).to.be(clone.getImage(1).height);
         done();
@@ -377,27 +355,54 @@ describe('ol.style.Icon', function () {
   });
 
   describe('#getImageSize', function () {
-    const imgSize = [144, 192];
-
-    it('takes the real image size', function () {
-      // pretend that the image is already in the cache,
-      // this image will be used for the icon.
-      const src = 'test.png';
-      const iconImage = new IconImage(null, 'test.png', imgSize);
+    it('uses the cache', function (done) {
+      const src = './spec/ol/data/dot.png';
+      const iconImage = new IconImage(new Image(), src);
       iconImageCache.set(src, null, null, iconImage);
+      iconImage.load();
 
       const iconStyle = new Icon({
-        src: 'test.png',
+        src: src,
       });
-      expect(iconStyle.getImageSize()).to.eql(imgSize);
+      iconImage.addEventListener('change', function changed() {
+        if (iconImage.getImageState() === ImageState.LOADED) {
+          iconImage.removeEventListener('change', changed);
+          try {
+            expect(iconStyle.getImage()).to.eql(iconImage.getImage());
+            expect(iconStyle.getImage()).to.be.a(HTMLImageElement);
+            expect(iconStyle.getImageSize()).to.eql([
+              iconStyle.getImage().width,
+              iconStyle.getImage().height,
+            ]);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+      });
     });
 
-    it('uses the given image size', function () {
+    it('has the image size after the image has finished loading', function (done) {
+      const image = new Image();
       const iconStyle = new Icon({
-        img: {src: 'test.png'},
-        imgSize: imgSize,
+        img: image,
       });
-      expect(iconStyle.getImageSize()).to.eql(imgSize);
+      iconStyle.iconImage_.addEventListener('change', function changed() {
+        if (iconStyle.getImageState() === ImageState.LOADED) {
+          iconStyle.iconImage_.removeEventListener('change', changed);
+          try {
+            expect(iconStyle.getImageSize()).to.eql([
+              image.width,
+              image.height,
+            ]);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }
+      });
+      image.src = './spec/ol/data/dot.png';
+      iconStyle.load();
     });
   });
 

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -326,7 +326,6 @@ describe('ol.webgl.styleparser', () => {
         beforeEach(() => {
           const style = {
             'icon-img': new Image(10, 20),
-            'icon-img-size': [10, 10],
             'icon-opacity': ['*', 0.5, 0.75],
             'icon-color': ['get', 'color1'],
             'icon-displacement': ['array', -2, 1],
@@ -365,7 +364,7 @@ describe('ol.webgl.styleparser', () => {
             'vec2(-2.0, 1.0)'
           );
           expect(result.builder.texCoordExpression_).to.eql(
-            '(vec4((vec2(a_attr1, 20.0)).xyxy) + vec4(0., 0., vec2(30.0, 40.0))) / (vec2(10.0, 10.0)).xyxy'
+            '(vec4((vec2(a_attr1, 20.0)).xyxy) + vec4(0., 0., vec2(30.0, 40.0))) / (vec2(10.0, 20.0)).xyxy'
           );
           expect(result.builder.symbolRotateWithView_).to.eql(true);
           expect(Object.keys(result.attributes).length).to.eql(3);

--- a/test/rendering/cases/immediate-pixel-ratio/main.js
+++ b/test/rendering/cases/immediate-pixel-ratio/main.js
@@ -18,7 +18,6 @@ const pointStyle = new Style({
   image: new Icon({
     img: img,
     size: [10, 10],
-    imgSize: [10, 10],
   }),
 });
 const line = new LineString(coordinates);

--- a/test/rendering/cases/webgl-icons/main.js
+++ b/test/rendering/cases/webgl-icons/main.js
@@ -24,7 +24,6 @@ const iconSimple = {
 };
 const dataDriven = {
   'icon-img': canvas,
-  'icon-img-size': [20, 20],
   'icon-color': ['get', 'color'],
   'icon-displacement': [40, 0],
 };


### PR DESCRIPTION
This pull request removes the `imgSize` property and its flat style `icon-img-size` counterpart, changing the loading sequence so they are no longer needed.

The image is now loaded using the simple `ol/Image.load()` function instead of the more involved `listenImage()` one, because the way `listenImage` decodes the image was only guaranteed to provide the decoded image for a single render frame, which does not bring a real performance benefit. We could also use `ol/Image.decode()`, but that would make SVG images, which are frequently used as icons, blurry when scaled or on retina displays.