### PR TITLE
Recreate WebGL helper when context is lost and restored

### DIFF
--- a/src/ol/renderer/webgl/Layer.js
+++ b/src/ol/renderer/webgl/Layer.js
@@ -167,7 +167,11 @@ class WebGLLayerRenderer extends LayerRenderer {
       const canvasCacheKey =
         'map/' + frameState.mapId + '/group/' + groupNumber;
 
-      if (!this.helper || !this.helper.canvasCacheKeyMatches(canvasCacheKey)) {
+      if (
+        !this.helper ||
+        !this.helper.canvasCacheKeyMatches(canvasCacheKey) ||
+        this.helper.needsToBeRecreated()
+      ) {
         this.removeHelper();
 
         this.helper = new WebGLHelper({

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -356,6 +356,12 @@ class WebGLHelper extends Disposable {
      */
     this.currentProgram_ = null;
 
+    /**
+     * @private
+     * @type boolean
+     */
+    this.needsToBeRecreated_ = false;
+
     const canvas = this.gl_.canvas;
 
     canvas.addEventListener(
@@ -1046,18 +1052,31 @@ class WebGLHelper extends Disposable {
 
   /**
    * WebGL context was lost
+   * @param {WebGLContextEvent} event The context loss event.
    * @private
    */
-  handleWebGLContextLost() {
+  handleWebGLContextLost(event) {
     clear(this.bufferCache_);
     this.currentProgram_ = null;
+
+    event.preventDefault();
   }
 
   /**
    * WebGL context was restored
    * @private
    */
-  handleWebGLContextRestored() {}
+  handleWebGLContextRestored() {
+    this.needsToBeRecreated_ = true;
+  }
+
+  /**
+   * Returns whether this helper needs to be recreated, as the context was lost and then restored.
+   * @return {boolean} Whether this helper needs to be recreated.
+   */
+  needsToBeRecreated() {
+    return this.needsToBeRecreated_;
+  }
 
   /**
    * Will create or reuse a given webgl texture and apply the given size. If no image data


### PR DESCRIPTION
For any reason, the WebGL context might be lost, causing the map to stop rendering. This adjusts the code to set a flag indicating that any resources used have to be recreated on the WebGL context.

This fix piggybacks on the fact that recreating the helper (because of e.g. a canvas switch) recreates all resources, since different canvases may have different WebGL contexts.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
