### PR TITLE
Add missing links to old version

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -51,6 +51,7 @@
             </a>
             <div class="dropdown-menu dropdown-menu-end mb-3" aria-labelledby="apidropdown">
               <a class="dropdown-item" href="/en/latest/apidoc/"><i class="fa fa-sitemap fa-fw me-2 fa-lg"></i>{{ version }} (latest)</a>
+              <a class="dropdown-item" href="/en/v7.5.2/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v7.5.2</a>
               <a class="dropdown-item" href="/en/v6.15.1/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v6.15.1</a>
               <a class="dropdown-item" href="/en/v5.3.0/apidoc/"><i class="fa fa-sitemap fa-fw me-2 fa-lg"></i>v5.3.0</a>
               <a class="dropdown-item" href="/en/v4.6.5/apidoc/"><i class="fa fa-sitemap fa-fw me-2 fa-lg"></i>v4.6.5</a>

--- a/site/src/index.hbs
+++ b/site/src/index.hbs
@@ -95,10 +95,11 @@ head:
     <div class='col-sm-12'>
       <p>In case you are not ready (yet) for the latest version of OpenLayers, we provide links to selected resources of older major versions of the software.</p>
       <ul>
+        <li>Latest v7: <a href="https://github.com/openlayers/openlayers/releases/tag/v7.5.2">v7.5.2</a> released 2023-08-31 &mdash; <a href="/en/v7.5.2/doc/">docs</a>, <a href="/en/v7.5.2/apidoc/">API</a> &amp;  <a href="/en/v7.5.2/examples/">examples</a></li>
         <li>Latest v6: <a href="https://github.com/openlayers/openlayers/releases/tag/v6.15.1">v6.15.1</a> released 2022-07-18 &mdash; <a href="/en/v6.15.1/doc/">docs</a>, <a href="/en/v6.15.1/apidoc/">API</a> &amp;  <a href="/en/v6.15.1/examples/">examples</a></li>
         <li>Latest v5: <a href="https://github.com/openlayers/openlayers/releases/tag/v5.3.0">v5.3.0</a> released 2018-11-06 &mdash; <a href="/en/v5.3.0/doc/">docs</a>, <a href="/en/v5.3.0/apidoc/">API</a> &amp;  <a href="/en/v5.3.0/examples/">examples</a></li>
         <li>Latest v4: <a href="https://github.com/openlayers/openlayers/releases/tag/v4.6.5">v4.6.5</a> released 2018-03-20 &mdash; <a href="/en/v4.6.5/doc/">docs</a>, <a href="/en/v4.6.5/apidoc/">API</a> &amp;  <a href="/en/v4.6.5/examples/">examples</a></li>
-        <li>Latest v3: <a href="https://github.com/openlayers/openlayers/releases/tag/v3.20.1">v3.20.1</a>, released 2016-12-12 &mdash; <a href="/en/v3.20.1/doc/">docs</a>, <a href="/en/v3.20.1/apidoc/">API</a> &amp;  <a href="/en/v3.20.1/examples/">examples</a></li>
+        <li>Latest v3: <a href="https://github.com/openlayers/openlayers/releases/tag/v3.20.1">v3.20.1</a>, released 2016-12-21 &mdash; <a href="/en/v3.20.1/doc/">docs</a>, <a href="/en/v3.20.1/apidoc/">API</a> &amp;  <a href="/en/v3.20.1/examples/">examples</a></li>
         <li>Latest v2: v2.13.1, released 2013-07-09 &mdash; you'll find everything you need on the <a href="./two/">2.x page</a></li>
       </ul>
       <p>Please consider upgrading to benefit from the latest features and bug fixes. Get better performance and usability for free by using recent versions of OpenLayers.</p>


### PR DESCRIPTION
Fixed release date for [v3.20.1](https://github.com/openlayers/openlayers/releases/tag/v3.20.1)