### PR TITLE
Accept a number or an array of numbers for icon scale

### DIFF
--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -996,7 +996,11 @@ function sizeLikeEvaluator(flatStyle, name, context) {
   if (!(name in flatStyle)) {
     return null;
   }
-  const evaluator = buildExpression(flatStyle[name], NumberArrayType, context);
+  const evaluator = buildExpression(
+    flatStyle[name],
+    NumberArrayType | NumberType,
+    context
+  );
   return function (context) {
     return requireSizeLike(evaluator(context), name);
   };


### PR DESCRIPTION
This makes it possible to supply a number or an array of numbers for the `icon-scale` property in a style.

Fixes #15073.