### PR TITLE
Avoid Chrome/Edge deprecated feature warning

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -109,6 +109,7 @@
 
 .ol-viewport canvas {
   all: unset;
+  overflow: hidden;
 }
 
 .ol-viewport {


### PR DESCRIPTION
Avoids the browser warning reported in  https://stackoverflow.com/questions/77031326/getting-css-overflow-error-while-working-with-openlayers-v7-5-2
