### PR TITLE
Support for Graticule Drawing for Grid Projections Other than EPSG432

### DIFF
--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -144,8 +144,8 @@ export function greatCircleArc(
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
  */
-export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
-  const epsg4326Projection = getProjection('EPSG:4326');
+export function meridian(lon, lat1, lat2, projection, squaredTolerance, sourceProjection) {  // Add @sourceProjection
+  if(sourceProjection === undefined) sourceProjection = getProjection('EPSG:4326');
   return line(
     /**
      * @param {number} frac Fraction.
@@ -154,7 +154,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
     function (frac) {
       return [lon, lat1 + (lat2 - lat1) * frac];
     },
-    getTransform(epsg4326Projection, projection),
+    getTransform(sourceProjection, projection),
     squaredTolerance
   );
 }
@@ -168,8 +168,8 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
  * @param {number} squaredTolerance Squared tolerance.
  * @return {Array<number>} Flat coordinates.
  */
-export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
-  const epsg4326Projection = getProjection('EPSG:4326');
+export function parallel(lat, lon1, lon2, projection, squaredTolerance, sourceProjection) {  // Add @sourceProjection
+  if(sourceProjection === undefined) sourceProjection = getProjection('EPSG:4326');
   return line(
     /**
      * @param {number} frac Fraction.
@@ -178,7 +178,7 @@ export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
     function (frac) {
       return [lon1 + (lon2 - lon1) * frac, lat];
     },
-    getTransform(epsg4326Projection, projection),
+    getTransform(sourceProjection, projection),
     squaredTolerance
   );
 }

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -33,7 +33,7 @@ import {
   getTransform,
 } from '../proj.js';
 import {getVectorContext} from '../render.js';
-import {meridian, parallel} from '../geom/flat/geodesic.js';
+import {meridian, parallel} from '../geom/flat/geodesic.js';  // altered version
 
 /**
  * @type {Stroke}
@@ -208,12 +208,21 @@ class Graticule extends VectorLayer {
     delete baseOptions.lonLabelStyle;
     delete baseOptions.latLabelStyle;
     delete baseOptions.intervals;
+    delete baseOptions.gridProjection;
     super(baseOptions);
 
     /**
      * @type {import("../proj/Projection.js").default}
      */
     this.projection_ = null;
+
+    /**
+     * @type {Projection|PorjectionLike}
+     * @private
+     */
+    this.gridProjection_ = (options.gridProjection === undefined)?       getProjection('EPSG:4326'):   //default WGS84;
+                           (typeof options.gridProjection === "string")? getProjection(options.gridProjection):
+                           options.gridProjection;
 
     /**
      * @type {number}
@@ -1017,9 +1026,9 @@ class Graticule extends VectorLayer {
     /** @type {Array<number>} **/
     const p2 = [];
     for (let i = 0, ii = this.intervals_.length; i < ii; ++i) {
-      const delta = clamp(this.intervals_[i] / 2, 0, 90);
+      const delta = clamp(this.intervals_[i] / 2, 0, this.maxLat_);
       // Don't attempt to transform latitudes beyond the poles!
-      const clampedLat = clamp(centerLat, -90 + delta, 90 - delta);
+      const clampedLat = clamp(centerLat, this.minLat_ + delta, this.maxLat_ - delta);
       p1[0] = centerLon - delta;
       p1[1] = clampedLat - delta;
       p2[0] = centerLon + delta;
@@ -1050,7 +1059,8 @@ class Graticule extends VectorLayer {
       minLat,
       maxLat,
       this.projection_,
-      squaredTolerance
+      squaredTolerance,
+      this.gridProjection_,
     );
     let lineString = this.meridians_[index];
     if (!lineString) {
@@ -1120,7 +1130,8 @@ class Graticule extends VectorLayer {
       minLon,
       maxLon,
       this.projection_,
-      squaredTolerance
+      squaredTolerance,
+      this.gridProjection_
     );
     let lineString = this.parallels_[index];
     if (!lineString) {
@@ -1179,9 +1190,7 @@ class Graticule extends VectorLayer {
    * @private
    */
   updateProjectionInfo_(projection) {
-    const epsg4326Projection = getProjection('EPSG:4326');
-
-    const worldExtent = projection.getWorldExtent();
+    const worldExtent = this.gridProjection_.getExtent();
 
     this.maxLat_ = worldExtent[3];
     this.maxLon_ = worldExtent[2];
@@ -1191,7 +1200,7 @@ class Graticule extends VectorLayer {
     // If the world extent crosses the dateline define a custom transform to
     // return longitudes which wrap the dateline
 
-    const toLonLatTransform = getTransform(projection, epsg4326Projection);
+    const toLonLatTransform = getTransform(projection, this.gridProjection_);
     if (this.minLon_ < this.maxLon_) {
       this.toLonLatTransform_ = toLonLatTransform;
     } else {
@@ -1216,7 +1225,7 @@ class Graticule extends VectorLayer {
     // Transform the extent to get the limits of the view projection extent
     // which should be available to the graticule
 
-    this.fromLonLatTransform_ = getTransform(epsg4326Projection, projection);
+    this.fromLonLatTransform_ = getTransform(this.gridProjection_, projection);
     const worldExtentP = applyTransform(
       [this.minLon_, this.minLat_, this.maxLon_, this.maxLat_],
       this.fromLonLatTransform_,
@@ -1241,9 +1250,10 @@ class Graticule extends VectorLayer {
     // Some projections may have a void area at the poles
     // so replace any NaN latitudes with the min or max value closest to a pole
 
-    this.projectionCenterLonLat_ = this.toLonLatTransform_(
-      getCenter(projection.getExtent())
-    );
+    this.projectionCenterLonLat_ = this.gridProjection_.getExtent()?
+      getCenter(this.gridProjection_.getExtent()):
+      this.toLonLatTransform_(projection.getExtent());
+
     if (isNaN(this.projectionCenterLonLat_[1])) {
       this.projectionCenterLonLat_[1] =
         Math.abs(this.maxLat_) >= Math.abs(this.minLat_)


### PR DESCRIPTION
Support for Graticule Drawing for Grid Projections Other than EPSG4326, with a additional option gridProjection

- modified:   src/ol/geom/flat/geodesic.js
    - patch meridian() and parallel() to allow to pass the sourceProjection, instead of hardcoded EPSG4326

- modified:   src/ol/layer/Graticule.js
  - add ctor options 'gridProjection', assign to property this.gridProjection_
  - use this.gridProjection_ to replace hardcoded EPSG4326
  - use gridProjection_.getExtent() to get the extent. (so users should define the extent for the gridProjection, if needed)
    (Originally, projection_.getWorldExtent() is used to do that, but it is only ok when gridProjection_ is EPSG4326)

- TODO: suggest to change the variables' name from lonlat to xy

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

Use Example:
```javascript
import {addProjection, Projection} from 'ol/proj';
import {register} from 'ol/proj/proj4';
import proj4 from 'proj4';

// ref: https://epsg.io/<NUMBER>.js
// ref: http://mutolisp.logdown.com/posts/207563-taiwan-geodetic-coordinate-system-conversion
 proj4.defs([
   ["EPSG:3828", "+title=TWD67 TM2 Taiwan +proj=tmerc +lat_0=0 +lon_0=121 +k=0.9999 +x_0=250000 +y_0=0 +ellps=aust_SA +towgs84=-752,-358,-179,-0.0000011698,0.0000018398,0.0000009822,0.00002329 +units=m +no_defs"],
 ]);

// reigster for openlayers
register(proj4);

export const TWD67 = new Projection({
  code: 'EPSG:3828',
  //center: 252551.25 2611288.37
  extent: [ 145616.57, 2419514.81, 356704.34, 2803869.61 ],
  worldExtent: [119.99, 21.87, 122.06, 25.34 ],
  units: 'm',
});

addProjection(TWD67);


//-----------------------------------------------------

import {Stroke} from 'ol/style';
import Graticule from 'ol/layer/Graticule';

const tm2_label_formatter = n => {
  const s = Math.floor(n).toString();
  return s.slice(0, -3) + ' ' + s.slice(-3);
}

const layer = new Graticule({
  strokeStyle: new Stroke({
    color: 'rgba(64,64,64,1)',
    width: 2,
    lineDash: [0.5, 4]
  }),
  lonLabelPosition: 0,
  latLabelPosition: 0,
  lonLabelStyle: lonLabelStyle(),
  latLabelStyle: latLabelStyle(),
  showLabels: true,
  maxLines: 20,
  wrapX: true,
  intervals: [100000, 10000, 1000, 100, 10, 1],
  lonLabelFormatter: tm2_label_formatter,
  latLabelFormatter: tm2_label_formatter,
  targetSize: 80,
  gridProjection: 'EPSG:3828',  //TWD67
});

```