### PR TITLE
Support for Graticule Drawing for Grid Projections Other than EPSG4326

### DIFF
--- a/src/ol/geom/flat/geodesic.js
+++ b/src/ol/geom/flat/geodesic.js
@@ -142,10 +142,18 @@ export function greatCircleArc(
  * @param {number} lat2 Latitude 2.
  * @param {import("../../proj/Projection.js").default} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
+ * @param {import("../../proj/Projection.js").default|undefined} sourceProjection Source projection.
  * @return {Array<number>} Flat coordinates.
  */
-export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
-  const epsg4326Projection = getProjection('EPSG:4326');
+export function meridian(
+  lon,
+  lat1,
+  lat2,
+  projection,
+  squaredTolerance,
+  sourceProjection
+) {
+  sourceProjection = sourceProjection || getProjection('EPSG:4326');
   return line(
     /**
      * @param {number} frac Fraction.
@@ -154,7 +162,7 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
     function (frac) {
       return [lon, lat1 + (lat2 - lat1) * frac];
     },
-    getTransform(epsg4326Projection, projection),
+    getTransform(sourceProjection, projection),
     squaredTolerance
   );
 }
@@ -166,10 +174,18 @@ export function meridian(lon, lat1, lat2, projection, squaredTolerance) {
  * @param {number} lon2 Longitude 2.
  * @param {import("../../proj/Projection.js").default} projection Projection.
  * @param {number} squaredTolerance Squared tolerance.
+ * @param {import("../../proj/Projection.js").default|undefined} sourceProjection Source projection.
  * @return {Array<number>} Flat coordinates.
  */
-export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
-  const epsg4326Projection = getProjection('EPSG:4326');
+export function parallel(
+  lat,
+  lon1,
+  lon2,
+  projection,
+  squaredTolerance,
+  sourceProjection
+) {
+  sourceProjection = sourceProjection || getProjection('EPSG:4326');
   return line(
     /**
      * @param {number} frac Fraction.
@@ -178,7 +194,7 @@ export function parallel(lat, lon1, lon2, projection, squaredTolerance) {
     function (frac) {
       return [lon1 + (lon2 - lon1) * frac, lat];
     },
-    getTransform(epsg4326Projection, projection),
+    getTransform(sourceProjection, projection),
     squaredTolerance
   );
 }


### PR DESCRIPTION
Support for Graticule Drawing for Grid Projections Other than EPSG4326, with a additional option gridProjection

- modified:   src/ol/geom/flat/geodesic.js
    - patch meridian() and parallel() to allow to pass the sourceProjection, instead of hardcoded EPSG4326

- modified:   src/ol/layer/Graticule.js
  - add ctor options 'gridProjection', assign to property this.gridProjection_
  - use this.gridProjection_ to replace hardcoded EPSG4326
  - use gridProjection_.getExtent() to get the extent. (so users should define the extent for the gridProjection, if needed)
    (Originally, projection_.getWorldExtent() is used to do that, but it is only ok when gridProjection_ is EPSG4326)

- TODO: suggest to change the variables' name from lonlat to xy

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

Use Example:
```javascript
import {addProjection, Projection} from 'ol/proj';
import {register} from 'ol/proj/proj4';
import proj4 from 'proj4';

// ref: https://epsg.io/<NUMBER>.js
// ref: http://mutolisp.logdown.com/posts/207563-taiwan-geodetic-coordinate-system-conversion
 proj4.defs([
   ["EPSG:3828", "+title=TWD67 TM2 Taiwan +proj=tmerc +lat_0=0 +lon_0=121 +k=0.9999 +x_0=250000 +y_0=0 +ellps=aust_SA +towgs84=-752,-358,-179,-0.0000011698,0.0000018398,0.0000009822,0.00002329 +units=m +no_defs"],
 ]);

// reigster for openlayers
register(proj4);

export const TWD67 = new Projection({
  code: 'EPSG:3828',
  //center: 252551.25 2611288.37
  extent: [ 145616.57, 2419514.81, 356704.34, 2803869.61 ],
  worldExtent: [119.99, 21.87, 122.06, 25.34 ],
  units: 'm',
});

addProjection(TWD67);


//-----------------------------------------------------

import {Stroke} from 'ol/style';
import Graticule from 'ol/layer/Graticule';

const tm2_label_formatter = n => {
  const s = Math.floor(n).toString();
  return s.slice(0, -3) + ' ' + s.slice(-3);
}

const layer = new Graticule({
  strokeStyle: new Stroke({
    color: 'rgba(64,64,64,1)',
    width: 2,
    lineDash: [0.5, 4]
  }),
  lonLabelPosition: 0,
  latLabelPosition: 0,
  lonLabelStyle: lonLabelStyle(),
  latLabelStyle: latLabelStyle(),
  showLabels: true,
  maxLines: 20,
  wrapX: true,
  intervals: [100000, 10000, 1000, 100, 10, 1],
  lonLabelFormatter: tm2_label_formatter,
  latLabelFormatter: tm2_label_formatter,
  targetSize: 80,
  gridProjection: 'EPSG:3828',  //TWD67
});

```
