### PR TITLE
Do not attempt to decode image if `src` is not set

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -296,7 +296,7 @@ export function decodeFallback(image, src) {
   if (src) {
     image.src = src;
   }
-  return IMAGE_DECODE
+  return image.src && IMAGE_DECODE
     ? new Promise((resolve, reject) =>
         image.decode().then(() => resolve(image), reject)
       )
@@ -316,7 +316,7 @@ export function decode(image, src) {
   if (src) {
     image.src = src;
   }
-  return IMAGE_DECODE && CREATE_IMAGE_BITMAP
+  return image.src && IMAGE_DECODE && CREATE_IMAGE_BITMAP
     ? image.decode().then(() => createImageBitmap(image))
     : decodeFallback(image);
 }


### PR DESCRIPTION
Fixes #15093

Calling `image.decode()` if `image.src` is not set will throw an error, so we need to fall back to using `load`.
