### PR TITLE
setStyle should pass paletteTextures in WebGLTile Layer and Renderer

### DIFF
--- a/examples/cog-style.html
+++ b/examples/cog-style.html
@@ -17,4 +17,6 @@ Set the layer style
   <option value="trueColor">True Color</option>
   <option value="falseColor">False Color</option>
   <option value="ndvi">NDVI</option>
+  <option value="ndviPalettePlasma">NDVI w/ palette 1</option>
+  <option value="ndviPaletteViridis">NDVI w/ palette 2</option>
 </select>

--- a/examples/cog-style.js
+++ b/examples/cog-style.js
@@ -72,6 +72,37 @@ const ndvi = {
   ],
 };
 
+const ndviPalettePlasma = {
+  color: [
+    'palette',
+    [
+      'interpolate',
+      ['linear'],
+      ['/', ['-', nir, red], ['+', nir, red]],
+      -0.2,
+      0,
+      0.65,
+      4,
+    ],
+    ['#0d0887', '#7e03a8', '#cb4778', '#f89540', '#f0f921'],
+  ],
+};
+const ndviPaletteViridis = {
+  color: [
+    'palette',
+    [
+      'interpolate',
+      ['linear'],
+      ['/', ['-', nir, red], ['+', nir, red]],
+      -0.2,
+      0,
+      0.65,
+      4,
+    ],
+    ['#440154', '#3b528b', '#21918c', '#5ec962', '#fde725'],
+  ],
+};
+
 const layer = new TileLayer({
   style: trueColor,
   source: new GeoTIFF({
@@ -95,7 +126,14 @@ const map = new Map({
   }),
 });
 
-const styles = {trueColor, falseColor, ndvi};
+const styles = {
+  trueColor,
+  falseColor,
+  ndvi,
+  ndviPalettePlasma,
+  ndviPaletteViridis,
+};
+
 const styleSelector = document.getElementById('style');
 
 function update() {

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -498,6 +498,7 @@ class WebGLTileLayer extends BaseTileLayer {
       vertexShader: parsedStyle.vertexShader,
       fragmentShader: parsedStyle.fragmentShader,
       uniforms: parsedStyle.uniforms,
+      paletteTextures: parsedStyle.paletteTextures,
     });
     this.changed();
   }

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -132,7 +132,7 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
 
     this.vertexShader_ = options.vertexShader;
     this.fragmentShader_ = options.fragmentShader;
-
+    this.paletteTextures_ = options.paletteTextures || [];
     if (this.helper) {
       this.program_ = this.helper.getProgram(
         this.fragmentShader_,


### PR DESCRIPTION
Addreses #15100

~~need to test a bit further as there's a strange artifact that happens in top-left tile when paletteTexture is updated.~~
EDIT: in further testing, the above i think is an unrelated issue in my application. I do not see it in included examples