### PR TITLE
Catch `image.decode()` errors and return image if loaded

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -311,7 +311,7 @@ export function decodeFallback(image, src) {
           return image;
         }
         listener();
-        return Promise.reject(e.message);
+        return Promise.reject(e);
       });
   }
   return load(image);
@@ -345,7 +345,7 @@ export function decode(image, src) {
           return image;
         }
         listener();
-        return Promise.reject(e.message);
+        return Promise.reject(e);
       });
   }
   return decodeFallback(image);


### PR DESCRIPTION
Fixes the regression noted in https://github.com/openlayers/openlayers/issues/15097#issuecomment-1712819423

Probably also fixes #15097
