### PR TITLE
Allow render features to be transformed

### DIFF
--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -328,6 +328,33 @@ class RenderFeature {
       );
     }
   }
+
+  /**
+   * Apply a transform function to the coordinates of the geometry.
+   * The geometry is modified in place.
+   * If you do not want the geometry modified in place, first `clone()` it and
+   * then use this function on the clone.
+   * @param {import("../proj.js").TransformFunction} transformFn Transform function.
+   */
+  applyTransform(transformFn) {
+    if (this.flatCoordinates_) {
+      transformFn(this.flatCoordinates_, this.flatCoordinates_, 2);
+    }
+  }
+
+  /**
+   * @return {RenderFeature} A cloned render feature.
+   */
+  clone() {
+    return new RenderFeature(
+      this.type_,
+      this.flatCoordinates_.slice(),
+      this.ends_.slice(),
+      Object.assign({}, this.properties_),
+      this.id_
+    );
+  }
+
   /**
    * @return {Array<number>|Array<Array<number>>} Ends or endss.
    */

--- a/test/node/ol/render/Feature.test.js
+++ b/test/node/ol/render/Feature.test.js
@@ -223,4 +223,54 @@ describe('ol/render/Feature', function () {
     delete props.geom;
     expect(props).to.eql(properties);
   });
+
+  describe('clone()', () => {
+    it('creates a clone', () => {
+      const id = 'asdf';
+      const properties = {geometry: '123'};
+      const geometry = new MultiLineString([
+        [
+          [0, 0],
+          [4, 5],
+        ],
+        [
+          [0, 0],
+          [4, 5],
+        ],
+      ]);
+      const feature = new RenderFeature(
+        geometry.getType(),
+        geometry.getFlatCoordinates().slice(),
+        geometry.getEnds().slice(),
+        properties,
+        id
+      );
+
+      const clone = feature.clone();
+      expect(clone).to.be.a(RenderFeature);
+      expect(clone.getFlatCoordinates()).to.eql(feature.getFlatCoordinates());
+      expect(clone.getEnds()).to.eql(feature.getEnds());
+      expect(clone.getId()).to.be(feature.getId());
+      expect(clone.getProperties()).to.eql(feature.getProperties());
+
+      const modifiedCoordinates = clone.getFlatCoordinates();
+      modifiedCoordinates.length = 0;
+
+      const originalCoordinates = feature.getFlatCoordinates();
+      expect(originalCoordinates).to.not.be(modifiedCoordinates);
+
+      const modifiedEnds = clone.getEnds();
+      modifiedEnds.length = 0;
+
+      const originalEnds = feature.getEnds();
+      expect(originalEnds).to.not.be(modifiedEnds);
+
+      const modifiedProperties = clone.getProperties();
+      for (const key in modifiedProperties) {
+        delete modifiedProperties[key];
+      }
+      const originalProperties = feature.getProperties();
+      expect(originalProperties).to.not.be(modifiedProperties);
+    });
+  });
 });


### PR DESCRIPTION
This adds `clone` and `applyTransform` methods to render features, allowing them to be transformed as with regular features.