### PR TITLE
Support updating and tracking extra params in the link interaction

### DIFF
--- a/examples/link.html
+++ b/examples/link.html
@@ -7,6 +7,14 @@ docs: >
   The view center, zoom level, and rotation will be reflected in the URL as you
   navigate around the map.  Layer visibility is also reflected in the URL.
   Reloading the page restores the map view state.
+
+  The interaction can also be used to track other parts of your application state.
+  For example, toggling the checkbox below updates the URL.  Navigating back through
+  history will also update the state of the checkbox.
 tags: "link, permalink, url, query, search, params"
 ---
 <div id="map" class="map"></div>
+<label>
+  <input type="checkbox" id="example-checkbox">
+  See the <code>example</code> search parameter update when toggling this checkbox.
+</label>

--- a/examples/link.js
+++ b/examples/link.js
@@ -17,4 +17,22 @@ const map = new Map({
   }),
 });
 
-map.addInteraction(new Link());
+const link = new Link();
+
+const exampleCheckbox = document.getElementById('example-checkbox');
+exampleCheckbox.addEventListener('change', function () {
+  if (exampleCheckbox.checked) {
+    link.update('example', 'checked');
+  } else {
+    // updating to null will remove the param from the URL
+    link.update('example', null);
+  }
+});
+
+const initialValue = link.track('example', (newValue) => {
+  exampleCheckbox.checked = newValue === 'checked';
+});
+
+exampleCheckbox.checked = initialValue === 'checked';
+
+map.addInteraction(link);

--- a/src/ol/interaction/Link.js
+++ b/src/ol/interaction/Link.js
@@ -55,6 +55,10 @@ function differentArray(a, b) {
 /** @typedef {'x'|'y'|'z'|'r'|'l'} Params */
 
 /**
+ * @typedef {function(string):void} Callback
+ */
+
+/**
  * @typedef {Object} Options
  * @property {boolean|import('../View.js').AnimationOptions} [animate=true] Animate view transitions.
  * @property {Array<Params>} [params=['x', 'y', 'z', 'r', 'l']] Properties to track. Default is to track
@@ -138,6 +142,20 @@ class Link extends Interaction {
     this.initial_ = true;
 
     this.updateState_ = this.updateState_.bind(this);
+
+    /**
+     * The tracked parameter callbacks.
+     * @private
+     * @type {Object<string, Callback>}
+     */
+    this.trackedCallbacks_ = {};
+
+    /**
+     * The tracked parameter values.
+     * @private
+     * @type {Object<string, string|null>}
+     */
+    this.trackedValues_ = {};
   }
 
   /**
@@ -264,6 +282,16 @@ class Link extends Interaction {
    * @private
    */
   updateState_() {
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    for (const key in this.trackedCallbacks_) {
+      const value = params.get(key);
+      if (key in this.trackedCallbacks_ && value !== this.trackedValues_[key]) {
+        this.trackedValues_[key] = value;
+        this.trackedCallbacks_[key](value);
+      }
+    }
+
     const map = this.getMap();
     if (!map) {
       return;
@@ -272,8 +300,6 @@ class Link extends Interaction {
     if (!view) {
       return;
     }
-    const url = new URL(window.location.href);
-    const params = url.searchParams;
 
     let updateView = false;
 
@@ -343,6 +369,46 @@ class Link extends Interaction {
   }
 
   /**
+   * Register a listener for a URL search parameter.  The callback will be called with a new value
+   * when the corresponding search parameter changes due to history events (e.g. browser navigation).
+   *
+   * @param {string} key The URL search parameter.
+   * @param {Callback} callback The function to call when the search parameter changes.
+   * @return {string|null} The initial value of the search parameter (or null if absent from the URL).
+   * @api
+   */
+  track(key, callback) {
+    this.trackedCallbacks_[key] = callback;
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    const value = params.get(key);
+    this.trackedValues_[key] = value;
+    return value;
+  }
+
+  /**
+   * Update the URL with a new search parameter value.  If the value is null, it will be
+   * deleted from the search parameters.
+   *
+   * @param {string} key The URL search parameter.
+   * @param {string|null} value The updated value (or null to remove it from the URL).
+   * @api
+   */
+  update(key, value) {
+    const url = new URL(window.location.href);
+    const params = url.searchParams;
+    if (value === null) {
+      params.delete(key);
+    } else {
+      params.set(key, value);
+    }
+    if (key in this.trackedValues_) {
+      this.trackedValues_[key] = value;
+    }
+    this.updateHistory_(url);
+  }
+
+  /**
    * @private
    */
   updateUrl_() {
@@ -354,8 +420,6 @@ class Link extends Interaction {
     if (!view) {
       return;
     }
-    const initial = this.initial_;
-    this.initial_ = false;
 
     const center = view.getCenter();
     const zoom = view.getZoom();
@@ -376,8 +440,17 @@ class Link extends Interaction {
     this.set_(params, 'r', writeNumber(rotation));
     this.set_(params, 'l', visibilities.join(''));
 
+    this.updateHistory_(url);
+    this.initial_ = false;
+  }
+
+  /**
+   * @private
+   * @param {URL} url The URL.
+   */
+  updateHistory_(url) {
     if (url.href !== window.location.href) {
-      if (initial || this.replace_) {
+      if (this.initial_ || this.replace_) {
         window.history.replaceState(history.state, '', url);
       } else {
         window.history.pushState(null, '', url);

--- a/test/browser/spec/ol/interaction/Link.test.js
+++ b/test/browser/spec/ol/interaction/Link.test.js
@@ -88,4 +88,22 @@ describe('ol/interaction/Link', () => {
       view.setRotation(0.5);
     });
   });
+
+  describe('track()', (done) => {
+    it('makes it possible to synchronize additional state with the URL', () => {
+      const link = new Link();
+      map.addInteraction(link);
+
+      const testProperty = 'test-property';
+      const testValue = 'test-value';
+
+      const initialValue = link.track(testProperty, (newValue) => {
+        expect(newValue).to.be(testValue);
+        done();
+      });
+
+      expect(initialValue).to.be(null);
+      link.update(testProperty, testValue);
+    });
+  });
 });


### PR DESCRIPTION
This makes it possible to synchronize other parts of the application state in the URL using the link interaction.  By default, the link interaction only synchronizes parts of the map state with the URL.  The `track` method can be used to add a listener for changes to other params.  And the `update` method can be called to update the URL with new values.