### PR TITLE
Add hit detection support to WebGL vector layer

### DIFF
--- a/examples/webgl-vector-layer.html
+++ b/examples/webgl-vector-layer.html
@@ -8,3 +8,4 @@ tags: "vector, geojson, webgl"
 experimental: true
 ---
 <div id="map" class="map"></div>
+<div id="info">&nbsp;</div>

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -42,3 +42,48 @@ const map = new Map({
     zoom: 1,
   }),
 });
+
+const featureOverlay = new WebGLLayer({
+  source: new VectorSource(),
+  map: map,
+  style: {
+    'stroke-color': 'rgba(255, 255, 255, 0.7)',
+    'stroke-width': 2,
+  },
+});
+
+let highlight;
+const displayFeatureInfo = function (pixel) {
+  const feature = map.forEachFeatureAtPixel(pixel, function (feature) {
+    return feature;
+  });
+
+  const info = document.getElementById('info');
+  if (feature) {
+    info.innerHTML = feature.get('ECO_NAME') || '&nbsp;';
+  } else {
+    info.innerHTML = '&nbsp;';
+  }
+
+  if (feature !== highlight) {
+    if (highlight) {
+      featureOverlay.getSource().removeFeature(highlight);
+    }
+    if (feature) {
+      featureOverlay.getSource().addFeature(feature);
+    }
+    highlight = feature;
+  }
+};
+
+map.on('pointermove', function (evt) {
+  if (evt.dragging) {
+    return;
+  }
+  const pixel = map.getEventPixel(evt.originalEvent);
+  displayFeatureInfo(pixel);
+});
+
+map.on('click', function (evt) {
+  displayFeatureInfo(evt.pixel);
+});

--- a/site/src/doc/errors/index.md
+++ b/site/src/doc/errors/index.md
@@ -225,7 +225,6 @@ Layer opacity must be a number.
 ### 66
 
 `forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has not been enabled.
-This is done by providing adequate shaders using the `hitVertexShader` and `hitFragmentShader` properties of `WebGLPointsLayerRenderer`.
 
 ### 67
 

--- a/src/ol/render/webgl/MixedGeometryBatch.js
+++ b/src/ol/render/webgl/MixedGeometryBatch.js
@@ -6,7 +6,7 @@ import {getUid} from '../../util.js';
 import {inflateEnds} from '../../geom/flat/orient.js';
 
 /**
- * @typedef {import("../../Feature").default} Feature
+ * @typedef {import("../../Feature.js").default} Feature
  */
 /**
  * @typedef {import("../../geom/Geometry.js").Type} GeometryType
@@ -19,6 +19,7 @@ import {inflateEnds} from '../../geom/flat/orient.js';
  * @property {number} [verticesCount] Only defined for linestring and polygon batches
  * @property {number} [ringsCount] Only defined for polygon batches
  * @property {Array<Array<number>>} [ringsVerticesCounts] Array of vertices counts in each ring for each geometry; only defined for polygons batches
+ * @property {number} [ref] The reference in the global batch (used for hit detection)
  */
 
 /**
@@ -70,6 +71,29 @@ import {inflateEnds} from '../../geom/flat/orient.js';
  */
 class MixedGeometryBatch {
   constructor() {
+    this.globalCounter_ = 0;
+    /**
+     * Refs are used as keys for hit detection.
+     * @type {Map<number, Feature|RenderFeature>}
+     * @private
+     */
+    this.refToFeature_ = new Map();
+
+    /**
+     * Features are split in "entries", which are individual geometries. We use the following map to share a single ref for all those entries.
+     * @type {Map<string, number>}
+     * @private
+     */
+    this.uidToRef_ = new Map();
+
+    /**
+     * The precision in WebGL shaders is limited.
+     * To keep the refs as small as possible we maintain an array of returned references.
+     * @type {Array<number>}
+     * @private
+     */
+    this.freeGlobalRef_ = [];
+
     /**
      * @type {PolygonGeometryBatch}
      */
@@ -126,6 +150,7 @@ class MixedGeometryBatch {
 
   /**
    * @param {Feature|RenderFeature} feature Feature
+   * @return {GeometryBatchItem|void} the cleared entry
    * @private
    */
   clearFeatureEntryInPointBatch_(feature) {
@@ -135,10 +160,12 @@ class MixedGeometryBatch {
     }
     this.pointBatch.geometriesCount -= entry.flatCoordss.length;
     delete this.pointBatch.entries[getUid(feature)];
+    return entry;
   }
 
   /**
    * @param {Feature|RenderFeature} feature Feature
+   * @return {GeometryBatchItem|void} the cleared entry
    * @private
    */
   clearFeatureEntryInLineStringBatch_(feature) {
@@ -149,10 +176,12 @@ class MixedGeometryBatch {
     this.lineStringBatch.verticesCount -= entry.verticesCount;
     this.lineStringBatch.geometriesCount -= entry.flatCoordss.length;
     delete this.lineStringBatch.entries[getUid(feature)];
+    return entry;
   }
 
   /**
    * @param {Feature|RenderFeature} feature Feature
+   * @return {GeometryBatchItem|void} the cleared entry
    * @private
    */
   clearFeatureEntryInPolygonBatch_(feature) {
@@ -164,28 +193,30 @@ class MixedGeometryBatch {
     this.polygonBatch.ringsCount -= entry.ringsCount;
     this.polygonBatch.geometriesCount -= entry.flatCoordss.length;
     delete this.polygonBatch.entries[getUid(feature)];
+    return entry;
   }
 
   /**
-   * @param {import("../../geom").Geometry|RenderFeature} geometry Geometry
+   * @param {import("../../geom.js").Geometry|RenderFeature} geometry Geometry
    * @param {Feature|RenderFeature} feature Feature
    * @private
    */
   addGeometry_(geometry, feature) {
     const type = geometry.getType();
     switch (type) {
-      case 'GeometryCollection':
+      case 'GeometryCollection': {
         const geometries =
-          /** @type {import("../../geom").GeometryCollection} */ (
+          /** @type {import("../../geom.js").GeometryCollection} */ (
             geometry
           ).getGeometriesArray();
         for (const geometry of geometries) {
           this.addGeometry_(geometry, feature);
         }
         break;
-      case 'MultiPolygon':
+      }
+      case 'MultiPolygon': {
         const multiPolygonGeom =
-          /** @type {import("../../geom").MultiPolygon} */ (geometry);
+          /** @type {import("../../geom.js").MultiPolygon} */ (geometry);
         this.addCoordinates_(
           type,
           multiPolygonGeom.getFlatCoordinates(),
@@ -195,9 +226,10 @@ class MixedGeometryBatch {
           multiPolygonGeom.getStride()
         );
         break;
-      case 'MultiLineString':
+      }
+      case 'MultiLineString': {
         const multiLineGeom =
-          /** @type {import("../../geom").MultiLineString|RenderFeature} */ (
+          /** @type {import("../../geom.js").MultiLineString|RenderFeature} */ (
             geometry
           );
         this.addCoordinates_(
@@ -209,9 +241,10 @@ class MixedGeometryBatch {
           multiLineGeom.getStride()
         );
         break;
-      case 'MultiPoint':
+      }
+      case 'MultiPoint': {
         const multiPointGeom =
-          /** @type {import("../../geom").MultiPoint|RenderFeature} */ (
+          /** @type {import("../../geom.js").MultiPoint|RenderFeature} */ (
             geometry
           );
         this.addCoordinates_(
@@ -223,9 +256,12 @@ class MixedGeometryBatch {
           multiPointGeom.getStride()
         );
         break;
-      case 'Polygon':
+      }
+      case 'Polygon': {
         const polygonGeom =
-          /** @type {import("../../geom").Polygon|RenderFeature} */ (geometry);
+          /** @type {import("../../geom.js").Polygon|RenderFeature} */ (
+            geometry
+          );
         this.addCoordinates_(
           type,
           polygonGeom.getFlatCoordinates(),
@@ -235,8 +271,11 @@ class MixedGeometryBatch {
           polygonGeom.getStride()
         );
         break;
-      case 'Point':
-        const pointGeom = /** @type {import("../../geom").Point} */ (geometry);
+      }
+      case 'Point': {
+        const pointGeom = /** @type {import("../../geom.js").Point} */ (
+          geometry
+        );
         this.addCoordinates_(
           type,
           pointGeom.getFlatCoordinates(),
@@ -246,9 +285,10 @@ class MixedGeometryBatch {
           pointGeom.getStride()
         );
         break;
+      }
       case 'LineString':
-      case 'LinearRing':
-        const lineGeom = /** @type {import("../../geom").LineString} */ (
+      case 'LinearRing': {
+        const lineGeom = /** @type {import("../../geom.js").LineString} */ (
           geometry
         );
         this.addCoordinates_(
@@ -260,6 +300,7 @@ class MixedGeometryBatch {
           lineGeom.getStride()
         );
         break;
+      }
       default:
       // pass
     }
@@ -278,7 +319,7 @@ class MixedGeometryBatch {
     /** @type {number} */
     let verticesCount;
     switch (type) {
-      case 'MultiPolygon':
+      case 'MultiPolygon': {
         const multiPolygonEndss = /** @type {Array<Array<number>>} */ (ends);
         for (let i = 0, ii = multiPolygonEndss.length; i < ii; i++) {
           let polygonEnds = multiPolygonEndss[i];
@@ -301,12 +342,13 @@ class MixedGeometryBatch {
           );
         }
         break;
-      case 'MultiLineString':
+      }
+      case 'MultiLineString': {
         const multiLineEnds = /** @type {Array<number>} */ (ends);
         for (let i = 0, ii = multiLineEnds.length; i < ii; i++) {
           const startIndex = i > 0 ? multiLineEnds[i - 1] : 0;
           this.addCoordinates_(
-            'LinearRing',
+            'LineString',
             flatCoords.slice(startIndex, multiLineEnds[i]),
             null,
             feature,
@@ -315,6 +357,7 @@ class MixedGeometryBatch {
           );
         }
         break;
+      }
       case 'MultiPoint':
         for (let i = 0, ii = flatCoords.length; i < ii; i += stride) {
           this.addCoordinates_(
@@ -327,7 +370,7 @@ class MixedGeometryBatch {
           );
         }
         break;
-      case 'Polygon':
+      case 'Polygon': {
         const polygonEnds = /** @type {Array<number>} */ (ends);
         if (feature instanceof RenderFeature) {
           const multiPolygonEnds = inflateEnds(flatCoords, polygonEnds);
@@ -344,13 +387,16 @@ class MixedGeometryBatch {
           }
         }
         if (!this.polygonBatch.entries[featureUid]) {
-          this.polygonBatch.entries[featureUid] = {
-            feature: feature,
-            flatCoordss: [],
-            verticesCount: 0,
-            ringsCount: 0,
-            ringsVerticesCounts: [],
-          };
+          this.polygonBatch.entries[featureUid] = this.addRefToEntry_(
+            featureUid,
+            {
+              feature: feature,
+              flatCoordss: [],
+              verticesCount: 0,
+              ringsCount: 0,
+              ringsVerticesCounts: [],
+            }
+          );
         }
         verticesCount = flatCoords.length / stride;
         const ringsCount = ends.length;
@@ -380,12 +426,16 @@ class MixedGeometryBatch {
           );
         }
         break;
+      }
       case 'Point':
         if (!this.pointBatch.entries[featureUid]) {
-          this.pointBatch.entries[featureUid] = {
-            feature: feature,
-            flatCoordss: [],
-          };
+          this.pointBatch.entries[featureUid] = this.addRefToEntry_(
+            featureUid,
+            {
+              feature: feature,
+              flatCoordss: [],
+            }
+          );
         }
         this.pointBatch.geometriesCount++;
         this.pointBatch.entries[featureUid].flatCoordss.push(flatCoords);
@@ -393,11 +443,14 @@ class MixedGeometryBatch {
       case 'LineString':
       case 'LinearRing':
         if (!this.lineStringBatch.entries[featureUid]) {
-          this.lineStringBatch.entries[featureUid] = {
-            feature: feature,
-            flatCoordss: [],
-            verticesCount: 0,
-          };
+          this.lineStringBatch.entries[featureUid] = this.addRefToEntry_(
+            featureUid,
+            {
+              feature: feature,
+              flatCoordss: [],
+              verticesCount: 0,
+            }
+          );
         }
         verticesCount = flatCoords.length / stride;
         this.lineStringBatch.verticesCount += verticesCount;
@@ -413,12 +466,45 @@ class MixedGeometryBatch {
   }
 
   /**
+   * @param {string} featureUid Feature uid
+   * @param {GeometryBatchItem} entry The entry to add
+   * @return {GeometryBatchItem} the added entry
+   * @private
+   */
+  addRefToEntry_(featureUid, entry) {
+    const currentRef = this.uidToRef_.get(featureUid);
+
+    // the ref starts at 1 to distinguish from white color (no feature)
+    const ref =
+      currentRef || this.freeGlobalRef_.pop() || ++this.globalCounter_;
+    entry.ref = ref;
+    if (!currentRef) {
+      this.refToFeature_.set(ref, entry.feature);
+      this.uidToRef_.set(featureUid, ref);
+    }
+    return entry;
+  }
+
+  /**
+   * Return a ref to the pool of available refs.
+   * @param {number} ref the ref to return
+   * @param {string} featureUid the feature uid
+   * @private
+   */
+  returnRef_(ref, featureUid) {
+    if (!ref) {
+      throw new Error('This feature has no ref: ' + featureUid);
+    }
+    this.refToFeature_.delete(ref);
+    this.uidToRef_.delete(featureUid);
+    this.freeGlobalRef_.push(ref);
+  }
+
+  /**
    * @param {Feature|RenderFeature} feature Feature
    */
   changeFeature(feature) {
-    this.clearFeatureEntryInPointBatch_(feature);
-    this.clearFeatureEntryInPolygonBatch_(feature);
-    this.clearFeatureEntryInLineStringBatch_(feature);
+    this.removeFeature(feature);
     const geometry = feature.getGeometry();
     if (!geometry) {
       return;
@@ -430,9 +516,13 @@ class MixedGeometryBatch {
    * @param {Feature|RenderFeature} feature Feature
    */
   removeFeature(feature) {
-    this.clearFeatureEntryInPointBatch_(feature);
-    this.clearFeatureEntryInPolygonBatch_(feature);
-    this.clearFeatureEntryInLineStringBatch_(feature);
+    let entry;
+    entry = this.clearFeatureEntryInPointBatch_(feature) || entry;
+    entry = this.clearFeatureEntryInPolygonBatch_(feature) || entry;
+    entry = this.clearFeatureEntryInLineStringBatch_(feature) || entry;
+    if (entry) {
+      this.returnRef_(entry.ref, getUid(entry.feature));
+    }
   }
 
   clear() {
@@ -445,6 +535,19 @@ class MixedGeometryBatch {
     this.lineStringBatch.verticesCount = 0;
     this.pointBatch.entries = {};
     this.pointBatch.geometriesCount = 0;
+    this.globalCounter_ = 0;
+    this.freeGlobalRef_ = [];
+    this.refToFeature_.clear();
+    this.uidToRef_.clear();
+  }
+
+  /**
+   * Resolve the feature associated to a ref.
+   * @param {number} ref Hit detected ref
+   * @return {Feature|RenderFeature} feature
+   */
+  getFeatureFromRef(ref) {
+    return this.refToFeature_.get(ref);
   }
 }
 

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -182,10 +182,10 @@ class VectorStyleRenderer {
     this.customAttributes_ = shaders.attributes;
     this.uniforms_ = shaders.uniforms;
 
-    const customAttributesDesc = Object.keys(this.customAttributes_).map(
-      (name) => ({
+    const customAttributesDesc = Object.entries(this.customAttributes_).map(
+      ([name, value]) => ({
         name: `a_${name}`,
-        size: this.customAttributes_[name].size || 1,
+        size: value.size || 1,
         type: AttributeType.FLOAT,
       })
     );
@@ -470,12 +470,15 @@ class VectorStyleRenderer {
     frameState,
     preRenderCallback
   ) {
+    const renderCount = indicesBuffer.getSize();
+    if (renderCount === 0) {
+      return;
+    }
     this.helper_.useProgram(program, frameState);
     this.helper_.bindBuffer(verticesBuffer);
     this.helper_.bindBuffer(indicesBuffer);
     this.helper_.enableAttributes(attributes);
     preRenderCallback();
-    const renderCount = indicesBuffer.getSize();
     this.helper_.drawElements(0, renderCount);
   }
 }

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -41,7 +41,7 @@ export const Attributes = {
  * for each feature.
  * @property {number} [size] Amount of numerical values composing the attribute, either 1, 2, 3 or 4; in case size is > 1, the return value
  * of the callback should be an array; if unspecified, assumed to be a single float value
- * @property {function(import("../../Feature").FeatureLike):number|Array<number>} callback This callback computes the numerical value of the
+ * @property {function(this:import("./MixedGeometryBatch.js").GeometryBatchItem, import("../../Feature").FeatureLike):number|Array<number>} callback This callback computes the numerical value of the
  * attribute for a given feature.
  */
 

--- a/src/ol/render/webgl/constants.js
+++ b/src/ol/render/webgl/constants.js
@@ -19,8 +19,8 @@ export const WebGLWorkerMessageType = {
  * Note that any addition properties present in the message *will* be sent back to the main thread.
  * @property {number} id Message id; will be used both in request and response as a means of identification
  * @property {WebGLWorkerMessageType} type Message type
- * @property {ArrayBuffer} renderInstructions Polygon render instructions raw binary buffer.
- * @property {number} [customAttributesSize] Amount of custom attributes count in the polygon render instructions.
+ * @property {ArrayBuffer} renderInstructions render instructions raw binary buffer.
+ * @property {number} [customAttributesSize] Amount of hit detection + custom attributes count in the render instructions.
  * @property {ArrayBuffer} [vertexBuffer] Vertices array raw binary buffer (sent by the worker).
  * @property {ArrayBuffer} [indexBuffer] Indices array raw binary buffer (sent by the worker).
  * @property {import("../../transform").Transform} [renderInstructionsTransform] Transformation matrix used to project the instructions coordinates

--- a/src/ol/render/webgl/renderinstructions.js
+++ b/src/ol/render/webgl/renderinstructions.js
@@ -20,7 +20,7 @@ function pushCustomAttributesInRenderInstructions(
   let shift = 0;
   for (const key in customAttributes) {
     const attr = customAttributes[key];
-    const value = attr.callback(batchEntry.feature);
+    const value = attr.callback.call(batchEntry, batchEntry.feature);
     renderInstructions[currentIndex + shift++] = value[0] || value;
     if (!attr.size || attr.size === 1) {
       continue;

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -24,6 +24,8 @@ import {getIntersection} from '../../extent.js';
 /**
  * @typedef {Object} Options
  * @property {VectorStyle|Array<VectorStyle>} style Vector style as literal style or shaders; can also accept an array of styles
+ * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
+ * prevent all hit detection on the layer.
  * @property {number} [cacheSize=512] The vector tile cache size.
  */
 
@@ -43,6 +45,12 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
    */
   constructor(tileLayer, options) {
     super(tileLayer, options);
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.hitDetectionEnabled_ = !options.disableHitDetection;
 
     /**
      * @type {Array<VectorStyle>}
@@ -98,7 +106,8 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
    */
   createRenderers_() {
     this.styleRenderers_ = this.styles_.map(
-      (style) => new VectorStyleRenderer(style, this.helper)
+      (style) =>
+        new VectorStyleRenderer(style, this.helper, this.hitDetectionEnabled_)
     );
   }
 

--- a/src/ol/renderer/webgl/worldUtil.js
+++ b/src/ol/renderer/webgl/worldUtil.js
@@ -1,0 +1,27 @@
+import {getWidth} from '../../extent.js';
+
+/**
+ * Compute world params
+ * @param {import("../../Map.js").FrameState} frameState Frame state.
+ * @param {any} layer The layer
+ * @return {Array<number>} The world start, end and width.
+ */
+export function getWorldParameters(frameState, layer) {
+  const projection = frameState.viewState.projection;
+
+  const vectorSource = layer.getSource();
+  const multiWorld = vectorSource.getWrapX() && projection.canWrapX();
+  const projectionExtent = projection.getExtent();
+
+  const extent = frameState.extent;
+  const worldWidth = multiWorld ? getWidth(projectionExtent) : null;
+  const endWorld = multiWorld
+    ? Math.ceil((extent[2] - projectionExtent[2]) / worldWidth) + 1
+    : 1;
+
+  const startWorld = multiWorld
+    ? Math.floor((extent[0] - projectionExtent[0]) / worldWidth)
+    : 0;
+
+  return [startWorld, endWorld, worldWidth];
+}

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -865,6 +865,7 @@ ${this.varyings_
 ${this.vertexShaderFunctions_.join('\n')}
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
+  v_hitColor = a_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return '  ' + varying.name + ' = ' + varying.expression + ';';

--- a/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
+++ b/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
@@ -12,6 +12,9 @@ import RenderFeature from '../../../../../../src/ol/render/Feature.js';
 import {getUid} from '../../../../../../src/ol/index.js';
 
 describe('MixedGeometryBatch', function () {
+  /**
+   * @type {MixedGeometryBatch}
+   */
   let mixedBatch;
 
   beforeEach(() => {
@@ -63,10 +66,12 @@ describe('MixedGeometryBatch', function () {
         expect(keys).to.eql([uid1, uid2]);
         expect(mixedBatch.pointBatch.entries[uid1]).to.eql({
           feature: feature1,
+          ref: 1,
           flatCoordss: [[0, 1]],
         });
         expect(mixedBatch.pointBatch.entries[uid2]).to.eql({
           feature: feature2,
+          ref: 2,
           flatCoordss: [[2, 3]],
         });
       });
@@ -78,6 +83,12 @@ describe('MixedGeometryBatch', function () {
         expect(Object.keys(mixedBatch.lineStringBatch.entries)).to.have.length(
           0
         );
+      });
+      it('assigns a hit detection ref to the entry', () => {
+        expect(mixedBatch.globalCounter_).to.be(2);
+        expect(mixedBatch.freeGlobalRef_.length).to.be(0);
+        expect(mixedBatch.getFeatureFromRef(1)).to.be(feature1);
+        expect(mixedBatch.getFeatureFromRef(2)).to.be(feature2);
       });
     });
 
@@ -174,11 +185,13 @@ describe('MixedGeometryBatch', function () {
           feature: feature1,
           flatCoordss: [[0, 1, 2, 3, 4, 5, 6, 7]],
           verticesCount: 4,
+          ref: 1,
         });
         expect(mixedBatch.lineStringBatch.entries[uid2]).to.eql({
           feature: feature2,
           flatCoordss: [[8, 9, 10, 11, 12, 13]],
           verticesCount: 3,
+          ref: 2,
         });
       });
       it('computes the aggregated metrics on all geoms', () => {
@@ -317,6 +330,7 @@ describe('MixedGeometryBatch', function () {
           verticesCount: 7,
           ringsCount: 2,
           ringsVerticesCounts: [[4, 3]],
+          ref: 1,
         });
         expect(mixedBatch.polygonBatch.entries[uid2]).to.eql({
           feature: feature2,
@@ -329,6 +343,7 @@ describe('MixedGeometryBatch', function () {
           verticesCount: 10,
           ringsCount: 3,
           ringsVerticesCounts: [[3, 3, 4]],
+          ref: 2,
         });
       });
       it('computes the aggregated metrics on all polygons', () => {
@@ -346,6 +361,7 @@ describe('MixedGeometryBatch', function () {
             [20, 21, 22, 23, -24, 25],
           ],
           verticesCount: 7,
+          ref: 1,
         });
         expect(mixedBatch.lineStringBatch.entries[getUid(feature2)]).to.eql({
           feature: feature2,
@@ -355,6 +371,7 @@ describe('MixedGeometryBatch', function () {
             [40, 41, 42, 43, 44, 45, -46, 47],
           ],
           verticesCount: 10,
+          ref: 2,
         });
       });
       it('computes the aggregated metrics on all linestrings', () => {
@@ -443,6 +460,11 @@ describe('MixedGeometryBatch', function () {
         expect(mixedBatch.polygonBatch.verticesCount).to.be(10);
         expect(mixedBatch.polygonBatch.geometriesCount).to.be(1);
         expect(mixedBatch.polygonBatch.ringsCount).to.be(3);
+      });
+      it('keeps the removed ref for later use', () => {
+        expect(mixedBatch.freeGlobalRef_).to.eql([1]);
+        expect(mixedBatch.globalCounter_).to.be(2);
+        expect(mixedBatch.refToFeature_.size).to.be(1);
       });
     });
   });
@@ -535,6 +557,7 @@ describe('MixedGeometryBatch', function () {
             [4, 3],
             [3, 3, 4],
           ],
+          ref: 1,
         });
       });
       it('puts the polygon rings and linestrings in the linestring batch', () => {
@@ -551,6 +574,7 @@ describe('MixedGeometryBatch', function () {
             [8, 9, 10, 11, 12, 13],
           ],
           verticesCount: 24,
+          ref: 1,
         });
       });
       it('puts the points in the point batch', () => {
@@ -562,6 +586,7 @@ describe('MixedGeometryBatch', function () {
             [201, 202],
             [301, 302],
           ],
+          ref: 1,
         });
       });
       it('computes the aggregated metrics on all polygons', () => {
@@ -620,6 +645,7 @@ describe('MixedGeometryBatch', function () {
             verticesCount: 22,
             ringsCount: 6,
             ringsVerticesCounts: [[4, 3], [3, 3, 4], [5]],
+            ref: 1,
           });
         });
         it('updates the geometries in the linestring batch', () => {
@@ -638,6 +664,7 @@ describe('MixedGeometryBatch', function () {
               [500, 501, 502, 503, 504, 505, 506, 507],
             ],
             verticesCount: 33,
+            ref: 1,
           });
         });
         it('updates the aggregated metrics on the polygon batch', () => {
@@ -672,6 +699,7 @@ describe('MixedGeometryBatch', function () {
             verticesCount: 4,
             ringsCount: 1,
             ringsVerticesCounts: [[4]],
+            ref: 1,
           });
         });
         it('updates the geometries in the linestring batch', () => {
@@ -680,6 +708,7 @@ describe('MixedGeometryBatch', function () {
             feature: feature,
             flatCoordss: [[201, 202, 203, 204, 205, 206, 2070, 208]],
             verticesCount: 4,
+            ref: 1,
           });
         });
         it('updates the aggregated metrics on the polygon batch', () => {
@@ -772,6 +801,7 @@ describe('MixedGeometryBatch', function () {
           verticesCount: 4,
           ringsCount: 1,
           ringsVerticesCounts: [[4]],
+          ref: 1,
         });
       });
       it('puts the polygon rings and linestrings in the linestring batch', () => {
@@ -783,6 +813,7 @@ describe('MixedGeometryBatch', function () {
             [0, 1, 2, 3, 4, 5, 6, 7],
           ],
           verticesCount: 8,
+          ref: 1,
         });
       });
       it('puts the points in the point batch', () => {
@@ -794,6 +825,7 @@ describe('MixedGeometryBatch', function () {
             [201, 202],
             [301, 302],
           ],
+          ref: 1,
         });
       });
       it('computes the aggregated metrics on all polygons', () => {
@@ -854,6 +886,7 @@ describe('MixedGeometryBatch', function () {
           verticesCount: 7,
           ringsCount: 2,
           ringsVerticesCounts: [[4, 3]],
+          ref: 1,
         });
       });
       it('computes the aggregated metrics on all polygons', () => {
@@ -871,6 +904,7 @@ describe('MixedGeometryBatch', function () {
             [20, 21, 22, 23, -24, 25],
           ],
           verticesCount: 7,
+          ref: 1,
         });
       });
       it('computes the aggregated metrics on all linestrings', () => {
@@ -954,6 +988,7 @@ describe('MixedGeometryBatch', function () {
           [4, 3],
           [3, 3],
         ],
+        ref: 1,
       });
     });
     it('puts the linear rings in the linestring batch', () => {
@@ -966,6 +1001,7 @@ describe('MixedGeometryBatch', function () {
           [30, 31, 32, 33, -34, 35],
         ],
         verticesCount: 13,
+        ref: 1,
       });
     });
   });
@@ -1088,6 +1124,7 @@ describe('MixedGeometryBatch', function () {
             [4, 3],
             [3, 3, 4],
           ],
+          ref: 2,
         });
       });
       it('puts the polygon rings and linestrings in the linestring batch', () => {
@@ -1098,6 +1135,7 @@ describe('MixedGeometryBatch', function () {
             [8, 9, 10, 11, 12, 13],
           ],
           verticesCount: 7,
+          ref: 1,
         });
         expect(mixedBatch.lineStringBatch.entries[uid2]).to.eql({
           feature: feature2,
@@ -1109,6 +1147,7 @@ describe('MixedGeometryBatch', function () {
             [40, 41, 42, 43, 44, 45, 46, -47],
           ],
           verticesCount: 17,
+          ref: 2,
         });
       });
       it('computes the aggregated metrics on all polygons', () => {

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -308,6 +308,8 @@ describe('ol/renderer/webgl/VectorLayer', function () {
   });
 
   describe('#renderFrame', () => {
+    const withHit = 2;
+
     beforeEach(async () => {
       // call once without tracking in order to initialize helper
       renderer.prepareFrame(frameState);
@@ -348,7 +350,7 @@ describe('ol/renderer/webgl/VectorLayer', function () {
       const calls = renderer.helper.setUniformMatrixValue
         .getCalls()
         .filter((c) => c.args[0] === 'u_projectionMatrix');
-      expect(calls.length).to.be(6);
+      expect(calls.length).to.be(6 * withHit);
       expect(calls[0].args).to.eql([
         'u_projectionMatrix',
         // 0.5   0     0     0      combination of:
@@ -363,7 +365,7 @@ describe('ol/renderer/webgl/VectorLayer', function () {
       const calls = renderer.helper.setUniformMatrixValue
         .getCalls()
         .filter((c) => c.args[0] === 'u_screenToWorldMatrix');
-      expect(calls.length).to.be(6);
+      expect(calls.length).to.be(6 * withHit);
       expect(calls[1].args).to.eql([
         'u_screenToWorldMatrix',
         // 2     0     0     0      invert of u_projectionMatrix
@@ -374,8 +376,8 @@ describe('ol/renderer/webgl/VectorLayer', function () {
       ]);
     });
     it('calls render once for each renderer', () => {
-      expect(renderer.styleRenderers_[0].render.callCount).to.be(1);
-      expect(renderer.styleRenderers_[1].render.callCount).to.be(1);
+      expect(renderer.styleRenderers_[0].render.callCount).to.be(1 * withHit);
+      expect(renderer.styleRenderers_[1].render.callCount).to.be(1 * withHit);
     });
     it('calls helper.prepareDraw once', () => {
       expect(renderer.helper.prepareDraw.calledOnce).to.eql(true);
@@ -404,8 +406,8 @@ describe('ol/renderer/webgl/VectorLayer', function () {
         renderer.renderFrame(frameState);
       });
       it('calls render three times for each renderer', () => {
-        expect(renderer.styleRenderers_[0].render.callCount).to.be(3);
-        expect(renderer.styleRenderers_[1].render.callCount).to.be(3);
+        expect(renderer.styleRenderers_[0].render.callCount).to.be(3 * withHit);
+        expect(renderer.styleRenderers_[1].render.callCount).to.be(3 * withHit);
       });
     });
   });

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -1,4 +1,5 @@
 import Map from '../../../../../../src/ol/Map.js';
+import RenderFeature from '../../../../../../src/ol/render/Feature.js';
 import TileGeometry from '../../../../../../src/ol/webgl/TileGeometry.js';
 import TileQueue from '../../../../../../src/ol/TileQueue.js';
 import TileState from '../../../../../../src/ol/TileState.js';
@@ -10,6 +11,7 @@ import VectorTileSource from '../../../../../../src/ol/source/VectorTile.js';
 import View from '../../../../../../src/ol/View.js';
 import WebGLHelper from '../../../../../../src/ol/webgl/Helper.js';
 import WebGLVectorTileLayerRenderer from '../../../../../../src/ol/renderer/webgl/VectorTileLayer.js';
+import {Polygon} from '../../../../../../src/ol/geom.js';
 import {Projection} from '../../../../../../src/ol/proj.js';
 import {VOID} from '../../../../../../src/ol/functions.js';
 import {create} from '../../../../../../src/ol/transform.js';
@@ -77,7 +79,38 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
           extent: [-128, -128, 128, 128],
         }),
         tileUrlFunction: (tileCoord) => tileCoord.join('/'),
-        tileLoadFunction: (tile) => tile.setFeatures([]),
+        tileLoadFunction: (tile) => {
+          const polygon = new Polygon([
+            [
+              [0, 0],
+              [0, 10],
+              [10, 10],
+              [10, 0],
+              [0, 0],
+            ],
+          ]);
+          tile.setFeatures([
+            new RenderFeature('Point', [0, 16], [], 2, {}, 1),
+            new RenderFeature(
+              'LineString',
+              [0, 5, 4, 12],
+              [],
+              2,
+              {
+                'color': 'red',
+              },
+              2
+            ),
+            new RenderFeature(
+              'Polygon',
+              polygon.getOrientedFlatCoordinates(),
+              polygon.getEnds(),
+              2,
+              {},
+              3
+            ),
+          ]);
+        },
       }),
     });
 

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -826,6 +826,7 @@ varying vec3 v_test;
 
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
+  v_hitColor = a_hitColor;
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);


### PR DESCRIPTION
Add hit detection to the WebGL vector layer renderer.
This is similar to the points layer:
- when hit detection is enabled (the default), compute a color for each feature and add it to the vertex buffer;
- render the frame twice: for the main framebuffer and for the hit detection buffer;
- use the hit detection buffer to implement the `forEachFeatureAtCoordinate` method.