### PR TITLE
Parse JSON only once

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -85,7 +85,9 @@ export function loadFeaturesXhr(
       const type = format.getType();
       /** @type {Document|Node|Object|string|undefined} */
       let source;
-      if (type == 'json' || type == 'text') {
+      if (type == 'json') {
+        source = JSON.parse(xhr.responseText);
+      } else if (type == 'text') {
         source = xhr.responseText;
       } else if (type == 'xml') {
         source = xhr.responseXML;


### PR DESCRIPTION
For JSON type formats, the XHR loader (which should eventually beome a `fetch` loader, but that's a different issue) calls `readFeatures()` and `readProjection()` on the format with the text instead of the JSON. Both methods parse the text into a JSON. To parse only once, we can do that already before calling `readFeatures()` and `readProjection()`.