### PR TITLE
Make RenderFeature work for untiled vector data

### DIFF
--- a/config/jsdoc/api/template/publish.js
+++ b/config/jsdoc/api/template/publish.js
@@ -72,7 +72,7 @@ function linkto(longname, linkText, cssClass, fragmentId) {
   }
   if (parseTypes) {
     // collections or generics with unions get parsed by catharsis and
-    // will unfortunamely include long module:ol/foo names
+    // will unfortunately include long module:ol/foo names
     return helper.linkto(longname, '', cssClass, fragmentId);
   }
 

--- a/src/ol/Feature.js
+++ b/src/ol/Feature.js
@@ -23,7 +23,7 @@ import {listen, unlistenByKey} from './events.js';
  */
 
 /***
- * @template Geometry
+ * @template {import("./geom/Geometry.js").default} [Geometry=import("./geom/Geometry.js").default]
  * @typedef {Object<string, *> & { geometry?: Geometry }} ObjectWithGeometry
  */
 

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -1,12 +1,30 @@
 /**
  * @module ol/format/Feature
  */
+import Feature from '../Feature.js';
+import RenderFeature from '../render/Feature.js';
+import {
+  GeometryCollection,
+  LineString,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+  Polygon,
+} from '../geom.js';
 import {abstract} from '../util.js';
 import {
   equivalent as equivalentProjection,
   get as getProjection,
+  getTransform,
   transformExtent,
 } from '../proj.js';
+import {
+  linearRingsAreOriented,
+  linearRingssAreOriented,
+  orientLinearRings,
+  orientLinearRingsArray,
+} from '../geom/flat/orient.js';
 
 /**
  * @typedef {Object} ReadOptions
@@ -54,6 +72,29 @@ import {
  */
 
 /**
+ * @typedef {Object} SimpleGeometryObject
+ * @property {import('../geom/Geometry.js').Type} type Type.
+ * @property {Array<number>} flatCoordinates Flat coordinates.
+ * @property {Array<number>|Array<Array<number>>} [ends] Ends or endss.
+ * @property {import('../geom/Geometry.js').GeometryLayout} [layout] Layout.
+ */
+
+/**
+ * @typedef {Array<GeometryObject>} GeometryCollectionObject
+ */
+
+/**
+ * @typedef {SimpleGeometryObject|GeometryCollectionObject} GeometryObject
+ */
+
+/**
+ * @typedef {Object} FeatureObject
+ * @property {string|number} [id] Id.
+ * @property {GeometryObject} [geometry] Geometry.
+ * @property {Object<string, *>} [properties] Properties.
+ */
+
+/**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
@@ -78,6 +119,12 @@ class FeatureFormat {
      * @type {import("../proj/Projection.js").default|undefined}
      */
     this.defaultFeatureProjection = undefined;
+
+    /**
+     * @protected
+     * @type {import("../Feature.js").FeatureClass}
+     */
+    this.featureClass = Feature;
 
     /**
      * A list media types supported by the format in descending order of preference.
@@ -128,6 +175,7 @@ class FeatureFormat {
       {
         dataProjection: this.dataProjection,
         featureProjection: this.defaultFeatureProjection,
+        featureClass: this.featureClass,
       },
       options
     );
@@ -147,7 +195,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Element|Object|string} source Source.
    * @param {ReadOptions} [options] Read options.
-   * @return {import("../Feature.js").FeatureLike} Feature.
+   * @return {import("../Feature.js").FeatureLike|Array<import("../render/Feature.js").default>} Feature.
    */
   readFeature(source, options) {
     return abstract();
@@ -228,10 +276,11 @@ class FeatureFormat {
 export default FeatureFormat;
 
 /**
- * @param {import("../geom/Geometry.js").default} geometry Geometry.
+ * @template {import("../geom/Geometry.js").default|RenderFeature} T
+ * @param {T} geometry Geometry.
  * @param {boolean} write Set to true for writing, false for reading.
  * @param {WriteOptions|ReadOptions} [options] Options.
- * @return {import("../geom/Geometry.js").default} Transformed geometry.
+ * @return {T} Transformed geometry.
  */
 export function transformGeometryWithOptions(geometry, write, options) {
   const featureProjection = options
@@ -239,18 +288,22 @@ export function transformGeometryWithOptions(geometry, write, options) {
     : null;
   const dataProjection = options ? getProjection(options.dataProjection) : null;
 
-  let transformed;
+  let transformed = geometry;
   if (
     featureProjection &&
     dataProjection &&
     !equivalentProjection(featureProjection, dataProjection)
   ) {
-    transformed = (write ? geometry.clone() : geometry).transform(
-      write ? featureProjection : dataProjection,
-      write ? dataProjection : featureProjection
-    );
-  } else {
-    transformed = geometry;
+    if (write) {
+      transformed = /** @type {T} */ (geometry.clone());
+    }
+    const fromProjection = write ? featureProjection : dataProjection;
+    const toProjection = write ? dataProjection : featureProjection;
+    if (fromProjection.getUnits() === 'tile-pixels') {
+      transformed.transform(fromProjection, toProjection);
+    } else {
+      transformed.applyTransform(getTransform(fromProjection, toProjection));
+    }
   }
   if (
     write &&
@@ -270,7 +323,7 @@ export function transformGeometryWithOptions(geometry, write, options) {
       return coordinates;
     };
     if (transformed === geometry) {
-      transformed = geometry.clone();
+      transformed = /** @type {T} */ (geometry.clone());
     }
     transformed.applyTransform(transform);
   }
@@ -296,4 +349,91 @@ export function transformExtentWithOptions(extent, options) {
     return transformExtent(extent, dataProjection, featureProjection);
   }
   return extent;
+}
+
+const GeometryConstructor = {
+  Point: Point,
+  LineString: LineString,
+  Polygon: Polygon,
+  MultiPoint: MultiPoint,
+  MultiLineString: MultiLineString,
+  MultiPolygon: MultiPolygon,
+};
+
+function orientFlatCoordinates(flatCoordinates, ends, stride) {
+  if (Array.isArray(ends[0])) {
+    // MultiPolagon
+    if (!linearRingssAreOriented(flatCoordinates, 0, ends, stride)) {
+      flatCoordinates = flatCoordinates.slice();
+      orientLinearRingsArray(flatCoordinates, 0, ends, stride);
+    }
+    return flatCoordinates;
+  }
+  if (!linearRingsAreOriented(flatCoordinates, 0, ends, stride)) {
+    flatCoordinates = flatCoordinates.slice();
+    orientLinearRings(flatCoordinates, 0, ends, stride);
+  }
+  return flatCoordinates;
+}
+
+/**
+ * @param {FeatureObject} object Feature object.
+ * @param {WriteOptions|ReadOptions} [options] Options.
+ * @return {RenderFeature|Array<RenderFeature>} Render feature.
+ */
+export function createRenderFeature(object, options) {
+  const geometry = object.geometry;
+  if (!geometry) {
+    return [];
+  }
+  if (Array.isArray(geometry)) {
+    return geometry
+      .map((geometry) => createRenderFeature({...object, geometry}))
+      .flat();
+  }
+
+  const geometryType =
+    geometry.type === 'MultiPolygon' ? 'Polygon' : geometry.type;
+  if (geometryType === 'GeometryCollection' || geometryType === 'Circle') {
+    throw new Error('Unsupported geometry type: ' + geometryType);
+  }
+
+  const stride = geometry.layout.length;
+  return transformGeometryWithOptions(
+    new RenderFeature(
+      geometryType,
+      geometryType === 'Polygon'
+        ? orientFlatCoordinates(geometry.flatCoordinates, geometry.ends, stride)
+        : geometry.flatCoordinates,
+      geometry.ends?.flat(),
+      stride,
+      object.properties || {},
+      object.id
+    ).enableSimplifyTransformed(),
+    false,
+    options
+  );
+}
+
+/**
+ * @param {GeometryObject|null} object Geometry object.
+ * @param {WriteOptions|ReadOptions} [options] Options.
+ * @return {import("../geom/Geometry.js").default} Geometry.
+ */
+export function createGeometry(object, options) {
+  if (!object) {
+    return null;
+  }
+  if (Array.isArray(object)) {
+    const geometries = object.map((geometry) =>
+      createGeometry(geometry, options)
+    );
+    return new GeometryCollection(geometries);
+  }
+  const Geometry = GeometryConstructor[object.type];
+  return transformGeometryWithOptions(
+    new Geometry(object.flatCoordinates, object.layout, object.ends),
+    false,
+    options
+  );
 }

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -30,7 +30,7 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {import("../Feature.js").default} Feature.
+   * @return {import("../Feature.js").FeatureLike|Array<import("../render/Feature.js").default>} Feature.
    * @api
    */
   readFeature(source, options) {
@@ -46,7 +46,7 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import("../Feature.js").default>} Features.
+   * @return {Array<import("../Feature.js").FeatureLike>} Features.
    * @api
    */
   readFeatures(source, options) {
@@ -61,7 +61,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {import("../Feature.js").default} Feature.
+   * @return {import("../Feature.js").default|import("../render/Feature.js").default|Array<import("../render/Feature.js").default>} Feature.
    */
   readFeatureFromObject(object, options) {
     return abstract();
@@ -72,7 +72,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {Array<import("../Feature.js").default>} Features.
+   * @return {Array<import("../Feature.js").default|import("../render/Feature.js").default>} Features.
    */
   readFeaturesFromObject(object, options) {
     return abstract();

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -191,6 +191,7 @@ class MVT extends FeatureFormat {
         geometryType,
         flatCoordinates,
         ends,
+        2,
         values,
         id
       );
@@ -412,10 +413,10 @@ function readRawFeature(pbf, layer, i) {
  * @param {number} type The raw feature's geometry type
  * @param {number} numEnds Number of ends of the flat coordinates of the
  * geometry.
- * @return {import("../geom/Geometry.js").Type} The geometry type.
+ * @return {import("../render/Feature.js").Type} The geometry type.
  */
 function getGeometryType(type, numEnds) {
-  /** @type {import("../geom/Geometry.js").Type} */
+  /** @type {import("../render/Feature.js").Type} */
   let geometryType;
   if (type === 1) {
     geometryType = numEnds === 1 ? 'Point' : 'MultiPoint';

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -296,7 +296,7 @@ class SimpleGeometry extends Geometry {
  * @param {number} stride Stride.
  * @return {import("./Geometry.js").GeometryLayout} layout Layout.
  */
-function getLayoutForStride(stride) {
+export function getLayoutForStride(stride) {
   let layout;
   if (stride == 2) {
     layout = 'XY';

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -33,7 +33,7 @@ import {createCanvasContext2D} from '../dom.js';
  * @property {string|function(import("../Feature.js").default):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
- * @property {import("../source/Vector.js").default<import("../geom/Point.js").default>} [source] Point source.
+ * @property {import("../source/Vector.js").default} [source] Point source.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -6,7 +6,7 @@ import WebGLPointsLayerRenderer from '../renderer/webgl/PointsLayer.js';
 import {parseLiteralStyle} from '../webgl/styleparser.js';
 
 /**
- * @template {import("../source/Vector.js").default<import("../geom/Point.js").default>} VectorSourceType
+ * @template {import("../source/Vector.js").default} VectorSourceType
  * @typedef {Object} Options
  * @property {import('../style/literal.js').LiteralStyle} style Literal style to apply to the layer features.
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
@@ -62,7 +62,7 @@ import {parseLiteralStyle} from '../webgl/styleparser.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../source/Vector.js").default<import("../geom/Point.js").default>} VectorSourceType
+ * @template {import("../source/Vector.js").default} VectorSourceType
  * @extends {Layer<VectorSourceType, WebGLPointsLayerRenderer>}
  * @fires import("../render/Event.js").RenderEvent
  */

--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -20,6 +20,11 @@ import {
   getCenter,
   getHeight,
 } from '../extent.js';
+import {
+  douglasPeucker,
+  douglasPeuckerArray,
+  quantizeArray,
+} from '../geom/flat/simplify.js';
 import {extend} from '../array.js';
 import {
   getInteriorPointOfArray,
@@ -29,7 +34,14 @@ import {get as getProjection} from '../proj.js';
 import {inflateEnds} from '../geom/flat/orient.js';
 import {interpolatePoint} from '../geom/flat/interpolate.js';
 import {linearRingss as linearRingssCenter} from '../geom/flat/center.js';
+import {memoizeOne} from '../functions.js';
 import {transform2D} from '../geom/flat/transform.js';
+
+/**
+ * @typedef {'Point' | 'LineString' | 'LinearRing' | 'Polygon' | 'MultiPoint' | 'MultiLineString'} Type
+ * The geometry type.  One of `'Point'`, `'LineString'`, `'LinearRing'`,
+ * `'Polygon'`, `'MultiPoint'` or 'MultiLineString'`.
+ */
 
 /**
  * @type {import("../transform.js").Transform}
@@ -43,14 +55,15 @@ const tmpTransform = createTransform();
  */
 class RenderFeature {
   /**
-   * @param {import("../geom/Geometry.js").Type} type Geometry type.
+   * @param {Type} type Geometry type.
    * @param {Array<number>} flatCoordinates Flat coordinates. These always need
    *     to be right-handed for polygons.
-   * @param {Array<number>|Array<Array<number>>} ends Ends or Endss.
+   * @param {Array<number>} ends Ends.
+   * @param {number} stride Stride.
    * @param {Object<string, *>} properties Properties.
    * @param {number|string|undefined} id Feature id.
    */
-  constructor(type, flatCoordinates, ends, properties, id) {
+  constructor(type, flatCoordinates, ends, stride, properties, id) {
     /**
      * @type {import("../style/Style.js").StyleFunction|undefined}
      */
@@ -70,7 +83,7 @@ class RenderFeature {
 
     /**
      * @private
-     * @type {import("../geom/Geometry.js").Type}
+     * @type {Type}
      */
     this.type_ = type;
 
@@ -94,7 +107,7 @@ class RenderFeature {
 
     /**
      * @private
-     * @type {Array<number>|Array<Array<number>>}
+     * @type {Array<number>}
      */
     this.ends_ = ends;
 
@@ -103,6 +116,22 @@ class RenderFeature {
      * @type {Object<string, *>}
      */
     this.properties_ = properties;
+
+    /**
+     * @type {number}
+     */
+    this.squaredTolerance_;
+
+    /**
+     * @type {number}
+     */
+    this.stride_ = stride;
+
+    /**
+     * @private
+     * @type {RenderFeature}
+     */
+    this.simplifiedGeometry_;
   }
 
   /**
@@ -158,16 +187,12 @@ class RenderFeature {
    */
   getFlatInteriorPoints() {
     if (!this.flatInteriorPoints_) {
-      const flatCenters = linearRingssCenter(
-        this.flatCoordinates_,
-        0,
-        /** @type {Array<Array<number>>} */ (this.ends_),
-        2
-      );
+      const ends = inflateEnds(this.flatCoordinates_, this.ends_);
+      const flatCenters = linearRingssCenter(this.flatCoordinates_, 0, ends, 2);
       this.flatInteriorPoints_ = getInteriorPointsOfMultiArray(
         this.flatCoordinates_,
         0,
-        /** @type {Array<Array<number>>} */ (this.ends_),
+        ends,
         2,
         flatCenters
       );
@@ -247,7 +272,6 @@ class RenderFeature {
 
   /**
    * Get a transformed and simplified version of the geometry.
-   * @abstract
    * @param {number} squaredTolerance Squared tolerance.
    * @param {import("../proj.js").TransformFunction} [transform] Optional transform function.
    * @return {RenderFeature} Simplified geometry.
@@ -278,7 +302,7 @@ class RenderFeature {
    * @return {number} Stride.
    */
   getStride() {
-    return 2;
+    return this.stride_;
   }
 
   /**
@@ -290,7 +314,7 @@ class RenderFeature {
 
   /**
    * Get the type of this feature's geometry.
-   * @return {import("../geom/Geometry.js").Type} Geometry type.
+   * @return {Type} Geometry type.
    * @api
    */
   getType() {
@@ -337,9 +361,7 @@ class RenderFeature {
    * @param {import("../proj.js").TransformFunction} transformFn Transform function.
    */
   applyTransform(transformFn) {
-    if (this.flatCoordinates_) {
-      transformFn(this.flatCoordinates_, this.flatCoordinates_, 2);
-    }
+    transformFn(this.flatCoordinates_, this.flatCoordinates_, this.stride_);
   }
 
   /**
@@ -350,20 +372,92 @@ class RenderFeature {
       this.type_,
       this.flatCoordinates_.slice(),
       this.ends_.slice(),
+      this.stride_,
       Object.assign({}, this.properties_),
       this.id_
     );
   }
 
   /**
-   * @return {Array<number>|Array<Array<number>>} Ends or endss.
+   * @return {Array<number>} Ends.
    */
   getEnds() {
     return this.ends_;
   }
-}
 
-RenderFeature.prototype.getEndss = RenderFeature.prototype.getEnds;
+  /**
+   * Add transform and resolution based geometry simplification to this instance.
+   * @return {RenderFeature} This render feature.
+   */
+  enableSimplifyTransformed() {
+    this.simplifyTransformed = memoizeOne((squaredTolerance, transform) => {
+      if (squaredTolerance === this.squaredTolerance_) {
+        return this.simplifiedGeometry_;
+      }
+      this.simplifiedGeometry_ = this.clone();
+      if (transform) {
+        this.simplifiedGeometry_.applyTransform(transform);
+      }
+      const simplifiedFlatCoordinates =
+        this.simplifiedGeometry_.getFlatCoordinates();
+      let simplifiedEnds;
+      switch (this.type_) {
+        case 'LineString':
+          simplifiedFlatCoordinates.length = douglasPeucker(
+            simplifiedFlatCoordinates,
+            0,
+            this.simplifiedGeometry_.flatCoordinates_.length,
+            this.simplifiedGeometry_.stride_,
+            squaredTolerance,
+            simplifiedFlatCoordinates,
+            0
+          );
+          simplifiedEnds = [simplifiedFlatCoordinates.length];
+          break;
+        case 'MultiLineString':
+          simplifiedEnds = [];
+          simplifiedFlatCoordinates.length = douglasPeuckerArray(
+            simplifiedFlatCoordinates,
+            0,
+            this.simplifiedGeometry_.ends_,
+            this.simplifiedGeometry_.stride_,
+            squaredTolerance,
+            simplifiedFlatCoordinates,
+            0,
+            simplifiedEnds
+          );
+          break;
+        case 'Polygon':
+          simplifiedEnds = [];
+          simplifiedFlatCoordinates.length = quantizeArray(
+            simplifiedFlatCoordinates,
+            0,
+            this.simplifiedGeometry_.ends_,
+            this.simplifiedGeometry_.stride_,
+            Math.sqrt(squaredTolerance),
+            simplifiedFlatCoordinates,
+            0,
+            simplifiedEnds
+          );
+          break;
+        default:
+      }
+      if (simplifiedEnds) {
+        this.simplifiedGeometry_ = new RenderFeature(
+          this.type_,
+          simplifiedFlatCoordinates,
+          simplifiedEnds,
+          2,
+          this.properties_,
+          this.id_
+        );
+      }
+      this.squaredTolerance_ = squaredTolerance;
+      return this.simplifiedGeometry_;
+    });
+    return this;
+  }
+}
 
 /**
  * @return {Array<number>} Flat coordinates.

--- a/src/ol/render/webgl/MixedGeometryBatch.js
+++ b/src/ol/render/webgl/MixedGeometryBatch.js
@@ -185,9 +185,7 @@ class MixedGeometryBatch {
         break;
       case 'MultiPolygon':
         const multiPolygonGeom =
-          /** @type {import("../../geom").MultiPolygon|RenderFeature} */ (
-            geometry
-          );
+          /** @type {import("../../geom").MultiPolygon} */ (geometry);
         this.addCoordinates_(
           type,
           multiPolygonGeom.getFlatCoordinates(),

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -8,6 +8,7 @@ import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
 import ObjectEventType from '../ObjectEventType.js';
 import RBush from '../structs/RBush.js';
+import RenderFeature from '../render/Feature.js';
 import Source from './Source.js';
 import VectorEventType from './VectorEventType.js';
 import {TRUE, VOID} from '../functions.js';
@@ -33,27 +34,27 @@ import {xhr} from '../featureloader.js';
  * @classdesc
  * Events emitted by {@link module:ol/source/Vector~VectorSource} instances are instances of this
  * type.
- * @template {import("../geom/Geometry.js").default} [Geometry=import("../geom/Geometry.js").default]
+ * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
  */
 export class VectorSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {import("../Feature.js").default<Geometry>} [feature] Feature.
-   * @param {Array<import("../Feature.js").default<Geometry>>} [features] Features.
+   * @param {FeatureClass} [feature] Feature.
+   * @param {Array<FeatureClass>} [features] Features.
    */
   constructor(type, feature, features) {
     super(type);
 
     /**
      * The added or removed feature for the `ADDFEATURE` and `REMOVEFEATURE` events, `undefined` otherwise.
-     * @type {import("../Feature.js").default<Geometry>|undefined}
+     * @type {FeatureClass|undefined}
      * @api
      */
     this.feature = feature;
 
     /**
      * The loaded features for the `FEATURESLOADED` event, `undefined` otherwise.
-     * @type {Array<import("../Feature.js").default<Geometry>>|undefined}
+     * @type {Array<FeatureClass>|undefined}
      * @api
      */
     this.features = features;
@@ -70,10 +71,10 @@ export class VectorSourceEvent extends Event {
  */
 
 /**
- * @template {import("../geom/Geometry.js").default} [Geometry=import("../geom/Geometry.js").default]
+ * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {Array<import("../Feature.js").default<Geometry>>|Collection<import("../Feature.js").default<Geometry>>} [features]
+ * @property {Array<FeatureClass>|Collection<FeatureClass>} [features]
  * Features. If provided as {@link module:ol/Collection~Collection}, the features in the source
  * and the collection will stay in sync.
  * @property {import("../format/Feature.js").default} [format] The feature format used by the XHR
@@ -170,11 +171,11 @@ export class VectorSourceEvent extends Event {
  *
  * @fires VectorSourceEvent
  * @api
- * @template {import("../geom/Geometry.js").default} [Geometry=import("../geom/Geometry.js").default]
+ * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
  */
 class VectorSource extends Source {
   /**
-   * @param {Options<Geometry>} [options] Vector source options.
+   * @param {Options<FeatureClass>} [options] Vector source options.
    */
   constructor(options) {
     options = options || {};
@@ -249,7 +250,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {RBush<import("../Feature.js").default<Geometry>>}
+     * @type {RBush<FeatureClass>}
      */
     this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
@@ -267,21 +268,21 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {!Object<string, import("../Feature.js").default<Geometry>>}
+     * @type {!Object<string, FeatureClass>}
      */
     this.nullGeometryFeatures_ = {};
 
     /**
      * A lookup of features by id (the return from feature.getId()).
      * @private
-     * @type {!Object<string, import("../Feature.js").default<Geometry>>}
+     * @type {!Object<string, FeatureClass|Array<RenderFeature>>}
      */
     this.idIndex_ = {};
 
     /**
      * A lookup of features by uid (using getUid(feature)).
      * @private
-     * @type {!Object<string, import("../Feature.js").default<Geometry>>}
+     * @type {!Object<string, FeatureClass>}
      */
     this.uidIndex_ = {};
 
@@ -293,13 +294,13 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {Collection<import("../Feature.js").default<Geometry>>|null}
+     * @type {Collection<FeatureClass>|null}
      */
     this.featuresCollection_ = null;
 
-    /** @type {Collection<import("../Feature.js").default<Geometry>>} */
+    /** @type {Collection<FeatureClass>} */
     let collection;
-    /** @type {Array<import("../Feature.js").default<Geometry>>} */
+    /** @type {Array<FeatureClass>} */
     let features;
     if (Array.isArray(options.features)) {
       features = options.features;
@@ -327,7 +328,7 @@ class VectorSource extends Source {
    * Note: this also applies if an {@link module:ol/Collection~Collection} is used for features,
    * meaning that if a feature with a duplicate id is added in the collection, it will
    * be removed from it right away.
-   * @param {import("../Feature.js").default<Geometry>} feature Feature to add.
+   * @param {FeatureClass} feature Feature to add.
    * @api
    */
   addFeature(feature) {
@@ -337,7 +338,7 @@ class VectorSource extends Source {
 
   /**
    * Add a feature without firing a `change` event.
-   * @param {import("../Feature.js").default<Geometry>} feature Feature.
+   * @param {FeatureClass} feature Feature.
    * @protected
    */
   addFeatureInternal(feature) {
@@ -369,10 +370,13 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {import("../Feature.js").default<Geometry>} feature The feature.
+   * @param {FeatureClass} feature The feature.
    * @private
    */
   setupChangeEvents_(featureKey, feature) {
+    if (feature instanceof RenderFeature) {
+      return;
+    }
     this.featureChangeKeys_[featureKey] = [
       listen(feature, EventType.CHANGE, this.handleFeatureChange_, this),
       listen(
@@ -386,17 +390,28 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {import("../Feature.js").default<Geometry>} feature The feature.
+   * @param {FeatureClass} feature The feature.
    * @return {boolean} The feature is "valid", in the sense that it is also a
    *     candidate for insertion into the Rtree.
    * @private
    */
   addToIndex_(featureKey, feature) {
     let valid = true;
-    const id = feature.getId();
-    if (id !== undefined) {
-      if (!(id.toString() in this.idIndex_)) {
-        this.idIndex_[id.toString()] = feature;
+    if (feature.getId() !== undefined) {
+      const id = String(feature.getId());
+      if (!(id in this.idIndex_)) {
+        this.idIndex_[id] = feature;
+      } else if (feature instanceof RenderFeature) {
+        const indexedFeature = this.idIndex_[id];
+        if (!(indexedFeature instanceof RenderFeature)) {
+          valid = false;
+        } else {
+          if (!Array.isArray(indexedFeature)) {
+            this.idIndex_[id] = [indexedFeature, feature];
+          } else {
+            indexedFeature.push(feature);
+          }
+        }
       } else {
         valid = false;
       }
@@ -413,7 +428,7 @@ class VectorSource extends Source {
 
   /**
    * Add a batch of features to the source.
-   * @param {Array<import("../Feature.js").default<Geometry>>} features Features to add.
+   * @param {Array<FeatureClass>} features Features to add.
    * @api
    */
   addFeatures(features) {
@@ -423,12 +438,14 @@ class VectorSource extends Source {
 
   /**
    * Add features without firing a `change` event.
-   * @param {Array<import("../Feature.js").default<Geometry>>} features Features.
+   * @param {Array<FeatureClass>} features Features.
    * @protected
    */
   addFeaturesInternal(features) {
     const extents = [];
+    /** @type {Array<FeatureClass>} */
     const newFeatures = [];
+    /** @type Array<FeatureClass> */
     const geometryFeatures = [];
 
     for (let i = 0, length = features.length; i < length; i++) {
@@ -467,7 +484,7 @@ class VectorSource extends Source {
   }
 
   /**
-   * @param {!Collection<import("../Feature.js").default<Geometry>>} collection Collection.
+   * @param {!Collection<FeatureClass>} collection Collection.
    * @private
    */
   bindFeaturesCollection_(collection) {
@@ -475,7 +492,7 @@ class VectorSource extends Source {
     this.addEventListener(
       VectorEventType.ADDFEATURE,
       /**
-       * @param {VectorSourceEvent<Geometry>} evt The vector source event
+       * @param {VectorSourceEvent<FeatureClass>} evt The vector source event
        */
       function (evt) {
         if (!modifyingCollection) {
@@ -488,7 +505,7 @@ class VectorSource extends Source {
     this.addEventListener(
       VectorEventType.REMOVEFEATURE,
       /**
-       * @param {VectorSourceEvent<Geometry>} evt The vector source event
+       * @param {VectorSourceEvent<FeatureClass>} evt The vector source event
        */
       function (evt) {
         if (!modifyingCollection) {
@@ -501,7 +518,7 @@ class VectorSource extends Source {
     collection.addEventListener(
       CollectionEventType.ADD,
       /**
-       * @param {import("../Collection.js").CollectionEvent<import("../Feature.js").default<Geometry>>} evt The collection event
+       * @param {import("../Collection.js").CollectionEvent<FeatureClass>} evt The collection event
        */
       (evt) => {
         if (!modifyingCollection) {
@@ -514,7 +531,7 @@ class VectorSource extends Source {
     collection.addEventListener(
       CollectionEventType.REMOVE,
       /**
-       * @param {import("../Collection.js").CollectionEvent<import("../Feature.js").default<Geometry>>} evt The collection event
+       * @param {import("../Collection.js").CollectionEvent<FeatureClass>} evt The collection event
        */
       (evt) => {
         if (!modifyingCollection) {
@@ -574,7 +591,7 @@ class VectorSource extends Source {
    * stop and the function will return the same value.
    * Note: this function only iterate through the feature that have a defined geometry.
    *
-   * @param {function(import("../Feature.js").default<Geometry>): T} callback Called with each feature
+   * @param {function(FeatureClass): T} callback Called with each feature
    *     on the source.  Return a truthy value to stop iteration.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -595,8 +612,11 @@ class VectorSource extends Source {
    * a "truthy" value, iteration will stop and the function will return the same
    * value.
    *
+   * For {@link module:ol/render/Feature~RenderFeature} features, the callback will be
+   * called for all features.
+   *
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(import("../Feature.js").default<Geometry>): T} callback Called with each feature
+   * @param {function(FeatureClass): T} callback Called with each feature
    *     whose goemetry contains the provided coordinate.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -605,7 +625,10 @@ class VectorSource extends Source {
     const extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
     return this.forEachFeatureInExtent(extent, function (feature) {
       const geometry = feature.getGeometry();
-      if (geometry.intersectsCoordinate(coordinate)) {
+      if (
+        geometry instanceof RenderFeature ||
+        geometry.intersectsCoordinate(coordinate)
+      ) {
         return callback(feature);
       }
       return undefined;
@@ -625,7 +648,7 @@ class VectorSource extends Source {
    * features, equivalent to {@link module:ol/source/Vector~VectorSource#forEachFeature #forEachFeature()}.
    *
    * @param {import("../extent.js").Extent} extent Extent.
-   * @param {function(import("../Feature.js").default<Geometry>): T} callback Called with each feature
+   * @param {function(FeatureClass): T} callback Called with each feature
    *     whose bounding box intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -649,7 +672,7 @@ class VectorSource extends Source {
    * {@link module:ol/source/Vector~VectorSource#forEachFeatureInExtent #forEachFeatureInExtent()} method instead.
    *
    * @param {import("../extent.js").Extent} extent Extent.
-   * @param {function(import("../Feature.js").default<Geometry>): T} callback Called with each feature
+   * @param {function(FeatureClass): T} callback Called with each feature
    *     whose geometry intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -659,12 +682,15 @@ class VectorSource extends Source {
     return this.forEachFeatureInExtent(
       extent,
       /**
-       * @param {import("../Feature.js").default<Geometry>} feature Feature.
+       * @param {FeatureClass} feature Feature.
        * @return {T|undefined} The return value from the last call to the callback.
        */
       function (feature) {
         const geometry = feature.getGeometry();
-        if (geometry.intersectsExtent(extent)) {
+        if (
+          geometry instanceof RenderFeature ||
+          geometry.intersectsExtent(extent)
+        ) {
           const result = callback(feature);
           if (result) {
             return result;
@@ -678,7 +704,7 @@ class VectorSource extends Source {
    * Get the features collection associated with this source. Will be `null`
    * unless the source was configured with `useSpatialIndex` set to `false`, or
    * with an {@link module:ol/Collection~Collection} as `features`.
-   * @return {Collection<import("../Feature.js").default<Geometry>>|null} The collection of features.
+   * @return {Collection<FeatureClass>|null} The collection of features.
    * @api
    */
   getFeaturesCollection() {
@@ -688,7 +714,7 @@ class VectorSource extends Source {
   /**
    * Get a snapshot of the features currently on the source in random order. The returned array
    * is a copy, the features are references to the features in the source.
-   * @return {Array<import("../Feature.js").default<Geometry>>} Features.
+   * @return {Array<FeatureClass>} Features.
    * @api
    */
   getFeatures() {
@@ -701,15 +727,13 @@ class VectorSource extends Source {
         extend(features, Object.values(this.nullGeometryFeatures_));
       }
     }
-    return /** @type {Array<import("../Feature.js").default<Geometry>>} */ (
-      features
-    );
+    return features;
   }
 
   /**
    * Get all features whose geometry intersects the provided coordinate.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @return {Array<import("../Feature.js").default<Geometry>>} Features.
+   * @return {Array<import("../Feature.js").default>} Features.
    * @api
    */
   getFeaturesAtCoordinate(coordinate) {
@@ -731,7 +755,7 @@ class VectorSource extends Source {
    * @param {import("../extent.js").Extent} extent Extent.
    * @param {import("../proj/Projection.js").default} [projection] Include features
    * where `extent` exceeds the x-axis bounds of `projection` and wraps around the world.
-   * @return {Array<import("../Feature.js").default<Geometry>>} Features.
+   * @return {Array<FeatureClass>} Features.
    * @api
    */
   getFeaturesInExtent(extent, projection) {
@@ -758,12 +782,13 @@ class VectorSource extends Source {
    * Get the closest feature to the provided coordinate.
    *
    * This method is not available when the source is configured with
-   * `useSpatialIndex` set to `false`.
+   * `useSpatialIndex` set to `false` and the features in this source are of type
+   * {@link module:ol/Feature~Feature}.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(import("../Feature.js").default<Geometry>):boolean} [filter] Feature filter function.
+   * @param {function(FeatureClass):boolean} [filter] Feature filter function.
    *     The filter function will receive one argument, the {@link module:ol/Feature~Feature feature}
    *     and it should return a boolean value. By default, no filtering is made.
-   * @return {import("../Feature.js").default<Geometry>} Closest feature.
+   * @return {FeatureClass} Closest feature.
    * @api
    */
   getClosestFeatureToCoordinate(coordinate, filter) {
@@ -784,18 +809,16 @@ class VectorSource extends Source {
     this.featuresRtree_.forEachInExtent(
       extent,
       /**
-       * @param {import("../Feature.js").default<Geometry>} feature Feature.
+       * @param {FeatureClass} feature Feature.
        */
       function (feature) {
         if (filter(feature)) {
           const geometry = feature.getGeometry();
           const previousMinSquaredDistance = minSquaredDistance;
-          minSquaredDistance = geometry.closestPointXY(
-            x,
-            y,
-            closestPoint,
-            minSquaredDistance
-          );
+          minSquaredDistance =
+            geometry instanceof RenderFeature
+              ? 0
+              : geometry.closestPointXY(x, y, closestPoint, minSquaredDistance);
           if (minSquaredDistance < previousMinSquaredDistance) {
             closestFeature = feature;
             // This is sneaky.  Reduce the extent that it is currently being
@@ -829,12 +852,15 @@ class VectorSource extends Source {
   }
 
   /**
-   * Get a feature by its identifier (the value returned by feature.getId()).
+   * Get a feature by its identifier (the value returned by feature.getId()). When `RenderFeature`s
+   * are used, `getFeatureById()` can return an array of `RenderFeature`s. This allows for handling
+   * of `GeometryCollection` geometries, where format readers create one `RenderFeature` per
+   * `GeometryCollection` member.
    * Note that the index treats string and numeric identifiers as the same.  So
    * `source.getFeatureById(2)` will return a feature with id `'2'` or `2`.
    *
    * @param {string|number} id Feature identifier.
-   * @return {import("../Feature.js").default<Geometry>|null} The feature (or `null` if not found).
+   * @return {FeatureClass|Array<RenderFeature>|null} The feature (or `null` if not found).
    * @api
    */
   getFeatureById(id) {
@@ -846,7 +872,7 @@ class VectorSource extends Source {
    * Get a feature by its internal unique identifier (using `getUid`).
    *
    * @param {string} uid Feature identifier.
-   * @return {import("../Feature.js").default<Geometry>|null} The feature (or `null` if not found).
+   * @return {FeatureClass|null} The feature (or `null` if not found).
    */
   getFeatureByUid(uid) {
     const feature = this.uidIndex_[uid];
@@ -885,9 +911,7 @@ class VectorSource extends Source {
    * @private
    */
   handleFeatureChange_(event) {
-    const feature = /** @type {import("../Feature.js").default<Geometry>} */ (
-      event.target
-    );
+    const feature = /** @type {FeatureClass} */ (event.target);
     const featureKey = getUid(feature);
     const geometry = feature.getGeometry();
     if (!geometry) {
@@ -929,7 +953,7 @@ class VectorSource extends Source {
 
   /**
    * Returns true if the feature is contained within the source.
-   * @param {import("../Feature.js").default<Geometry>} feature Feature.
+   * @param {FeatureClass} feature Feature.
    * @return {boolean} Has feature.
    * @api
    */
@@ -1039,7 +1063,7 @@ class VectorSource extends Source {
    * Remove a single feature from the source.  If you want to remove all features
    * at once, use the {@link module:ol/source/Vector~VectorSource#clear #clear()} method
    * instead.
-   * @param {import("../Feature.js").default<Geometry>} feature Feature to remove.
+   * @param {FeatureClass} feature Feature to remove.
    * @api
    */
   removeFeature(feature) {
@@ -1062,8 +1086,8 @@ class VectorSource extends Source {
 
   /**
    * Remove feature without firing a `change` event.
-   * @param {import("../Feature.js").default<Geometry>} feature Feature.
-   * @return {import("../Feature.js").default<Geometry>|undefined} The removed feature
+   * @param {FeatureClass} feature Feature.
+   * @return {FeatureClass|undefined} The removed feature
    *     (or undefined if the feature was not found).
    * @protected
    */
@@ -1089,14 +1113,21 @@ class VectorSource extends Source {
   /**
    * Remove a feature from the id index.  Called internally when the feature id
    * may have changed.
-   * @param {import("../Feature.js").default<Geometry>} feature The feature.
+   * @param {FeatureClass} feature The feature.
    * @return {boolean} Removed the feature from the index.
    * @private
    */
   removeFromIdIndex_(feature) {
     let removed = false;
     for (const id in this.idIndex_) {
-      if (this.idIndex_[id] === feature) {
+      const indexedFeature = this.idIndex_[id];
+      if (
+        feature instanceof RenderFeature &&
+        Array.isArray(indexedFeature) &&
+        indexedFeature.includes(feature)
+      ) {
+        indexedFeature.splice(indexedFeature.indexOf(feature), 1);
+      } else if (this.idIndex_[id] === feature) {
         delete this.idIndex_[id];
         removed = true;
         break;

--- a/test/browser/spec/ol/render/feature.test.js
+++ b/test/browser/spec/ol/render/feature.test.js
@@ -16,6 +16,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -29,6 +30,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -42,6 +44,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -55,6 +58,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -66,6 +70,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -73,7 +78,13 @@ describe('ol.render.Feature', function () {
     });
 
     it('returns the correct extent for a linestring', function () {
-      const feature = new RenderFeature('LineString', [-1, -2, 2, 1], null, {});
+      const feature = new RenderFeature(
+        'LineString',
+        [-1, -2, 2, 1],
+        null,
+        2,
+        {}
+      );
       expect(feature.getExtent()).to.eql([-1, -2, 2, 1]);
     });
   });
@@ -84,6 +95,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -105,7 +117,8 @@ describe('ol.render.Feature', function () {
       const feature = new RenderFeature(
         'Polygon',
         polygon.getOrientedFlatCoordinates(),
-        polygon.getEnds()
+        polygon.getEnds(),
+        2
       );
       expect(feature.getFlatInteriorPoint()).to.eql([5, 5, 10]);
       expect(feature.getFlatInteriorPoint()).to.be(feature.flatInteriorPoints_);
@@ -135,9 +148,10 @@ describe('ol.render.Feature', function () {
         ],
       ]);
       const feature = new RenderFeature(
-        'MultiPolygon',
+        'Polygon',
         polygon.getOrientedFlatCoordinates(),
-        polygon.getEndss()
+        polygon.getEndss().flat(),
+        2
       );
       expect(feature.getFlatInteriorPoints()).to.eql([5, 5, 10, 15, 5, 10]);
       expect(feature.getFlatInteriorPoints()).to.be(
@@ -157,7 +171,9 @@ describe('ol.render.Feature', function () {
       ]);
       const feature = new RenderFeature(
         'LineString',
-        line.getFlatCoordinates()
+        line.getFlatCoordinates(),
+        [10],
+        2
       );
       expect(feature.getFlatMidpoint()).to.eql([10, 10]);
       expect(feature.getFlatMidpoint()).to.eql(feature.flatMidpoints_);
@@ -185,7 +201,8 @@ describe('ol.render.Feature', function () {
       const feature = new RenderFeature(
         'MultiLineString',
         line.getFlatCoordinates(),
-        line.getEnds()
+        line.getEnds(),
+        2
       );
       expect(feature.getFlatMidpoints()).to.eql([10, 10, 20, 10]);
       expect(feature.getFlatMidpoints()).to.be(feature.flatMidpoints_);
@@ -198,6 +215,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -211,6 +229,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -224,6 +243,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -237,6 +257,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -250,6 +271,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -263,6 +285,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );
@@ -276,6 +299,7 @@ describe('ol.render.Feature', function () {
         type,
         flatCoordinates,
         ends,
+        2,
         properties,
         'foo'
       );

--- a/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
+++ b/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
@@ -832,6 +832,7 @@ describe('MixedGeometryBatch', function () {
         'Polygon',
         geometry.getFlatCoordinates(),
         geometry.getEnds(),
+        2,
         {
           prop1: 'abcd',
           prop2: 'efgh',
@@ -929,6 +930,7 @@ describe('MixedGeometryBatch', function () {
         'Polygon',
         geometry.getFlatCoordinates(),
         geometry.getEnds(),
+        2,
         {
           prop1: 'abcd',
           prop2: 'efgh',
@@ -1034,15 +1036,17 @@ describe('MixedGeometryBatch', function () {
         'MultiLineString',
         multiLine.getFlatCoordinates(),
         multiLine.getEnds(),
+        2,
         {
           prop3: 'abcd',
           prop4: 'efgh',
         }
       );
       feature2 = new RenderFeature(
-        'MultiPolygon',
+        'Polygon',
         multiPolygon.getFlatCoordinates(),
-        multiPolygon.getEndss(),
+        multiPolygon.getEndss().flat(),
+        2,
         {
           prop3: 'uvw',
           prop4: 'xyz',
@@ -1052,6 +1056,7 @@ describe('MixedGeometryBatch', function () {
         'MultiPoint',
         multiPoint.getFlatCoordinates(),
         multiPoint.getPoints().map((p, i) => i + 1),
+        2,
         {
           prop3: 'uvw',
           prop4: 'xyz',

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -74,7 +74,7 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       ];
       feature1 = new Feature(new Point([1, -1]));
       feature2 = new Feature(new Point([0, 0]));
-      feature3 = new RenderFeature('Point', [1, -1], []);
+      feature3 = new RenderFeature('Point', [1, -1], [], 2);
       feature2.setStyle(featureStyle);
       class TileClass extends VectorTile {
         constructor() {
@@ -421,7 +421,7 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
         }),
       });
       const sourceTile = new VectorTile([0, 0, 0], 2);
-      sourceTile.features_ = [new RenderFeature('Point', [0, 0])];
+      sourceTile.features_ = [new RenderFeature('Point', [0, 0], [], 2)];
       sourceTile.getImage = function () {
         return document.createElement('canvas');
       };

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -4,6 +4,7 @@ import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import Map from '../../../../../src/ol/Map.js';
 import Point from '../../../../../src/ol/geom/Point.js';
+import RenderFeature from '../../../../../src/ol/render/Feature.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
 import View from '../../../../../src/ol/View.js';
@@ -17,7 +18,7 @@ import {
 import {getUid} from '../../../../../src/ol/util.js';
 import {listen} from '../../../../../src/ol/events.js';
 
-describe('ol.source.Vector', function () {
+describe('ol/source/Vector', function () {
   let pointFeature;
   let infiniteExtent;
   beforeEach(function () {
@@ -106,6 +107,16 @@ describe('ol.source.Vector', function () {
         source.addFeature(feature1);
         source.addFeature(feature2);
         expect(source.getFeatures().length).to.be(1);
+      });
+
+      it('Render features with the same id are gathered in an array', function () {
+        const source = new VectorSource();
+        const feature1 = new RenderFeature('Point', [1, 1], [], 2, {}, 1);
+        const feature2 = new RenderFeature('Point', [2, 2], [], 2, {}, 1);
+        source.addFeature(feature1);
+        source.addFeature(feature2);
+        expect(source.getFeatures().length).to.be(2);
+        expect(source.getFeatureById(1)).to.eql([feature1, feature2]);
       });
     });
 

--- a/test/node/ol/geom/flat/orient.test.js
+++ b/test/node/ol/geom/flat/orient.test.js
@@ -245,6 +245,7 @@ describe('ol/geom/flat/orient.js', function () {
         'Polygon',
         flatCoordinates,
         ends,
+        2,
         {},
         feature.getId()
       );

--- a/test/node/ol/render/Feature.test.js
+++ b/test/node/ol/render/Feature.test.js
@@ -19,7 +19,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
-        []
+        [],
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(Point);
@@ -36,7 +37,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
-        []
+        [],
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(MultiPoint);
@@ -53,7 +55,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
-        []
+        [],
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(LineString);
@@ -76,7 +79,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
-        geometry.getEnds().slice()
+        geometry.getEnds().slice(),
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(MultiLineString);
@@ -104,7 +108,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
-        geometry.getEnds().slice()
+        geometry.getEnds().slice(),
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(Polygon);
@@ -142,7 +147,8 @@ describe('ol/render/Feature', function () {
       const renderFeature = new RenderFeature(
         'Polygon',
         geometry.getFlatCoordinates().slice(),
-        geometry.getEndss().flat(1)
+        geometry.getEndss().flat(1),
+        2
       );
       const converted = toGeometry(renderFeature);
       expect(converted).to.be.a(MultiPolygon);
@@ -163,6 +169,7 @@ describe('ol/render/Feature', function () {
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
         [],
+        2,
         properties,
         id
       );
@@ -181,6 +188,7 @@ describe('ol/render/Feature', function () {
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
         [],
+        2,
         properties,
         id
       );
@@ -207,6 +215,7 @@ describe('ol/render/Feature', function () {
       geometry.getType(),
       geometry.getFlatCoordinates().slice(),
       [],
+      2,
       properties,
       id
     );
@@ -242,6 +251,7 @@ describe('ol/render/Feature', function () {
         geometry.getType(),
         geometry.getFlatCoordinates().slice(),
         geometry.getEnds().slice(),
+        2,
         properties,
         id
       );


### PR DESCRIPTION
This pull request makes `ol/render/Feature` work for `Vector` sources. This is useful for rendering large amounts of vector data more efficiently, because `ol/render/Feature` does not have the event handling overhead of `ol/Feature` and `ol/geom/Geometry`.

To make this work, render features can now be enabled to handle resolution based geometry simplification, by calling `simplifyGeometry()` once on the `RenderFeature` instance.

To use this with `ol/format/Feature` formats, the format constructor needs to be configured with `{featureClass: RenderFeature}`. Currently this is only implemented for `ol/format/GeoJSON`.
