### PR TITLE
Fix the type for VectorTile features

### DIFF
--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -30,7 +30,7 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {Array<import("./Feature.js").default>}
+     * @type {Array<import("./Feature.js").FeatureLike>}
      */
     this.features_ = null;
 
@@ -117,7 +117,7 @@ class VectorTile extends Tile {
   /**
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the features for the tile.
-   * @param {Array<import("./Feature.js").default>} features Features.
+   * @param {Array<import("./Feature.js").FeatureLike>} features Features.
    * @api
    */
   setFeatures(features) {


### PR DESCRIPTION
This is a small fix for the type of the features used by `ol/VectorTile`. I'm surprised this went unnoticed for so long.