### PR TITLE
Parse more variety of color strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.1.1-dev",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "color-name": "^2.0.0",
+        "color-rgba": "^2.4.0",
         "earcut": "^2.2.3",
         "geotiff": "^2.0.7",
         "pbf": "3.2.1",
@@ -728,47 +728,6 @@
       },
       "engines": {
         "node": ">=16.3.0"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@radiantearth/stac-migrate": {
@@ -2220,19 +2179,32 @@
         "color-name": "1.1.3"
       }
     },
-    "node_modules/color-convert/node_modules/color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
-    "node_modules/color-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
-      "engines": {
-        "node": ">=12.20"
+    "node_modules/color-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
+      "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
+      "dependencies": {
+        "color-name": "^1.0.0"
       }
+    },
+    "node_modules/color-rgba": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
+      "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
+      "dependencies": {
+        "color-parse": "^1.4.2",
+        "color-space": "^2.0.0"
+      }
+    },
+    "node_modules/color-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
+      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
     "node_modules/colorette": {
       "version": "2.0.16",
@@ -5856,16 +5828,22 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/magic-string/node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/mapbox-to-css-font": {
       "version": "2.4.2",
@@ -7295,9 +7273,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
@@ -7523,9 +7501,9 @@
       }
     },
     "node_modules/rollup-plugin-external-globals/node_modules/is-reference": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
-      "integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+      "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*"
@@ -7573,15 +7551,15 @@
       "dev": true
     },
     "node_modules/schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
+        "ajv": "^8.9.0",
         "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
+        "ajv-keywords": "^5.1.0"
       },
       "engines": {
         "node": ">= 12.13.0"
@@ -8565,9 +8543,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-      "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -9182,9 +9160,9 @@
       }
     },
     "node_modules/webpack-cli/node_modules/webpack-merge": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-      "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
+      "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -9282,9 +9260,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+      "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -9314,9 +9292,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
+      "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -9492,9 +9470,9 @@
       }
     },
     "node_modules/worker-loader/node_modules/schema-utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-      "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -9628,9 +9606,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -10197,40 +10175,6 @@
         "tar-fs": "3.0.4",
         "unbzip2-stream": "1.4.3",
         "yargs": "17.7.1"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^8.0.1",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.3",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^21.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
-        }
       }
     },
     "@radiantearth/stac-migrate": {
@@ -11395,20 +11339,34 @@
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
-      },
-      "dependencies": {
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        }
       }
     },
     "color-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
-      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "color-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
+      "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
+    "color-rgba": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
+      "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
+      "requires": {
+        "color-parse": "^1.4.2",
+        "color-space": "^2.0.0"
+      }
+    },
+    "color-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
+      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
     "colorette": {
       "version": "2.0.16",
@@ -14167,12 +14125,20 @@
       }
     },
     "magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
+      "integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
       "dev": true,
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": {
+          "version": "1.4.15",
+          "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+          "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+          "dev": true
+        }
       }
     },
     "mapbox-to-css-font": {
@@ -15256,9 +15222,9 @@
       }
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.3",
@@ -15427,9 +15393,9 @@
           }
         },
         "is-reference": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
-          "integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.2.tgz",
+          "integrity": "sha512-v3rht/LgVcsdZa3O2Nqs+NMowLOxeOm7Ay9+/ARQ2F+qEoANRcqrjAZKGN0v8ymUetZGgkp26LTnGT7H0Qo9Pg==",
           "dev": true,
           "requires": {
             "@types/estree": "*"
@@ -15465,15 +15431,15 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-      "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "ajv": "^8.8.0",
+        "ajv": "^8.9.0",
         "ajv-formats": "^2.1.1",
-        "ajv-keywords": "^5.0.0"
+        "ajv-keywords": "^5.1.0"
       },
       "dependencies": {
         "ajv": {
@@ -16253,9 +16219,9 @@
           }
         },
         "schema-utils": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.2.tgz",
-          "integrity": "sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.8",
@@ -16720,9 +16686,9 @@
           }
         },
         "webpack-merge": {
-          "version": "5.8.0",
-          "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.8.0.tgz",
-          "integrity": "sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==",
+          "version": "5.9.0",
+          "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
+          "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
           "dev": true,
           "requires": {
             "clone-deep": "^4.0.1",
@@ -16783,9 +16749,9 @@
       },
       "dependencies": {
         "ipaddr.js": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
-          "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.1.0.tgz",
+          "integrity": "sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==",
           "dev": true
         },
         "webpack-dev-middleware": {
@@ -16802,9 +16768,9 @@
           }
         },
         "ws": {
-          "version": "8.13.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-          "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+          "version": "8.14.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.1.tgz",
+          "integrity": "sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==",
           "dev": true,
           "requires": {}
         }
@@ -16916,9 +16882,9 @@
       },
       "dependencies": {
         "schema-utils": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-          "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
           "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.8",
@@ -17017,9 +16983,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
       "requires": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "url": "https://opencollective.com/openlayers"
   },
   "dependencies": {
-    "color-name": "^2.0.0",
+    "color-rgba": "^2.4.0",
     "earcut": "^2.2.3",
     "geotiff": "^2.0.7",
     "pbf": "3.2.1",

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -1,7 +1,7 @@
 /**
  * @module ol/color
  */
-import colorNames from 'color-name';
+import parseRgba from 'color-rgba';
 import {clamp} from './math.js';
 
 /**
@@ -12,22 +12,6 @@ import {clamp} from './math.js';
  * @typedef {Array<number>} Color
  * @api
  */
-
-/**
- * This RegExp matches # followed by 3, 4, 6, or 8 hex digits.
- * @const
- * @type {RegExp}
- * @private
- */
-const HEX_COLOR_RE_ = /^#([a-f0-9]{3}|[a-f0-9]{4}(?:[a-f0-9]{2}){0,2})$/i;
-
-/**
- * Regular expression for matching potential named color style strings.
- * @const
- * @type {RegExp}
- * @private
- */
-const NAMED_COLOR_RE_ = /^([a-z]*)$|^hsla?\(.*\)$/i;
 
 /**
  * Return the color as an rgba string.
@@ -43,74 +27,55 @@ export function asString(color) {
 }
 
 /**
- * Return named color as an rgb(a) string.
- * @param {string} color Named color.
- * @return {string} RGB(A) string.
+ * @type {number}
  */
-function fromNamed(color) {
-  const name = color.toLowerCase();
-  if (!colorNames.hasOwnProperty(name)) {
-    if (name === 'transparent') {
-      return 'rgba(0,0,0,0)';
-    }
-    return '';
-  }
-  const rgb = colorNames[name];
-  return 'rgb(' + rgb[0] + ',' + rgb[1] + ',' + rgb[2] + ')';
-}
+const MAX_CACHE_SIZE = 1024;
+
+/**
+ * We maintain a small cache of parsed strings.  Whenever the cache grows too large,
+ * we delete an arbitrary set of the entries.
+ *
+ * @type {Object<string, Color>}
+ */
+const cache = {};
+
+/**
+ * @type {number}
+ */
+let cacheSize = 0;
 
 /**
  * @param {string} s String.
  * @return {Color} Color.
  */
-export const fromString = (function () {
-  // We maintain a small cache of parsed strings.  To provide cheap LRU-like
-  // semantics, whenever the cache grows too large we simply delete an
-  // arbitrary 25% of the entries.
-
-  /**
-   * @const
-   * @type {number}
-   */
-  const MAX_CACHE_SIZE = 1024;
-
-  /**
-   * @type {Object<string, Color>}
-   */
-  const cache = {};
-
-  /**
-   * @type {number}
-   */
-  let cacheSize = 0;
-
-  return (
-    /**
-     * @param {string} s String.
-     * @return {Color} Color.
-     */
-    function (s) {
-      let color;
-      if (cache.hasOwnProperty(s)) {
-        color = cache[s];
-      } else {
-        if (cacheSize >= MAX_CACHE_SIZE) {
-          let i = 0;
-          for (const key in cache) {
-            if ((i++ & 3) === 0) {
-              delete cache[key];
-              --cacheSize;
-            }
-          }
-        }
-        color = fromStringInternal_(s);
-        cache[s] = color;
-        ++cacheSize;
+export function fromString(s) {
+  if (cache.hasOwnProperty(s)) {
+    return cache[s];
+  }
+  if (cacheSize >= MAX_CACHE_SIZE) {
+    let i = 0;
+    for (const key in cache) {
+      if ((i++ & 3) === 0) {
+        delete cache[key];
+        --cacheSize;
       }
-      return color;
     }
-  );
-})();
+  }
+
+  const color = parseRgba(s);
+  if (color.length !== 4) {
+    throw new Error('Failed to parse "' + s + '" as color');
+  }
+  for (const c of color) {
+    if (isNaN(c)) {
+      throw new Error('Failed to parse "' + s + '" as color');
+    }
+  }
+  normalize(color);
+  cache[s] = color;
+  ++cacheSize;
+  return color;
+}
 
 /**
  * Return the color as an array. This function maintains a cache of calculated
@@ -124,60 +89,6 @@ export function asArray(color) {
     return color;
   }
   return fromString(color);
-}
-
-/**
- * @param {string} s String.
- * @private
- * @return {Color} Color.
- */
-function fromStringInternal_(s) {
-  let r, g, b, a, color;
-
-  if (NAMED_COLOR_RE_.exec(s)) {
-    s = fromNamed(s);
-  }
-
-  if (HEX_COLOR_RE_.exec(s)) {
-    // hex
-    const n = s.length - 1; // number of hex digits
-    let d; // number of digits per channel
-    if (n <= 4) {
-      d = 1;
-    } else {
-      d = 2;
-    }
-    const hasAlpha = n === 4 || n === 8;
-    r = parseInt(s.substr(1 + 0 * d, d), 16);
-    g = parseInt(s.substr(1 + 1 * d, d), 16);
-    b = parseInt(s.substr(1 + 2 * d, d), 16);
-    if (hasAlpha) {
-      a = parseInt(s.substr(1 + 3 * d, d), 16);
-    } else {
-      a = 255;
-    }
-    if (d == 1) {
-      r = (r << 4) + r;
-      g = (g << 4) + g;
-      b = (b << 4) + b;
-      if (hasAlpha) {
-        a = (a << 4) + a;
-      }
-    }
-    color = [r, g, b, a / 255];
-  } else if (s.startsWith('rgba(')) {
-    // rgba()
-    color = s.slice(5, -1).split(',').map(Number);
-    normalize(color);
-  } else if (s.startsWith('rgb(')) {
-    // rgb()
-    color = s.slice(4, -1).split(',').map(Number);
-    color.push(1);
-    normalize(color);
-  } else {
-    throw new Error('Invalid color');
-  }
-  return color;
 }
 
 /**
@@ -219,8 +130,10 @@ export function toString(color) {
  * @return {boolean} Whether the string is actually a valid color
  */
 export function isStringColor(s) {
-  if (NAMED_COLOR_RE_.test(s)) {
-    s = fromNamed(s);
+  try {
+    fromString(s);
+    return true;
+  } catch (_) {
+    return false;
   }
-  return HEX_COLOR_RE_.test(s) || s.startsWith('rgba(') || s.startsWith('rgb(');
 }

--- a/test/node/ol/color.test.js
+++ b/test/node/ol/color.test.js
@@ -56,8 +56,9 @@ describe('ol/color', () => {
   });
 
   describe('fromString()', () => {
-    describe('with named colors', () => {
+    describe('parses a variety of formats', () => {
       const cases = [
+        // named colors
         ['red', [255, 0, 0, 1]],
         ['green', [0, 128, 0, 1]],
         ['blue', [0, 0, 255, 1]],
@@ -70,7 +71,23 @@ describe('ol/color', () => {
         ['wheat', [245, 222, 179, 1]],
         ['olive', [128, 128, 0, 1]],
         ['transparent', [0, 0, 0, 0]],
-        ['oops', 'Invalid color'],
+        ['oops', 'Failed to parse "oops" as color'],
+
+        // rgb(a) varieties
+        ['rgba(255,122,127,0.8)', [255, 122, 127, 0.8]],
+        ['rgb(255 122 127 / 80%)', [255, 122, 127, 1]],
+        ['rgb(255 122 127 / .2)', [255, 122, 127, 1]],
+        ['rgb(30% 20% 50%)', [77, 51, 128, 1]],
+
+        // hsl(a) varieties
+        ['hsla(84, 51%, 87%, 0.7)', [225, 239, 205, 0.7]],
+        ['hsl(46, 24%, 82%)', [220, 215, 198, 1]],
+        ['hsl(50 80% 40%)', [184, 156, 20, 1]],
+        ['hsl(150deg 30% 60%)', [122, 184, 153, 1]],
+        ['hsl(0 80% 50% / 25%)', [230, 25, 25, 0.25]],
+
+        // hwb
+        ['hwb(50deg 30% 40%)', [133, 122, 71, 1]],
       ];
       for (const c of cases) {
         it(`works for ${c[0]}`, () => {
@@ -78,7 +95,9 @@ describe('ol/color', () => {
           if (typeof expected === 'string') {
             expect(() => {
               fromString(c[0]);
-            }).to.throwException(expected);
+            }).to.throwException((e) => {
+              expect(e.message).to.be(expected);
+            });
             return;
           }
           expect(fromString(c[0])).to.eql(c[1]);
@@ -145,13 +164,24 @@ describe('ol/color', () => {
       );
     });
 
-    it('throws an error on invalid colors', () => {
-      const invalidColors = ['tuesday', '#12345', '#1234567'];
-      let i, ii;
-      for (i = 0, ii = invalidColors.length; i < ii; ++i) {
-        expect(() => {
-          fromString(invalidColors[i]);
-        }).to.throwException();
+    describe('with invalid colors', () => {
+      const cases = [
+        'tuesday',
+        'rgb(garbage)',
+        'hsl(oops)',
+        'rgba(42)',
+        'hsla(5)',
+      ];
+
+      for (const c of cases) {
+        it(`throws an error on ${c}`, () => {
+          try {
+            const color = fromString(c);
+            expect().fail(`Expected an error, got ${color}`);
+          } catch (err) {
+            expect(err.message).to.be(`Failed to parse "${c}" as color`);
+          }
+        });
       }
     });
   });

--- a/test/rendering/cases/webgl-vectortile-masking/main.js
+++ b/test/rendering/cases/webgl-vectortile-masking/main.js
@@ -46,7 +46,7 @@ class WebGLVectorTileLayer extends VectorTile {
       className: this.getClassName(),
       style: {
         'fill-color': '#eee',
-        'stroke-color': 'rgb(136,136,136, 0.5)',
+        'stroke-color': 'rgba(136,136,136, 0.5)',
         'stroke-width': 2,
         'circle-radius': 2,
         'circle-fill-color': '#707070',

--- a/test/rendering/cases/webgl-vectortile/main.js
+++ b/test/rendering/cases/webgl-vectortile/main.js
@@ -12,7 +12,7 @@ class WebGLVectorTileLayer extends VectorTile {
       className: this.getClassName(),
       style: {
         'fill-color': '#eee',
-        'stroke-color': 'rgb(136,136,136, 0.5)',
+        'stroke-color': 'rgba(136,136,136, 0.5)',
         'stroke-width': 2,
         'circle-radius': 2,
         'circle-fill-color': '#707070',


### PR DESCRIPTION
This removes the custom color parsing logic in `ol/color.js` and replaces it with color parsing from https://github.com/colorjs/color-parse.

Previously, our color parsing didn't support `rgb(255 122 127 / 80%)` and similar new syntaxes.  This change brings support for that.

Closes #15135.