### PR TITLE
Throw an error when building flat styles that result in an empty style

### DIFF
--- a/test/browser/spec/ol/render/canvas/style.test.js
+++ b/test/browser/spec/ol/render/canvas/style.test.js
@@ -284,6 +284,22 @@ describe('ol/render/canvas/style.js', () => {
           }),
         }),
       },
+      {
+        name: 'missing circle-radius',
+        style: {
+          'circle-stroke-color': 'red',
+          'circle-size': 10,
+        },
+        error: 'No fill, stroke, point, or text symbolizer properties in style',
+      },
+      {
+        name: 'missing fill-color or stroke-color',
+        style: {
+          'fill': 'red',
+          'stroke': 'white',
+        },
+        error: 'No fill, stroke, point, or text symbolizer properties in style',
+      },
     ];
 
     for (const c of cases) {
@@ -297,7 +313,7 @@ describe('ol/render/canvas/style.js', () => {
 
         if (c.error) {
           expect(error).to.be.an(Error);
-          expect(error.message).to.be(c.error);
+          expect(error.message).to.contain(c.error);
           return;
         }
         if (error) {


### PR DESCRIPTION
Currently, if you make a typo in a flat style or fail to include a required property for some symbolizers (e.g. a circle requires `circle-radius`), either nothing renders or you get an obscure error from the renderer (`Uncaught TypeError: Cannot read properties of null (reading 'getGeometryFunction')`).

This change makes it so if you pass a flat style that results in a style with no stroke, fill, point, or label symbolizers, an error is thrown.

I pulled this out of #15141 (it was discovered there while trying to make the example work).