### PR TITLE
Properly hit detect circles after updating size

### DIFF
--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -505,6 +505,7 @@ class RegularShape extends ImageStyle {
     this.renderOptions_ = this.createRenderOptions();
     const size = this.renderOptions_.size;
     this.canvas_ = {};
+    this.hitDetectionCanvas_ = null;
     this.size_ = [size, size];
   }
 

--- a/test/browser/spec/ol/style/Circle.test.js
+++ b/test/browser/spec/ol/style/Circle.test.js
@@ -2,7 +2,7 @@ import CircleStyle from '../../../../../src/ol/style/Circle.js';
 import Fill from '../../../../../src/ol/style/Fill.js';
 import Stroke from '../../../../../src/ol/style/Stroke.js';
 
-describe('ol.style.Circle', function () {
+describe('ol/style/Circle', function () {
   describe('#constructor', function () {
     it('creates a canvas (no fill-style)', function () {
       const style = new CircleStyle({radius: 10});
@@ -126,8 +126,17 @@ describe('ol.style.Circle', function () {
         }),
       });
       expect(style.getRadius()).to.eql(10);
+
+      const hitImageBefore = style.getHitDetectionImage();
+      expect(hitImageBefore).to.be.an(HTMLCanvasElement);
+      expect(hitImageBefore.width).to.eql(20);
+
       style.setRadius(20);
       expect(style.getRadius()).to.eql(20);
+
+      const hitImageAfter = style.getHitDetectionImage();
+      expect(hitImageAfter).to.be.an(HTMLCanvasElement);
+      expect(hitImageAfter.width).to.eql(40);
     });
   });
 });

--- a/test/browser/spec/ol/style/RegularShape.test.js
+++ b/test/browser/spec/ol/style/RegularShape.test.js
@@ -2,7 +2,7 @@ import Fill from '../../../../../src/ol/style/Fill.js';
 import RegularShape from '../../../../../src/ol/style/RegularShape.js';
 import Stroke from '../../../../../src/ol/style/Stroke.js';
 
-describe('ol.style.RegularShape', function () {
+describe('ol/style/RegularShape', function () {
   describe('#constructor', function () {
     it('can use rotateWithView', function () {
       const style = new RegularShape({


### PR DESCRIPTION
After calling `circle.setRadius()` with a new radius, circles are no longer properly hit detected.  This is because we keep around the old hit detection image.

This change makes it so we clear the hit detection image in the `render` call ~~if the size doesn't match the previous size~~.  The new test demonstrates that the hit detection image is properly updated when requested after a `setRadius` call.

I pulled this out of #15141 after discovering it while trying to make that example.