### PR TITLE
WebGL / fix hit detection for vector layer on certain systems

### DIFF
--- a/src/ol/render/webgl/renderinstructions.js
+++ b/src/ol/render/webgl/renderinstructions.js
@@ -21,7 +21,7 @@ function pushCustomAttributesInRenderInstructions(
   for (const key in customAttributes) {
     const attr = customAttributes[key];
     const value = attr.callback.call(batchEntry, batchEntry.feature);
-    renderInstructions[currentIndex + shift++] = value[0] || value;
+    renderInstructions[currentIndex + shift++] = value[0] ?? value;
     if (!attr.size || attr.size === 1) {
       continue;
     }

--- a/test/browser/spec/ol/render/webgl/renderinstructions.test.js
+++ b/test/browser/spec/ol/render/webgl/renderinstructions.test.js
@@ -140,4 +140,28 @@ describe('Render instructions utilities', function () {
       ]);
     });
   });
+
+  describe('custom attribute returning an array', () => {
+    beforeEach(function () {
+      renderInstructions = generatePointRenderInstructions(
+        mixedBatch.pointBatch,
+        new Float32Array(0),
+        [
+          {
+            name: 'test',
+            size: 4,
+            callback: function () {
+              return [0, 1, 2, 3];
+            },
+          },
+        ],
+        SAMPLE_TRANSFORM
+      );
+    });
+    it('generates render instructions', function () {
+      expect(Array.from(renderInstructions)).to.eql([
+        2, 2, 0, 1, 2, 3, 6, 6, 0, 1, 2, 3,
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Previously, custom attributes that returned an array starting with 0 would produce invalid render instructions.

Followup of #15120 by @gberaudo 