### PR TITLE
Make rules documentation example syntax valid

### DIFF
--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -28,19 +28,20 @@
  *
  *     const rules = [
  *       {
- *         filter: ['>', 'population', 1_000_000],
+ *         filter: ['>', ['get', 'population'], 1_000_000],
  *         style: {
  *           'circle-radius': 10,
- *           'circle-color': 'red',
+ *           'circle-fill-color': 'red',
  *         }
  *       },
  *       {
  *         else: true,
  *         style: {
  *           'circle-radius': 5,
- *           'circle-color': 'blue',
- *        },
- *      ];
+ *           'circle-fill-color': 'blue',
+ *         },
+ *       },
+ *     ];
  */
 
 /**


### PR DESCRIPTION
The rules example script in https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html has syntax errors and would not work, so change it to something usable as in  https://codesandbox.io/s/webgl-points-layer-forked-9s97tl?file=/main.js
