### PR TITLE
Remove radius1 for regular shapes, use radius instead

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,8 +1,12 @@
 ## Upgrade notes
 
-### Next Release
+### 9.0.0
 
- * `ol/geom/GeometryCollection` can no longer be created without providing a Geometry array. Emtpy arrays are still valid.
+ Removed the `ol/style/RegularShape`'s `radius1` property. Use `radius` for regular polygons or `radius` and `radius2` for stars.
+
+ Removed the `shape-radius1` property from `ol/style/flat~FlatShape`. Use  `shape-radius` instead.
+
+ `ol/geom/GeometryCollection` can no longer be created without providing a Geometry array. Emtpy arrays are still valid.
 
 ### 8.0.0
 

--- a/examples/earthquake-clusters.js
+++ b/examples/earthquake-clusters.js
@@ -46,7 +46,7 @@ function createEarthquakeStyle(feature) {
   return new Style({
     geometry: feature.getGeometry(),
     image: new RegularShape({
-      radius1: radius,
+      radius: radius,
       radius2: 3,
       points: 5,
       angle: Math.PI,

--- a/examples/webgl-points-layer.js
+++ b/examples/webgl-points-layer.js
@@ -103,7 +103,7 @@ const predefinedStyles = {
   'rotating-bars': {
     'shape-rotation': ['*', ['time'], 0.13],
     'shape-points': 4,
-    'shape-radius1': 4,
+    'shape-radius': 4,
     'shape-radius2': 4 * Math.sqrt(2),
     'shape-scale': [
       'array',

--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -787,7 +787,9 @@ function buildShape(flatStyle, context) {
 
   // required property
   const pointsName = prefix + 'points';
+  const radiusName = prefix + 'radius';
   const points = requireNumber(flatStyle[pointsName], pointsName);
+  const radius = requireNumber(flatStyle[radiusName], radiusName);
 
   // settable properties
   const evaluateFill = buildFill(flatStyle, prefix, context);
@@ -810,8 +812,6 @@ function buildShape(flatStyle, context) {
   );
 
   // the remaining properties are not currently settable
-  const radius = optionalNumber(flatStyle, prefix + 'radius');
-  const radius1 = optionalNumber(flatStyle, prefix + 'radius1');
   const radius2 = optionalNumber(flatStyle, prefix + 'radius2');
   const angle = optionalNumber(flatStyle, prefix + 'angle');
   const declutterMode = optionalDeclutterMode(
@@ -822,7 +822,6 @@ function buildShape(flatStyle, context) {
   const shape = new RegularShape({
     points,
     radius,
-    radius1,
     radius2,
     angle,
     declutterMode,

--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -17,14 +17,13 @@ import {
 } from '../render/canvas.js';
 
 /**
- * Specify radius for regular polygons, or radius1 and radius2 for stars.
+ * Specify radius for regular polygons, or both radius and radius2 for stars.
  * @typedef {Object} Options
  * @property {import("./Fill.js").default} [fill] Fill style.
  * @property {number} points Number of points for stars and regular polygons. In case of a polygon, the number of points
  * is the number of sides.
- * @property {number} [radius] Radius of a regular polygon.
- * @property {number} [radius1] First radius of a star. Ignored if radius is set.
- * @property {number} [radius2] Second radius of a star.
+ * @property {number} radius Radius of a regular polygon.
+ * @property {number} [radius2] Second radius to make a star instead of a regular polygon.
  * @property {number} [angle=0] Shape's angle in radians. A value of 0 will have one of the shape's points facing up.
  * @property {Array<number>} [displacement=[0, 0]] Displacement of the shape in pixels.
  * Positive values will shift the shape right and up.
@@ -32,7 +31,7 @@ import {
  * @property {number} [rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {boolean} [rotateWithView=false] Whether to rotate the shape with the view.
  * @property {number|import("../size.js").Size} [scale=1] Scale. Unless two dimensional scaling is required a better
- * result may be obtained with appropriate settings for `radius`, `radius1` and `radius2`.
+ * result may be obtained with appropriate settings for `radius` and `radius2`.
  * @property {"declutter"|"obstacle"|"none"|undefined} [declutterMode] Declutter mode.
  */
 
@@ -51,7 +50,7 @@ import {
 /**
  * @classdesc
  * Set regular shape style for vector features. The resulting shape will be
- * a regular polygon when `radius` is provided, or a star when `radius1` and
+ * a regular polygon when `radius` is provided, or a star when both `radius` and
  * `radius2` are provided.
  * @api
  */
@@ -60,15 +59,10 @@ class RegularShape extends ImageStyle {
    * @param {Options} options Options.
    */
   constructor(options) {
-    /**
-     * @type {boolean}
-     */
-    const rotateWithView =
-      options.rotateWithView !== undefined ? options.rotateWithView : false;
-
     super({
       opacity: 1,
-      rotateWithView: rotateWithView,
+      rotateWithView:
+        options.rotateWithView !== undefined ? options.rotateWithView : false,
       rotation: options.rotation !== undefined ? options.rotation : 0,
       scale: options.scale !== undefined ? options.scale : 1,
       displacement:
@@ -110,8 +104,7 @@ class RegularShape extends ImageStyle {
      * @protected
      * @type {number}
      */
-    this.radius_ =
-      options.radius !== undefined ? options.radius : options.radius1;
+    this.radius_ = options.radius;
 
     /**
      * @private

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -219,14 +219,13 @@
  * @property {NumberExpression} [shape-stroke-line-dash-offset=0] Line dash offset.
  * @property {NumberExpression} [shape-stroke-miter-limit=10] Miter limit.
  * @property {number} [shape-radius] Radius of a regular polygon.
- * @property {number} [shape-radius1] First radius of a star. Ignored if radius is set.
- * @property {number} [shape-radius2] Second radius of a star.
+ * @property {number} [shape-radius2] Second radius to make a star instead of a regular polygon.
  * @property {number} [shape-angle=0] Shape's angle in radians. A value of 0 will have one of the shape's point facing up.
  * @property {NumberArrayExpression} [shape-displacement=[0,0]] Displacement of the shape
  * @property {NumberExpression} [shape-rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {BooleanExpression} [shape-rotate-with-view=false] Whether to rotate the shape with the view.
  * @property {SizeExpression} [shape-scale=1] Scale. Unless two dimensional scaling is required a better
- * result may be obtained with appropriate settings for `shape-radius`, `shape-radius1` and `shape-radius2`.
+ * result may be obtained with appropriate settings for `shape-radius` and `shape-radius2`.
  * @property {"declutter"|"obstacle"|"none"|undefined} [shape-declutter-mode] Declutter mode.
  * @property {NumberExpression} [z-index] The zIndex of the style.
  */

--- a/src/ol/style/webgl.js
+++ b/src/ol/style/webgl.js
@@ -93,14 +93,13 @@
  * @property {ExpressionValue|number} [shape-stroke-width] Stroke pixel width.
  * @property {ExpressionValue|number} [shape-opacity] Shape opacity.
  * @property {ExpressionValue|number} [shape-radius] Radius of a regular polygon.
- * @property {ExpressionValue|number} [shape-radius1] First radius of a star. Ignored if radius is set.
- * @property {ExpressionValue|number} [shape-radius2] Second radius of a star.
+ * @property {ExpressionValue|number} [shape-radius2] Second radius to make a star instead of a regular polygon.
  * @property {ExpressionValue|number} [shape-angle=0] Shape's angle in radians. A value of 0 will have one of the shape's point facing up.
  * @property {Array<ExpressionValue>|Array<number>} [shape-displacement=[0,0]] Displacement of the shape
  * @property {ExpressionValue|number} [shape-rotation=0] Rotation in radians (positive rotation clockwise).
  * @property {boolean} [shape-rotate-with-view=false] Whether to rotate the shape with the view.
  * @property {ExpressionValue|Array<ExpressionValue>|number|import("../size.js").Size} [shape-scale=1] Scale. Unless two dimensional scaling is required a better
- * result may be obtained with appropriate settings for `shape-radius`, `shape-radius1` and `shape-radius2`.
+ * result may be obtained with appropriate settings for `shape-radius` and `shape-radius2`.
  */
 
 /**

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -113,6 +113,14 @@ function parseCommonSymbolProperties(style, builder, vertContext, prefix) {
       style[`${prefix}radius`],
       NumberType
     );
+    if (`${prefix}radius2` in style) {
+      const radius2 = expressionToGlsl(
+        vertContext,
+        style[`${prefix}radius2`],
+        NumberType
+      );
+      radius = `max(${radius}, ${radius2})`;
+    }
     if (`${prefix}stroke-width` in style) {
       radius = `(${radius} + ${expressionToGlsl(
         vertContext,
@@ -372,7 +380,7 @@ function parseShapeProperties(
   // inspired by https://github.com/zranger1/PixelblazePatterns/blob/master/Toolkit/sdf2d.md#n-sided-regular-polygon
   fragContext.functions[
     'starDistanceField'
-  ] = `float starDistanceField(vec2 point, float numPoints, float radiusIn, float radiusOut, float angle) {
+  ] = `float starDistanceField(vec2 point, float numPoints, float radius, float radius2, float angle) {
   float startAngle = -PI * 0.5 + angle; // tip starts upwards and rotates clockwise with angle
   float c = cos(startAngle);
   float s = sin(startAngle);
@@ -383,8 +391,8 @@ function parseShapeProperties(
   c = cos(-gamma);
   s = sin(-gamma);
   vec2 inSector = vec2(c * pointRotated.x - s * pointRotated.y, abs(s * pointRotated.x + c * pointRotated.y));
-  vec2 tipToPoint = inSector + vec2(-radiusOut, 0.);
-  vec2 edgeNormal = vec2(radiusIn * sin(alpha * 0.5), -radiusIn * cos(alpha * 0.5) + radiusOut);
+  vec2 tipToPoint = inSector + vec2(-radius, 0.);
+  vec2 edgeNormal = vec2(radius2 * sin(alpha * 0.5), -radius2 * cos(alpha * 0.5) + radius);
   return dot(normalize(edgeNormal), tipToPoint);
 }`;
   fragContext.functions[
@@ -477,7 +485,7 @@ function parseShapeProperties(
     if (strokeWidth !== null) {
       radius2 = `${radius2} + ${strokeWidth} * 0.5`;
     }
-    shapeField = `starDistanceField(${currentPoint}, ${numPoints}, ${radius2}, ${radius}, ${angle})`;
+    shapeField = `starDistanceField(${currentPoint}, ${numPoints}, ${radius}, ${radius2}, ${angle})`;
   } else {
     shapeField = `regularDistanceField(${currentPoint}, ${numPoints}, ${radius}, ${angle})`;
   }

--- a/test/browser/spec/ol/style/RegularShape.test.js
+++ b/test/browser/spec/ol/style/RegularShape.test.js
@@ -21,15 +21,6 @@ describe('ol/style/RegularShape', function () {
       expect(style.getRadius2()).to.eql(10);
     });
 
-    it('can use radius1 as an alias for radius', function () {
-      const style = new RegularShape({
-        radius1: 5,
-        radius2: 10,
-      });
-      expect(style.getRadius()).to.eql(5);
-      expect(style.getRadius2()).to.eql(10);
-    });
-
     it('creates a canvas (no fill-style)', function () {
       const style = new RegularShape({radius: 10});
       expect(style.getImage(1)).to.be.an(HTMLCanvasElement);

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -207,7 +207,7 @@ describe('ol.webgl.styleparser', () => {
         beforeEach(() => {
           result = parseLiteralStyle({
             'shape-points': ['-', 10, 3],
-            'shape-radius1': ['get', 'attr1'],
+            'shape-radius': ['get', 'attr1'],
             'shape-radius2': ['*', 2, 5],
             'shape-fill-color': ['get', 'color1'],
             'shape-stroke-color': ['get', 'color2'],
@@ -261,22 +261,6 @@ describe('ol.webgl.styleparser', () => {
           expect(result.attributes).to.have.property('color1');
           expect(result.attributes).to.have.property('color2');
           expect(result.uniforms).to.eql({});
-        });
-      });
-      describe('contains radius, radius1 and radius2', () => {
-        beforeEach(() => {
-          result = parseLiteralStyle({
-            'shape-points': 5,
-            'shape-radius': 10,
-            'shape-radius1': 15,
-            'shape-radius2': 7,
-            'shape-fill-color': 'rgba(255, 255, 255, 0.5)',
-          });
-        });
-        it('uses a regular shape formula, ignores radius1 and radius2', () => {
-          expect(result.builder.symbolColorExpression_).to.eql(
-            'vec4(0.5, 0.5, 0.5, 0.5) * (1.0 - smoothstep(-0.63, 0.58, regularDistanceField(coordsPx, 5.0, 10.0, 0.)))'
-          );
         });
       });
       describe('contains no stroke', () => {

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -246,10 +246,10 @@ describe('ol.webgl.styleparser', () => {
             },
           ]);
           expect(result.builder.symbolColorExpression_).to.eql(
-            'mix(v_prop_color2, v_prop_color1, smoothstep(-(3.0 + 4.0) + 0.63, -(3.0 + 4.0) - 0.58, starDistanceField(coordsPx / vec2(1.5, 1.7), (10.0 - 3.0), (2.0 * 5.0) + (3.0 + 4.0) * 0.5, v_prop_attr1 + (3.0 + 4.0) * 0.5, (0.5 * 3.141592653589793)))) * (1.0 - smoothstep(-0.63, 0.58, starDistanceField(coordsPx / vec2(1.5, 1.7), (10.0 - 3.0), (2.0 * 5.0) + (3.0 + 4.0) * 0.5, v_prop_attr1 + (3.0 + 4.0) * 0.5, (0.5 * 3.141592653589793)))) * (0.5 * 0.75)'
+            'mix(v_prop_color2, v_prop_color1, smoothstep(-(3.0 + 4.0) + 0.63, -(3.0 + 4.0) - 0.58, starDistanceField(coordsPx / vec2(1.5, 1.7), (10.0 - 3.0), v_prop_attr1 + (3.0 + 4.0) * 0.5, (2.0 * 5.0) + (3.0 + 4.0) * 0.5, (0.5 * 3.141592653589793)))) * (1.0 - smoothstep(-0.63, 0.58, starDistanceField(coordsPx / vec2(1.5, 1.7), (10.0 - 3.0), v_prop_attr1 + (3.0 + 4.0) * 0.5, (2.0 * 5.0) + (3.0 + 4.0) * 0.5, (0.5 * 3.141592653589793)))) * (0.5 * 0.75)'
           );
           expect(result.builder.symbolSizeExpression_).to.eql(
-            'vec2((a_prop_attr1 + (3.0 + 4.0) * 0.5) * 2. + 0.5) * vec2(1.5, 1.7)'
+            'vec2((max(a_prop_attr1, (2.0 * 5.0)) + (3.0 + 4.0) * 0.5) * 2. + 0.5) * vec2(1.5, 1.7)'
           );
           expect(result.builder.symbolOffsetExpression_).to.eql(
             'vec2(-2.0, 1.0)'

--- a/test/rendering/cases/webgl-shapes/main.js
+++ b/test/rendering/cases/webgl-shapes/main.js
@@ -10,7 +10,7 @@ import XYZ from '../../../../src/ol/source/XYZ.js';
 
 const blueStar = {
   'shape-points': 5,
-  'shape-radius1': 20,
+  'shape-radius': 20,
   'shape-radius2': 10,
   'shape-fill-color': 'rgba(255,255,255,0.4)',
   'shape-stroke-width': 4,
@@ -29,7 +29,7 @@ const dataDriven = {
 };
 const scaledRotated = {
   'shape-points': 10,
-  'shape-radius1': 12,
+  'shape-radius': 12,
   'shape-radius2': 9,
   'shape-scale': [4, 0.5],
   'shape-fill-color': 'rgba(255,255,255,0.4)',


### PR DESCRIPTION
Having two optional parameters where one is required is bad for type-checking.

Current handling is inconsistent. RegularShape constructor treated radius and radius1 as aliases while the webgl style parser used radius exclusively for polygons and radius1 exclusively for stars.