### PR TITLE
Better types for geometries

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -83,18 +83,16 @@ class Geometry extends BaseObject {
      * @param {import("../proj.js").TransformFunction} [transform] Optional transform function.
      * @return {Geometry} Simplified geometry.
      */
-    this.simplifyTransformedInternal = memoizeOne(function (
-      revision,
-      squaredTolerance,
-      transform
-    ) {
-      if (!transform) {
-        return this.getSimplifiedGeometry(squaredTolerance);
+    this.simplifyTransformedInternal = memoizeOne(
+      (revision, squaredTolerance, transform) => {
+        if (!transform) {
+          return this.getSimplifiedGeometry(squaredTolerance);
+        }
+        const clone = this.clone();
+        clone.applyTransform(transform);
+        return clone.getSimplifiedGeometry(squaredTolerance);
       }
-      const clone = this.clone();
-      clone.applyTransform(transform);
-      return clone.getSimplifiedGeometry(squaredTolerance);
-    });
+    );
   }
 
   /**

--- a/src/ol/geom/LineString.js
+++ b/src/ol/geom/LineString.js
@@ -30,7 +30,7 @@ class LineString extends SimpleGeometry {
 
     /**
      * @private
-     * @type {import("../coordinate.js").Coordinate}
+     * @type {import("../coordinate.js").Coordinate|null}
      */
     this.flatMidpoint_ = null;
 
@@ -73,11 +73,7 @@ class LineString extends SimpleGeometry {
    * @api
    */
   appendCoordinate(coordinate) {
-    if (!this.flatCoordinates) {
-      this.flatCoordinates = coordinate.slice();
-    } else {
-      extend(this.flatCoordinates, coordinate);
-    }
+    extend(this.flatCoordinates, coordinate);
     this.changed();
   }
 
@@ -237,10 +233,13 @@ class LineString extends SimpleGeometry {
    */
   getFlatMidpoint() {
     if (this.flatMidpointRevision_ != this.getRevision()) {
-      this.flatMidpoint_ = this.getCoordinateAt(0.5, this.flatMidpoint_);
+      this.flatMidpoint_ = this.getCoordinateAt(
+        0.5,
+        this.flatMidpoint_ ?? undefined
+      );
       this.flatMidpointRevision_ = this.getRevision();
     }
-    return this.flatMidpoint_;
+    return /** @type {Array<number>} */ (this.flatMidpoint_);
   }
 
   /**
@@ -249,6 +248,7 @@ class LineString extends SimpleGeometry {
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
+    /** @type {Array<number>} */
     const simplifiedFlatCoordinates = [];
     simplifiedFlatCoordinates.length = douglasPeucker(
       this.flatCoordinates,

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -132,6 +132,7 @@ class LinearRing extends SimpleGeometry {
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
+    /** @type {Array<number>} */
     const simplifiedFlatCoordinates = [];
     simplifiedFlatCoordinates.length = douglasPeucker(
       this.flatCoordinates,

--- a/src/ol/geom/MultiLineString.js
+++ b/src/ol/geom/MultiLineString.js
@@ -64,18 +64,19 @@ class MultiLineString extends SimpleGeometry {
       );
       this.ends_ = ends;
     } else {
-      let layout = this.getLayout();
       const lineStrings = /** @type {Array<LineString>} */ (coordinates);
+      /** @type {Array<number>} */
       const flatCoordinates = [];
       const ends = [];
       for (let i = 0, ii = lineStrings.length; i < ii; ++i) {
         const lineString = lineStrings[i];
-        if (i === 0) {
-          layout = lineString.getLayout();
-        }
         extend(flatCoordinates, lineString.getFlatCoordinates());
         ends.push(flatCoordinates.length);
       }
+      const layout =
+        lineStrings.length === 0
+          ? this.getLayout()
+          : lineStrings[0].getLayout();
       this.setFlatCoordinates(layout, flatCoordinates);
       this.ends_ = ends;
     }
@@ -87,11 +88,7 @@ class MultiLineString extends SimpleGeometry {
    * @api
    */
   appendLineString(lineString) {
-    if (!this.flatCoordinates) {
-      this.flatCoordinates = lineString.getFlatCoordinates().slice();
-    } else {
-      extend(this.flatCoordinates, lineString.getFlatCoordinates().slice());
-    }
+    extend(this.flatCoordinates, lineString.getFlatCoordinates().slice());
     this.ends_.push(this.flatCoordinates.length);
     this.changed();
   }
@@ -258,6 +255,7 @@ class MultiLineString extends SimpleGeometry {
    * @return {Array<number>} Flat midpoints.
    */
   getFlatMidpoints() {
+    /** @type {Array<number>} */
     const midpoints = [];
     const flatCoordinates = this.flatCoordinates;
     let offset = 0;
@@ -284,7 +282,9 @@ class MultiLineString extends SimpleGeometry {
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
+    /** @type {Array<number>} */
     const simplifiedFlatCoordinates = [];
+    /** @type {Array<number>} */
     const simplifiedEnds = [];
     simplifiedFlatCoordinates.length = douglasPeuckerArray(
       this.flatCoordinates,

--- a/src/ol/geom/MultiPoint.js
+++ b/src/ol/geom/MultiPoint.js
@@ -44,11 +44,7 @@ class MultiPoint extends SimpleGeometry {
    * @api
    */
   appendPoint(point) {
-    if (!this.flatCoordinates) {
-      this.flatCoordinates = point.getFlatCoordinates().slice();
-    } else {
-      extend(this.flatCoordinates, point.getFlatCoordinates());
-    }
+    extend(this.flatCoordinates, point.getFlatCoordinates());
     this.changed();
   }
 
@@ -118,9 +114,7 @@ class MultiPoint extends SimpleGeometry {
    * @api
    */
   getPoint(index) {
-    const n = !this.flatCoordinates
-      ? 0
-      : this.flatCoordinates.length / this.stride;
+    const n = this.flatCoordinates.length / this.stride;
     if (index < 0 || n <= index) {
       return null;
     }

--- a/src/ol/geom/MultiPolygon.js
+++ b/src/ol/geom/MultiPolygon.js
@@ -53,7 +53,7 @@ class MultiPolygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array<number>}
+     * @type {Array<number>|null}
      */
     this.flatInteriorPoints_ = null;
 
@@ -77,20 +77,17 @@ class MultiPolygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array<number>}
+     * @type {Array<number>|null}
      */
     this.orientedFlatCoordinates_ = null;
 
     if (!endss && !Array.isArray(coordinates[0])) {
-      let thisLayout = this.getLayout();
       const polygons = /** @type {Array<Polygon>} */ (coordinates);
+      /** @type {Array<number>} */
       const flatCoordinates = [];
       const thisEndss = [];
       for (let i = 0, ii = polygons.length; i < ii; ++i) {
         const polygon = polygons[i];
-        if (i === 0) {
-          thisLayout = polygon.getLayout();
-        }
         const offset = flatCoordinates.length;
         const ends = polygon.getEnds();
         for (let j = 0, jj = ends.length; j < jj; ++j) {
@@ -99,7 +96,8 @@ class MultiPolygon extends SimpleGeometry {
         extend(flatCoordinates, polygon.getFlatCoordinates());
         thisEndss.push(ends);
       }
-      layout = thisLayout;
+      layout =
+        polygons.length === 0 ? this.getLayout() : polygons[0].getLayout();
       coordinates = flatCoordinates;
       endss = thisEndss;
     }
@@ -295,7 +293,7 @@ class MultiPolygon extends SimpleGeometry {
       );
       this.flatInteriorPointsRevision_ = this.getRevision();
     }
-    return this.flatInteriorPoints_;
+    return /** @type {Array<number>} */ (this.flatInteriorPoints_);
   }
 
   /**
@@ -329,7 +327,7 @@ class MultiPolygon extends SimpleGeometry {
       }
       this.orientedRevision_ = this.getRevision();
     }
-    return this.orientedFlatCoordinates_;
+    return /** @type {Array<number>} */ (this.orientedFlatCoordinates_);
   }
 
   /**
@@ -338,7 +336,9 @@ class MultiPolygon extends SimpleGeometry {
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
+    /** @type {Array<number>} */
     const simplifiedFlatCoordinates = [];
+    /** @type {Array<Array<number>>} */
     const simplifiedEndss = [];
     simplifiedFlatCoordinates.length = quantizeMultiArray(
       this.flatCoordinates,

--- a/src/ol/geom/Point.js
+++ b/src/ol/geom/Point.js
@@ -65,7 +65,7 @@ class Point extends SimpleGeometry {
    * @api
    */
   getCoordinates() {
-    return !this.flatCoordinates ? [] : this.flatCoordinates.slice();
+    return this.flatCoordinates.slice();
   }
 
   /**

--- a/src/ol/geom/Polygon.js
+++ b/src/ol/geom/Polygon.js
@@ -53,7 +53,7 @@ class Polygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {import("../coordinate.js").Coordinate}
+     * @type {import("../coordinate.js").Coordinate|null}
      */
     this.flatInteriorPoint_ = null;
 
@@ -77,7 +77,7 @@ class Polygon extends SimpleGeometry {
 
     /**
      * @private
-     * @type {Array<number>}
+     * @type {Array<number>|null}
      */
     this.orientedFlatCoordinates_ = null;
 
@@ -242,7 +242,9 @@ class Polygon extends SimpleGeometry {
       );
       this.flatInteriorPointRevision_ = this.getRevision();
     }
-    return this.flatInteriorPoint_;
+    return /** @type {import("../coordinate.js").Coordinate} */ (
+      this.flatInteriorPoint_
+    );
   }
 
   /**
@@ -331,7 +333,7 @@ class Polygon extends SimpleGeometry {
       }
       this.orientedRevision_ = this.getRevision();
     }
-    return this.orientedFlatCoordinates_;
+    return /** @type {Array<number>} */ (this.orientedFlatCoordinates_);
   }
 
   /**
@@ -340,7 +342,9 @@ class Polygon extends SimpleGeometry {
    * @protected
    */
   getSimplifiedGeometryInternal(squaredTolerance) {
+    /** @type {Array<number>} */
     const simplifiedFlatCoordinates = [];
+    /** @type {Array<number>} */
     const simplifiedEnds = [];
     simplifiedFlatCoordinates.length = quantizeArray(
       this.flatCoordinates,

--- a/src/ol/geom/SimpleGeometry.js
+++ b/src/ol/geom/SimpleGeometry.js
@@ -34,7 +34,7 @@ class SimpleGeometry extends Geometry {
      * @protected
      * @type {Array<number>}
      */
-    this.flatCoordinates = null;
+    this.flatCoordinates;
   }
 
   /**
@@ -174,7 +174,6 @@ class SimpleGeometry extends Geometry {
    * @protected
    */
   setLayout(layout, coordinates, nesting) {
-    /** @type {number} */
     let stride;
     if (layout) {
       stride = getStrideForLayout(layout);
@@ -185,7 +184,7 @@ class SimpleGeometry extends Geometry {
           this.stride = 2;
           return;
         }
-        coordinates = /** @type {Array} */ (coordinates[0]);
+        coordinates = /** @type {Array<unknown>} */ (coordinates[0]);
       }
       stride = coordinates.length;
       layout = getLayoutForStride(stride);


### PR DESCRIPTION
Also removes some unnecessary checks whether flatCoordinates is defined.
It is only possibly undefined in `setCoordinates` and `setFlatCoordinates` which is called in the constructor of each geometry type.