### PR TITLE
Allow `touch-action: pan-x pan-y;` on viewport

### DIFF
--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -113,7 +113,7 @@
 }
 
 .ol-viewport {
-  touch-action: none;
+  touch-action: pan-x pan-y;
 }
 
 .ol-selectable {


### PR DESCRIPTION
Possible fix for https://github.com/openlayers/openlayers/issues/9936#issuecomment-1747866325

Explicitly setting `touch-action: pan-x pan-y;` seems to fix the issue described on Android Chrome, but unlike `touch-action: none;` it can cause a pull-to-refresh to be triggered, which may be unexpected.