### PR TITLE
Use version specific ol.css in examples

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/fontawesome.min.css" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/solid.css" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/brands.css" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="/theme/ol.css">
+    <link rel="stylesheet" type="text/css" href="../ol/ol.css">
     <link rel="stylesheet" type="text/css" href="/theme/site.css">
 {{#each css.local}}
     <link rel="stylesheet" type="text/css" href="{{{ . }}}">


### PR DESCRIPTION
As noted in https://github.com/openlayers/openlayers/pull/15208#issuecomment-1749563333 all versions of the examples since 7.0.0 are using the same ol.css instead of the css for that version.  Therefore the behaviour of https://openlayers.org/en/main/examples/two-finger-pan-scroll.html does not yet reflect the changes in #15208, but at the next release that change will be picked up by old versions of the examples.  Examples which use specific versions of the library JavaScript should also be using the corresponding version of the css.