### PR TITLE
Fix `fromUserResolution` and `toUserResolution` for `useGeographic()`

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -666,10 +666,10 @@ export function toUserResolution(resolution, sourceProjection) {
   if (!userProjection) {
     return resolution;
   }
-  const sourceUnits = get(sourceProjection).getUnits();
-  const userUnits = userProjection.getUnits();
-  return sourceUnits && userUnits
-    ? (resolution * METERS_PER_UNIT[sourceUnits]) / METERS_PER_UNIT[userUnits]
+  const sourceMetersPerUnit = get(sourceProjection).getMetersPerUnit();
+  const userMetersPerUnit = userProjection.getMetersPerUnit();
+  return sourceMetersPerUnit && userMetersPerUnit
+    ? (resolution * sourceMetersPerUnit) / userMetersPerUnit
     : resolution;
 }
 
@@ -685,10 +685,10 @@ export function fromUserResolution(resolution, destProjection) {
   if (!userProjection) {
     return resolution;
   }
-  const sourceUnits = get(destProjection).getUnits();
-  const userUnits = userProjection.getUnits();
-  return sourceUnits && userUnits
-    ? (resolution * METERS_PER_UNIT[userUnits]) / METERS_PER_UNIT[sourceUnits]
+  const destMetersPerUnit = get(destProjection).getMetersPerUnit();
+  const userMetersPerUnit = userProjection.getMetersPerUnit();
+  return destMetersPerUnit && userMetersPerUnit
+    ? (resolution * userMetersPerUnit) / destMetersPerUnit
     : resolution;
 }
 

--- a/test/node/ol/proj.test.js
+++ b/test/node/ol/proj.test.js
@@ -158,7 +158,7 @@ describe('ol/proj.js', function () {
   describe('fromUserResolution()', function () {
     it("adjusts a resolution for the user projection's units", function () {
       useGeographic();
-      const user = 1 / METERS_PER_UNIT.degrees;
+      const user = 1 / getProjection('EPSG:4326').getMetersPerUnit();
       const resolution = fromUserResolution(user, 'EPSG:3857');
       expect(resolution).to.roughlyEqual(1, 1e-9);
     });
@@ -175,7 +175,10 @@ describe('ol/proj.js', function () {
       useGeographic();
       const dest = 1;
       const resolution = toUserResolution(dest, 'EPSG:3857');
-      expect(resolution).to.eql(1 / METERS_PER_UNIT.degrees);
+      expect(resolution).to.roughlyEqual(
+        1 / getProjection('EPSG:4326').getMetersPerUnit(),
+        1e-9
+      );
     });
 
     it('returns the original if no user projection is set', function () {


### PR DESCRIPTION
The `fromUserResolution` and `toUserResolution` should use each projection's `getMetersPerUnit()` instead of direct `METERS_PER_UNIT[]` reference.
I also had to change tests because EPSG:4326 (designated by `useGeographic()`) uses 6378137 (WGS84's) as a radius to calculate meters per units, and the tests used 6370997 (Normal sphere's) instead.

I've found this bug when I try to use a `Cluster` with a custom projection that have `units: 'pixels'`, and the `metersPerUnit` option didn't work either.