### PR TITLE
Style Expressions Concat Function

### DIFF
--- a/examples/style-expressions.js
+++ b/examples/style-expressions.js
@@ -44,7 +44,7 @@ const map = new Map({
               'concat',
               ['get', 'adm1name'],
               ', ',
-              ['get', 'adm0name']
+              ['get', 'adm0name'],
             ],
             'text-font': '16px sans-serif',
             'text-fill-color': 'white',

--- a/examples/style-expressions.js
+++ b/examples/style-expressions.js
@@ -40,7 +40,7 @@ const map = new Map({
         {
           filter: ['>', ['get', 'pop_max'], 10_000_000],
           style: {
-            'text-value': ['get', 'nameascii'],
+            'text-value': ['concat', ['get', 'adm1name'], ', ', ['get', 'adm0name']],
             'text-font': '16px sans-serif',
             'text-fill-color': 'white',
             'text-stroke-color': 'gray',

--- a/examples/style-expressions.js
+++ b/examples/style-expressions.js
@@ -40,7 +40,12 @@ const map = new Map({
         {
           filter: ['>', ['get', 'pop_max'], 10_000_000],
           style: {
-            'text-value': ['concat', ['get', 'adm1name'], ', ', ['get', 'adm0name']],
+            'text-value': [
+              'concat',
+              ['get', 'adm1name'],
+              ', ',
+              ['get', 'adm0name']
+            ],
             'text-font': '16px sans-serif',
             'text-fill-color': 'white',
             'text-stroke-color': 'gray',

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -202,13 +202,10 @@ function compileAccessorExpression(expression, context) {
       return (context) => context.variables[name];
     }
     case Ops.Concat: {
-      return (context_) => {
-        return ''.concat(
-          ...expression.args.reduce((a, c) => {
-            return [...a, compileExpression(c, context)(context_).toString()];
-          }, [])
-        );
-      }
+      const args = expression.args.map((e) => compileExpression(e, context));
+      return (context) => ''.concat(
+        ...args.map((arg) => arg(context).toString())
+      );
     }
     default: {
       throw new Error(`Unsupported accessor operator ${expression.operator}`);

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -203,9 +203,11 @@ function compileAccessorExpression(expression, context) {
     }
     case Ops.Concat: {
       return (context_) => {
-        return "".concat(...expression.args.reduce((a, c) => {
-          return [...a, compileExpression(c, context)(context_).toString()];
-        }, []));
+        return ''.concat(
+          ...expression.args.reduce((a, c) => {
+            return [...a, compileExpression(c, context)(context_).toString()];
+          }, [])
+        );
       }
     }
     default: {

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -203,9 +203,8 @@ function compileAccessorExpression(expression, context) {
     }
     case Ops.Concat: {
       const args = expression.args.map((e) => compileExpression(e, context));
-      return (context) => ''.concat(
-        ...args.map((arg) => arg(context).toString())
-      );
+      return (context) =>
+        ''.concat(...args.map((arg) => arg(context).toString()));
     }
     default: {
       throw new Error(`Unsupported accessor operator ${expression.operator}`);

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -105,9 +105,13 @@ function compileExpression(expression, context) {
       return compileAssertionExpression(expression, context);
     }
     case Ops.Get:
-    case Ops.Var:
-    case Ops.Concat: {
+    case Ops.Var: {
       return compileAccessorExpression(expression, context);
+    }
+    case Ops.Concat: {
+      const args = expression.args.map((e) => compileExpression(e, context));
+      return (context) =>
+        ''.concat(...args.map((arg) => arg(context).toString()));
     }
     case Ops.Resolution: {
       return (context) => context.resolution;
@@ -200,11 +204,6 @@ function compileAccessorExpression(expression, context) {
     }
     case Ops.Var: {
       return (context) => context.variables[name];
-    }
-    case Ops.Concat: {
-      const args = expression.args.map((e) => compileExpression(e, context));
-      return (context) =>
-        ''.concat(...args.map((arg) => arg(context).toString()));
     }
     default: {
       throw new Error(`Unsupported accessor operator ${expression.operator}`);

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -105,7 +105,8 @@ function compileExpression(expression, context) {
       return compileAssertionExpression(expression, context);
     }
     case Ops.Get:
-    case Ops.Var: {
+    case Ops.Var:
+    case Ops.Concat: {
       return compileAccessorExpression(expression, context);
     }
     case Ops.Resolution: {
@@ -199,6 +200,13 @@ function compileAccessorExpression(expression, context) {
     }
     case Ops.Var: {
       return (context) => context.variables[name];
+    }
+    case Ops.Concat: {
+      return (context_) => {
+        return "".concat(...expression.args.reduce((a, c) => {
+          return [...a, compileExpression(c, context)(context_).toString()];
+        }, []));
+      }
     }
     default: {
       throw new Error(`Unsupported accessor operator ${expression.operator}`);

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -242,7 +242,7 @@ const parsers = {
   [Ops.Get]: createParser(AnyType, withArgsCount(1, 1), withGetArgs),
   [Ops.Var]: createParser(AnyType, withArgsCount(1, 1), withVarArgs),
   [Ops.Concat]: createParser(
-    AnyType,
+    StringType,
     withArgsCount(2, Infinity),
     parseArgsOfType(AnyType)
   ),

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -241,7 +241,11 @@ export const Ops = {
 const parsers = {
   [Ops.Get]: createParser(AnyType, withArgsCount(1, 1), withGetArgs),
   [Ops.Var]: createParser(AnyType, withArgsCount(1, 1), withVarArgs),
-  [Ops.Concat]: createParser(AnyType, withArgsCount(2, Infinity), parseArgsOfType(AnyType)),
+  [Ops.Concat]: createParser(
+    AnyType,
+    withArgsCount(2, Infinity),
+    parseArgsOfType(AnyType)
+  ),
   [Ops.GeometryType]: createParser(StringType, withNoArgs),
   [Ops.Resolution]: createParser(NumberType, withNoArgs),
   [Ops.Zoom]: createParser(NumberType, withNoArgs),

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -190,6 +190,7 @@ export function parse(encoded, context, typeHint) {
 export const Ops = {
   Get: 'get',
   Var: 'var',
+  Concat: 'concat',
   GeometryType: 'geometry-type',
   Any: 'any',
   All: 'all',
@@ -240,6 +241,7 @@ export const Ops = {
 const parsers = {
   [Ops.Get]: createParser(AnyType, withArgsCount(1, 1), withGetArgs),
   [Ops.Var]: createParser(AnyType, withArgsCount(1, 1), withVarArgs),
+  [Ops.Concat]: createParser(AnyType, withArgsCount(2, Infinity), parseArgsOfType(AnyType)),
   [Ops.GeometryType]: createParser(StringType, withNoArgs),
   [Ops.Resolution]: createParser(NumberType, withNoArgs),
   [Ops.Zoom]: createParser(NumberType, withNoArgs),

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -70,6 +70,24 @@ describe('ol/expr/cpu.js', () => {
         expected: true,
       },
       {
+        name: 'concat (2 arguments)',
+        type: BooleanType,
+        expression: ['concat', ['get', 'val'], ' '],
+        context: {
+          properties: {val: 'test'},
+        },
+        expected: 'test ',
+      },
+      {
+        name: 'concat (3 arguments)',
+        type: BooleanType,
+        expression: ['concat', ['get', 'val'], ' ', ['get', 'val2']],
+        context: {
+          properties: {val: 'test', val2: 'another'},
+        },
+        expected: 'test another',
+      },
+      {
         name: 'any (true)',
         type: BooleanType,
         expression: ['any', ['get', 'nope'], ['get', 'yep'], ['get', 'nope']],

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -71,7 +71,7 @@ describe('ol/expr/cpu.js', () => {
       },
       {
         name: 'concat (2 arguments)',
-        type: BooleanType,
+        type: StringType,
         expression: ['concat', ['get', 'val'], ' '],
         context: {
           properties: {val: 'test'},
@@ -80,7 +80,7 @@ describe('ol/expr/cpu.js', () => {
       },
       {
         name: 'concat (3 arguments)',
-        type: BooleanType,
+        type: StringType,
         expression: ['concat', ['get', 'val'], ' ', ['get', 'val2']],
         context: {
           properties: {val: 'test', val2: 'another'},

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -71,6 +71,15 @@ describe('ol/expr/expression.js', () => {
       expect(context.variables.has('foo')).to.be(true);
     });
 
+    it('parses a concat expression', () => {
+      const context = newParsingContext();
+      const expression = parse(['concat', ['get', 'foo'], ' ', 'random'], context);
+      expect(expression).to.be.a(CallExpression);
+      expect(expression.operator).to.be('concat');
+      expect(isType(expression.type, AnyType));
+      expect(context.properties.has('foo')).to.be(true);
+    });
+
     it('parses a == expression', () => {
       const context = newParsingContext();
       const expression = parse(['==', ['get', 'foo'], 'bar'], context);

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -73,7 +73,10 @@ describe('ol/expr/expression.js', () => {
 
     it('parses a concat expression', () => {
       const context = newParsingContext();
-      const expression = parse(['concat', ['get', 'foo'], ' ', 'random'], context);
+      const expression = parse(
+        ['concat', ['get', 'foo'], ' ', 'random'],
+        context
+      );
       expect(expression).to.be.a(CallExpression);
       expect(expression.operator).to.be('concat');
       expect(isType(expression.type, AnyType));


### PR DESCRIPTION
Added the concat function which can take in 2+ arguments to use the String.concat function. The function can be utilized with other expressions or just regular strings. Arguments are just like the following (from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat)):

```javascript
const greetList = ["Hello", " ", "Venkat", "!"];
"".concat(...greetList); // "Hello Venkat!"
```

This should close #15246.

Note that this is only applied to the canvas expression list and not webgl. I was confused how to actually get the values and haven't worked with raw webgl before. This is also my first pull request so hopefully not too many changes are needed for this. I also updated the style expression example just to show this off. I can revert it back if requested.
