### PR TITLE
Implement ID operator for style expression

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -108,6 +108,9 @@ function compileExpression(expression, context) {
     case Ops.Var: {
       return compileAccessorExpression(expression, context);
     }
+    case Ops.Id: {
+      return (expression) => expression.variables.id;
+    }
     case Ops.Concat: {
       const args = expression.args.map((e) => compileExpression(e, context));
       return (context) =>

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -228,6 +228,7 @@ export const Ops = {
   String: 'string',
   Array: 'array',
   Color: 'color',
+  Id: 'id',
 };
 
 /**
@@ -241,6 +242,7 @@ export const Ops = {
 const parsers = {
   [Ops.Get]: createParser(AnyType, withArgsCount(1, 1), withGetArgs),
   [Ops.Var]: createParser(AnyType, withArgsCount(1, 1), withVarArgs),
+  [Ops.Id]: createParser(StringType, withNoArgs),
   [Ops.Concat]: createParser(
     StringType,
     withArgsCount(2, Infinity),

--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -76,6 +76,7 @@ export function rulesToStyleFunction(rules) {
   return function (feature, resolution) {
     evaluationContext.properties = feature.getPropertiesInternal();
     evaluationContext.resolution = resolution;
+    evaluationContext.variables.id = feature['ol_uid'];
     return evaluator(evaluationContext);
   };
 }

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -83,6 +83,16 @@ describe('ol/expr/expression.js', () => {
       expect(context.properties.has('foo')).to.be(true);
     });
 
+    it('parses Id expression', () => {
+      const context = newParsingContext();
+      context.variables.id = '12345';
+      const expression = parse(['id'], context);
+      expect(expression).to.be.a(CallExpression);
+      expect(expression.operator).to.be('id');
+      expect(isType(expression.type, AnyType));
+      expect(context.variables.id).to.be('12345');
+    });
+
     it('parses a == expression', () => {
       const context = newParsingContext();
       const expression = parse(['==', ['get', 'foo'], 'bar'], context);


### PR DESCRIPTION
Added the Id operator for style expression. The Id operator returns feature's `ol-uid`, which is stored in `context.variables.id`.

`['id']` is an expression without parameters. Following style expression should display the id as the text label:

```
  style: {
    'text-value': ['id'],
  }
```



This should close https://github.com/openlayers/openlayers/issues/15251.