### PR TITLE
Use local theme instead of root website theme for versioned examples

### DIFF
--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -8,17 +8,17 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/fontawesome.min.css" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/solid.css" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/brands.css" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="/theme/ol.css">
-    <link rel="stylesheet" type="text/css" href="/theme/site.css">
+    <link rel="stylesheet" type="text/css" href="./theme/ol.css">
+    <link rel="stylesheet" type="text/css" href="./theme/site.css">
 {{#each css.local}}
     <link rel="stylesheet" type="text/css" href="{{{ . }}}">
 {{/each}}
-    <link rel="icon" type="image/svg+xml" href="/theme/img/logo-light.svg" media="(prefers-color-scheme: light)" />
-    <link rel="icon" type="image/svg+xml" href="/theme/img/logo-dark.svg" media="(prefers-color-scheme: dark)" />
+    <link rel="icon" type="image/svg+xml" href="./theme/img/logo-light.svg" media="(prefers-color-scheme: light)" />
+    <link rel="icon" type="image/svg+xml" href="./theme/img/logo-dark.svg" media="(prefers-color-scheme: dark)" />
   </head>
   <body>
     <header class="navbar navbar-expand-md navbar-dark mb-3 px-3 py-0 fixed-top" role="navigation">
-      <a class="navbar-brand" href="/"><img src="/theme/img/logo-dark.svg" width="70" height="70" alt="">&nbsp;OpenLayers</a>
+      <a class="navbar-brand" href="/"><img src="./theme/img/logo-dark.svg" width="70" height="70" alt="">&nbsp;OpenLayers</a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#olmenu" aria-controls="olmenu" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
Previously, the examples on the website used the theme of the website, which contains ol.css of the latest version. This pull request changes the links to the local theme of the versioned examples, so ol.css matches the version of the examples.

Replaces and closes #15210
Replaces and closes https://github.com/openlayers/openlayers.github.io/pull/133