### PR TITLE
Export TileGrid and WMTSTileGrid from ol/tilegrid

### DIFF
--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -13,6 +13,9 @@ import {
 } from './extent.js';
 import {toSize} from './size.js';
 
+export {TileGrid};
+export {default as WMTS} from './tilegrid/WMTS.js';
+
 /**
  * @param {import("./proj/Projection.js").default} projection Projection.
  * @return {!TileGrid} Default tile grid for the


### PR DESCRIPTION
It seems inconsistent that
`import {Projection, fromLonLat} from 'ol/proj.js'
`
and
`import {Layer, Tile as TileLayer} from 'ol/layer.js'
`
will work,

while
`import {TileGrid, createXYZ} from 'ol/tilegrid.js'
`
or
`import {TileGrid, WMTS as WMTSTileGrid} from 'ol/tilegrid.js'
`
do not.

This adds the missing exports to support that