### PR TITLE
Do not throw error in `ol/source/Raster` if VectorLayer used

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -952,6 +952,9 @@ function getImageData(layer, frameState) {
     if (container) {
       element = container.firstElementChild;
     }
+    if (!element) {
+      return null;
+    }
     if (!(element instanceof HTMLCanvasElement)) {
       throw new Error('Unsupported rendered element: ' + element);
     }


### PR DESCRIPTION
I found `ol/source/Raster` with this patch works as expected with a VectorLayer and WebGL to produced the output shown in https://github.com/openlayers/openlayers/pull/15295#issuecomment-1804231066  Throwing an error seems unnecessarily restrictive, although unlike a VectorImageLayer it will not capture declutter items.
