### PR TITLE
Fix reading of flat style icon declutter mode

### DIFF
--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -729,7 +729,10 @@ function buildIcon(flatStyle, context) {
   const width = optionalNumber(flatStyle, prefix + 'width');
   const height = optionalNumber(flatStyle, prefix + 'height');
   const size = optionalSize(flatStyle, prefix + 'size');
-  const declutterMode = optionalDeclutterMode(flatStyle, prefix + 'declutter');
+  const declutterMode = optionalDeclutterMode(
+    flatStyle,
+    prefix + 'declutter-mode'
+  );
 
   const icon = new Icon({
     src,


### PR DESCRIPTION
It is documented as `icon-declutter-mode`, but was read from `icon-declutter`.
https://github.com/openlayers/openlayers/blob/4c6eb5adf1bc9bb65cf48727db567f7356742bb7/src/ol/style/flat.js#L203