### PR TITLE
Increase alpha precision in rgba strings created from color arrays

### DIFF
--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -159,7 +159,7 @@ export function toString(color) {
   if (b != (b | 0)) {
     b = (b + 0.5) | 0;
   }
-  const a = color[3] === undefined ? 1 : Math.round(color[3] * 100) / 100;
+  const a = color[3] === undefined ? 1 : Math.round(color[3] * 1000) / 1000;
   return 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
 }
 


### PR DESCRIPTION
As noted in https://github.com/openlayers/openlayers/pull/15295#issuecomment-1804231066 2 decimal place alpha in rbga strings is not as precise as eight character hex notation, sometimes differing from the hex value by 2, and this means that color arrays cannot be reliably used to provide string values with precise alpha for canvas drawing.  3 places are needed to match the precision of hex format.
