### PR TITLE
Add information whether snapped to line extremity

### DIFF
--- a/src/ol/events/SnapEvent.js
+++ b/src/ol/events/SnapEvent.js
@@ -24,6 +24,7 @@ export class SnapEvent extends Event {
    * @param {SnapEventType} type Type.
    * @param {Object} options Options.
    * @param {import("../coordinate.js").Coordinate} options.vertex The snapped vertex.
+   * @param {boolean} options.vertexIsExtremity Whether the snapped vertex is a line extremity.
    * @param {import("../coordinate.js").Coordinate} options.vertexPixel The pixel of the snapped vertex.
    * @param {import("../Feature.js").default} options.feature The feature being snapped.
    * @param {Array<import("../coordinate.js").Coordinate>|null} options.segment Segment, or `null` if snapped to a vertex.
@@ -36,6 +37,14 @@ export class SnapEvent extends Event {
      * @api
      */
     this.vertex = options.vertex;
+
+    /**
+     * Whether the snapped vertex is a line extremity.
+     * @type {boolean}
+     * @api
+     */
+    this.vertexIsExtremity = options.vertexIsExtremity;
+
     /**
      * The Map pixel of the snapped point.
      * @type {Array<number>&Array<number>}

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -220,6 +220,87 @@ describe('ol.interaction.Snap', function () {
       snapInteraction.handleEvent(event);
     });
 
+    it('snap to extremities', function (done) {
+      const line = new Feature(
+        new LineString([
+          [-20, 0],
+          [-10, 0],
+          [10, 0],
+          [20, 0],
+        ])
+      );
+      const snapInteraction = new Snap({
+        features: new Collection([line]),
+        pixelTolerance: 5,
+        edge: false,
+      });
+      snapInteraction.setMap(map);
+
+      let event = {
+        pixel: [-22 + width / 2, height / 2 - 4],
+        coordinate: [-22, 4],
+        map: map,
+      };
+      snapInteraction.on('snap', function (snapEvent) {
+        expect(snapEvent.feature).to.be(line);
+        expect(snapEvent.segment).to.be(null);
+
+        expect(event.coordinate).to.eql([-20, 0]);
+        expect(event.vertexIsExtremity).to.be(true);
+
+        done();
+      });
+      snapInteraction.handleEvent(event);
+
+      event = {
+        pixel: [-12 + width / 2, height / 2 - 4],
+        coordinate: [-12, 4],
+        map: map,
+      };
+      snapInteraction.on('snap', function (snapEvent) {
+        expect(snapEvent.feature).to.be(line);
+        expect(snapEvent.segment).to.be(null);
+
+        expect(event.coordinate).to.eql([-10, 0]);
+        expect(event.vertexIsExtremity).to.be(false);
+
+        done();
+      });
+      snapInteraction.handleEvent(event);
+
+      event = {
+        pixel: [12 + width / 2, height / 2 - 4],
+        coordinate: [12, 4],
+        map: map,
+      };
+      snapInteraction.on('snap', function (snapEvent) {
+        expect(snapEvent.feature).to.be(line);
+        expect(snapEvent.segment).to.be(null);
+
+        expect(event.coordinate).to.eql([10, 0]);
+        expect(event.vertexIsExtremity).to.be(false);
+
+        done();
+      });
+      snapInteraction.handleEvent(event);
+
+      event = {
+        pixel: [22 + width / 2, height / 2 - 4],
+        coordinate: [22, 4],
+        map: map,
+      };
+      snapInteraction.on('snap', function (snapEvent) {
+        expect(snapEvent.feature).to.be(line);
+        expect(snapEvent.segment).to.be(null);
+
+        expect(event.coordinate).to.eql([20, 0]);
+        expect(event.vertexIsExtremity).to.be(true);
+
+        done();
+      });
+      snapInteraction.handleEvent(event);
+    });
+
     it('snaps to point', function (done) {
       const line = new Feature(
         new LineString([


### PR DESCRIPTION
This PR adds the information whether a snapped vertex is a line extremity to the snap result.