### PR TITLE
More specific return types in Format#readFeatures

### DIFF
--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -94,6 +94,11 @@ import {
  * @property {Object<string, *>} [properties] Properties.
  */
 
+/***
+ * @template {import("../Feature.js").FeatureClass} T
+ * @typedef {T extends typeof import("../render/Feature.js").default ? import("../render/Feature.js").default : import("../Feature.js").default} FeatureOrRenderFeature<T>
+ */
+
 /**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
@@ -103,6 +108,7 @@ import {
  * {@link module:ol/Feature~Feature} objects from a variety of commonly used geospatial
  * file formats.  See the documentation for each format for more details.
  *
+ * @template {import('../Feature.js').FeatureClass} [T=typeof import('../Feature.js').default]
  * @abstract
  * @api
  */
@@ -207,7 +213,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Element|ArrayBuffer|Object|string} source Source.
    * @param {ReadOptions} [options] Read options.
-   * @return {Array<import("../Feature.js").FeatureLike>} Features.
+   * @return {Array<FeatureOrRenderFeature<T>>} Features.
    */
   readFeatures(source, options) {
     return abstract();

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -33,7 +33,9 @@ import {isEmpty} from '../obj.js';
  */
 
 /**
+ * @template {import("../Feature.js").FeatureClass} FeatureOrRenderFeature
  * @typedef {Object} Options
+ *
  * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
  * @property {import("../proj.js").ProjectionLike} [featureProjection] Projection for features read or
  * written by the format.  Options passed to read or write methods will take precedence.
@@ -42,7 +44,7 @@ import {isEmpty} from '../obj.js';
  * the geometry_name field in the feature GeoJSON. If set to `true` the GeoJSON reader
  * will look for that field to set the geometry name. If both this field is set to `true`
  * and a `geometryName` is provided, the `geometryName` will take precedence.
- * @property {import("../Feature.js").FeatureClass} [featureClass] Feature class
+ * @property {FeatureOrRenderFeature} [featureClass] Feature class
  * to be used when reading features. The default is {@link module:ol/Feature~Feature}. If performance is
  * the primary concern, and features are not going to be modified or round-tripped through the format,
  * consider using {@link module:ol/render/Feature~RenderFeature}
@@ -52,11 +54,13 @@ import {isEmpty} from '../obj.js';
  * @classdesc
  * Feature format for reading and writing data in the GeoJSON format.
  *
+ * @template {import('../Feature.js').FeatureClass} [T=typeof Feature]
+ * @extends {JSONFeature<T>}
  * @api
  */
 class GeoJSON extends JSONFeature {
   /**
-   * @param {Options} [options] Options.
+   * @param {Options<T>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -4,11 +4,6 @@
 import FeatureFormat from './Feature.js';
 import {abstract} from '../util.js';
 
-/***
- * @template {import("../Feature.js").FeatureClass} T
- * @typedef {T extends typeof import("../render/Feature.js").default ? import("../render/Feature.js").default : import("../Feature.js").default} FeatureOrRenderFeature<T>
- */
-
 /**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
@@ -16,6 +11,7 @@ import {abstract} from '../util.js';
  * Base class for JSON feature formats.
  *
  * @template {import('../Feature.js').FeatureClass} [T=typeof import('../Feature.js').default]
+ * @extends {FeatureFormat<T>}
  * @abstract
  */
 class JSONFeature extends FeatureFormat {
@@ -52,11 +48,11 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<FeatureOrRenderFeature<T>>} Features.
+   * @return {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} Features.
    * @api
    */
   readFeatures(source, options) {
-    return /** @type {Array<FeatureOrRenderFeature<T>>} */ (
+    return /** @type {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} */ (
       this.readFeaturesFromObject(
         getObject(source),
         this.getReadOptions(source, options)

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -4,12 +4,18 @@
 import FeatureFormat from './Feature.js';
 import {abstract} from '../util.js';
 
+/***
+ * @template {import("../Feature.js").FeatureClass} T
+ * @typedef {T extends typeof import("../render/Feature.js").default ? import("../render/Feature.js").default : import("../Feature.js").default} FeatureOrRenderFeature<T>
+ */
+
 /**
  * @classdesc
  * Abstract base class; normally only used for creating subclasses and not
  * instantiated in apps.
  * Base class for JSON feature formats.
  *
+ * @template {import('../Feature.js').FeatureClass} [T=typeof import('../Feature.js').default]
  * @abstract
  */
 class JSONFeature extends FeatureFormat {
@@ -46,13 +52,15 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import("../Feature.js").FeatureLike>} Features.
+   * @return {Array<FeatureOrRenderFeature<T>>} Features.
    * @api
    */
   readFeatures(source, options) {
-    return this.readFeaturesFromObject(
-      getObject(source),
-      this.getReadOptions(source, options)
+    return /** @type {Array<FeatureOrRenderFeature<T>>} */ (
+      this.readFeaturesFromObject(
+        getObject(source),
+        this.getReadOptions(source, options)
+      )
     );
   }
 

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -17,8 +17,9 @@ import {get} from '../proj.js';
 import {inflateEnds} from '../geom/flat/orient.js';
 
 /**
+ * @template {import("../Feature.js").FeatureClass} FeatureOrRenderFeature
  * @typedef {Object} Options
- * @property {import("../Feature.js").FeatureClass} [featureClass] Class for features returned by
+ * @property {FeatureOrRenderFeature} [featureClass] Class for features returned by
  * {@link module:ol/format/MVT~MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
  * support at the cost of decreased rendering performance. The default is
  * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
@@ -33,12 +34,13 @@ import {inflateEnds} from '../geom/flat/orient.js';
  * @classdesc
  * Feature format for reading data in the Mapbox MVT format.
  *
- * @param {Options} [options] Options.
+ * @template {import('../Feature.js').FeatureClass} [T=typeof import("../render/Feature.js").default]
+ * @extends {FeatureFormat<T>}
  * @api
  */
 class MVT extends FeatureFormat {
   /**
-   * @param {Options} [options] Options.
+   * @param {Options<T>} [options] Options.
    */
   constructor(options) {
     super();
@@ -246,7 +248,7 @@ class MVT extends FeatureFormat {
    *
    * @param {ArrayBuffer} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import("../Feature.js").FeatureLike>} Features.
+   * @return {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} Features.
    * @api
    */
   readFeatures(source, options) {
@@ -277,7 +279,9 @@ class MVT extends FeatureFormat {
       }
     }
 
-    return features;
+    return /** @type {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} */ (
+      features
+    );
   }
 
   /**


### PR DESCRIPTION
This pull request improves the types of the GeoJSON and MVT format so they can infer the return type of `readFeatures()` from the `featureClass` constructor option. This means that no type casts are needed any more in the code snippets below:
```js
/** @type {Array<Feature>} */
const features = new GeoJSON().readFeatures(source);

/** @type {Array<RenderFeature>} */
const renderFeatures = new GeoJSON({featureClass: RenderFeature}).readFeatures(source);
```

For all other formats, the `Feature` return type is used for `readFeatures()`, as before v8.2.0.

Fixes #15334.