### PR TITLE
WebGL / Fix hit detection for vector layers

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -196,7 +196,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     if (this.hitDetectionEnabled_) {
       this.attributes.push({
-        name: 'a_hitColor',
+        name: 'a_prop_hitColor',
         size: 4,
         type: AttributeType.FLOAT,
       });

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -480,7 +480,7 @@ ${this.uniforms_
   .join('\n')}
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
@@ -488,7 +488,7 @@ ${this.attributes_
   .join('\n')}
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -532,7 +532,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -562,7 +562,7 @@ ${this.uniforms_
   })
   .join('\n')}
 varying vec2 v_texCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -582,7 +582,7 @@ void main(void) {
   gl_FragColor = ${this.symbolColorExpression_};
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`;
   }
@@ -609,7 +609,7 @@ attribute vec2 a_segmentEnd;
 attribute float a_parameters;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
@@ -620,7 +620,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_distanceOffsetPx;
 ${this.varyings_
   .map(function (varying) {
@@ -696,7 +696,7 @@ void main(void) {
   v_segmentStart = segmentStartPx;
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
 ${this.varyings_
   .map(function (varying) {
@@ -727,7 +727,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_distanceOffsetPx;
 ${this.varyings_
   .map(function (varying) {
@@ -856,7 +856,7 @@ void main(void) {
   gl_FragColor = color * smoothstep(0., -1., distance);
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`;
   }
@@ -878,13 +878,13 @@ ${this.uniforms_
   })
   .join('\n')}
 attribute vec2 a_position;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
   })
   .join('\n')}
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return 'varying ' + varying.type + ' ' + varying.name + ';';
@@ -893,7 +893,7 @@ ${this.varyings_
 ${this.vertexShaderFunctions_.join('\n')}
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, u_depth, 1.0);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return '  ' + varying.name + ' = ' + varying.expression + ';';
@@ -917,7 +917,7 @@ ${this.uniforms_
     return 'uniform ' + uniform + ';';
   })
   .join('\n')}
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return 'varying ' + varying.type + ' ' + varying.name + ';';
@@ -954,7 +954,7 @@ void main(void) {
   gl_FragColor = ${this.fillColorExpression_} * u_globalAlpha;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`;
   }

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -24,11 +24,11 @@ describe('ol.webgl.ShaderBuilder', () => {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -69,7 +69,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -92,11 +92,11 @@ void main(void) {
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -136,7 +136,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -157,11 +157,11 @@ void main(void) {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -201,7 +201,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -221,11 +221,11 @@ void main(void) {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -265,7 +265,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -296,7 +296,7 @@ void main(void) {
       expect(builder.getSymbolFragmentShader()).to.eql(`${COMMON_HEADER}
 
 varying vec2 v_texCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -313,7 +313,7 @@ void main(void) {
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0);
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`);
     });
@@ -331,7 +331,7 @@ void main(void) {
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -347,7 +347,7 @@ void main(void) {
   gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`);
     });
@@ -388,14 +388,14 @@ attribute vec2 a_segmentEnd;
 attribute float a_parameters;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_segmentStart;
 varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_opacity;
 varying vec3 v_test;
@@ -468,7 +468,7 @@ void main(void) {
   v_segmentStart = segmentStartPx;
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
@@ -489,7 +489,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_opacity;
 varying vec3 v_test;
@@ -615,7 +615,7 @@ void main(void) {
   gl_FragColor = color * smoothstep(0., -1., distance);
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`);
       });
@@ -640,15 +640,15 @@ void main(void) {
       expect(builder.getFillVertexShader()).to.eql(`${COMMON_HEADER}
 uniform float u_myUniform;
 attribute vec2 a_position;
-attribute vec4 a_hitColor;
+attribute vec4 a_prop_hitColor;
 attribute vec2 a_myAttr;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, u_depth, 1.0);
-  v_hitColor = a_hitColor;
+  v_prop_hitColor = a_prop_hitColor;
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
@@ -671,7 +671,7 @@ void main(void) {
 
       expect(builder.getFillFragmentShader()).to.eql(`${COMMON_HEADER}
 uniform float u_myUniform;
-varying vec4 v_hitColor;
+varying vec4 v_prop_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -705,7 +705,7 @@ void main(void) {
   gl_FragColor = vec4(0.3137254901960784, 0.0, 1.0, 1.0) * u_globalAlpha;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_hitColor;
+    gl_FragColor = v_prop_hitColor;
   }
 }`);
     });


### PR DESCRIPTION
Hit detection for the `WebGLVectorLayerRenderer` was broken by #15121 and somehow we missed a test for it, which means it sadly went undetected.

This PR adds a test that is initially failing, as long as a fix which was simply a missing `prop` prefix for the features hit detection color.

Note that this problem was also causing rendering artifacts on some browsers and platforms; these should now be gone.

Addresses the issues mentioned in https://github.com/openlayers/openlayers/discussions/14446#discussioncomment-7578596 and https://github.com/openlayers/openlayers/pull/15279#issuecomment-1783888157