### PR TITLE
Align sources to pixels in stitchContext when interpolate false

### DIFF
--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -266,10 +266,10 @@ export function render(
     const stitchScale = pixelRatio / sourceResolution;
 
     sources.forEach(function (src, i, arr) {
-      const xPos = src.extent[0] - sourceDataExtent[0];
-      const yPos = -(src.extent[3] - sourceDataExtent[3]);
-      const srcWidth = getWidth(src.extent);
-      const srcHeight = getHeight(src.extent);
+      const xPos = (src.extent[0] - sourceDataExtent[0]) * stitchScale;
+      const yPos = -(src.extent[3] - sourceDataExtent[3]) * stitchScale;
+      const srcWidth = getWidth(src.extent) * stitchScale;
+      const srcHeight = getHeight(src.extent) * stitchScale;
 
       // This test should never fail -- but it does. Need to find a fix the upstream condition
       if (src.image.width > 0 && src.image.height > 0) {
@@ -279,10 +279,14 @@ export function render(
           gutter,
           src.image.width - 2 * gutter,
           src.image.height - 2 * gutter,
-          xPos * stitchScale,
-          yPos * stitchScale,
-          srcWidth * stitchScale,
-          srcHeight * stitchScale
+          interpolate ? xPos : Math.round(xPos),
+          interpolate ? yPos : Math.round(yPos),
+          interpolate
+            ? srcWidth
+            : Math.round(xPos + srcWidth) - Math.round(xPos),
+          interpolate
+            ? srcHeight
+            : Math.round(yPos + srcHeight) - Math.round(yPos)
         );
       }
     });

--- a/src/ol/reproj.js
+++ b/src/ol/reproj.js
@@ -250,20 +250,20 @@ export function render(
   });
 
   let stitchContext;
+  const stitchScale = pixelRatio / sourceResolution;
+  // Round up Float32 scale values to prevent interpolation in Firefox.
+  const inverseScale = (interpolate ? 1 : 1 + Math.pow(2, -24)) / stitchScale;
+
   if (!drawSingle || sources.length !== 1 || gutter !== 0) {
-    const canvasWidthInUnits = getWidth(sourceDataExtent);
-    const canvasHeightInUnits = getHeight(sourceDataExtent);
     stitchContext = createCanvasContext2D(
-      Math.round((pixelRatio * canvasWidthInUnits) / sourceResolution),
-      Math.round((pixelRatio * canvasHeightInUnits) / sourceResolution),
+      Math.round(getWidth(sourceDataExtent) * stitchScale),
+      Math.round(getHeight(sourceDataExtent) * stitchScale),
       canvasPool
     );
 
     if (!interpolate) {
       stitchContext.imageSmoothingEnabled = false;
     }
-
-    const stitchScale = pixelRatio / sourceResolution;
 
     sources.forEach(function (src, i, arr) {
       const xPos = (src.extent[0] - sourceDataExtent[0]) * stitchScale;
@@ -410,10 +410,7 @@ export function render(
     let image;
     if (stitchContext) {
       image = stitchContext.canvas;
-      context.scale(
-        sourceResolution / pixelRatio,
-        -sourceResolution / pixelRatio
-      );
+      context.scale(inverseScale, -inverseScale);
     } else {
       const source = sources[0];
       const extent = source.extent;


### PR DESCRIPTION
Fixes #15331

As well as fractional gaps in the stitchContext I also noticed that the stitchContext was sometimes fractionally missing the edge of the reprojected context, which can be seen in https://codesandbox.io/s/simple-forked-3m7md5?file=/main.js in Firefox.  This seems to be a rounding issue and adding a small tolerance to the final scale ensures there is no unwanted downscaling.  As Firefox uses Float32 precision in its context transform, the adjustment is refined to round up any implicit `fround` operations.
