### PR TITLE
Create css matrix without using the DOM

### DIFF
--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/transform
  */
-import {WORKER_OFFSCREEN_CANVAS} from './has.js';
 import {assert} from './asserts.js';
 
 /**
@@ -266,10 +265,9 @@ export function determinant(mat) {
 }
 
 /**
- * @type {HTMLElement}
- * @private
+ * @type {Array}
  */
-let transformStringDiv;
+const matrixPrecision = [1e6, 1e6, 1e6, 1e6, 2, 2];
 
 /**
  * A rounded string version of the transform.  This can be used
@@ -278,12 +276,14 @@ let transformStringDiv;
  * @return {string} The transform as a string.
  */
 export function toString(mat) {
-  const transformString = 'matrix(' + mat.join(', ') + ')';
-  if (WORKER_OFFSCREEN_CANVAS) {
-    return transformString;
-  }
-  const node =
-    transformStringDiv || (transformStringDiv = document.createElement('div'));
-  node.style.transform = transformString;
-  return node.style.transform;
+  const transformString =
+    'matrix(' +
+    mat
+      .map(
+        (value, i) =>
+          Math.round(value * matrixPrecision[i]) / matrixPrecision[i]
+      )
+      .join(', ') +
+    ')';
+  return transformString;
 }

--- a/test/browser/spec/ol/renderer/canvas/Layer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/Layer.test.js
@@ -1,0 +1,48 @@
+import Feature from '../../../../../../src/ol/Feature.js';
+import Map from '../../../../../../src/ol/Map.js';
+import TileLayer from '../../../../../../src/ol/layer/Tile.js';
+import VectorLayer from '../../../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../../../src/ol/source/Vector.js';
+import View from '../../../../../../src/ol/View.js';
+import XYZ from '../../../../../../src/ol/source/XYZ.js';
+import {Point} from '../../../../../../src/ol/geom.js';
+
+describe('ol/renderer/canvas/Layer', function () {
+  let map;
+  beforeEach(function (done) {
+    map = new Map({
+      target: createMapDiv(100, 100),
+      pixelRatio: 1.7999999999999998,
+      layers: [
+        new TileLayer({
+          source: new XYZ({
+            url: 'spec/ol/data/osm/{z}-{x}-{y}.png',
+          }),
+        }),
+        new VectorLayer({
+          source: new VectorSource({
+            features: [
+              new Feature({
+                geometry: new Point([0, 0]),
+              }),
+            ],
+          }),
+        }),
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 0,
+        rotation: 1e-8,
+        constrainRotation: false,
+      }),
+    });
+    map.once('rendercomplete', () => done());
+  });
+  afterEach(function () {
+    disposeMap(map);
+  });
+
+  it('reuses container', function () {
+    expect(map.getTargetElement().querySelectorAll('canvas').length).to.be(1);
+  });
+});


### PR DESCRIPTION
This pull request fixes a performance problem that occurs e.g. when the view is rotated or the browser viewport is scaled (by css or cmd/ctrl and +/- keys): in this case it can happen that the canvas layer renderer is unable to reuse the container of the previous layer, due to a css matrix that differs due to floating point inaccuracies.

Previously, we tried to work around this by creating the css transform matrix by applying the desired transform to a DOM element and using the returned css transform matrix. In this process, some rounding happened. It seems that modern browsers don't round the matrix parameters any more.

The change in this pull request changes things so no DOM element is used to create the css transform matrix. Instead, each element of the transform is rounded appropriately - the first 4 parameters which contain sin and cos values from the rotation to 6 decimal places, the last 2 parameters which represent the translation to half a pixel.