### PR TITLE
Accept any service URL for arcgisRest

### DIFF
--- a/src/ol/source/arcgisRest.js
+++ b/src/ol/source/arcgisRest.js
@@ -53,9 +53,6 @@ export function getRequestUrl(
   const modifiedUrl = baseUrl
     .replace(/MapServer\/?$/, 'MapServer/export')
     .replace(/ImageServer\/?$/, 'ImageServer/exportImage');
-  if (modifiedUrl == baseUrl) {
-    throw new Error('`options.featureTypes` should be an Array');
-  }
   return appendParams(modifiedUrl, params);
 }
 


### PR DESCRIPTION
This pull request removes a legacy assertion, which is by the way wrong - the assertion used to read "Unknown REST service" several years ago. The code above was the same in TileArcGISRest and ImageArcGISRest, but the assertion was only in ImageArcGISRest. So I think it can be removed.

Fixes #15345.