### PR TITLE
Extend WebGL color operator

### DIFF
--- a/examples/pmtiles-elevation.js
+++ b/examples/pmtiles-elevation.js
@@ -66,6 +66,7 @@ const incidence = [
   ['*', ['sin', sunEl], ['cos', slope]],
   ['*', ['cos', sunEl], ['sin', slope], ['cos', ['-', sunAz, aspect]]],
 ];
+const scaled = ['*', 255, incidence];
 
 const variables = {};
 
@@ -79,7 +80,7 @@ const layer = new TileLayer({
   }),
   style: {
     variables: variables,
-    color: ['array', incidence, incidence, incidence, 1],
+    color: ['color', scaled],
   },
 });
 

--- a/examples/webgl-shaded-relief.js
+++ b/examples/webgl-shaded-relief.js
@@ -59,7 +59,7 @@ const shadedRelief = new TileLayer({
   }),
   style: {
     variables: variables,
-    color: ['color', scaled, scaled, scaled],
+    color: ['color', scaled],
   },
 });
 

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -94,9 +94,9 @@ import {isStringColor} from '../color.js';
  * * Conversion operators:
  *   * `['array', value1, ...valueN]` creates a numerical array from `number` values; please note that the amount of
  *     values can currently only be 2, 3 or 4.
- *   * `['color', red, green, blue, alpha]` creates a `color` value from `number` values; the `alpha` parameter is
- *     optional; if not specified, it will be set to 1.
- *     Note: `red`, `green` and `blue` components must be values between 0 and 255; `alpha` between 0 and 1.
+ *   * `['color', red, green, blue, alpha]` or `['color', shade, alpha]` creates a `color` value from `number` values;
+ *     the `alpha` parameter is optional; if not specified, it will be set to 1.
+ *     Note: `red`, `green` and `blue` or `shade` components must be values between 0 and 255; `alpha` between 0 and 1.
  *   * `['palette', index, colors]` picks a `color` value from an array of colors using the given index; the `index`
  *     expression must evaluate to a number; the items in the `colors` array must be strings with hex colors
  *     (e.g. `'#86A136'`), colors using the rgba[a] functional notation (e.g. `'rgb(134, 161, 54)'` or `'rgba(134, 161, 54, 1)'`),
@@ -602,7 +602,7 @@ const parsers = {
   ),
   [Ops.Color]: createParser(
     ColorType,
-    withArgsCount(3, 4),
+    withArgsCount(1, 4),
     parseArgsOfType(NumberType)
   ),
   [Ops.Band]: createParser(

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -383,11 +383,11 @@ ${tests.join('\n')}
     (args) => `vec${args.length}(${args.join(', ')})`
   ),
   [Ops.Color]: createCompiler((compiledArgs) => {
-    if (compiledArgs.length == 1) {
+    if (compiledArgs.length === 1) {
       //grayscale
       return `vec4(vec3(${compiledArgs[0]} / 255.0), 1.0)`;
     }
-    if (compiledArgs.length == 2) {
+    if (compiledArgs.length === 2) {
       //grayscale with alpha
       return `(${compiledArgs[1]} * vec4(vec3(${compiledArgs[0]} / 255.0), 1.0))`;
     }

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -56,19 +56,11 @@ export function arrayToGlsl(array) {
  * Will normalize and converts to string a `vec4` color array compatible with GLSL.
  * @param {string|import("../color.js").Color} color Color either in string format or [r, g, b, a] array format,
  * with RGB components in the 0..255 range and the alpha component in the 0..1 range.
- * Alternatively only 2 element array can be supplied as [shade, alpha] for grayscale colors.
- * Alpha value is optional. Note that the final array will always have 4 components.
+ * Note that the final array will always have 4 components.
  * @return {string} The color expressed in the `vec4(1.0, 1.0, 1.0, 1.0)` form.
  */
 export function colorToGlsl(color) {
   const array = asArray(color);
-  if (array.length < 3) {
-    if (array.length == 2) {
-      array[3] = array[1];
-    }
-    array[1] = array[0];
-    array[2] = array[0];
-  }
   const alpha = array.length > 3 ? array[3] : 1;
   // all components are premultiplied with alpha value
   return arrayToGlsl([

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -53,12 +53,6 @@ describe('ol/expr/gpu.js', () => {
 
   describe('colorToGlsl()', () => {
     it('normalizes color and outputs numbers with dot separators, including premultiplied alpha', () => {
-      expect(colorToGlsl([100])).to.eql(
-        'vec4(0.39215686274509803, 0.39215686274509803, 0.39215686274509803, 1.0)'
-      );
-      expect(colorToGlsl([100, 0.7])).to.eql(
-        'vec4(0.2745098039215686, 0.2745098039215686, 0.2745098039215686, 0.7)'
-      );
       expect(colorToGlsl([100, 0, 255])).to.eql(
         'vec4(0.39215686274509803, 0.0, 1.0, 1.0)'
       );

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -53,6 +53,12 @@ describe('ol/expr/gpu.js', () => {
 
   describe('colorToGlsl()', () => {
     it('normalizes color and outputs numbers with dot separators, including premultiplied alpha', () => {
+      expect(colorToGlsl([100])).to.eql(
+        'vec4(0.39215686274509803, 0.39215686274509803, 0.39215686274509803, 1.0)'
+      );
+      expect(colorToGlsl([100, 0.7])).to.eql(
+        'vec4(0.2745098039215686, 0.2745098039215686, 0.2745098039215686, 0.7)'
+      );
       expect(colorToGlsl([100, 0, 255])).to.eql(
         'vec4(0.39215686274509803, 0.0, 1.0, 1.0)'
       );
@@ -402,6 +408,31 @@ describe('ol/expr/gpu.js', () => {
         expression: ['color', ['get', 'attr4'], 1, 2, 0.5],
         expected:
           '(0.5 * vec4(a_prop_attr4 / 255.0, 1.0 / 255.0, 2.0 / 255.0, 1.0))',
+      },
+      {
+        name: 'grayscale color',
+        type: AnyType,
+        expression: ['color', 100],
+        expected: 'vec4(vec3(100.0 / 255.0), 1.0)',
+      },
+      {
+        name: 'grayscale color with alpha',
+        type: AnyType,
+        expression: ['color', 100, 0.5],
+        expected: '(0.5 * vec4(vec3(100.0 / 255.0), 1.0))',
+      },
+      {
+        name: 'rgb color',
+        type: AnyType,
+        expression: ['color', 100, 150, 200],
+        expected: 'vec4(100.0 / 255.0, 150.0 / 255.0, 200.0 / 255.0, 1.0)',
+      },
+      {
+        name: 'rgb color with alpha',
+        type: AnyType,
+        expression: ['color', 100, 150, 200, 0.5],
+        expected:
+          '(0.5 * vec4(100.0 / 255.0, 150.0 / 255.0, 200.0 / 255.0, 1.0))',
       },
       {
         name: 'band',


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This improvement is inspired by issue https://github.com/openlayers/openlayers/issues/14350

It solves the overhead calculations for grayscale colors in WebGL style expression where same value was calculated three times and it also caused troubles on legacy devices.

I updated the code, comments for the docs and examples.