### PR TITLE
Fix WMTS Capabilities Layer.BoundingBox

### DIFF
--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -104,6 +104,7 @@ const LAYER_PARSERS = makeStructureNS(
     'Title': makeObjectPropertySetter(readString),
     'Abstract': makeObjectPropertySetter(readString),
     'WGS84BoundingBox': makeObjectPropertySetter(readBoundingBox),
+    'BoundingBox': makeObjectPropertySetter(readBoundingBox),
     'Identifier': makeObjectPropertySetter(readString),
   })
 );

--- a/test/browser/spec/ol/format/wmts/ogcsample.xml
+++ b/test/browser/spec/ol/format/wmts/ogcsample.xml
@@ -73,6 +73,11 @@ access interface to some TileMatrixSets</ows:Abstract>
 				<ows:LowerCorner>-180 -90</ows:LowerCorner>
 				<ows:UpperCorner>180 90</ows:UpperCorner>
 			</ows:WGS84BoundingBox>
+			<ows:BoundingBox>
+				<ows:LowerCorner>-180 -90</ows:LowerCorner>
+				<ows:UpperCorner>180 90</ows:UpperCorner>
+				<ows:crs>urn:ogc:def:crs:CRS::84</ows:crs>
+			</ows:BoundingBox>
 			<ows:Identifier>BlueMarbleNextGeneration</ows:Identifier>
 			<Style isDefault="true">
 				<ows:Title>Dark Blue</ows:Title>

--- a/test/browser/spec/ol/format/wmtscapabilities.test.js
+++ b/test/browser/spec/ol/format/wmtscapabilities.test.js
@@ -66,6 +66,13 @@ describe('ol.format.WMTSCapabilities', function () {
       expect(wgs84Bbox[1]).to.be.eql(-90);
       expect(wgs84Bbox[3]).to.be.eql(90.0);
 
+      const bbox = layer.BoundingBox;
+      expect(bbox).to.be.an('array');
+      expect(bbox[0]).to.be.eql(-180);
+      expect(bbox[2]).to.be.eql(180);
+      expect(bbox[1]).to.be.eql(-90);
+      expect(bbox[3]).to.be.eql(90.0);
+
       expect(layer.ResourceURL).to.be.an('array');
       expect(layer.ResourceURL).to.have.length(2);
       expect(layer.ResourceURL[0].format).to.be.eql('image/png');


### PR DESCRIPTION
In WMTS OGC standard, each Layer node might have `BoundingBox` children instead of the regular `WGS84BoundingBox`

This solve #15363 

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
