### PR TITLE
Revert "Fix WMTS Capabilities Layer.BoundingBox"

### DIFF
--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -104,7 +104,6 @@ const LAYER_PARSERS = makeStructureNS(
     'Title': makeObjectPropertySetter(readString),
     'Abstract': makeObjectPropertySetter(readString),
     'WGS84BoundingBox': makeObjectPropertySetter(readBoundingBox),
-    'BoundingBox': makeObjectPropertySetter(readBoundingBox),
     'Identifier': makeObjectPropertySetter(readString),
   })
 );

--- a/test/browser/spec/ol/format/wmts/ogcsample.xml
+++ b/test/browser/spec/ol/format/wmts/ogcsample.xml
@@ -73,11 +73,6 @@ access interface to some TileMatrixSets</ows:Abstract>
 				<ows:LowerCorner>-180 -90</ows:LowerCorner>
 				<ows:UpperCorner>180 90</ows:UpperCorner>
 			</ows:WGS84BoundingBox>
-			<ows:BoundingBox>
-				<ows:LowerCorner>-180 -90</ows:LowerCorner>
-				<ows:UpperCorner>180 90</ows:UpperCorner>
-				<ows:crs>urn:ogc:def:crs:CRS::84</ows:crs>
-			</ows:BoundingBox>
 			<ows:Identifier>BlueMarbleNextGeneration</ows:Identifier>
 			<Style isDefault="true">
 				<ows:Title>Dark Blue</ows:Title>

--- a/test/browser/spec/ol/format/wmtscapabilities.test.js
+++ b/test/browser/spec/ol/format/wmtscapabilities.test.js
@@ -66,13 +66,6 @@ describe('ol.format.WMTSCapabilities', function () {
       expect(wgs84Bbox[1]).to.be.eql(-90);
       expect(wgs84Bbox[3]).to.be.eql(90.0);
 
-      const bbox = layer.BoundingBox;
-      expect(bbox).to.be.an('array');
-      expect(bbox[0]).to.be.eql(-180);
-      expect(bbox[2]).to.be.eql(180);
-      expect(bbox[1]).to.be.eql(-90);
-      expect(bbox[3]).to.be.eql(90.0);
-
       expect(layer.ResourceURL).to.be.an('array');
       expect(layer.ResourceURL).to.have.length(2);
       expect(layer.ResourceURL[0].format).to.be.eql('image/png');


### PR DESCRIPTION
Reverts openlayers/openlayers#15364

@ahocevar Sorry I just saw an issue with my PR, the `BoundingBox` element can contain a `crs` element that specify the CRS of the bounding box, see printscreen from the spec

![image](https://github.com/openlayers/openlayers/assets/67745584/a7226ffc-9348-4029-9e9b-dbee4b067e3c)

The actual code to read the `BoundingBox` in the PR #15364 rely on the code to read `WGS84BoundingBox` that returns an array. For the `BoundingBox` we should not return an array but an object, containing the following keys:
- bbox (or extent): mandatory array
- crs: optional string
- dimensions: optional number

What do you think of my proposal for the object structure ? If you agree I would do another PR with a proper implementation.