### PR TITLE
Improve return type of JSONFeatureFormat#readFeature

### DIFF
--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -32,13 +32,15 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {import("../Feature.js").FeatureLike|Array<import("../render/Feature.js").default>} Feature.
+   * @return {import('./Feature.js').FeatureOrRenderFeature<T>} Feature.
    * @api
    */
   readFeature(source, options) {
-    return this.readFeatureFromObject(
-      getObject(source),
-      this.getReadOptions(source, options)
+    return /** @type {import('./Feature.js').FeatureOrRenderFeature<T>} */ (
+      this.readFeatureFromObject(
+        getObject(source),
+        this.getReadOptions(source, options)
+      )
     );
   }
 


### PR DESCRIPTION
Like #15338, this pull request improves the return type for `#readFeature()`.

Fixes https://github.com/openlayers/openlayers/issues/15334#issuecomment-1826392468.