### PR TITLE
Fix WMTS Capabilities Layer.BoundingBox

### DIFF
--- a/src/ol/format/WMTSCapabilities.js
+++ b/src/ol/format/WMTSCapabilities.js
@@ -104,6 +104,7 @@ const LAYER_PARSERS = makeStructureNS(
     'Title': makeObjectPropertySetter(readString),
     'Abstract': makeObjectPropertySetter(readString),
     'WGS84BoundingBox': makeObjectPropertySetter(readBoundingBox),
+    'BoundingBox': makeObjectPropertyPusher(readBoundingBoxWithCrs),
     'Identifier': makeObjectPropertySetter(readString),
   })
 );
@@ -318,6 +319,25 @@ function readBoundingBox(node, objectStack) {
     return undefined;
   }
   return boundingExtent(coordinates);
+}
+
+/**
+ * @param {Element} node Node.
+ * @param {Array<*>} objectStack Object stack.
+ * @return {Object|undefined} BBox object.
+ */
+function readBoundingBoxWithCrs(node, objectStack) {
+  const crs = node.getAttribute('crs');
+  const coordinates = pushParseAndPop(
+    [],
+    WGS84_BBOX_READERS,
+    node,
+    objectStack
+  );
+  if (coordinates.length != 2) {
+    return undefined;
+  }
+  return {extent: boundingExtent(coordinates), crs: crs};
 }
 
 /**

--- a/test/browser/spec/ol/format/wmts/ogcsample.xml
+++ b/test/browser/spec/ol/format/wmts/ogcsample.xml
@@ -73,6 +73,14 @@ access interface to some TileMatrixSets</ows:Abstract>
 				<ows:LowerCorner>-180 -90</ows:LowerCorner>
 				<ows:UpperCorner>180 90</ows:UpperCorner>
 			</ows:WGS84BoundingBox>
+			<ows:BoundingBox crs="urn:ogc:def:crs:CRS::84">
+				<ows:LowerCorner>-180 -90</ows:LowerCorner>
+				<ows:UpperCorner>180 90</ows:UpperCorner>
+			</ows:BoundingBox>
+			<ows:BoundingBox>
+				<ows:LowerCorner>-180 -90</ows:LowerCorner>
+				<ows:UpperCorner>180 90</ows:UpperCorner>
+			</ows:BoundingBox>
 			<ows:Identifier>BlueMarbleNextGeneration</ows:Identifier>
 			<Style isDefault="true">
 				<ows:Title>Dark Blue</ows:Title>

--- a/test/browser/spec/ol/format/wmtscapabilities.test.js
+++ b/test/browser/spec/ol/format/wmtscapabilities.test.js
@@ -66,6 +66,16 @@ describe('ol.format.WMTSCapabilities', function () {
       expect(wgs84Bbox[1]).to.be.eql(-90);
       expect(wgs84Bbox[3]).to.be.eql(90.0);
 
+      const bbox = layer.BoundingBox;
+      expect(bbox).to.be.an('array');
+      expect(bbox[0].extent).to.be.an('array');
+      expect(bbox[0].extent[0]).to.be.eql(-180);
+      expect(bbox[0].extent[2]).to.be.eql(180);
+      expect(bbox[0].extent[1]).to.be.eql(-90);
+      expect(bbox[0].extent[3]).to.be.eql(90.0);
+      expect(bbox[0].crs).to.be.eql('urn:ogc:def:crs:CRS::84');
+      expect(bbox[1].crs).to.be.eql(null);
+
       expect(layer.ResourceURL).to.be.an('array');
       expect(layer.ResourceURL).to.have.length(2);
       expect(layer.ResourceURL[0].format).to.be.eql('image/png');


### PR DESCRIPTION
In WMTS OGC standard, each Layer node might have one or more `BoundingBox` children instead of the regular `WGS84BoundingBox`. Those bounding box might have a `crs` attribute that specify the coordinate reference system of the box.

This solve https://github.com/openlayers/openlayers/issues/15363
