### PR TITLE
Add change:source to BaseLayerObjectEventTypes according to docs

### DIFF
--- a/src/ol/layer/Base.js
+++ b/src/ol/layer/Base.js
@@ -16,7 +16,8 @@ import {clamp} from '../math.js';
 
 /**
  * @typedef {import("../ObjectEventType").Types|'change:extent'|'change:maxResolution'|'change:maxZoom'|
- *    'change:minResolution'|'change:minZoom'|'change:opacity'|'change:visible'|'change:zIndex'} BaseLayerObjectEventTypes
+ *    'change:minResolution'|'change:minZoom'|'change:opacity'|'change:visible'|'change:zIndex'|
+ *    'change:source'} BaseLayerObjectEventTypes
  */
 
 /***


### PR DESCRIPTION
Closes #15360

This is still draft because I couldn't test this yet

```
…/src/openlayers main % npm run build-package

> ol@9.0.0-dev build-package
> npm run build-full && npm run copy-css && npm run generate-types && node tasks/prepare-package.js


> ol@9.0.0-dev build-full
> shx rm -rf build/full && npm run build-index && npx rollup --config config/rollup-full-build.js


> ol@9.0.0-dev build-index
> shx rm -f build/index.js && npm run transpile && node tasks/generate-index.js


> ol@9.0.0-dev transpile
> shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build && node tasks/serialize-workers.cjs && node tasks/set-version.js

node:internal/modules/cjs/loader:446
      throw err;
      ^

Error: Cannot find module '/home/hannes/src/openlayers/node_modules/bluebird/js/release/bluebird.js'. Please verify that the package.json has a valid "main" entry
    at tryPackage (node:internal/modules/cjs/loader:438:19)
    at Module._findPath (node:internal/modules/cjs/loader:680:18)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1063:27)
    at Requizzle.requizzle (/home/hannes/src/openlayers/node_modules/requizzle/lib/requizzle.js:84:29)
    at infectProxy (/home/hannes/src/openlayers/node_modules/requizzle/lib/loader.js:79:31)
    at targetModule.require (/home/hannes/src/openlayers/node_modules/requizzle/lib/loader.js:97:44)
    at require (node:internal/modules/cjs/helpers:121:18)
    at /home/hannes/src/openlayers/node_modules/jsdoc/cli.js:18:21
    at Object.<anonymous> (/home/hannes/src/openlayers/node_modules/jsdoc/cli.js:465:3)
    at Module._compile (node:internal/modules/cjs/loader:1256:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/home/hannes/src/openlayers/node_modules/bluebird/package.json',
  requestPath: 'bluebird'
}

Node.js v18.17.1
```

Happens with node 16 and node 18. Probably because I am on `aarch64`. Will try on another machine the coming days.