### PR TITLE
Replace :package: with 📦

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -71,7 +71,7 @@ jobs:
           script: |
             const pullRequestNumber = parseInt(${{steps.pull-request-number.outputs.result}}, 10);
 
-            const start = ':package:';
+            const start = '📦';
             const author = 'github-actions[bot]';
 
             const comments = await github.rest.issues.listComments({


### PR DESCRIPTION
It looks like GitHub is no longer replacing `:package:` with `📦` when adding comments via the API

<img width="926" alt="image" src="https://github.com/openlayers/openlayers/assets/41094/5a2c75c0-2d69-475a-8517-5443d1091118">

This change makes use of 📦 directly in the comment.
