### PR TITLE
Clarify limitation on the WebGL layer swipe example

### DIFF
--- a/examples/webgl-layer-swipe.html
+++ b/examples/webgl-layer-swipe.html
@@ -7,6 +7,10 @@ docs: >
   used to manipulate the WebGL context before and after rendering.  In this case, the 
   <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/scissor"><code>gl.scissor()</code></a>
   method is called to clip the top layer based on the position of a slider.
+  <p><b>Note: </b>This example is minimalist and works as there is only one WebGL layer rendered. That might works as well if the layers are drawn to different contexts. This does not apply to
+    to several layers drawn to a single context, such as set with the 'className' property to 'canvas3d' on multiple layers. In such case, it's would be wise 
+    adapt your code using 'gl.clear' and other tweaks to the prerender/postrender event.
+  </p>
 tags: "swipe, webgl"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB


### PR DESCRIPTION
Following discussion with @jahow from past work we had and other issues that had popped up here and there (https://github.com/openlayers/openlayers/issues/14641) with the limitation of the WebGL swipe example, we discussed the fact that it should be a bit more visible that the current example is not perfect for real use case scenarios. 

I tried my best to just get some word around possible workarounds and the current state of "why it works now". It's by no mean perfect, as I wanted to stay short without going full technical.


