### PR TITLE
Fix `updateParams` in ImageMapGuide and ImageArcGISRest

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -93,7 +93,7 @@ class ImageArcGISRest extends ImageSource {
      * @private
      * @type {!Object}
      */
-    this.params_ = options.params || {};
+    this.params_ = Object.assign({}, options.params);
 
     /**
      * @private

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -97,12 +97,6 @@ class ImageArcGISRest extends ImageSource {
 
     /**
      * @private
-     * @type {import("../Image.js").default}
-     */
-    this.image_ = null;
-
-    /**
-     * @private
      * @type {import("../size.js").Size}
      */
     this.imageSize_ = [0, 0];
@@ -192,7 +186,6 @@ class ImageArcGISRest extends ImageSource {
    * @api
    */
   setImageLoadFunction(imageLoadFunction) {
-    this.image_ = null;
     this.imageLoadFunction_ = imageLoadFunction;
     this.changed();
   }
@@ -205,7 +198,7 @@ class ImageArcGISRest extends ImageSource {
   setUrl(url) {
     if (url != this.url_) {
       this.url_ = url;
-      this.image_ = null;
+      this.loader = null;
       this.changed();
     }
   }
@@ -217,8 +210,12 @@ class ImageArcGISRest extends ImageSource {
    */
   updateParams(params) {
     Object.assign(this.params_, params);
-    this.image_ = null;
     this.changed();
+  }
+
+  changed() {
+    this.image = null;
+    super.changed();
   }
 }
 

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -109,12 +109,6 @@ class ImageMapGuide extends ImageSource {
 
     /**
      * @private
-     * @type {import("../Image.js").default}
-     */
-    this.image_ = null;
-
-    /**
-     * @private
      * @type {number}
      */
     this.renderedRevision_ = 0;
@@ -194,9 +188,13 @@ class ImageMapGuide extends ImageSource {
    * @api
    */
   setImageLoadFunction(imageLoadFunction) {
-    this.image_ = null;
     this.imageLoadFunction_ = imageLoadFunction;
     this.changed();
+  }
+
+  changed() {
+    this.image = null;
+    super.changed();
   }
 }
 

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -64,7 +64,7 @@ class ImageMapGuide extends ImageSource {
      * @private
      * @type {!Object}
      */
-    this.params_ = options.params || {};
+    this.params_ = Object.assign({}, options.params);
 
     /**
      * @private

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -81,7 +81,7 @@ class ImageWMS extends ImageSource {
      * @private
      * @type {!Object}
      */
-    this.params_ = options.params;
+    this.params_ = Object.assign({}, options.params);
 
     /**
      * @private

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -92,7 +92,7 @@ class TileArcGISRest extends TileImage {
      * @private
      * @type {!Object}
      */
-    this.params_ = options.params || {};
+    this.params_ = Object.assign({}, options.params);
 
     /**
      * @private

--- a/test/browser/spec/ol/source/ImageArcGISRest.test.js
+++ b/test/browser/spec/ol/source/ImageArcGISRest.test.js
@@ -163,32 +163,26 @@ describe('ol/source/ImageArcGISRest', function () {
     it('verify getting a param', function () {
       options.params.TEST = 'value';
       const source = new ImageArcGISRest(options);
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'value'});
     });
 
     it('verify on adding a param', function () {
       options.params.TEST = 'value';
-
       const source = new ImageArcGISRest(options);
       source.updateParams({'TEST2': 'newValue'});
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'value', TEST2: 'newValue'});
+      expect(options.params).to.eql({TEST: 'value'});
     });
 
     it('verify on update a param', function () {
       options.params.TEST = 'value';
-
       const source = new ImageArcGISRest(options);
       source.updateParams({'TEST': 'newValue'});
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'newValue'});
+      expect(options.params).to.eql({TEST: 'value'});
     });
   });
 

--- a/test/browser/spec/ol/source/ImageMapGuide.test.js
+++ b/test/browser/spec/ol/source/ImageMapGuide.test.js
@@ -1,0 +1,37 @@
+import ImageMapGuide from '../../../../../src/ol/source/ImageMapGuide.js';
+
+describe('ol/source/ImageMapGuide', function () {
+  let options;
+  beforeEach(function () {
+    options = {
+      params: {
+        'MAPDEFINITION': 'mdf',
+      },
+      url: new URL('/mapagent.fcgi?', window.location.href).toString(),
+    };
+  });
+
+  describe('#getParams', function () {
+    it('verify getting a param', function () {
+      const source = new ImageMapGuide(options);
+      const setParams = source.getParams();
+      expect(setParams).to.eql({MAPDEFINITION: 'mdf'});
+    });
+
+    it('verify on adding a param', function () {
+      const source = new ImageMapGuide(options);
+      source.updateParams({'TEST': 'value'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({MAPDEFINITION: 'mdf', TEST: 'value'});
+      expect(options.params).to.eql({MAPDEFINITION: 'mdf'});
+    });
+
+    it('verify on update a param', function () {
+      const source = new ImageMapGuide(options);
+      source.updateParams({'MAPDEFINITION': 'newValue'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({MAPDEFINITION: 'newValue'});
+      expect(options.params).to.eql({MAPDEFINITION: 'mdf'});
+    });
+  });
+});

--- a/test/browser/spec/ol/source/ImageMapGuide.test.js
+++ b/test/browser/spec/ol/source/ImageMapGuide.test.js
@@ -1,4 +1,8 @@
+import ImageLayer from '../../../../../src/ol/layer/Image.js';
 import ImageMapGuide from '../../../../../src/ol/source/ImageMapGuide.js';
+import ImageState from '../../../../../src/ol/ImageState.js';
+import Map from '../../../../../src/ol/Map.js';
+import View from '../../../../../src/ol/View.js';
 
 describe('ol/source/ImageMapGuide', function () {
   let options;
@@ -9,6 +13,52 @@ describe('ol/source/ImageMapGuide', function () {
       },
       url: new URL('/mapagent.fcgi?', window.location.href).toString(),
     };
+  });
+
+  describe('#updateParams', function () {
+    let map;
+    beforeEach(function () {
+      const target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      document.body.removeChild(map.getTargetElement());
+      map.setTarget(null);
+    });
+
+    it('reloads from server', function (done) {
+      const srcs = [];
+      const source = new ImageMapGuide(options);
+      source.setImageLoadFunction(function (image, src) {
+        srcs.push(src);
+        image.state = ImageState.LOADED;
+        source.loading = false;
+      });
+      map.addLayer(new ImageLayer({source: source}));
+      map.once('rendercomplete', function () {
+        source.updateParams({'MAPDEFINITION': 'newValue'});
+        map.once('rendercomplete', function () {
+          expect(srcs.length).to.be(2);
+          expect(new URL(srcs[0]).searchParams.get('MAPDEFINITION')).to.be(
+            'mdf'
+          );
+          expect(new URL(srcs[1]).searchParams.get('MAPDEFINITION')).to.be(
+            'newValue'
+          );
+          done();
+        });
+      });
+    });
   });
 
   describe('#getParams', function () {

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -34,6 +34,30 @@ describe('ol/source/ImageWMS', function () {
     };
   });
 
+  describe('#getParams', function () {
+    it('verify getting a param', function () {
+      const source = new ImageWMS(options);
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'layer'});
+    });
+
+    it('verify on adding a param', function () {
+      const source = new ImageWMS(options);
+      source.updateParams({'TEST': 'value'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'layer', TEST: 'value'});
+      expect(options.params).to.eql({'LAYERS': 'layer'});
+    });
+
+    it('verify on update a param', function () {
+      const source = new ImageWMS(options);
+      source.updateParams({'LAYERS': 'newLayer'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'newLayer'});
+      expect(options.params).to.eql({'LAYERS': 'layer'});
+    });
+  });
+
   describe('#getImage', function () {
     it('creates an image with the expected URL', function () {
       [1, 1.5].forEach(function (ratio) {

--- a/test/browser/spec/ol/source/TileArcGISRest.test.js
+++ b/test/browser/spec/ol/source/TileArcGISRest.test.js
@@ -148,32 +148,26 @@ describe('ol.source.TileArcGISRest', function () {
     it('verify getting a param', function () {
       options.params.TEST = 'value';
       const source = new TileArcGISRest(options);
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'value'});
     });
 
     it('verify on adding a param', function () {
       options.params.TEST = 'value';
-
       const source = new TileArcGISRest(options);
       source.updateParams({'TEST2': 'newValue'});
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'value', TEST2: 'newValue'});
+      expect(options.params).to.eql({TEST: 'value'});
     });
 
     it('verify on update a param', function () {
       options.params.TEST = 'value';
-
       const source = new TileArcGISRest(options);
       source.updateParams({'TEST': 'newValue'});
-
       const setParams = source.getParams();
-
       expect(setParams).to.eql({TEST: 'newValue'});
+      expect(options.params).to.eql({TEST: 'value'});
     });
   });
 

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -32,6 +32,30 @@ describe('ol/source/TileWMS', function () {
     });
   });
 
+  describe('#getParams', function () {
+    it('verify getting a param', function () {
+      const source = new TileWMS(options);
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'layer'});
+    });
+
+    it('verify on adding a param', function () {
+      const source = new TileWMS(options);
+      source.updateParams({'TEST': 'value'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'layer', TEST: 'value'});
+      expect(options.params).to.eql({'LAYERS': 'layer'});
+    });
+
+    it('verify on update a param', function () {
+      const source = new TileWMS(options);
+      source.updateParams({'LAYERS': 'newLayer'});
+      const setParams = source.getParams();
+      expect(setParams).to.eql({'LAYERS': 'newLayer'});
+      expect(options.params).to.eql({'LAYERS': 'layer'});
+    });
+  });
+
   describe('#getInterpolate()', function () {
     it('is true by default', function () {
       const source = new TileWMS();


### PR DESCRIPTION
Fixes #15407

Ensure `updateParams` takes immediate effect, resetting the inherited `this.image` instead of the unused `this.image_` by making the code consistent with ImageWMS.

Also apply the #14048 changes for WMS to these and TileArcGISRest (reapplying to ImageWMS to prevent a regression).