### PR TITLE
Implement `geometry-type` operator in CPU

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -32,6 +32,7 @@ import {
  * @property {Object} variables The values for variables used in 'var' expressions.
  * @property {number} resolution The map resolution.
  * @property {string|number|null} featureId The feature id.
+ * @property {string} geometryType Geometry type of the current object.
  */
 
 /**
@@ -43,6 +44,7 @@ export function newEvaluationContext() {
     properties: {},
     resolution: NaN,
     featureId: null,
+    geometryType: '',
   };
 }
 
@@ -129,7 +131,10 @@ function compileExpression(expression, context) {
       return compileAccessorExpression(expression, context);
     }
     case Ops.Id: {
-      return (expression) => expression.featureId;
+      return (context) => context.featureId;
+    }
+    case Ops.GeometryType: {
+      return (context) => context.geometryType;
     }
     case Ops.Concat: {
       const args = expression.args.map((e) => compileExpression(e, context));
@@ -182,7 +187,6 @@ function compileExpression(expression, context) {
       throw new Error(`Unsupported operator ${operator}`);
     }
     // TODO: unimplemented
-    // Ops.GeometryType
     // Ops.Zoom
     // Ops.Time
     // Ops.Between

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -11,6 +11,7 @@ import {
   NumberType,
   Ops,
   StringType,
+  computeGeometryType,
   isType,
   overlapsType,
   parse,
@@ -232,31 +233,13 @@ const compilers = {
   },
   [Ops.GeometryType]: (context, expression, type) => {
     const propName = 'geometryType';
-    const computeType = (geometry) => {
-      const type = geometry.getType();
-      switch (type) {
-        case 'Point':
-        case 'LineString':
-        case 'Polygon':
-          return type;
-        case 'MultiPoint':
-        case 'MultiLineString':
-        case 'MultiPolygon':
-          return type.substring(5);
-        case 'Circle':
-          return 'Polygon';
-        case 'GeometryCollection':
-          return computeType(geometry.getGeometries()[0]);
-        default:
-      }
-    };
     const isExisting = propName in context.properties;
     if (!isExisting) {
       context.properties[propName] = {
         name: propName,
         type: StringType,
         evaluator: (feature) => {
-          return computeType(feature.getGeometry());
+          return computeGeometryType(feature.getGeometry());
         },
       };
     }

--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -15,6 +15,7 @@ import {
   NumberArrayType,
   NumberType,
   StringType,
+  computeGeometryType,
   newParsingContext,
 } from '../../expr/expression.js';
 import {buildExpression, newEvaluationContext} from '../../expr/cpu.js';
@@ -83,6 +84,11 @@ export function rulesToStyleFunction(rules) {
       } else {
         evaluationContext.featureId = null;
       }
+    }
+    if (parsingContext.geometryType) {
+      evaluationContext.geometryType = computeGeometryType(
+        feature.getGeometry()
+      );
     }
     return evaluator(evaluationContext);
   };

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -70,6 +70,24 @@ describe('ol/expr/cpu.js', () => {
         expected: 'forty-two',
       },
       {
+        name: 'geometry-type',
+        type: StringType,
+        expression: ['geometry-type'],
+        context: {
+          geometryType: 'LineString',
+        },
+        expected: 'LineString',
+      },
+      {
+        name: 'geometry-type (empty)',
+        type: StringType,
+        expression: ['geometry-type'],
+        context: {
+          geometryType: '',
+        },
+        expected: '',
+      },
+      {
         name: 'resolution',
         type: NumberType,
         expression: ['resolution'],

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -9,12 +9,21 @@ import {
   NumberArrayType,
   NumberType,
   StringType,
+  computeGeometryType,
   includesType,
   isType,
   newParsingContext,
   parse,
   typeName,
 } from '../../../../src/ol/expr/expression.js';
+import {
+  Circle,
+  GeometryCollection,
+  MultiLineString,
+  MultiPoint,
+  MultiPolygon,
+  Point,
+} from '../../../../src/ol/geom.js';
 
 describe('ol/expr/expression.js', () => {
   describe('parse()', () => {
@@ -622,6 +631,31 @@ describe('ol/expr/expression.js', () => {
       expect(isType(ColorType, NumberArrayType)).to.be(false);
       expect(isType(NumberArrayType, NumberArrayType)).to.be(true);
       expect(isType(AnyType, NumberArrayType)).to.be(false);
+    });
+  });
+  describe('computeGeometryType', () => {
+    it('returns empty string for falsy geom', () => {
+      expect(computeGeometryType(undefined)).to.eql('');
+    });
+    it('returns Point for Point geom', () => {
+      expect(computeGeometryType(new Point([0, 1]))).to.eql('Point');
+    });
+    it('returns Polygon for MultiPolygon geom', () => {
+      expect(computeGeometryType(new MultiPolygon([]))).to.eql('Polygon');
+    });
+    it('returns LineString for MultiLineString geom', () => {
+      expect(computeGeometryType(new MultiLineString([]))).to.eql('LineString');
+    });
+    it('returns first geom type in geometry collection', () => {
+      expect(
+        computeGeometryType(new GeometryCollection([new Circle([0, 1])]))
+      ).to.eql('Polygon');
+      expect(
+        computeGeometryType(new GeometryCollection([new MultiPoint([])]))
+      ).to.eql('Point');
+    });
+    it('returns empty string for empty geom collection', () => {
+      expect(computeGeometryType(new GeometryCollection([]))).to.eql('');
     });
   });
 });

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -9,14 +9,7 @@ import {
   StringType,
   newParsingContext,
 } from '../../../../src/ol/expr/expression.js';
-import {
-  Circle,
-  GeometryCollection,
-  MultiLineString,
-  MultiPoint,
-  MultiPolygon,
-  Point,
-} from '../../../../src/ol/geom.js';
+import {MultiPolygon} from '../../../../src/ol/geom.js';
 import {
   arrayToGlsl,
   buildExpression,
@@ -171,20 +164,8 @@ describe('ol/expr/gpu.js', () => {
           expect(prop.name).to.equal('geometryType');
           expect(prop.type).to.equal(StringType);
           expect(prop.evaluator).to.be.an(Function);
-          const results = [
-            new Feature(new Point([0, 1])),
-            new Feature(new MultiPolygon([])),
-            new Feature(new MultiLineString([])),
-            new Feature(new GeometryCollection([new Circle([0, 1])])),
-            new Feature(new GeometryCollection([new MultiPoint([])])),
-          ].map(prop.evaluator);
-          expect(results).to.eql([
-            'Point',
-            'Polygon',
-            'LineString',
-            'Polygon',
-            'Point',
-          ]);
+          const feature = new Feature(new MultiPolygon([]));
+          expect(prop.evaluator(feature)).to.eql('Polygon');
         },
       },
       {


### PR DESCRIPTION
This PR implements the `geometry-type` operator on the CPU compiler.

Part of #15413 