### PR TITLE
WebGL / Filter geometries before processing them for rendering

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -253,6 +253,7 @@ export class CallExpression {
  * @property {Set<string>} properties Properties referenced with the 'get' operator.
  * @property {boolean} featureId The style uses the feature id.
  * @property {boolean} geometryType The style uses the feature geometry type.
+ * @property {boolean} mapState The style uses the map state (view state or time elapsed).
  */
 
 /**
@@ -264,6 +265,7 @@ export function newParsingContext() {
     properties: new Set(),
     featureId: false,
     geometryType: false,
+    mapState: false,
   };
 }
 
@@ -443,9 +445,9 @@ const parsers = {
   ),
   [Ops.GeometryType]: createCallExpressionParser(usesGeometryType, withNoArgs),
   [Ops.LineMetric]: createCallExpressionParser(withNoArgs),
-  [Ops.Resolution]: createCallExpressionParser(withNoArgs),
-  [Ops.Zoom]: createCallExpressionParser(withNoArgs),
-  [Ops.Time]: createCallExpressionParser(withNoArgs),
+  [Ops.Resolution]: createCallExpressionParser(usesMapState, withNoArgs),
+  [Ops.Zoom]: createCallExpressionParser(usesMapState, withNoArgs),
+  [Ops.Time]: createCallExpressionParser(usesMapState, withNoArgs),
   [Ops.Any]: createCallExpressionParser(
     hasArgsCount(2, Infinity),
     withArgsOfType(BooleanType),
@@ -658,6 +660,13 @@ function usesFeatureId(encoded, returnType, context) {
  */
 function usesGeometryType(encoded, returnType, context) {
   context.geometryType = true;
+}
+
+/**
+ * @type {ArgValidator}
+ */
+function usesMapState(encoded, returnType, context) {
+  context.mapState = true;
 }
 
 /**

--- a/src/ol/render/webgl/MixedGeometryBatch.js
+++ b/src/ol/render/webgl/MixedGeometryBatch.js
@@ -92,7 +92,7 @@ class MixedGeometryBatch {
 
     /**
      * The precision in WebGL shaders is limited.
-     * To keep the refs as small as possible we maintain an array of returned references.
+     * To keep the refs as small as possible we maintain an array of freed up references.
      * @type {Array<number>}
      * @private
      */
@@ -533,8 +533,7 @@ class MixedGeometryBatch {
    * @param {Feature|RenderFeature} feature Feature
    */
   removeFeature(feature) {
-    let entry;
-    entry = this.clearFeatureEntryInPointBatch_(feature) || entry;
+    let entry = this.clearFeatureEntryInPointBatch_(feature);
     entry = this.clearFeatureEntryInPolygonBatch_(feature) || entry;
     entry = this.clearFeatureEntryInLineStringBatch_(feature) || entry;
     if (entry) {
@@ -565,6 +564,27 @@ class MixedGeometryBatch {
    */
   getFeatureFromRef(ref) {
     return this.refToFeature_.get(ref);
+  }
+
+  isEmpty() {
+    return this.globalCounter_ === 0;
+  }
+
+  /**
+   * Will return a new instance of this class that only contains the features
+   * for which the provided callback returned true
+   * @param {function((Feature|RenderFeature)): boolean} featureFilter Feature filter callback
+   * @return {MixedGeometryBatch} Filtered geometry batch
+   */
+  filter(featureFilter) {
+    const filtered = new MixedGeometryBatch();
+    const features = this.refToFeature_.entries();
+    for (const [, feature] of features) {
+      if (featureFilter(feature)) {
+        filtered.addFeature(feature);
+      }
+    }
+    return filtered;
   }
 }
 

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -1,6 +1,12 @@
 /**
  * @module ol/render/webgl/VectorStyleRenderer
  */
+import {buildExpression, newEvaluationContext} from '../../expr/cpu.js';
+import {
+  BooleanType,
+  computeGeometryType,
+  newParsingContext,
+} from '../../expr/expression.js';
 import {
   create as createTransform,
   makeInverse as makeInverseTransform,
@@ -120,8 +126,9 @@ class VectorStyleRenderer {
    * @param {import('../../style/flat.js').StyleVariables} variables Style variables
    * @param {import('../../webgl/Helper.js').default} helper Helper
    * @param {boolean} [enableHitDetection] Whether to enable the hit detection (needs compatible shader)
+   * @param {import("../../expr/expression.js").ExpressionValue} [filter] Optional filter expression
    */
-  constructor(styleOrShaders, variables, helper, enableHitDetection) {
+  constructor(styleOrShaders, variables, helper, enableHitDetection, filter) {
     /**
      * @private
      * @type {import('../../webgl/Helper.js').default}
@@ -213,6 +220,15 @@ class VectorStyleRenderer {
        * @private
        */
       this.symbolFragmentShader_ = asShaders.builder.getSymbolFragmentShader();
+    }
+
+    /**
+     * @type {function(import('../../Feature.js').FeatureLike): boolean}
+     * @private
+     */
+    this.featureFilter_ = null;
+    if (filter) {
+      this.featureFilter_ = this.computeFeatureFilter(filter);
     }
 
     const hitDetectionAttributes = this.hitDetectionEnabled_
@@ -322,13 +338,56 @@ class VectorStyleRenderer {
   }
 
   /**
+   * Will apply the style filter when generating geometry batches (if it can be evaluated outside a map context)
+   * @param {import("../../expr/expression.js").ExpressionValue} filter Style filter
+   * @return {function(import('../../Feature.js').FeatureLike): boolean} Feature filter
+   * @private
+   */
+  computeFeatureFilter(filter) {
+    const parsingContext = newParsingContext();
+    try {
+      const compiled = buildExpression(filter, BooleanType, parsingContext);
+
+      // do not apply the filter if it depends on map state (e.g. zoom level) or any variable
+      if (parsingContext.mapState || parsingContext.variables.size > 0) {
+        return null;
+      }
+
+      const evalContext = newEvaluationContext();
+      return (feature) => {
+        evalContext.properties = feature.getPropertiesInternal();
+        if (parsingContext.featureId) {
+          const id = feature.getId();
+          if (id !== undefined) {
+            evalContext.featureId = id;
+          } else {
+            evalContext.featureId = null;
+          }
+        }
+        evalContext.geometryType = computeGeometryType(feature.getGeometry());
+        return /** @type {boolean} */ (compiled(evalContext));
+      };
+    } catch {
+      // filter expression failed to compile for CPU: ignore it
+      return null;
+    }
+  }
+
+  /**
    * @param {import('./MixedGeometryBatch.js').default} geometryBatch Geometry batch
    * @param {import("../../transform.js").Transform} transform Transform to apply to coordinates
-   * @return {Promise<WebGLBuffers>} A promise resolving to WebGL buffers
+   * @return {Promise<WebGLBuffers|null>} A promise resolving to WebGL buffers; returns null if buffers are empty
    */
   async generateBuffers(geometryBatch, transform) {
+    let filteredBatch = geometryBatch;
+    if (this.featureFilter_) {
+      filteredBatch = filteredBatch.filter(this.featureFilter_);
+      if (filteredBatch.isEmpty()) {
+        return null;
+      }
+    }
     const renderInstructions = this.generateRenderInstructions_(
-      geometryBatch,
+      filteredBatch,
       transform,
     );
     const [polygonBuffers, lineStringBuffers, pointBuffers] = await Promise.all(

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -249,6 +249,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
           this.styleVariables_,
           this.helper,
           this.hitDetectionEnabled_,
+          'filter' in style ? style.filter : null,
         ),
     );
   }
@@ -566,7 +567,9 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    */
   disposeInternal() {
     this.buffers_.forEach((buffers) => {
-      this.disposeBuffers(buffers);
+      if (buffers) {
+        this.disposeBuffers(buffers);
+      }
     });
     if (this.sourceListenKeys_) {
       this.sourceListenKeys_.forEach(function (key) {

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -218,6 +218,7 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
         this.styleVariables_,
         this.helper,
         this.hitDetectionEnabled_,
+        'filter' in style ? style.filter : null,
       );
     });
   }
@@ -376,6 +377,9 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
     for (let i = 0, ii = this.styleRenderers_.length; i < ii; i++) {
       const renderer = this.styleRenderers_[i];
       const buffers = tileRepresentation.buffers[i];
+      if (!buffers) {
+        continue;
+      }
       renderer.render(buffers, frameState, () => {
         this.applyUniforms_(
           alpha,

--- a/src/ol/webgl/TileGeometry.js
+++ b/src/ol/webgl/TileGeometry.js
@@ -100,6 +100,38 @@ class TileGeometry extends BaseTileRepresentation {
       this.setReady();
     });
   }
+
+  /**
+   * @override
+   */
+  disposeInternal() {
+    this.buffers.forEach((buffers) => {
+      this.disposeBuffers(buffers);
+    });
+    super.disposeInternal();
+  }
+
+  /**
+   * Will release a set of Webgl buffers
+   * @param {import('../render/webgl/VectorStyleRenderer.js').WebGLBuffers} buffers Buffers
+   */
+  disposeBuffers(buffers) {
+    if (buffers.pointBuffers) {
+      buffers.pointBuffers
+        .filter(Boolean)
+        .forEach((buffer) => this.helper.deleteBuffer(buffer));
+    }
+    if (buffers.lineStringBuffers) {
+      buffers.lineStringBuffers
+        .filter(Boolean)
+        .forEach((buffer) => this.helper.deleteBuffer(buffer));
+    }
+    if (buffers.polygonBuffers) {
+      buffers.polygonBuffers
+        .filter(Boolean)
+        .forEach((buffer) => this.helper.deleteBuffer(buffer));
+    }
+  }
 }
 
 export default TileGeometry;

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -901,6 +901,8 @@ export function parseLiteralStyle(style, variables, filter) {
   parseStrokeProperties(style, builder, uniforms, vertContext, fragContext);
   parseFillProperties(style, builder, uniforms, vertContext, fragContext);
 
+  // note that the style filter may have already been applied earlier when building the rendering instructions
+  // this is still needed in case a filter cannot be evaluated statically beforehand (e.g. depending on time)
   if (filter) {
     const parsedFilter = expressionToGlsl(fragContext, filter, BooleanType);
     builder.setFragmentDiscardExpression(`!${parsedFilter}`);

--- a/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
+++ b/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
@@ -1226,4 +1226,73 @@ describe('MixedGeometryBatch', function () {
       expect(mixedBatch.pointBatch.geometriesCount).to.be(0);
     });
   });
+
+  describe('#filter', () => {
+    beforeEach(() => {
+      const feature1 = new Feature({
+        keep: true,
+        geometry: new Point([101, 102]),
+      });
+      const feature2 = new Feature({
+        keep: false,
+        geometry: new Point([201, 202]),
+      });
+      const feature3 = new Feature({
+        keep: false,
+        geometry: new Point([301, 302]),
+      });
+      const feature4 = new Feature({
+        keep: true,
+        geometry: new Point([401, 402]),
+      });
+      mixedBatch.addFeature(feature1);
+      mixedBatch.addFeature(feature2);
+      mixedBatch.addFeature(feature3);
+      mixedBatch.addFeature(feature4);
+    });
+    describe('partial filtering', () => {
+      beforeEach(() => {
+        mixedBatch = mixedBatch.filter((feature) => feature.get('keep'));
+      });
+
+      it('only keeps two features', () => {
+        expect(Object.keys(mixedBatch.pointBatch.entries)).to.have.length(2);
+        expect(mixedBatch.pointBatch.geometriesCount).to.be(2);
+      });
+
+      it('leaves polygon batch empty', () => {
+        expect(Object.keys(mixedBatch.polygonBatch.entries)).to.have.length(0);
+        expect(mixedBatch.polygonBatch.geometriesCount).to.be(0);
+      });
+
+      it('leaves linestring batch empty', () => {
+        expect(Object.keys(mixedBatch.lineStringBatch.entries)).to.have.length(
+          0,
+        );
+        expect(mixedBatch.lineStringBatch.geometriesCount).to.be(0);
+      });
+    });
+    describe('filtering out everything', () => {
+      beforeEach(() => {
+        mixedBatch = mixedBatch.filter(() => false);
+      });
+
+      it('leaves point batch empty', () => {
+        expect(Object.keys(mixedBatch.pointBatch.entries)).to.have.length(0);
+        expect(mixedBatch.pointBatch.geometriesCount).to.be(0);
+      });
+
+      it('leaves polygon batch empty', () => {
+        expect(Object.keys(mixedBatch.polygonBatch.entries)).to.have.length(0);
+        expect(mixedBatch.polygonBatch.geometriesCount).to.be(0);
+      });
+
+      it('leaves linestring batch empty', () => {
+        expect(Object.keys(mixedBatch.lineStringBatch.entries)).to.have.length(
+          0,
+        );
+        expect(mixedBatch.lineStringBatch.geometriesCount).to.be(0);
+      });
+    });
+  });
 });

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -475,4 +475,83 @@ describe('VectorStyleRenderer', () => {
       ]);
     });
   });
+  describe('applying a style filter', () => {
+    let buffers;
+    const style = {
+      'fill-color': 'green',
+      'stroke-width': 2,
+      'circle-radius': 6,
+    };
+    describe('excluding only some objects', () => {
+      beforeEach(async () => {
+        const filter = ['<', ['get', 'test'], 2500];
+        vectorStyleRenderer = new VectorStyleRenderer(
+          {style, filter},
+          {},
+          helper,
+          true,
+          filter,
+        );
+        sinonSpy(geometryBatch, 'filter');
+        buffers = await vectorStyleRenderer.generateBuffers(
+          geometryBatch,
+          SAMPLE_TRANSFORM,
+        );
+      });
+      it('compiles filter to be run on CPU', () => {
+        const filterFn = vectorStyleRenderer.featureFilter_;
+        expect(filterFn(geometryBatch.getFeatureFromRef(1))).to.be(true);
+        expect(filterFn(geometryBatch.getFeatureFromRef(2))).to.be(true);
+        expect(filterFn(geometryBatch.getFeatureFromRef(3))).to.be(false);
+        expect(filterFn(geometryBatch.getFeatureFromRef(4))).to.be(false);
+      });
+      it('applies filter and generates buffer', () => {
+        expect(geometryBatch.filter.callCount).to.be(1);
+        expect(buffers.pointBuffers).not.to.be(null);
+        expect(buffers.lineStringBuffers).not.to.be(null);
+        expect(buffers.polygonBuffers).not.to.be(null);
+      });
+    });
+    describe('excluding all objects', () => {
+      beforeEach(async () => {
+        const filter = ['>', ['get', 'test'], 10000];
+        vectorStyleRenderer = new VectorStyleRenderer(
+          {style, filter},
+          {},
+          helper,
+          true,
+          filter,
+        );
+        sinonSpy(geometryBatch, 'filter');
+        buffers = await vectorStyleRenderer.generateBuffers(
+          geometryBatch,
+          SAMPLE_TRANSFORM,
+        );
+      });
+      it('applies filter and returns null', () => {
+        expect(geometryBatch.filter.callCount).to.be(1);
+        expect(buffers).to.be(null);
+      });
+    });
+    describe('does not apply filter if it depends on map state', () => {
+      beforeEach(async () => {
+        const filter = ['>', ['zoom'], 2];
+        vectorStyleRenderer = new VectorStyleRenderer(
+          {style, filter},
+          {},
+          helper,
+          true,
+          filter,
+        );
+        sinonSpy(geometryBatch, 'filter');
+        buffers = await vectorStyleRenderer.generateBuffers(
+          geometryBatch,
+          SAMPLE_TRANSFORM,
+        );
+      });
+      it('does not filter the geometry batches', () => {
+        expect(geometryBatch.filter.callCount).to.be(0);
+      });
+    });
+  });
 });

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -188,6 +188,59 @@ describe('ol/renderer/webgl/VectorLayer', () => {
     });
   });
 
+  describe('style with filters', () => {
+    let spy, styleWithFilters;
+    beforeEach(() => {
+      styleWithFilters = [
+        {
+          style: {
+            'circle-radius': 4,
+          },
+          filter: ['==', ['get', 'category'], 'A'],
+        },
+        {
+          style: {
+            'stroke-width': 2,
+          },
+          else: true,
+        },
+      ];
+      renderer = new WebGLVectorLayerRenderer(vectorLayer, {
+        style: styleWithFilters,
+      });
+      spy = sinonSpy(ol_render_webgl_vectorstylerenderer, 'default');
+      renderer.helper = new WebGLHelper();
+      renderer.afterHelperCreated(frameState);
+    });
+    afterEach(() => {
+      renderer.helper.dispose();
+      spy.restore();
+    });
+
+    it('passes the filters along styles to renderers', () => {
+      expect(spy.callCount).to.be(2);
+      expect(
+        spy.calledWith(
+          styleWithFilters[0],
+          undefined,
+          renderer.helper,
+          true,
+          styleWithFilters[0].filter,
+        ),
+      ).to.be(true);
+      expect(
+        spy.calledWith({
+          style: styleWithFilters[1].style,
+          filter: ['!', styleWithFilters[0].filter],
+        }),
+        undefined,
+        renderer.helper,
+        true,
+        ['!', styleWithFilters[0].filter],
+      ).to.be(true);
+    });
+  });
+
   describe('#reset', () => {
     beforeEach(() => {
       // first call prepareFrame to initialize the helper

--- a/test/browser/spec/ol/webgl/TileGeometry.test.js
+++ b/test/browser/spec/ol/webgl/TileGeometry.test.js
@@ -136,5 +136,26 @@ describe('ol/webgl/TileGeometry', function () {
         -100, -200, 300, -200, 300, 400, -100, 400,
       ]);
     });
+
+    describe('#dispose', () => {
+      let deleteBufferSpy;
+      beforeEach(async () => {
+        deleteBufferSpy = sinonSpy(helper, 'deleteBuffer');
+        // generate buffers and dispose the tile
+        styleRenderers[0].endGenerate_({
+          pointBuffers: [{}, {}],
+          polygonBuffers: [{}, {}],
+        });
+        styleRenderers[1].endGenerate_({
+          polygonBuffers: [{}, {}],
+          lineStringBuffers: [{}, {}],
+        });
+        await new Promise((resolve) => setTimeout(resolve));
+        tileGeometry.dispose();
+      });
+      it('deletes webgl buffers', () => {
+        expect(deleteBufferSpy.callCount).to.be(8); // 2 for points, 4 for polygons, 2 for line strings
+      });
+    });
   });
 });

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -144,6 +144,20 @@ describe('ol/expr/expression.js', () => {
       expect(context.variables.has('foo')).to.be(true);
     });
 
+    it('parses an expression relying on map state', () => {
+      let context = newParsingContext();
+      parse(['zoom'], NumberType, context);
+      expect(context.mapState).to.be(true);
+
+      context = newParsingContext();
+      parse(['resolution'], NumberType, context);
+      expect(context.mapState).to.be(true);
+
+      context = newParsingContext();
+      parse(['time'], NumberType, context);
+      expect(context.mapState).to.be(true);
+    });
+
     it('parses a concat expression', () => {
       const context = newParsingContext();
       const expression = parse(


### PR DESCRIPTION
This PR introduces a `filter()` method on the `MixedGeometryBatch` class. Before generating WebGL buffers from a geometry batch, the `VectorStyleRenderer` will apply the style filter and exclude from the batch any geometry that does not match this filter. The style filter expression is evaluated on the CPU.

Some filters might not be evaluated at buffer generation time (e.g. a filter depending on `time` or `resolution` which are dynamic parameters). This entails that the filter is _also_ still applied on the GPU (fragment shader) to make sure that we filter our all relevant features at any given frame.

This change typically makes vector tiles processing a little bit longer, but is essential when rendering styles composed of dozens of different rules where it provides a huge performance boost.

Rebased on https://github.com/openlayers/openlayers/pull/15415

Part of https://github.com/openlayers/openlayers/pull/15413