### PR TITLE
Trackpad zoom by 1 too when view has a zoom constraint

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -221,7 +221,7 @@ class MouseWheelZoom extends Interaction {
     const view = map.getView();
     if (
       this.mode_ === 'trackpad' &&
-      !(view.getConstrainResolution() || this.constrainResolution_)
+      (view.getConstrainResolution() || this.constrainResolution_)
     ) {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);


### PR DESCRIPTION
Invert constrain check for trackpad to zoom by 1 too.

Thus, using similar _delta_ value inside `endInteraction_`, called after timeout, as in `handleWheelZoom_`.

Fix #15423 
