### PR TITLE
Make VectorLayer#getFeatures(pixel) work with useGeographic()

### DIFF
--- a/src/ol/render/canvas/hitdetect.js
+++ b/src/ol/render/canvas/hitdetect.js
@@ -7,6 +7,11 @@ import {Icon} from '../../style.js';
 import {ascending} from '../../array.js';
 import {clamp} from '../../math.js';
 import {createCanvasContext2D} from '../../dom.js';
+import {
+  getTransformFromProjections,
+  getUserProjection,
+  toUserExtent,
+} from '../../proj.js';
 import {intersects} from '../../extent.js';
 
 export const HIT_DETECT_RESOLUTION = 0.5;
@@ -20,9 +25,11 @@ export const HIT_DETECT_RESOLUTION = 0.5;
  * Features to consider for hit detection.
  * @param {import("../../style/Style.js").StyleFunction|undefined} styleFunction
  * Layer style function.
- * @param {import("../../extent.js").Extent} extent Extent.
+ * @param {import("../../extent.js").Extent} extent Extent in render projection.
  * @param {number} resolution Resolution.
  * @param {number} rotation Rotation.
+ * @param {number} [squaredTolerance] Squared tolerance.
+ * @param {import("../../proj/Projection.js").default} [projection] Render projection.
  * @return {ImageData} Hit detection image data.
  */
 export function createHitDetectionImageData(
@@ -32,8 +39,11 @@ export function createHitDetectionImageData(
   styleFunction,
   extent,
   resolution,
-  rotation
+  rotation,
+  squaredTolerance,
+  projection
 ) {
+  const userExtent = projection ? toUserExtent(extent, projection) : extent;
   const width = size[0] * HIT_DETECT_RESOLUTION;
   const height = size[1] * HIT_DETECT_RESOLUTION;
   const context = createCanvasContext2D(width, height);
@@ -44,7 +54,11 @@ export function createHitDetectionImageData(
     HIT_DETECT_RESOLUTION,
     extent,
     null,
-    rotation
+    rotation,
+    squaredTolerance,
+    projection
+      ? getTransformFromProjections(getUserProjection(), projection)
+      : null
   );
   const featureCount = features.length;
   // Stretch hit detection index to use the whole available color range
@@ -68,7 +82,7 @@ export function createHitDetectionImageData(
     for (let j = 0, jj = styles.length; j < jj; ++j) {
       const originalStyle = styles[j];
       const geometry = originalStyle.getGeometryFunction()(feature);
-      if (!geometry || !intersects(extent, geometry.getExtent())) {
+      if (!geometry || !intersects(userExtent, geometry.getExtent())) {
         continue;
       }
       const style = originalStyle.clone();

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -117,6 +117,12 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     /**
      * @private
+     * @type {number}
+     */
+    this.renderedPixelRatio_ = 1;
+
+    /**
+     * @private
      * @type {function(import("../../Feature.js").default, import("../../Feature.js").default): number|null}
      */
     this.renderedRenderOrder_ = null;
@@ -413,7 +419,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
             startX -= worldWidth;
           }
         }
-
+        const userProjection = getUserProjection();
         this.hitDetectionImageData_ = createHitDetectionImageData(
           size,
           transforms,
@@ -421,7 +427,9 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
           layer.getStyleFunction(),
           extent,
           resolution,
-          rotation
+          rotation,
+          getSquaredRenderTolerance(resolution, this.renderedPixelRatio_),
+          userProjection ? projection : null
         );
       }
       resolve(
@@ -740,6 +748,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     this.wrappedRenderedExtent_ = extent;
     this.renderedCenter_ = center;
     this.renderedProjection_ = projection;
+    this.renderedPixelRatio_ = pixelRatio;
     this.replayGroup_ = executorGroup;
     this.hitDetectionImageData_ = null;
 


### PR DESCRIPTION
`VectorLayer#getFeatures(pixel)` fails when a user projection is set (e.g. with `useGeographic()`). This pull request fixes that.