### PR TITLE
Fix RenderFeature#clone() for Point geometries

### DIFF
--- a/src/ol/render/Feature.js
+++ b/src/ol/render/Feature.js
@@ -107,9 +107,9 @@ class RenderFeature {
 
     /**
      * @private
-     * @type {Array<number>}
+     * @type {Array<number>|null}
      */
-    this.ends_ = ends;
+    this.ends_ = ends || null;
 
     /**
      * @private
@@ -173,7 +173,7 @@ class RenderFeature {
       this.flatInteriorPoints_ = getInteriorPointOfArray(
         this.flatCoordinates_,
         0,
-        /** @type {Array<number>} */ (this.ends_),
+        this.ends_,
         2,
         flatCenter,
         0
@@ -371,7 +371,7 @@ class RenderFeature {
     return new RenderFeature(
       this.type_,
       this.flatCoordinates_.slice(),
-      this.ends_.slice(),
+      this.ends_?.slice(),
       this.stride_,
       Object.assign({}, this.properties_),
       this.id_
@@ -379,7 +379,7 @@ class RenderFeature {
   }
 
   /**
-   * @return {Array<number>} Ends.
+   * @return {Array<number>|null} Ends.
    */
   getEnds() {
     return this.ends_;
@@ -490,7 +490,7 @@ export function toGeometry(renderFeature) {
       );
     case 'Polygon':
       const flatCoordinates = renderFeature.getFlatCoordinates();
-      const ends = /** @type {Array<number>} */ (renderFeature.getEnds());
+      const ends = renderFeature.getEnds();
       const endss = inflateEnds(flatCoordinates, ends);
       return endss.length > 1
         ? new MultiPolygon(flatCoordinates, 'XY', endss)

--- a/test/browser/spec/ol/render/feature.test.js
+++ b/test/browser/spec/ol/render/feature.test.js
@@ -306,4 +306,38 @@ describe('ol.render.Feature', function () {
       expect(feature.getType()).to.equal(type);
     });
   });
+
+  describe('#clone()', () => {
+    it('returns a clone of the feature', () => {
+      const feature = new RenderFeature(
+        type,
+        flatCoordinates,
+        ends,
+        2,
+        properties,
+        'foo'
+      );
+
+      const clone = feature.clone();
+      expect(clone).to.be.a(RenderFeature);
+      expect(clone.getType()).to.equal(feature.getType());
+      expect(clone.getFlatCoordinates()).to.eql(feature.getFlatCoordinates());
+      expect(clone.getEnds()).to.eql(feature.getEnds());
+      expect(clone.getStride()).to.equal(feature.getStride());
+      expect(clone.getProperties()).to.eql(feature.getProperties());
+      expect(clone.getId()).to.equal(feature.getId());
+    });
+
+    it('works with point geometries', () => {
+      const feature = new RenderFeature('Point', [1, 2], null, 2, {}, 'foo');
+      const clone = feature.clone();
+      expect(clone).to.be.a(RenderFeature);
+      expect(clone.getType()).to.equal(feature.getType());
+      expect(clone.getFlatCoordinates()).to.eql(feature.getFlatCoordinates());
+      expect(clone.getEnds()).to.eql(feature.getEnds());
+      expect(clone.getStride()).to.equal(feature.getStride());
+      expect(clone.getProperties()).to.eql(feature.getProperties());
+      expect(clone.getId()).to.equal(feature.getId());
+    });
+  });
 });


### PR DESCRIPTION
A RenderFeature with a Point geometry does not have `ends`, so the `clone()` method currently fails for Point geometries.

This pull request fixes that.