### PR TITLE
Use and recommend spatialreference.org for projection lookup

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -15,6 +15,16 @@
 
 * The `finishDrawing()` method now returns the drawn feature or `null` if no drawing could be finished. Previously it returned `undefined`.
 
+#### Removal of `epsgLookupMapTiler()` from `ol/proj/proj4.js`
+
+When upgrading, just remove
+```js
+setEPSGLookup(epsgLookupMapTiler(myApikey));
+```
+from your code.
+
+The `fromEPSGCode()` function from the `ol/proj/proj4.js` module now uses https://spatialreference.org/ instead of https://epsg.io/ to look up EPSG projection definitions. As a result, that function no longer creates projections from proj strings that require grid transforms to be configured in proj4.js. And because that was the only purpose why `epsgLookupMapTiler()` was created in the first place, it is now removed.
+
 ### 8.0.0
 
 #### Removal of deprecated properties and methods

--- a/examples/cog-projection.js
+++ b/examples/cog-projection.js
@@ -3,12 +3,7 @@ import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import XYZ from '../src/ol/source/XYZ.js';
 import proj4 from 'proj4';
-import {
-  epsgLookupMapTiler,
-  fromEPSGCode,
-  register,
-  setEPSGLookup,
-} from '../src/ol/proj/proj4.js';
+import {fromEPSGCode, register} from '../src/ol/proj/proj4.js';
 
 const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
 const attributions =
@@ -16,7 +11,6 @@ const attributions =
   '<a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>';
 
 register(proj4);
-setEPSGLookup(epsgLookupMapTiler(key));
 
 const cogSource = new GeoTIFF({
   sources: [

--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -1,12 +1,12 @@
 ---
 layout: example.html
-title: Reprojection with EPSG.io Search
+title: Reprojection with EPSG search
 shortdesc: Demonstrates client-side raster reprojection of OSM to arbitrary projection
 docs: >
   This example shows client-side raster reprojection capabilities from
   OSM (EPSG:3857) to arbitrary projection by searching
-  in <a href="https://epsg.io/">EPSG.io</a> database.
-tags: "reprojection, projection, proj4js, epsg.io, graticule"
+  for EPSG codes on <a href="https://spatialreference.org/">spatialreference.org</a>.
+tags: "reprojection, projection, proj4js, spatialreference.org, graticule"
 resources:
   - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css
 ---
@@ -15,7 +15,7 @@ resources:
   <span class="col-auto">
     <span class="input-group">
       <label class="input-group-text" for="epsg-query">Search projection:&nbsp</label>
-      <input type="text" id="epsg-query" placeholder="4326, 27700, 3031, US National Atlas, Swiss, France, ..." class="form-control" size="50" />
+      <input type="text" id="epsg-query" placeholder="4326, 27700, 3031, 9311, 2154, 21781, ..." class="form-control" size="50" />
       <button class="btn btn-outline-secondary" id="epsg-search">Search</button>
     </span>
   </span>

--- a/examples/wms-custom-proj.js
+++ b/examples/wms-custom-proj.js
@@ -8,6 +8,7 @@ import {
   addCoordinateTransforms,
   addProjection,
   transform,
+  transformExtent,
 } from '../src/ol/proj.js';
 
 // By default OpenLayers does not know about the EPSG:21781 (Swiss) projection.
@@ -17,9 +18,6 @@ import {
 
 const projection = new Projection({
   code: 'EPSG:21781',
-  // The extent is used to determine zoom level 0. Recommended values for a
-  // projection's validity extent can be found at https://epsg.io/.
-  extent: [485869.5728, 76443.1884, 837076.5648, 299941.7864],
   units: 'm',
 });
 addProjection(projection);
@@ -45,7 +43,15 @@ addCoordinateTransforms(
   },
 );
 
-const extent = [420000, 30000, 900000, 350000];
+// The extent is used to determine zoom level 0. Recommended values for a
+// projection's validity extent can be found at https://spatialreference.org/ref/epsg/21781/.
+const extent = transformExtent(
+  [5.96, 45.82, 10.49, 47.81],
+  'EPSG:4326',
+  projection,
+);
+projection.setExtent(extent);
+
 const layers = [
   new TileLayer({
     extent: extent,
@@ -88,6 +94,7 @@ const map = new Map({
     projection: projection,
     center: transform([8.23, 46.86], 'EPSG:4326', 'EPSG:21781'),
     extent: extent,
+    showFullExtent: true,
     zoom: 2,
   }),
 });

--- a/examples/wms-image-custom-proj.js
+++ b/examples/wms-image-custom-proj.js
@@ -5,7 +5,7 @@ import Projection from '../src/ol/proj/Projection.js';
 import View from '../src/ol/View.js';
 import proj4 from 'proj4';
 import {ScaleLine, defaults as defaultControls} from '../src/ol/control.js';
-import {fromLonLat} from '../src/ol/proj.js';
+import {fromLonLat, transformExtent} from '../src/ol/proj.js';
 import {register} from '../src/ol/proj/proj4.js';
 
 // Transparent Proj4js support:
@@ -16,10 +16,6 @@ import {register} from '../src/ol/proj/proj4.js';
 // Proj4js. To get the registered ol/proj/Projection instance with other
 // parameters like units and axis orientation applied from Proj4js, use
 // `ol/proj#get('EPSG:21781')`.
-//
-// Note that we are setting the projection's extent here, which is used to
-// determine the view resolution for zoom level 0. Recommended values for a
-// projection's validity extent can be found at https://epsg.io/.
 
 proj4.defs(
   'EPSG:21781',
@@ -31,10 +27,17 @@ register(proj4);
 
 const projection = new Projection({
   code: 'EPSG:21781',
-  extent: [485869.5728, 76443.1884, 837076.5648, 299941.7864],
 });
 
-const extent = [420000, 30000, 900000, 350000];
+// The extent is used to determine zoom level 0. Recommended values for a
+// projection's validity extent can be found at https://spatialreference.org/ref/epsg/21781/.
+const extent = transformExtent(
+  [5.96, 45.82, 10.49, 47.81],
+  'EPSG:4326',
+  projection,
+);
+projection.setExtent(extent);
+
 const layers = [
   new ImageLayer({
     extent: extent,
@@ -73,6 +76,7 @@ const map = new Map({
     projection: projection,
     center: fromLonLat([8.23, 46.86], projection),
     extent: extent,
+    showFullExtent: true,
     zoom: 2,
   }),
 });

--- a/site/src/doc/faq.md
+++ b/site/src/doc/faq.md
@@ -99,7 +99,7 @@ const map = new Map({
 ```
 
 We recommend to lookup parameters of your projection (like the validity extent)
-over at [epsg.io](https://epsg.io/).
+over at [spatialreference.org](https://spatialreference.org/).
 
 
 ## Why is my map centered on the gulf of guinea (or africa, the ocean, null-island)?

--- a/site/src/doc/tutorials/raster-reprojection.md
+++ b/site/src/doc/tutorials/raster-reprojection.md
@@ -11,7 +11,7 @@ The view in any Proj4js supported coordinate reference system is possible and pr
 
 # Usage
 
-The API usage is very simple. Just specify proper projection (e.g. using [EPSG](https://epsg.io) code) on `ol/View`:
+The API usage is very simple. Just specify proper projection (e.g. using [EPSG](https://spatialreference.org/ref/epsg/) code) on `ol/View`:
 
 ```js
 import Map from 'ol/Map.js';
@@ -46,7 +46,7 @@ If a source (based on `ol/source/TileImage` or `ol/source/Image`) has a projecti
 
 - [Raster reprojection demo](/en/latest/examples/reprojection.html)
 - [OpenStreetMap to WGS84 reprojection](/en/latest/examples/reprojection-wgs84.html)
-- [Reprojection with EPSG.io database search](/en/latest/examples/reprojection-by-code.html)
+- [Reprojection with EPSG database search](/en/latest/examples/reprojection-by-code.html)
 - [Image reprojection](/en/latest/examples/reprojection-image.html)
 
 ### Custom projection
@@ -55,7 +55,7 @@ The easiest way to use a custom projection is to add the [Proj4js](http://proj4j
 
     npm install proj4
 
-Following example shows definition of a [British National Grid](https://epsg.io/27700):
+Following example shows definition of a [British National Grid](https://spatialreference.org/ref/epsg/27700/):
 
 ```js
 import proj4 from 'proj4';

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -23,8 +23,7 @@
  * Proj4js, or create a custom build to support those projections you need; see
  * the Proj4js website for how to do this. You also need the Proj4js definitions
  * for the required projections. These definitions can be obtained from
- * https://epsg.io/, and are a JS function, so can be loaded in a script
- * tag (as in the examples) or pasted into your application.
+ * https://spatialreference.org/, using the PROJ4 or WKT v1 formats.
  *
  * After all required projection definitions are added to proj4's registry (by
  * using `proj4.defs()`), simply call `register(proj4)` from the `ol/proj/proj4`

--- a/test/node/ol/proj/proj4.test.js
+++ b/test/node/ol/proj/proj4.test.js
@@ -23,7 +23,7 @@ const epsgDefinitions = {
 async function mockEPSGLookup(code) {
   const definition = epsgDefinitions[code];
   if (!definition) {
-    throw new Error('Unexpected response from epsg.io: 404');
+    throw new Error('Unexpected response from spatialreference.org: 404');
   }
   return definition;
 }
@@ -124,7 +124,9 @@ describe('ol/proj/proj4.js', () => {
       }
 
       expect(error).to.be.an(Error);
-      expect(error.message).to.be('Unexpected response from epsg.io: 404');
+      expect(error.message).to.be(
+        'Unexpected response from spatialreference.org: 404',
+      );
     });
 
     it('throws if proj4 is not already registered', async () => {


### PR DESCRIPTION
Now that https://spatialreference.org/ is being [maintained by the PROJ OSGeo project](https://lists.osgeo.org/pipermail/proj/2024-January/011216.html) and has been updated to a static website built from the https://github.com/OSGeo/spatialreference.org/ repository,, I think it is time to switch back from epsg.io to spatialreference.org, both in our internal library use and in what we reference in examples and docs.

The key advantage is that the returned results from spatialreference.org are the same as  other projects that use PROJ, which - in the case of projections where grid transforms are available - means the returned definition will not use a grid transform. This is good because proj4.js requires additional configuration to work with grid transforms, and it allows us to get rid of the `fromEPSGLookupMaptiler()` function.

I also went through the examples and was able to simplify some of them.