### PR TITLE
Generate types for the full build

### DIFF
--- a/config/rollup-full-build.js
+++ b/config/rollup-full-build.js
@@ -4,7 +4,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
 export default {
-  input: 'build/index.js',
+  input: 'build/ol/dist/ol.js',
   output: {
     name: 'ol',
     format: 'iife',

--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -22,7 +22,7 @@ async function getSymbols() {
 function getImport(symbol, member) {
   const defaultExport = symbol.name.split('~');
   if (symbol.isDefaultExport) {
-    const from = defaultExport[0].replace(/^module\:/, './');
+    const from = defaultExport[0].replace(/^module\:/, '../../');
     const importName = from.replace(/[.\/]+/g, '$');
     return `import ${importName} from '${from}.js';`;
   }
@@ -32,7 +32,7 @@ function getImport(symbol, member) {
     namedExport.length > 1 &&
     (defaultExport.length <= 1 || defaultExport[0].includes('.'))
   ) {
-    const from = namedExport[0].replace(/^module\:/, './');
+    const from = namedExport[0].replace(/^module\:/, '../../');
     const importName = from.replace(/[.\/]+/g, '_');
     return `import {${member} as ${importName}$${member}} from '${from}.js';`;
   }
@@ -123,7 +123,7 @@ if (esMain(import.meta)) {
 
   main()
     .then(async (code) => {
-      const filepath = path.join(baseDir, '..', 'build', 'index.js');
+      const filepath = path.join(baseDir, '..', 'build', 'ol', 'dist', 'ol.js');
       await fse.outputFile(filepath, code);
     })
     .catch((err) => {


### PR DESCRIPTION
Fixes #15480.

The `ol/dist/` folder now gets additional `ol.d.ts` and `ol.d.ts.map` files. Because `ol.d.ts` is not a "full build d.ts" file and imports other `.d.ts` files from the distribution, users need to have the full distribution (downloaded from the website, or the ol package) available to make use of the types.