### PR TITLE
Fix #14954 - Add `willReadFrequently: true` to CanvasLayerRenderer context generation settings

### DIFF
--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -164,7 +164,9 @@ class CanvasLayerRenderer extends LayerRenderer {
     ) {
       const canvas = target.firstElementChild;
       if (canvas instanceof HTMLCanvasElement) {
-        context = canvas.getContext('2d');
+        context = canvas.getContext('2d', {
+          willReadFrequently: true,
+        });
       }
     }
     if (context && context.canvas.style.transform === transform) {
@@ -187,7 +189,9 @@ class CanvasLayerRenderer extends LayerRenderer {
       style.position = 'absolute';
       style.width = '100%';
       style.height = '100%';
-      context = createCanvasContext2D();
+      context = createCanvasContext2D(undefined, undefined, undefined, {
+        willReadFrequently: true,
+      });
       const canvas = context.canvas;
       container.appendChild(canvas);
       style = canvas.style;


### PR DESCRIPTION
Fixes #14954 by adding `willReadFrequently` in context generation settings for CanvasLayerRenderer.
