### PR TITLE
Add coalesce operator to expressions

### DIFF
--- a/examples/style-expressions.js
+++ b/examples/style-expressions.js
@@ -28,6 +28,7 @@ const map = new Map({
         'circle-fill-color': 'gray',
         'circle-stroke-color': 'white',
         'circle-stroke-width': 0.5,
+        'text-value': ['coalesce', ['get', 'missing'], 'default value'],
       },
     }),
     new Layer({

--- a/examples/style-expressions.js
+++ b/examples/style-expressions.js
@@ -28,7 +28,6 @@ const map = new Map({
         'circle-fill-color': 'gray',
         'circle-stroke-color': 'white',
         'circle-stroke-width': 0.5,
-        'text-value': ['coalesce', ['get', 'missing'], 'default value'],
       },
     }),
     new Layer({

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -183,6 +183,9 @@ function compileExpression(expression, context) {
     case Ops.Interpolate: {
       return compileInterpolateExpression(expression, context);
     }
+    case Ops.Coalesce: {
+      return compileCoalesceExpression(expression, context);
+    }
     default: {
       throw new Error(`Unsupported operator ${operator}`);
     }
@@ -460,6 +463,28 @@ function compileMatchExpression(expression, context) {
       }
     }
     return args[length - 1](context);
+  };
+}
+
+/**
+ * @param {import('./expression.js').CallExpression} expression The call expression.
+ * @param {import('./expression.js').ParsingContext} context The parsing context.
+ * @return {ExpressionEvaluator} The evaluator function.
+ */
+function compileCoalesceExpression(expression, context) {
+  const length = expression.args.length;
+  const args = new Array(length);
+  for (let i = 0; i < length; ++i) {
+    args[i] = compileExpression(expression.args[i], context);
+  }
+  return (ctx) => {
+    for (let i = 0; i < args.length; i++) {
+      const value = args[i](ctx);
+      if (typeof value !== 'undefined' && value !== null) {
+        return value;
+      }
+    }
+    return undefined;
   };
 }
 

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -70,6 +70,8 @@ import {isStringColor} from '../color.js';
  *     `input` and `stopX` values must all be of type `number`. `outputX` values can be `number` or `color` values.
  *     Note: `input` will be clamped between `stop1` and `stopN`, meaning that all output values will be comprised
  *     between `output1` and `outputN`.
+ *   * `['coalesce', value1, value2, ...]` returns the first value in the list which is not null or undefined.
+ *     An example would be to provide a default value for get: ['coalesce',['get','propertynanme'],'default value']]
  *
  * * Logical operators:
  *   * `['<', value1, value2]` returns `true` if `value1` is strictly lower than `value2`, or `false` otherwise.
@@ -357,6 +359,7 @@ export const Ops = {
   Match: 'match',
   Between: 'between',
   Interpolate: 'interpolate',
+  Coalesce: 'coalesce',
   Case: 'case',
   In: 'in',
   Number: 'number',
@@ -467,6 +470,19 @@ const parsers = {
     },
     withArgsCount(2, Infinity),
     parseArgsOfType(NumberType | ColorType),
+    narrowArgsType,
+  ),
+  [Ops.Coalesce]: createParser(
+    (parsedArgs) => {
+      let type = AnyType;
+      for (let i = 1; i < parsedArgs.length; i += 2) {
+        type &= parsedArgs[i].type;
+      }
+      type &= parsedArgs[parsedArgs.length - 1].type;
+      return type;
+    },
+    withArgsCount(2, Infinity),
+    parseArgsOfType(AnyType),
     narrowArgsType,
   ),
   [Ops.Divide]: createParser(

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -438,6 +438,7 @@ ${ifBlocks}
   // TODO: unimplemented
   // Ops.Number
   // Ops.String
+  // Ops.Coalesce
   // Ops.Concat
 };
 

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -133,6 +133,39 @@ describe('ol/expr/cpu.js', () => {
         expected: 'Feature foo',
       },
       {
+        name: 'coalesce (2 arguments, first has a value)',
+        type: StringType,
+        expression: ['coalesce', ['get', 'val'], 'default'],
+        context: {
+          properties: {val: 'test'},
+        },
+        expected: 'test',
+      },
+      {
+        name: 'coalesce (2 arguments, first has no value)',
+        type: StringType,
+        expression: ['coalesce', ['get', 'val'], 'default'],
+        context: {
+          properties: {},
+        },
+        expected: 'default',
+      },
+      {
+        name: 'coalesce (several arguments, first few have no value)',
+        type: StringType,
+        expression: [
+          'coalesce',
+          ['get', 'val'],
+          ['get', 'beer'],
+          ['get', 'present'],
+          'last resort',
+        ],
+        context: {
+          properties: {present: 'hello world'},
+        },
+        expected: 'hello world',
+      },
+      {
         name: 'any (true)',
         type: BooleanType,
         expression: ['any', ['get', 'nope'], ['get', 'yep'], ['get', 'nope']],

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -108,6 +108,18 @@ describe('ol/expr/expression.js', () => {
       expect(context.properties.has('foo')).to.be(true);
     });
 
+    it('parses a coalesce expression', () => {
+      const context = newParsingContext();
+      const expression = parse(
+        ['coalesce', ['get', 'foo'], 'default'],
+        context,
+      );
+      expect(expression).to.be.a(CallExpression);
+      expect(expression.operator).to.be('coalesce');
+      expect(isType(expression.type, AnyType));
+      expect(context.properties.has('foo')).to.be(true);
+    });
+
     it('parses id expression', () => {
       const context = newParsingContext();
       const expression = parse(['id'], context);


### PR DESCRIPTION
This adds a new operator to expressions - "coalesce", which takes 2 or more arguments, and returns the value of the first argument that is not null or undefined.

This is intended to be a solution which resolves #15490 , effectively providing a way of giving a default value for the event that a property value requested with the "get" operator does not exist for a feature.
