### PR TITLE
Generics for vector and vectortile source's formats

### DIFF
--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -9,7 +9,7 @@ class VectorTile extends Tile {
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
    * @param {string} src Data source url.
-   * @param {import("./format/Feature.js").default} format Feature format.
+   * @param {import("./format/Feature.js").default<typeof import("./Feature.js").default|typeof import("./render/Feature.js").default>} format Feature format.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
    * @param {import("./Tile.js").Options} [options] Tile options.
    */

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -130,7 +130,7 @@ export function loadFeaturesXhr(
  * loads features (with XHR), parses the features, and adds them to the
  * vector source.
  * @param {string|FeatureUrlFunction} url Feature URL service.
- * @param {import("./format/Feature.js").default} format Feature format.
+ * @param {import("./format/Feature.js").default<typeof import("./Feature.js").default|typeof import("./render/Feature.js").default>} format Feature format.
  * @return {FeatureLoader} The feature loader.
  * @api
  */

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -95,8 +95,13 @@ import {
  */
 
 /***
+ * @template {import("../Feature.js").FeatureLike} T
+ * @typedef {T extends import("../render/Feature.js").default ? typeof import("../render/Feature.js").default : typeof import("../Feature.js").default} FeatureToFeatureClass<T>
+ */
+
+/***
  * @template {import("../Feature.js").FeatureClass} T
- * @typedef {T extends typeof import("../render/Feature.js").default ? import("../render/Feature.js").default : import("../Feature.js").default} FeatureOrRenderFeature<T>
+ * @typedef {T[keyof T] extends import("../render/Feature.js").default ? import("../render/Feature.js").default : import("../Feature.js").default} FeatureClassToFeature<T>
  */
 
 /**
@@ -213,7 +218,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Element|ArrayBuffer|Object|string} source Source.
    * @param {ReadOptions} [options] Read options.
-   * @return {Array<FeatureOrRenderFeature<T>>} Features.
+   * @return {Array<import('../Feature.js').FeatureLike|FeatureClassToFeature<T>>} Features.
    */
   readFeatures(source, options) {
     return abstract();

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -33,7 +33,7 @@ import {isEmpty} from '../obj.js';
  */
 
 /**
- * @template {import("../Feature.js").FeatureClass} FeatureOrRenderFeature
+ * @template {import("../Feature.js").FeatureClass} FeatureClassToFeature
  * @typedef {Object} Options
  *
  * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
@@ -44,7 +44,7 @@ import {isEmpty} from '../obj.js';
  * the geometry_name field in the feature GeoJSON. If set to `true` the GeoJSON reader
  * will look for that field to set the geometry name. If both this field is set to `true`
  * and a `geometryName` is provided, the `geometryName` will take precedence.
- * @property {FeatureOrRenderFeature} [featureClass] Feature class
+ * @property {FeatureClassToFeature} [featureClass] Feature class
  * to be used when reading features. The default is {@link module:ol/Feature~Feature}. If performance is
  * the primary concern, and features are not going to be modified or round-tripped through the format,
  * consider using {@link module:ol/render/Feature~RenderFeature}

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -32,11 +32,11 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {import('./Feature.js').FeatureOrRenderFeature<T>} Feature.
+   * @return {import('./Feature.js').FeatureClassToFeature<T>} Feature.
    * @api
    */
   readFeature(source, options) {
-    return /** @type {import('./Feature.js').FeatureOrRenderFeature<T>} */ (
+    return /** @type {import('./Feature.js').FeatureClassToFeature<T>} */ (
       this.readFeatureFromObject(
         getObject(source),
         this.getReadOptions(source, options),
@@ -50,11 +50,11 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<T>>} Features.
    * @api
    */
   readFeatures(source, options) {
-    return /** @type {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} */ (
+    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<T>>} */ (
       this.readFeaturesFromObject(
         getObject(source),
         this.getReadOptions(source, options),

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -17,9 +17,9 @@ import {get} from '../proj.js';
 import {inflateEnds} from '../geom/flat/orient.js';
 
 /**
- * @template {import("../Feature.js").FeatureClass} FeatureOrRenderFeature
+ * @template {import("../Feature.js").FeatureClass} FeatureClassToFeature
  * @typedef {Object} Options
- * @property {FeatureOrRenderFeature} [featureClass] Class for features returned by
+ * @property {FeatureClassToFeature} [featureClass] Class for features returned by
  * {@link module:ol/format/MVT~MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
  * support at the cost of decreased rendering performance. The default is
  * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
@@ -248,7 +248,7 @@ class MVT extends FeatureFormat {
    *
    * @param {ArrayBuffer} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<T>>} Features.
    * @api
    */
   readFeatures(source, options) {
@@ -279,7 +279,7 @@ class MVT extends FeatureFormat {
       }
     }
 
-    return /** @type {Array<import('./Feature.js').FeatureOrRenderFeature<T>>} */ (
+    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<T>>} */ (
       features
     );
   }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -76,13 +76,13 @@ export class VectorSourceEvent extends Event {
  */
 
 /**
- * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
+ * @template {import("../Feature.js").FeatureLike} FeatureType
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {Array<FeatureClass>|Collection<FeatureClass>} [features]
+ * @property {Array<FeatureType>|Collection<FeatureType>} [features]
  * Features. If provided as {@link module:ol/Collection~Collection}, the features in the source
  * and the collection will stay in sync.
- * @property {import("../format/Feature.js").default} [format] The feature format used by the XHR
+ * @property {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>} [format] The feature format used by the XHR
  * feature loader when `url` is set. Required if `url` is set, otherwise ignored.
  * @property {import("../featureloader.js").FeatureLoader} [loader]
  * The loader function used to load features, from a remote source for example.
@@ -176,11 +176,11 @@ export class VectorSourceEvent extends Event {
  *
  * @fires VectorSourceEvent
  * @api
- * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
  */
 class VectorSource extends Source {
   /**
-   * @param {Options<FeatureClass>} [options] Vector source options.
+   * @param {Options<FeatureType>} [options] Vector source options.
    */
   constructor(options) {
     options = options || {};
@@ -216,7 +216,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {import("../format/Feature.js").default|undefined}
+     * @type {import("../format/Feature.js").default<import('../format/Feature.js').FeatureToFeatureClass<FeatureType>>|undefined}
      */
     this.format_ = options.format;
 
@@ -255,7 +255,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {RBush<FeatureClass>}
+     * @type {RBush<FeatureType>}
      */
     this.featuresRtree_ = useSpatialIndex ? new RBush() : null;
 
@@ -273,7 +273,7 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {!Object<string, FeatureClass>}
+     * @type {!Object<string, FeatureType>}
      */
     this.nullGeometryFeatures_ = {};
 
@@ -287,7 +287,7 @@ class VectorSource extends Source {
     /**
      * A lookup of features by uid (using getUid(feature)).
      * @private
-     * @type {!Object<string, FeatureClass>}
+     * @type {!Object<string, FeatureType>}
      */
     this.uidIndex_ = {};
 
@@ -299,13 +299,13 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {Collection<FeatureClass>|null}
+     * @type {Collection<FeatureType>|null}
      */
     this.featuresCollection_ = null;
 
-    /** @type {Collection<FeatureClass>} */
+    /** @type {Collection<FeatureType>} */
     let collection;
-    /** @type {Array<FeatureClass>} */
+    /** @type {Array<FeatureType>} */
     let features;
     if (Array.isArray(options.features)) {
       features = options.features;
@@ -333,7 +333,7 @@ class VectorSource extends Source {
    * Note: this also applies if an {@link module:ol/Collection~Collection} is used for features,
    * meaning that if a feature with a duplicate id is added in the collection, it will
    * be removed from it right away.
-   * @param {FeatureClass} feature Feature to add.
+   * @param {FeatureType} feature Feature to add.
    * @api
    */
   addFeature(feature) {
@@ -343,7 +343,7 @@ class VectorSource extends Source {
 
   /**
    * Add a feature without firing a `change` event.
-   * @param {FeatureClass} feature Feature.
+   * @param {FeatureType} feature Feature.
    * @protected
    */
   addFeatureInternal(feature) {
@@ -375,7 +375,7 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {FeatureClass} feature The feature.
+   * @param {FeatureType} feature The feature.
    * @private
    */
   setupChangeEvents_(featureKey, feature) {
@@ -395,7 +395,7 @@ class VectorSource extends Source {
 
   /**
    * @param {string} featureKey Unique identifier for the feature.
-   * @param {FeatureClass} feature The feature.
+   * @param {FeatureType} feature The feature.
    * @return {boolean} The feature is "valid", in the sense that it is also a
    *     candidate for insertion into the Rtree.
    * @private
@@ -433,7 +433,7 @@ class VectorSource extends Source {
 
   /**
    * Add a batch of features to the source.
-   * @param {Array<FeatureClass>} features Features to add.
+   * @param {Array<FeatureType>} features Features to add.
    * @api
    */
   addFeatures(features) {
@@ -443,14 +443,14 @@ class VectorSource extends Source {
 
   /**
    * Add features without firing a `change` event.
-   * @param {Array<FeatureClass>} features Features.
+   * @param {Array<FeatureType>} features Features.
    * @protected
    */
   addFeaturesInternal(features) {
     const extents = [];
-    /** @type {Array<FeatureClass>} */
+    /** @type {Array<FeatureType>} */
     const newFeatures = [];
-    /** @type Array<FeatureClass> */
+    /** @type Array<FeatureType> */
     const geometryFeatures = [];
 
     for (let i = 0, length = features.length; i < length; i++) {
@@ -489,7 +489,7 @@ class VectorSource extends Source {
   }
 
   /**
-   * @param {!Collection<FeatureClass>} collection Collection.
+   * @param {!Collection<FeatureType>} collection Collection.
    * @private
    */
   bindFeaturesCollection_(collection) {
@@ -497,7 +497,7 @@ class VectorSource extends Source {
     this.addEventListener(
       VectorEventType.ADDFEATURE,
       /**
-       * @param {VectorSourceEvent<FeatureClass>} evt The vector source event
+       * @param {VectorSourceEvent<FeatureType>} evt The vector source event
        */
       function (evt) {
         if (!modifyingCollection) {
@@ -510,7 +510,7 @@ class VectorSource extends Source {
     this.addEventListener(
       VectorEventType.REMOVEFEATURE,
       /**
-       * @param {VectorSourceEvent<FeatureClass>} evt The vector source event
+       * @param {VectorSourceEvent<FeatureType>} evt The vector source event
        */
       function (evt) {
         if (!modifyingCollection) {
@@ -523,7 +523,7 @@ class VectorSource extends Source {
     collection.addEventListener(
       CollectionEventType.ADD,
       /**
-       * @param {import("../Collection.js").CollectionEvent<FeatureClass>} evt The collection event
+       * @param {import("../Collection.js").CollectionEvent<FeatureType>} evt The collection event
        */
       (evt) => {
         if (!modifyingCollection) {
@@ -536,7 +536,7 @@ class VectorSource extends Source {
     collection.addEventListener(
       CollectionEventType.REMOVE,
       /**
-       * @param {import("../Collection.js").CollectionEvent<FeatureClass>} evt The collection event
+       * @param {import("../Collection.js").CollectionEvent<FeatureType>} evt The collection event
        */
       (evt) => {
         if (!modifyingCollection) {
@@ -596,7 +596,7 @@ class VectorSource extends Source {
    * stop and the function will return the same value.
    * Note: this function only iterate through the feature that have a defined geometry.
    *
-   * @param {function(FeatureClass): T} callback Called with each feature
+   * @param {function(FeatureType): T} callback Called with each feature
    *     on the source.  Return a truthy value to stop iteration.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -621,7 +621,7 @@ class VectorSource extends Source {
    * called for all features.
    *
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(FeatureClass): T} callback Called with each feature
+   * @param {function(FeatureType): T} callback Called with each feature
    *     whose goemetry contains the provided coordinate.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -653,7 +653,7 @@ class VectorSource extends Source {
    * features, equivalent to {@link module:ol/source/Vector~VectorSource#forEachFeature #forEachFeature()}.
    *
    * @param {import("../extent.js").Extent} extent Extent.
-   * @param {function(FeatureClass): T} callback Called with each feature
+   * @param {function(FeatureType): T} callback Called with each feature
    *     whose bounding box intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -677,7 +677,7 @@ class VectorSource extends Source {
    * {@link module:ol/source/Vector~VectorSource#forEachFeatureInExtent #forEachFeatureInExtent()} method instead.
    *
    * @param {import("../extent.js").Extent} extent Extent.
-   * @param {function(FeatureClass): T} callback Called with each feature
+   * @param {function(FeatureType): T} callback Called with each feature
    *     whose geometry intersects the provided extent.
    * @return {T|undefined} The return value from the last call to the callback.
    * @template T
@@ -687,7 +687,7 @@ class VectorSource extends Source {
     return this.forEachFeatureInExtent(
       extent,
       /**
-       * @param {FeatureClass} feature Feature.
+       * @param {FeatureType} feature Feature.
        * @return {T|undefined} The return value from the last call to the callback.
        */
       function (feature) {
@@ -709,7 +709,7 @@ class VectorSource extends Source {
    * Get the features collection associated with this source. Will be `null`
    * unless the source was configured with `useSpatialIndex` set to `false`, or
    * with an {@link module:ol/Collection~Collection} as `features`.
-   * @return {Collection<FeatureClass>|null} The collection of features.
+   * @return {Collection<FeatureType>|null} The collection of features.
    * @api
    */
   getFeaturesCollection() {
@@ -719,7 +719,7 @@ class VectorSource extends Source {
   /**
    * Get a snapshot of the features currently on the source in random order. The returned array
    * is a copy, the features are references to the features in the source.
-   * @return {Array<FeatureClass>} Features.
+   * @return {Array<FeatureType>} Features.
    * @api
    */
   getFeatures() {
@@ -760,7 +760,7 @@ class VectorSource extends Source {
    * @param {import("../extent.js").Extent} extent Extent.
    * @param {import("../proj/Projection.js").default} [projection] Include features
    * where `extent` exceeds the x-axis bounds of `projection` and wraps around the world.
-   * @return {Array<FeatureClass>} Features.
+   * @return {Array<FeatureType>} Features.
    * @api
    */
   getFeaturesInExtent(extent, projection) {
@@ -790,10 +790,10 @@ class VectorSource extends Source {
    * `useSpatialIndex` set to `false` and the features in this source are of type
    * {@link module:ol/Feature~Feature}.
    * @param {import("../coordinate.js").Coordinate} coordinate Coordinate.
-   * @param {function(FeatureClass):boolean} [filter] Feature filter function.
+   * @param {function(FeatureType):boolean} [filter] Feature filter function.
    *     The filter function will receive one argument, the {@link module:ol/Feature~Feature feature}
    *     and it should return a boolean value. By default, no filtering is made.
-   * @return {FeatureClass} Closest feature.
+   * @return {FeatureType} Closest feature.
    * @api
    */
   getClosestFeatureToCoordinate(coordinate, filter) {
@@ -814,7 +814,7 @@ class VectorSource extends Source {
     this.featuresRtree_.forEachInExtent(
       extent,
       /**
-       * @param {FeatureClass} feature Feature.
+       * @param {FeatureType} feature Feature.
        */
       function (feature) {
         if (filter(feature)) {
@@ -865,13 +865,13 @@ class VectorSource extends Source {
    * `source.getFeatureById(2)` will return a feature with id `'2'` or `2`.
    *
    * @param {string|number} id Feature identifier.
-   * @return {FeatureClassOrArrayOfRenderFeatures<FeatureClass>|null} The feature (or `null` if not found).
+   * @return {FeatureClassOrArrayOfRenderFeatures<FeatureType>|null} The feature (or `null` if not found).
    * @api
    */
   getFeatureById(id) {
     const feature = this.idIndex_[id.toString()];
     return feature !== undefined
-      ? /** @type {FeatureClassOrArrayOfRenderFeatures<FeatureClass>} */ (
+      ? /** @type {FeatureClassOrArrayOfRenderFeatures<FeatureType>} */ (
           feature
         )
       : null;
@@ -881,7 +881,7 @@ class VectorSource extends Source {
    * Get a feature by its internal unique identifier (using `getUid`).
    *
    * @param {string} uid Feature identifier.
-   * @return {FeatureClass|null} The feature (or `null` if not found).
+   * @return {FeatureType|null} The feature (or `null` if not found).
    */
   getFeatureByUid(uid) {
     const feature = this.uidIndex_[uid];
@@ -891,7 +891,7 @@ class VectorSource extends Source {
   /**
    * Get the format associated with this source.
    *
-   * @return {import("../format/Feature.js").default|undefined} The feature format.
+   * @return {import("../format/Feature.js").default<import('../format/Feature.js').FeatureToFeatureClass<FeatureType>>|undefined} The feature format.
    * @api
    */
   getFormat() {
@@ -920,7 +920,7 @@ class VectorSource extends Source {
    * @private
    */
   handleFeatureChange_(event) {
-    const feature = /** @type {FeatureClass} */ (event.target);
+    const feature = /** @type {FeatureType} */ (event.target);
     const featureKey = getUid(feature);
     const geometry = feature.getGeometry();
     if (!geometry) {
@@ -962,7 +962,7 @@ class VectorSource extends Source {
 
   /**
    * Returns true if the feature is contained within the source.
-   * @param {FeatureClass} feature Feature.
+   * @param {FeatureType} feature Feature.
    * @return {boolean} Has feature.
    * @api
    */
@@ -1072,7 +1072,7 @@ class VectorSource extends Source {
    * Remove a single feature from the source.  If you want to remove all features
    * at once, use the {@link module:ol/source/Vector~VectorSource#clear #clear()} method
    * instead.
-   * @param {FeatureClass} feature Feature to remove.
+   * @param {FeatureType} feature Feature to remove.
    * @api
    */
   removeFeature(feature) {
@@ -1095,8 +1095,8 @@ class VectorSource extends Source {
 
   /**
    * Remove feature without firing a `change` event.
-   * @param {FeatureClass} feature Feature.
-   * @return {FeatureClass|undefined} The removed feature
+   * @param {FeatureType} feature Feature.
+   * @return {FeatureType|undefined} The removed feature
    *     (or undefined if the feature was not found).
    * @protected
    */
@@ -1122,7 +1122,7 @@ class VectorSource extends Source {
   /**
    * Remove a feature from the id index.  Called internally when the feature id
    * may have changed.
-   * @param {FeatureClass} feature The feature.
+   * @param {FeatureType} feature The feature.
    * @return {boolean} Removed the feature from the index.
    * @private
    */

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -22,12 +22,13 @@ import {loadFeaturesXhr} from '../featureloader.js';
 import {toSize} from '../size.js';
 
 /**
+ * @template {import("../Feature.js").FeatureLike} FeatureType
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Initial tile cache size. Will auto-grow to hold at least twice the number of tiles in the viewport.
  * @property {import("../extent.js").Extent} [extent] Extent.
- * @property {import("../format/Feature.js").default} [format] Feature format for tiles. Used and required by the default.
+ * @property {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>} [format] Feature format for tiles. Used and required by the default.
  * @property {boolean} [overlaps=true] This source may have overlapping geometries. Setting this
  * to `false` (e.g. for sources with polygons that represent administrative
  * boundaries or TopoJSON sources) allows the renderer to optimise fill and
@@ -98,10 +99,11 @@ import {toSize} from '../size.js';
  *
  * @fires import("./Tile.js").TileSourceEvent
  * @api
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
  */
 class VectorTile extends UrlTile {
   /**
-   * @param {!Options} options Vector tile options.
+   * @param {!Options<FeatureType>} options Vector tile options.
    */
   constructor(options) {
     const projection = options.projection || 'EPSG:3857';
@@ -140,7 +142,7 @@ class VectorTile extends UrlTile {
 
     /**
      * @private
-     * @type {import("../format/Feature.js").default|null}
+     * @type {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>|null}
      */
     this.format_ = options.format ? options.format : null;
 


### PR DESCRIPTION
This pull request fixes a type issue when configuring a `Vector` or `VectorTile` source's `format`:
```js
new VectorTileSource({
  format: new MVT() // error here
});
```
yields
```
Type 'MVT<typeof RenderFeature>' is not assignable to type 'FeatureFormat<typeof Feature>'.
  The types returned by 'readFeatures(...)' are incompatible between these types.
    Type 'RenderFeature[]' is not assignable to type 'Feature<Geometry>[]'.
      Type 'RenderFeature' is missing the following properties from type 'Feature<Geometry>': on, once, un, geometryName_, and 39 more.ts(2322)
```

This pull request fixes that.

In addition, I renamed the `FeatureOrRenderFeature` typedef to `FeatureToFeatureClass`, because its name did not really reflect what it does. This became clear when introducing the opposite `FeatureClassToFeature` typedef that was needed to fix this problem.