### PR TITLE
Add note about cartesian measurements on scaleline

### DIFF
--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -69,6 +69,9 @@ const DEFAULT_DPI = 25.4 / 0.28;
  * but this can be changed by using the css selector `.ol-scale-line`.
  * When specifying `bar` as `true`, a scalebar will be rendered instead
  * of a scaleline.
+ * For cartesian measurements of the scalebar, you need to set the
+ * `getPointResolution` method of your projection to simply return the input
+ * value, e.g. `projection.setGetPointResolution(r => r);`
  *
  * @api
  */

--- a/src/ol/control/ScaleLine.js
+++ b/src/ol/control/ScaleLine.js
@@ -69,7 +69,7 @@ const DEFAULT_DPI = 25.4 / 0.28;
  * but this can be changed by using the css selector `.ol-scale-line`.
  * When specifying `bar` as `true`, a scalebar will be rendered instead
  * of a scaleline.
- * For cartesian measurements of the scalebar, you need to set the
+ * For cartesian measurements of the scaleline, you need to set the
  * `getPointResolution` method of your projection to simply return the input
  * value, e.g. `projection.setGetPointResolution(r => r);`
  *


### PR DESCRIPTION
This adds a short note to the scaleline about cartesian measurements.

For disucussion, see https://github.com/openlayers/openlayers/issues/15542