### PR TITLE
Dispatch prerender event before image rendering in hybrid mode

### DIFF
--- a/src/ol/render/canvas/ZIndexContext.js
+++ b/src/ol/render/canvas/ZIndexContext.js
@@ -2,6 +2,8 @@
  * @module ol/render/canvas/ZIndexContext
  */
 
+import {getSharedCanvasContext2D} from '../../dom.js';
+
 /** @typedef {CanvasRenderingContext2D & {globalAlpha: any}} ZIndexContextProxy */
 
 /**
@@ -30,7 +32,10 @@ class ZIndexContext {
     this.context_ = /** @type {ZIndexContextProxy} */ (
       new Proxy(CanvasRenderingContext2D.prototype, {
         get: (target, property) => {
-          if (typeof (/** @type {*} */ (target)[property]) !== 'function') {
+          if (
+            typeof (/** @type {*} */ (getSharedCanvasContext2D())[property]) !==
+            'function'
+          ) {
             // we only accept calling functions on the proxy, not accessing properties
             return undefined;
           }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -583,7 +583,11 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     context.globalAlpha = alpha;
   }
 
-  renderDeferredInternal() {
+  /**
+   * @param {import("../../Map.js").FrameState} frameState Frame state.
+   */
+  renderDeferredInternal(frameState) {
+    super.renderDeferredInternal(frameState);
     const tiles =
       /** @type {Array<import("../../VectorRenderTile.js").default>} */ (
         this.renderedTiles

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -413,6 +413,90 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
   });
 
   describe('#renderFrame', function () {
+    it('uses correct image - vector sequence in hybrid mode', function () {
+      const layer = new VectorTileLayer({
+        source: new VectorTileSource({
+          tileGrid: createXYZ(),
+        }),
+      });
+      const sourceTile = new VectorTile([0, 0, 0], 2);
+      sourceTile.features_ = [
+        new RenderFeature('LineString', [0, 0, 1000, 1000], [3], 2),
+        new RenderFeature('Point', [0, 0], [], 2),
+      ];
+      sourceTile.getImage = function () {
+        return document.createElement('canvas');
+      };
+      layer.getSource().getSourceTiles = () => [sourceTile];
+      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], function () {
+        return sourceTile;
+      });
+      tile.transition_ = 0;
+      tile.replayState_[getUid(layer)] = [{dirty: true}];
+      tile.setState(TileState.LOADED);
+      layer.getSource().getTile = function () {
+        return tile;
+      };
+      const renderer = new CanvasVectorTileLayerRenderer(layer);
+      renderer.isDrawableTile = function () {
+        return true;
+      };
+      const proj = getProjection('EPSG:3857');
+      const frameState = {
+        layerStatesArray: [layer.getLayerState()],
+        layerIndex: 0,
+        extent: proj.getExtent(),
+        pixelRatio: 1,
+        pixelToCoordinateTransform: create(),
+        time: Date.now(),
+        viewHints: [],
+        viewState: {
+          center: [0, 0],
+          resolution: 156543.03392804097,
+          rotation: 0,
+          projection: proj,
+        },
+        size: [256, 256],
+        usedTiles: {},
+        wantedTiles: {},
+      };
+
+      renderer.container = document.createElement('div');
+      const sequence = [];
+      renderer.context = {
+        clearRect: () => sequence.push('clearRect'),
+        save: () => sequence.push('save'),
+        restore: () => sequence.push('restore'),
+        beginPath: () => sequence.push('beginPath'),
+        moveTo: () => sequence.push('moveTo'),
+        lineTo: () => sequence.push('lineTo'),
+        clip: () => sequence.push('clip'),
+        setLineDash: () => sequence.push('setLineDash'),
+        stroke: () => sequence.push('stroke'),
+        drawImage: () => sequence.push('drawImage'),
+        canvas: {
+          style: {
+            transform: '',
+          },
+        },
+      };
+
+      layer.on('prerender', () => sequence.push('prerender'));
+      layer.on('postrender', () => sequence.push('postrender'));
+      renderer.renderFrame(frameState);
+      expect(sequence).to.eql([
+        'prerender',
+        'clearRect',
+        'save',
+        'drawImage',
+        'restore',
+        'save',
+        'drawImage',
+        'restore',
+        'postrender',
+      ]);
+    });
+
     it('uses correct image - vector sequence in vector mode', function () {
       const layer = new VectorTileLayer({
         renderMode: 'vector',


### PR DESCRIPTION
This pull request adds a deferred rendering capability to the canvas `TileLayer` renderer, so the `VectorTileLayer` renderer can defer rendering of the image tiles in hybrid mode. This makes sure the sequence `prerender` event - do all the rendering - `postrender` event is correct.

This fix revealed a problem with `ZIndexContext`'s proxy, because `get`ting properties from `CanvasRenderingContext2D` throws a type error. So instead, our shared 1x1 pixel context is used to test for non-function properties in the proxy's getter.

Fixes #15564.