### PR TITLE
Export Google source from ol/source.js

### DIFF
--- a/src/ol/source.js
+++ b/src/ol/source.js
@@ -10,6 +10,7 @@ export {default as CartoDB} from './source/CartoDB.js';
 export {default as Cluster} from './source/Cluster.js';
 export {default as DataTile} from './source/DataTile.js';
 export {default as GeoTIFF} from './source/GeoTIFF.js';
+export {default as Google} from './source/Google.js';
 export {default as IIIF} from './source/IIIF.js';
 export {default as Image} from './source/Image.js';
 export {default as ImageArcGISRest} from './source/ImageArcGISRest.js';


### PR DESCRIPTION
This exports the new source from #15465 from the `ol/source.js` module.