### PR TITLE
Fix #15595 - Stop caching TileRepresentation based on source key and use interimTile until tiles are loaded.

### DIFF
--- a/examples/webgl-dimensions.html
+++ b/examples/webgl-dimensions.html
@@ -1,0 +1,15 @@
+---
+layout: example.html
+title: WebGL Tile Transitions
+shortdesc: Example of smooth tile transitions when changing the dimension of a WebGL layer.
+docs: >
+  Demonstrates smooth reloading of layers when changing a dimension continuously. The reason this example exists is to show this feature working with the WebGL based renderer as compared to the default canvas based renderer shown in <a href="/en/latest/examples/wmts-dimensions.html">the WMTS Tile Transitions example</a>. The demonstration layer is a global sea-level computation (flooding computation from <a href="https://scalgo.com/">SCALGO</a>, underlying data from <a href="https://cgiarcsi.community/data/srtm-90m-digital-elevation-database-v4-1">CGIAR-CSI SRTM</a>) where cells that are flooded if the sea-level rises to more than <em>x</em> m are colored blue. The user selects the sea-level dimension using a slider.
+tags: "webgl, parameter, transition, grid"
+---
+
+<div id="map" class="map"></div>
+<label>
+  Sea-level
+  <input id="slider" type="range" value="10" max="100" min="-1">
+</label>
+<span id="theinfo"></span>

--- a/examples/webgl-dimensions.js
+++ b/examples/webgl-dimensions.js
@@ -1,0 +1,71 @@
+import Map from '../src/ol/Map.js';
+import OSM from '../src/ol/source/OSM.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import View from '../src/ol/View.js';
+import WMTS from '../src/ol/source/WMTS.js';
+import WMTSTileGrid from '../src/ol/tilegrid/WMTS.js';
+import WebGLTileLayer from '../src/ol/layer/WebGLTile.js';
+import {get as getProjection} from '../src/ol/proj.js';
+import {getTopLeft, getWidth} from '../src/ol/extent.js';
+
+// create the WMTS tile grid in the google projection
+const projection = getProjection('EPSG:3857');
+const tileSizePixels = 256;
+const tileSizeMtrs = getWidth(projection.getExtent()) / tileSizePixels;
+const matrixIds = [];
+const resolutions = [];
+for (let i = 0; i <= 14; i++) {
+  matrixIds[i] = i;
+  resolutions[i] = tileSizeMtrs / Math.pow(2, i);
+}
+const tileGrid = new WMTSTileGrid({
+  origin: getTopLeft(projection.getExtent()),
+  resolutions: resolutions,
+  matrixIds: matrixIds,
+});
+
+const scalgoToken = 'CC5BF28A7D96B320C7DFBFD1236B5BEB';
+
+const wmtsSource = new WMTS({
+  url: 'https://ts2.scalgo.com/olpatch/wmts?token=' + scalgoToken,
+  layer: 'SRTM_4_1:SRTM_4_1_flooded_sealevels',
+  format: 'image/png',
+  matrixSet: 'EPSG:3857',
+  attributions: [
+    '<a href="https://scalgo.com" target="_blank">SCALGO</a>',
+    '<a href="https://cgiarcsi.community/data/' +
+      'srtm-90m-digital-elevation-database-v4-1"' +
+      ' target="_blank">CGIAR-CSI SRTM</a>',
+  ],
+  tileGrid: tileGrid,
+  style: 'default',
+  dimensions: {
+    'threshold': 100,
+  },
+});
+
+const map = new Map({
+  target: 'map',
+  view: new View({
+    projection: projection,
+    center: [-9871995, 3566245],
+    zoom: 6,
+  }),
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+    new WebGLTileLayer({
+      opacity: 0.5,
+      source: wmtsSource,
+    }),
+  ],
+});
+
+const slider = document.getElementById('slider');
+const updateSourceDimension = function () {
+  wmtsSource.updateDimensions({'threshold': slider.value});
+  document.getElementById('theinfo').innerHTML = slider.value + ' meters';
+};
+slider.addEventListener('input', updateSourceDimension);
+updateSourceDimension();

--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -319,7 +319,7 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       --z
     ) {
       const tileCoord = tileGrid.getTileCoordForCoordAndZ(coordinate, z);
-      const cacheKey = getCacheKey(source, tileCoord);
+      const cacheKey = getCacheKey(tileCoord);
       if (!tileTextureCache.containsKey(cacheKey)) {
         continue;
       }

--- a/src/ol/webgl/BaseTileRepresentation.js
+++ b/src/ol/webgl/BaseTileRepresentation.js
@@ -67,8 +67,14 @@ class BaseTileRepresentation extends EventTarget {
       this.tile = tile;
       this.loaded = tile.getState() === TileState.LOADED;
       if (this.loaded) {
-        this.uploadTile();
+        this.uploadTile(tile);
       } else {
+        const interimTile = /** @type {TileType} */ (tile.getInterimTile());
+        // If `interimTile !== tile`, the interimTile is loaded.
+        if (interimTile !== tile) {
+          this.uploadTile(interimTile);
+        }
+
         if (tile instanceof ImageTile) {
           const image = tile.getImage();
           if (image instanceof Image && !image.crossOrigin) {
@@ -83,8 +89,9 @@ class BaseTileRepresentation extends EventTarget {
   /**
    * @abstract
    * @protected
+   * @param {TileType} tile tile to upload.
    */
-  uploadTile() {
+  uploadTile(tile) {
     abstract();
   }
 
@@ -96,7 +103,7 @@ class BaseTileRepresentation extends EventTarget {
   handleTileChange_() {
     if (this.tile.getState() === TileState.LOADED) {
       this.loaded = true;
-      this.uploadTile();
+      this.uploadTile(this.tile);
     }
   }
 

--- a/src/ol/webgl/TileGeometry.js
+++ b/src/ol/webgl/TileGeometry.js
@@ -53,9 +53,10 @@ class TileGeometry extends BaseTileRepresentation {
 
   /**
    * @private
+   * @param {TileType} tile tile to upload.
    */
-  generateMaskBuffer_() {
-    const extent = this.tile.getSourceTiles()[0].extent;
+  generateMaskBuffer_(tile) {
+    const extent = tile.getSourceTiles()[0].extent;
     this.maskVertices.fromArray([
       extent[0],
       extent[1],
@@ -69,11 +70,15 @@ class TileGeometry extends BaseTileRepresentation {
     this.helper_.flushBufferData(this.maskVertices);
   }
 
-  uploadTile() {
-    this.generateMaskBuffer_();
+  /**
+   * @protected
+   * @param {TileType} tile tile to upload.
+   */
+  uploadTile(tile) {
+    this.generateMaskBuffer_(tile);
 
     this.batch_.clear();
-    const sourceTiles = this.tile.getSourceTiles();
+    const sourceTiles = tile.getSourceTiles();
     const features = sourceTiles.reduce(
       (accumulator, sourceTile) => accumulator.concat(sourceTile.getFeatures()),
       [],

--- a/src/ol/webgl/TileTexture.js
+++ b/src/ol/webgl/TileTexture.js
@@ -143,6 +143,11 @@ class TileTexture extends BaseTileRepresentation {
     super(options);
 
     /**
+     * @type {TileType}
+     */
+    this.lastUploadedTile;
+
+    /**
      * @type {Array<WebGLTexture>}
      */
     this.textures = [];
@@ -181,10 +186,18 @@ class TileTexture extends BaseTileRepresentation {
     this.setTile(options.tile);
   }
 
-  uploadTile() {
+  /**
+   * @protected
+   * @param {TileType} tile tile to upload.
+   */
+  uploadTile(tile) {
+    if (tile === this.lastUploadedTile) {
+      return;
+    }
+    this.lastUploadedTile = tile;
+
     const helper = this.helper_;
     const gl = helper.getGL();
-    const tile = this.tile;
 
     this.textures.length = 0;
 

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -1,6 +1,5 @@
 import Map from '../../../../../../src/ol/Map.js';
 import TileQueue from '../../../../../../src/ol/TileQueue.js';
-import TileState from '../../../../../../src/ol/TileState.js';
 import TileTexture from '../../../../../../src/ol/webgl/TileTexture.js';
 import View from '../../../../../../src/ol/View.js';
 import WebGLTileLayer from '../../../../../../src/ol/layer/WebGLTile.js';
@@ -101,22 +100,6 @@ describe('ol/renderer/webgl/TileLayer', function () {
     expect(Object.keys(frameState.wantedTiles).length).to.be(1);
     expect(frameState.postRenderFunctions.length).to.be(1); // clear source cache (use renderer cache)
     expect(renderer.tileRepresentationCache.count_).to.be(1);
-  });
-
-  it('#isDrawableTile_()', function (done) {
-    const tile = tileLayer.getSource().getTile(0, 0, 0);
-    expect(renderer.isDrawableTile_(tile)).to.be(false);
-    tileLayer.getSource().on('tileloadend', () => {
-      expect(renderer.isDrawableTile_(tile)).to.be(true);
-      done();
-    });
-    tile.load();
-    const errorTile = tileLayer.getSource().getTile(1, 0, 1);
-    errorTile.setState(TileState.ERROR);
-    tileLayer.setUseInterimTilesOnError(false);
-    expect(renderer.isDrawableTile_(errorTile)).to.be(true);
-    tileLayer.setUseInterimTilesOnError(true);
-    expect(renderer.isDrawableTile_(errorTile)).to.be(false);
   });
 
   describe('enqueueTiles()', () => {


### PR DESCRIPTION
Fixes #15595 by stopping caching TileRepresentation based on source key and use interimTile until tiles are loaded.

I am new to contributing to this project so im not sure if this is the best way to fix the underlying issue. I think the main aspects are correct. For example I could not find a way to keep using `isDrawableTile_`, but the current way its used in  `WebGLBaseTileLayerRenderer` is also causing issues.