### PR TITLE
Add Alidade Satellite style

### DIFF
--- a/src/ol/source/StadiaMaps.js
+++ b/src/ol/source/StadiaMaps.js
@@ -78,6 +78,10 @@ const LayerConfig = {
     extension: 'png',
     opaque: true,
   },
+  'alidade_satellite': {
+    extension: 'png',
+    opaque: true,
+  },
   'outdoors': {
     extension: 'png',
     opaque: true,


### PR DESCRIPTION
Stadia Maps now offers fully baked raster tiles with imagery and basic contextual overlays (it was previously only vector overlays with a raster layer; imagery licensing is complicated!). This PR adds the new endpoint.