### PR TITLE
Updates to the Google attribution

### DIFF
--- a/src/ol/source/Google.js
+++ b/src/ol/source/Google.js
@@ -25,6 +25,7 @@ const maxZoom = 22;
  * @property {Array<string>} [layerTypes] The layer types added to the map (e.g. `'layerRoadmap'`, `'layerStreetview'`, or `'layerTraffic'`).
  * @property {boolean} [overlay=false] Display only the `layerTypes` and not the underlying `mapType` (only works if `layerTypes` is provided).
  * @property {Array<Object>} [styles] [Custom styles](https://developers.google.com/maps/documentation/tile/style-reference) applied to the map.
+ * @property {boolean} [attributionsCollapsible=true] Allow the attributions to be collapsed.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
  * linear interpolation is used when resampling.  Set to false to use the nearest neighbor instead.
  * @property {number} [cacheSize] Initial tile cache size. Will auto-grow to hold at least the number of tiles in the viewport.
@@ -83,7 +84,7 @@ class Google extends TileImage {
     const opaque = !(options.overlay === true);
 
     super({
-      attributionsCollapsible: false,
+      attributionsCollapsible: options.attributionsCollapsible,
       cacheSize: options.cacheSize,
       crossOrigin: 'anonymous',
       interpolate: options.interpolate,
@@ -253,12 +254,17 @@ class Google extends TileImage {
     const timeout = Math.max(expiry - Date.now() - 60 * 1000, 1);
     this.sessionRefreshId_ = setTimeout(() => this.createSession_(), timeout);
 
-    this.setAttributions(this.fetchAttributions.bind(this));
+    this.setAttributions(this.fetchAttributions_.bind(this));
     // even if the state is already ready, we want the change event
     this.setState('ready');
   }
 
-  async fetchAttributions(frameState) {
+  /**
+   * @param {import('../Map.js').FrameState} frameState The frame state.
+   * @return {Promise<string>} The attributions.
+   * @private
+   */
+  async fetchAttributions_(frameState) {
     if (
       frameState.viewHints[ViewHint.ANIMATING] ||
       frameState.viewHints[ViewHint.INTERACTING] ||


### PR DESCRIPTION
This makes a minor adjustment to the attribution handling added in #15598, exposing the `attributionsCollapsible` option on the source.  This makes it easier for developers to decide whether the attribution control is collapsed or not by default.  I think having the attribution be collapsed still complies with [the policies](https://developers.google.com/maps/documentation/tile/policies#displaying-googles-data-attributions):

> Data returned from the Map Tiles API requires the display of attribution and copyright information from the appropriate metadata or viewport information requests. You should display this information, in full as provided in the appropriate location, usually the bottom right corner of the displayed set of tiles, or in the 3D renderer view. Note that the attribution strings are variable, depending on the map data requested by the renderer's viewport.

> If it's infeasible to display data attributions in full due to viewport size constraints, consider adding a hover-over or clickable UI element labeled "Data sources", which opens within the map window to provide attribution information. Always aim to maintain good cartographic practices.

I think this allows for the attributions to be revealed based on user interaction