### PR TITLE
Listen for `change:size` event in Attributions example

### DIFF
--- a/examples/attributions.js
+++ b/examples/attributions.js
@@ -27,5 +27,5 @@ function checkSize() {
   attribution.setCollapsed(small);
 }
 
-window.addEventListener('resize', checkSize);
+map.on('change:size', checkSize);
 checkSize();


### PR DESCRIPTION
The window `resize` event does not fire in Chrome when maximising/restoring the window, but the map `change:size` event does.
