### PR TITLE
Store previous transform in FrameState

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -59,6 +59,7 @@ import {warn} from './console.js';
  * @property {import("./extent.js").Extent} [nextExtent] Next extent during an animation series.
  * @property {number} index Index.
  * @property {Array<import("./layer/Layer.js").State>} layerStatesArray LayerStatesArray.
+ * @property {import('./transform.js').Transform} layerTransform Current layer transform.
  * @property {number} layerIndex LayerIndex.
  * @property {import("./transform.js").Transform} pixelToCoordinateTransform PixelToCoordinateTransform.
  * @property {Array<PostRenderFunction>} postRenderFunctions PostRenderFunctions.
@@ -1538,6 +1539,7 @@ class Map extends BaseObject {
         ),
         index: this.frameIndex_++,
         layerIndex: 0,
+        layerTransform: null,
         layerStatesArray: this.getLayerGroup().getLayerStatesArray(),
         pixelRatio: this.pixelRatio_,
         pixelToCoordinateTransform: this.pixelToCoordinateTransform_,

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -8,7 +8,6 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   makeInverse,
-  toString as toTransformString,
 } from '../../transform.js';
 import {
   containsCoordinate,
@@ -187,9 +186,7 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     );
     makeInverse(this.inversePixelTransform, this.pixelTransform);
 
-    const canvasTransform = toTransformString(this.pixelTransform);
-
-    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+    this.useContainer(target, this.pixelTransform, frameState);
 
     const context = this.getRenderContext(frameState);
     const canvas = this.context.canvas;
@@ -258,10 +255,6 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       context.restore();
     }
     context.imageSmoothingEnabled = true;
-
-    if (canvasTransform !== canvas.style.transform) {
-      canvas.style.transform = canvasTransform;
-    }
 
     return this.container;
   }

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -10,7 +10,6 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   makeInverse,
-  toString as toTransformString,
 } from '../../transform.js';
 import {ascending} from '../../array.js';
 import {
@@ -380,9 +379,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       -height / 2,
     );
 
-    const canvasTransform = toTransformString(this.pixelTransform);
-
-    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+    this.useContainer(target, this.pixelTransform, frameState);
 
     const context = this.getRenderContext(frameState);
     const canvas = this.context.canvas;
@@ -565,10 +562,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       context.restore();
     }
     context.imageSmoothingEnabled = true;
-
-    if (canvasTransform !== canvas.style.transform) {
-      canvas.style.transform = canvasTransform;
-    }
 
     return this.container;
   }

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -105,7 +105,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
       !hints[ViewHint.INTERACTING] &&
       !isEmpty(renderedExtent)
     ) {
-      vectorRenderer.useContainer(null, null);
+      vectorRenderer.useContainer(null, null, frameState);
       const context = vectorRenderer.context;
       const layerState = frameState.layerStatesArray[frameState.layerIndex];
       const imageLayerState = Object.assign({}, layerState, {opacity: 1});

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -15,12 +15,7 @@ import {
   createHitDetectionImageData,
   hitDetect,
 } from '../../render/canvas/hitdetect.js';
-import {
-  apply,
-  makeInverse,
-  makeScale,
-  toString as transformToString,
-} from '../../transform.js';
+import {apply, makeInverse, makeScale} from '../../transform.js';
 import {
   buffer,
   containsExtent,
@@ -291,9 +286,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     makeScale(this.pixelTransform, 1 / pixelRatio, 1 / pixelRatio);
     makeInverse(this.inversePixelTransform, this.pixelTransform);
 
-    const canvasTransform = transformToString(this.pixelTransform);
-
-    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+    this.useContainer(target, this.pixelTransform, frameState);
 
     const context = this.context;
     const canvas = context.canvas;
@@ -315,9 +308,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     if (canvas.width != width || canvas.height != height) {
       canvas.width = width;
       canvas.height = height;
-      if (canvas.style.transform !== canvasTransform) {
-        canvas.style.transform = canvasTransform;
-      }
     } else if (!this.containerReused) {
       context.clearRect(0, 0, width, height);
     }

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -634,6 +634,7 @@ class RasterSource extends ImageSource {
       extent: null,
       index: 0,
       layerIndex: 0,
+      layerTransform: null,
       layerStatesArray: getLayerStatesArray(this.layers_),
       pixelRatio: 1,
       pixelToCoordinateTransform: createTransform(),

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -46,6 +46,26 @@ export function reset(transform) {
 }
 
 /**
+ * @param {!Transform} transform1 Transform 1.
+ * @param {!Transform} transform2 Transform 2.
+ * @return {boolean} Transform 1 and 2 are pixel equal.
+ */
+export function equals(transform1, transform2) {
+  if (transform1 === transform2) {
+    return true;
+  }
+  const tolerance = 1e-6;
+  return (
+    Math.abs(transform1[0] - transform2[0]) < tolerance &&
+    Math.abs(transform1[1] - transform2[1]) < tolerance &&
+    Math.abs(transform1[2] - transform2[2]) < tolerance &&
+    Math.abs(transform1[3] - transform2[3]) < tolerance &&
+    Math.abs(transform1[4] - transform2[4]) < tolerance &&
+    Math.abs(transform1[5] - transform2[5]) < tolerance
+  );
+}
+
+/**
  * Multiply the underlying matrices of two transforms and return the result in
  * the first transform.
  * @param {!Transform} transform1 Transform parameters of matrix 1.
@@ -265,25 +285,11 @@ export function determinant(mat) {
 }
 
 /**
- * @type {Array}
- */
-const matrixPrecision = [1e6, 1e6, 1e6, 1e6, 2, 2];
-
-/**
  * A rounded string version of the transform.  This can be used
  * for CSS transforms.
  * @param {!Transform} mat Matrix.
  * @return {string} The transform as a string.
  */
 export function toString(mat) {
-  const transformString =
-    'matrix(' +
-    mat
-      .map(
-        (value, i) =>
-          Math.round(value * matrixPrecision[i]) / matrixPrecision[i],
-      )
-      .join(', ') +
-    ')';
-  return transformString;
+  return 'matrix(' + mat.join(', ') + ')';
 }

--- a/test/browser/spec/ol/transform.test.js
+++ b/test/browser/spec/ol/transform.test.js
@@ -2,6 +2,7 @@ import {
   apply,
   compose,
   create,
+  equals,
   invert,
   makeInverse,
   makeScale,
@@ -11,7 +12,6 @@ import {
   scale,
   set,
   setFromArray,
-  toString,
   translate,
 } from '../../../../src/ol/transform.js';
 
@@ -178,12 +178,21 @@ describe('ol.transform', function () {
       expect(point).to.eql([3, 5]);
     });
   });
-  describe('toString()', function () {
+  describe('equals()', function () {
     it('compares with value read back from node', function () {
       const mat = [1 / 3, 0, 0, 1 / 3, 0, 0];
       const node = document.createElement('div');
       node.style.transform = 'matrix(' + mat.join(',') + ')';
-      expect(toString(mat)).to.be(node.style.transform);
+      const cssTransform = node.style.transform;
+      expect(
+        equals(
+          mat,
+          cssTransform
+            .substring(7, cssTransform.length - 2)
+            .split(',')
+            .map(Number),
+        ),
+      ).to.be(true);
     });
   });
 });


### PR DESCRIPTION
This pull request stores the previous layer's transform on the `FrameState`, instead of reading the CSS matrix transform from the canvas. This allows some code simplifications, and instead of comparing CSS matrix transform strings, we now compare transform arrays with a tolerance, using the new `equals()` function of the `ol/transform` module.

Fixes #15593