### PR TITLE
allow empty GeoJSON coordinate for MultiPolygon

### DIFF
--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -446,7 +446,7 @@ function readMultiPointGeometry(object) {
 function readMultiPolygonGeometry(object) {
   const coordinates = object['coordinates'];
   const flatCoordinates = [];
-  const stride = coordinates[0]?.[0]?.[0].length || 2;
+  const stride = coordinates[0]?.[0]?.[0]?.length || 2;
   const endss = deflateMultiCoordinatesArray(
     flatCoordinates,
     0,


### PR DESCRIPTION
When an MultiPolygonGeometry with empty coordinates is passed to readFeature() method, throws undefined error, to handle this, conditional operator(?) is added while reading the coordinates to assign the value to **stride** in **readMultiPolygonGeometry** method

Fixes: [15636](https://github.com/openlayers/openlayers/issues/15636)