### PR TITLE
Fix WFS property format writer for multiline strings

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -25,6 +25,7 @@ import {get as getProjection} from '../proj.js';
 import {
   readNonNegativeIntegerString,
   readPositiveInteger,
+  writeCDATASection,
   writeStringTextNode,
 } from './xsd.js';
 
@@ -938,7 +939,20 @@ function writeProperty(node, pair, objectStack) {
         GML32.prototype.writeGeometryElement(value, pair.value, objectStack);
       }
     } else {
-      writeStringTextNode(value, pair.value);
+      if (typeof pair.value === 'string') {
+        // Generate CDATA section to preserve whitespaces.
+        pair.value.split(']]>').forEach((part, i, a) => {
+          if (i < a.length - 1) {
+            part += ']]';
+          }
+          if (i > 0) {
+            part = '>' + part;
+          }
+          writeCDATASection(value, part);
+        });
+      } else {
+        writeStringTextNode(value, pair.value);
+      }
     }
   }
 }


### PR DESCRIPTION
  When updating a feature through WFS, if there are any newline
  characters in a string properties, these are lost (for example,
  geoserver handles these newlines as whitespace).

  To fix this, multiline string properties should be encoded as
  CDATA block.

Fix #10127