### PR TITLE
Avoid flickering by using transform matrix as returned from style

### DIFF
--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/transform
  */
+import {WORKER_OFFSCREEN_CANVAS} from './has.js';
 import {assert} from './asserts.js';
 
 /**
@@ -285,11 +286,24 @@ export function determinant(mat) {
 }
 
 /**
+ * @type {HTMLElement}
+ * @private
+ */
+let transformStringDiv;
+
+/**
  * A rounded string version of the transform.  This can be used
  * for CSS transforms.
  * @param {!Transform} mat Matrix.
  * @return {string} The transform as a string.
  */
 export function toString(mat) {
-  return 'matrix(' + mat.join(', ') + ')';
+  const transformString = 'matrix(' + mat.join(', ') + ')';
+  if (WORKER_OFFSCREEN_CANVAS) {
+    return transformString;
+  }
+  const node =
+    transformStringDiv || (transformStringDiv = document.createElement('div'));
+  node.style.transform = transformString;
+  return node.style.transform;
 }


### PR DESCRIPTION
Hopefully fixes #15644.

Instead of reverting to what we had before #15344, I decided to keep going with storing the current transform on the frame state, but use the css transform matrix as returned from the current style. This should avoid the extra canvases that were fixed with #15344, and avoid the flickering introduced therewith.