### PR TITLE
Calculate canvas width and height the same way for all renderers

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -59,7 +59,6 @@ import {warn} from './console.js';
  * @property {import("./extent.js").Extent} [nextExtent] Next extent during an animation series.
  * @property {number} index Index.
  * @property {Array<import("./layer/Layer.js").State>} layerStatesArray LayerStatesArray.
- * @property {import('./transform.js').Transform} layerTransform Current layer transform.
  * @property {number} layerIndex LayerIndex.
  * @property {import("./transform.js").Transform} pixelToCoordinateTransform PixelToCoordinateTransform.
  * @property {Array<PostRenderFunction>} postRenderFunctions PostRenderFunctions.
@@ -1539,7 +1538,6 @@ class Map extends BaseObject {
         ),
         index: this.frameIndex_++,
         layerIndex: 0,
-        layerTransform: null,
         layerStatesArray: this.getLayerGroup().getLayerStatesArray(),
         pixelRatio: this.pixelRatio_,
         pixelToCoordinateTransform: this.pixelToCoordinateTransform_,

--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -8,6 +8,7 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   makeInverse,
+  toString as toTransformString,
 } from '../../transform.js';
 import {
   containsCoordinate,
@@ -186,7 +187,9 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     );
     makeInverse(this.inversePixelTransform, this.pixelTransform);
 
-    this.useContainer(target, this.pixelTransform, frameState);
+    const canvasTransform = toTransformString(this.pixelTransform);
+
+    this.useContainer(target, canvasTransform, this.getBackground(frameState));
 
     const context = this.getRenderContext(frameState);
     const canvas = this.context.canvas;
@@ -255,6 +258,10 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       context.restore();
     }
     context.imageSmoothingEnabled = true;
+
+    if (canvasTransform !== canvas.style.transform) {
+      canvas.style.transform = canvasTransform;
+    }
 
     return this.container;
   }

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -9,12 +9,10 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   create as createTransform,
-  equals as equalTransforms,
-  toString as toTransformString,
 } from '../../transform.js';
 import {asArray} from '../../color.js';
 import {createCanvasContext2D} from '../../dom.js';
-import {equals as equalArrays} from '../../array.js';
+import {equals} from '../../array.js';
 import {
   getBottomLeft,
   getBottomRight,
@@ -154,12 +152,11 @@ class CanvasLayerRenderer extends LayerRenderer {
   /**
    * Get a rendering container from an existing target, if compatible.
    * @param {HTMLElement} target Potential render target.
-   * @param {import('../../transform.js').Transform} transform Transform parameters for the CSS matrix.
-   * @param {import('../../Map.js').FrameState} [frameState] Frame state.
+   * @param {string} transform CSS Transform.
+   * @param {string} [backgroundColor] Background color.
    */
-  useContainer(target, transform, frameState) {
+  useContainer(target, transform, backgroundColor) {
     const layerClassName = this.getLayer().getClassName();
-    const backgroundColor = this.getBackground(frameState);
     let container, context;
     if (
       target &&
@@ -167,7 +164,7 @@ class CanvasLayerRenderer extends LayerRenderer {
       (!backgroundColor ||
         (target &&
           target.style.backgroundColor &&
-          equalArrays(
+          equals(
             asArray(target.style.backgroundColor),
             asArray(backgroundColor),
           )))
@@ -177,11 +174,7 @@ class CanvasLayerRenderer extends LayerRenderer {
         context = canvas.getContext('2d');
       }
     }
-    const transformsAreEqual =
-      frameState.layerTransform &&
-      transform &&
-      equalTransforms(frameState.layerTransform, transform);
-    if (context && transformsAreEqual) {
+    if (context && context.canvas.style.transform === transform) {
       // Container of the previous layer renderer can be used.
       this.container = target;
       this.context = context;
@@ -217,12 +210,6 @@ class CanvasLayerRenderer extends LayerRenderer {
       !this.container.style.backgroundColor
     ) {
       this.container.style.backgroundColor = backgroundColor;
-    }
-    if (!transformsAreEqual) {
-      if (transform) {
-        this.context.canvas.style.transform = toTransformString(transform);
-      }
-      frameState.layerTransform = transform;
     }
   }
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -10,6 +10,7 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   makeInverse,
+  toString as toTransformString,
 } from '../../transform.js';
 import {ascending} from '../../array.js';
 import {
@@ -379,7 +380,9 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       -height / 2,
     );
 
-    this.useContainer(target, this.pixelTransform, frameState);
+    const canvasTransform = toTransformString(this.pixelTransform);
+
+    this.useContainer(target, canvasTransform, this.getBackground(frameState));
 
     const context = this.getRenderContext(frameState);
     const canvas = this.context.canvas;
@@ -562,6 +565,10 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       context.restore();
     }
     context.imageSmoothingEnabled = true;
+
+    if (canvasTransform !== canvas.style.transform) {
+      canvas.style.transform = canvasTransform;
+    }
 
     return this.container;
   }

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -105,7 +105,7 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
       !hints[ViewHint.INTERACTING] &&
       !isEmpty(renderedExtent)
     ) {
-      vectorRenderer.useContainer(null, null, frameState);
+      vectorRenderer.useContainer(null, null);
       const context = vectorRenderer.context;
       const layerState = frameState.layerStatesArray[frameState.layerIndex];
       const imageLayerState = Object.assign({}, layerState, {opacity: 1});

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -15,7 +15,12 @@ import {
   createHitDetectionImageData,
   hitDetect,
 } from '../../render/canvas/hitdetect.js';
-import {apply, makeInverse, makeScale} from '../../transform.js';
+import {
+  apply,
+  makeInverse,
+  makeScale,
+  toString as transformToString,
+} from '../../transform.js';
 import {
   buffer,
   containsExtent,
@@ -286,7 +291,9 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     makeScale(this.pixelTransform, 1 / pixelRatio, 1 / pixelRatio);
     makeInverse(this.inversePixelTransform, this.pixelTransform);
 
-    this.useContainer(target, this.pixelTransform, frameState);
+    const canvasTransform = transformToString(this.pixelTransform);
+
+    this.useContainer(target, canvasTransform, this.getBackground(frameState));
 
     const context = this.context;
     const canvas = context.canvas;
@@ -308,6 +315,9 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     if (canvas.width != width || canvas.height != height) {
       canvas.width = width;
       canvas.height = height;
+      if (canvas.style.transform !== canvasTransform) {
+        canvas.style.transform = canvasTransform;
+      }
     } else if (!this.containerReused) {
       context.clearRect(0, 0, width, height);
     }

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -634,7 +634,6 @@ class RasterSource extends ImageSource {
       extent: null,
       index: 0,
       layerIndex: 0,
-      layerTransform: null,
       layerStatesArray: getLayerStatesArray(this.layers_),
       pixelRatio: 1,
       pixelToCoordinateTransform: createTransform(),

--- a/src/ol/transform.js
+++ b/src/ol/transform.js
@@ -46,26 +46,6 @@ export function reset(transform) {
 }
 
 /**
- * @param {!Transform} transform1 Transform 1.
- * @param {!Transform} transform2 Transform 2.
- * @return {boolean} Transform 1 and 2 are pixel equal.
- */
-export function equals(transform1, transform2) {
-  if (transform1 === transform2) {
-    return true;
-  }
-  const tolerance = 1e-6;
-  return (
-    Math.abs(transform1[0] - transform2[0]) < tolerance &&
-    Math.abs(transform1[1] - transform2[1]) < tolerance &&
-    Math.abs(transform1[2] - transform2[2]) < tolerance &&
-    Math.abs(transform1[3] - transform2[3]) < tolerance &&
-    Math.abs(transform1[4] - transform2[4]) < tolerance &&
-    Math.abs(transform1[5] - transform2[5]) < tolerance
-  );
-}
-
-/**
  * Multiply the underlying matrices of two transforms and return the result in
  * the first transform.
  * @param {!Transform} transform1 Transform parameters of matrix 1.
@@ -285,11 +265,25 @@ export function determinant(mat) {
 }
 
 /**
+ * @type {Array}
+ */
+const matrixPrecision = [1e6, 1e6, 1e6, 1e6, 2, 2];
+
+/**
  * A rounded string version of the transform.  This can be used
  * for CSS transforms.
  * @param {!Transform} mat Matrix.
  * @return {string} The transform as a string.
  */
 export function toString(mat) {
-  return 'matrix(' + mat.join(', ') + ')';
+  const transformString =
+    'matrix(' +
+    mat
+      .map(
+        (value, i) =>
+          Math.round(value * matrixPrecision[i]) / matrixPrecision[i],
+      )
+      .join(', ') +
+    ')';
+  return transformString;
 }

--- a/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
@@ -466,7 +466,7 @@ describe('ol/renderer/canvas/VectorLayer', function () {
         size: [100, 100],
         viewState: {
           projection: projection,
-          resolution: 1,
+          resolution: 200,
           rotation: 0,
         },
       };

--- a/test/browser/spec/ol/transform.test.js
+++ b/test/browser/spec/ol/transform.test.js
@@ -2,7 +2,6 @@ import {
   apply,
   compose,
   create,
-  equals,
   invert,
   makeInverse,
   makeScale,
@@ -12,6 +11,7 @@ import {
   scale,
   set,
   setFromArray,
+  toString,
   translate,
 } from '../../../../src/ol/transform.js';
 
@@ -178,21 +178,12 @@ describe('ol.transform', function () {
       expect(point).to.eql([3, 5]);
     });
   });
-  describe('equals()', function () {
+  describe('toString()', function () {
     it('compares with value read back from node', function () {
       const mat = [1 / 3, 0, 0, 1 / 3, 0, 0];
       const node = document.createElement('div');
       node.style.transform = 'matrix(' + mat.join(',') + ')';
-      const cssTransform = node.style.transform;
-      expect(
-        equals(
-          mat,
-          cssTransform
-            .substring(7, cssTransform.length - 2)
-            .split(',')
-            .map(Number),
-        ),
-      ).to.be(true);
+      expect(toString(mat)).to.be(node.style.transform);
     });
   });
 });


### PR DESCRIPTION
This is an the same as #15651 (reverts the changes made with #15620 and #15344), but with one commit added that avoids the creation of multiple canvases on maps with tile and vector layers.

Fixes #15644.