### PR TITLE
Clear RenderBox on DragBox Deactivation

### DIFF
--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -269,6 +269,23 @@ class DragBox extends PointerInteraction {
    * @param {import("../MapBrowserEvent.js").default} event Event.
    */
   onBoxEnd(event) {}
+
+  /**
+   * Activate or deactivate the interaction.
+   * @param {boolean} active Active.
+   * @observable
+   * @api
+   */
+  setActive(active) {
+    if (!active) {
+      this.box_.setMap(null);
+      this.dispatchEvent(
+        new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),
+      );
+    }
+
+    super.setActive(active);
+  }
 }
 
 export default DragBox;

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -205,6 +205,10 @@ class DragBox extends PointerInteraction {
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
    */
   handleDragEvent(mapBrowserEvent) {
+    if (!this.startPixel_) {
+      return;
+    }
+
     this.box_.setPixels(this.startPixel_, mapBrowserEvent.pixel);
 
     this.dispatchEvent(
@@ -222,6 +226,10 @@ class DragBox extends PointerInteraction {
    * @return {boolean} If the event was consumed.
    */
   handleUpEvent(mapBrowserEvent) {
+    if (!this.startPixel_) {
+      return false;
+    }
+
     this.box_.setMap(null);
 
     const completeBox = this.boxEndCondition_(
@@ -279,6 +287,7 @@ class DragBox extends PointerInteraction {
   setActive(active) {
     if (!active) {
       this.box_.setMap(null);
+      this.startPixel_ = null;
       this.dispatchEvent(
         new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),
       );

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -286,7 +286,7 @@ class DragBox extends PointerInteraction {
    */
   setActive(active) {
     if (!active) {
-      this.box_.setMap(null);
+      this.box_.disposeInternal();
       this.startPixel_ = null;
       this.dispatchEvent(
         new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -287,10 +287,12 @@ class DragBox extends PointerInteraction {
   setActive(active) {
     if (!active) {
       this.box_.disposeInternal();
-      this.startPixel_ = null;
-      this.dispatchEvent(
-        new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),
-      );
+      if (this.startPixel_) {
+        this.dispatchEvent(
+          new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),
+        );
+        this.startPixel_ = null;
+      }
     }
 
     super.setActive(active);

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -286,7 +286,7 @@ class DragBox extends PointerInteraction {
    */
   setActive(active) {
     if (!active) {
-      this.box_setMap(null);
+      this.box_.setMap(null);
       if (this.startPixel_) {
         this.dispatchEvent(
           new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -286,7 +286,7 @@ class DragBox extends PointerInteraction {
    */
   setActive(active) {
     if (!active) {
-      this.box_.disposeInternal();
+      this.box_setMap(null);
       if (this.startPixel_) {
         this.dispatchEvent(
           new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),

--- a/src/ol/render/Box.js
+++ b/src/ol/render/Box.js
@@ -100,6 +100,10 @@ class RenderBox extends Disposable {
    * Creates or updates the cached geometry.
    */
   createOrUpdateGeometry() {
+    if (!this.map_) {
+      return;
+    }
+
     const startPixel = this.startPixel_;
     const endPixel = this.endPixel_;
     const pixels = [


### PR DESCRIPTION
Currently, when the DragBox interaction is deactivated by calling `setActive(false)`, the RenderBox (which visually represents the dragged area) remains on the map. This Pull Request should resolve #15571 by clearing the RenderBox when the DragBox is deactivated.

### Changes

In the `setActive` method of the `DragBox` class, a new line has been added to call the `disposeInternal` method of the `box_` (RenderBox) instance when active is set to `false`. This will ensure that the RenderBox is properly disposed and removed from the map.