### PR TITLE
Fix offscreen-canvas example and make code more web worker friendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "marked": "12.0.1",
         "metalsmith": "^2.5.0",
         "mocha": "10.4.0",
-        "ol-mapbox-style": "^12.2.0",
+        "ol-mapbox-style": "^12.3.1",
         "ol-stac": "^1.0.0-beta.8",
         "pixelmatch": "^5.1.0",
         "pngjs": "^7.0.0",
@@ -7223,9 +7223,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.0.tgz",
-      "integrity": "sha512-DPGWcEeC/XNejo0N10DpVOkMr2pRSzxOYWpe9RoOPiC9Ph34jiuyRpFQsLzlnJPrRo7pdQOYSYoM+mL8QF/HBA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.1.tgz",
+      "integrity": "sha512-pKBpKBns4YUgeFCp+aeuJtM+D2BKLc1HJmk5tFL0Nv7u7nelZnInUs/+XnSlHOa1hPBSrOyL+7CvKtegEyuYlg==",
       "dev": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "marked": "12.0.1",
     "metalsmith": "^2.5.0",
     "mocha": "10.4.0",
-    "ol-mapbox-style": "^12.2.0",
+    "ol-mapbox-style": "^12.3.1",
     "ol-stac": "^1.0.0-beta.8",
     "pixelmatch": "^5.1.0",
     "pngjs": "^7.0.0",

--- a/src/ol/render/canvas/ZIndexContext.js
+++ b/src/ol/render/canvas/ZIndexContext.js
@@ -30,7 +30,7 @@ class ZIndexContext {
      * @type {ZIndexContextProxy}
      */
     this.context_ = /** @type {ZIndexContextProxy} */ (
-      new Proxy(CanvasRenderingContext2D.prototype, {
+      new Proxy(getSharedCanvasContext2D(), {
         get: (target, property) => {
           if (
             typeof (/** @type {*} */ (getSharedCanvasContext2D())[property]) !==

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -186,7 +186,7 @@ class Icon extends ImageStyle {
     if (options.src !== undefined) {
       imageState = ImageState.IDLE;
     } else if (image !== undefined) {
-      if (image instanceof HTMLImageElement) {
+      if ('complete' in image) {
         if (image.complete) {
           imageState = image.src ? ImageState.LOADED : ImageState.IDLE;
         } else {

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -314,7 +314,7 @@ export function get(image, cacheKey, crossOrigin, imageState, color, pattern) {
   if (!iconImage) {
     iconImage = new IconImage(
       image,
-      image instanceof HTMLImageElement ? image.src || undefined : cacheKey,
+      image && 'src' in image ? image.src || undefined : cacheKey,
       crossOrigin,
       imageState,
       color,


### PR DESCRIPTION
This pull request fixes the offscreen-canvas example and makes the code more web worker friendly (again), by not assuming `window` globals in code that might be run in a web worker.

Fixes #15718 