### PR TITLE
Fix VectorImageLayer declutter description

### DIFF
--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -35,11 +35,11 @@ import CanvasVectorImageLayerRenderer from '../renderer/canvas/VectorImageLayer.
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use [map.addLayer()]{@link import("../Map.js").default#addLayer}.
- * @property {boolean|string|number} [declutter=false] Declutter images and text. Any truthy value will enable
- * decluttering. Within a layer, a feature rendered before another has higher priority. All layers with the
- * same `declutter` value will be decluttered together. The priority is determined by the drawing order of the
- * layers with the same `declutter` value. Higher in the layer stack means higher priority. To declutter distinct
- * layers or groups of layers separately, use different truthy values for `declutter`.
+ * @property {boolean|string|number} [declutter=false] Declutter images and text on this layer. Any truthy value will enable
+ * decluttering. The priority is defined by the `zIndex` of the style and the render order of features. Higher z-index means higher
+ * priority. Within the same z-index, a feature rendered before another has higher priority. Items will
+ * not be decluttered against or together with items on other layers with the same `declutter` value. If
+ * that is needed, use {@link import("../layer/Vector.js").default} instead.
  * @property {import("../style/Style.js").StyleLike|import("../style/flat.js").FlatStyleLike|null} [style] Layer style. When set to `null`, only
  * features that have their own style will be rendered. See {@link module:ol/style/Style~Style} for the default style
  * which will be used if this is not set.


### PR DESCRIPTION
Restores the previous description with the addition of "Any truthy value will enable decluttering" due to the type being wider now.

https://github.com/openlayers/openlayers/pull/15713#issuecomment-2047383187

I think it would make more sense if it worked the same way as VectorLayer, but I don't know the code well enough to try that.