### PR TITLE
Reuse container preparation code

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -7,8 +7,6 @@ import ViewHint from '../../ViewHint.js';
 import {
   apply as applyTransform,
   compose as composeTransform,
-  makeInverse,
-  toString as toTransformString,
 } from '../../transform.js';
 import {
   containsCoordinate,
@@ -167,39 +165,13 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
     const scaleY =
       (pixelRatio * imageResolutionY) / (viewResolution * imagePixelRatio);
 
-    const extent = frameState.extent;
-    const resolution = viewState.resolution;
-    const rotation = viewState.rotation;
+    this.prepareContainer(frameState, target);
+
     // desired dimensions of the canvas in pixels
-    const width = Math.round((getWidth(extent) / resolution) * pixelRatio);
-    const height = Math.round((getHeight(extent) / resolution) * pixelRatio);
-
-    // set forward and inverse pixel transforms
-    composeTransform(
-      this.pixelTransform,
-      frameState.size[0] / 2,
-      frameState.size[1] / 2,
-      1 / pixelRatio,
-      1 / pixelRatio,
-      rotation,
-      -width / 2,
-      -height / 2,
-    );
-    makeInverse(this.inversePixelTransform, this.pixelTransform);
-
-    const canvasTransform = toTransformString(this.pixelTransform);
-
-    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+    const width = this.context.canvas.width;
+    const height = this.context.canvas.height;
 
     const context = this.getRenderContext(frameState);
-    const canvas = this.context.canvas;
-
-    if (canvas.width != width || canvas.height != height) {
-      canvas.width = width;
-      canvas.height = height;
-    } else if (!this.containerReused) {
-      context.clearRect(0, 0, width, height);
-    }
 
     // clipped rendering if layer extent is set
     let clipped = false;
@@ -258,10 +230,6 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       context.restore();
     }
     context.imageSmoothingEnabled = true;
-
-    if (canvasTransform !== canvas.style.transform) {
-      canvas.style.transform = canvasTransform;
-    }
 
     return this.container;
   }

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -9,6 +9,8 @@ import {
   apply as applyTransform,
   compose as composeTransform,
   create as createTransform,
+  makeInverse,
+  toString as toTransformString,
 } from '../../transform.js';
 import {asArray} from '../../color.js';
 import {createCanvasContext2D} from '../../dom.js';
@@ -16,8 +18,10 @@ import {equals} from '../../array.js';
 import {
   getBottomLeft,
   getBottomRight,
+  getHeight,
   getTopLeft,
   getTopRight,
+  getWidth,
 } from '../../extent.js';
 
 /**
@@ -243,6 +247,48 @@ class CanvasLayerRenderer extends LayerRenderer {
     context.lineTo(Math.round(bottomRight[0]), Math.round(bottomRight[1]));
     context.lineTo(Math.round(bottomLeft[0]), Math.round(bottomLeft[1]));
     context.clip();
+  }
+
+  /**
+   * @param {import("../../Map.js").FrameState} frameState Frame state.
+   * @param {HTMLElement} target Target that may be used to render content to.
+   * @protected
+   */
+  prepareContainer(frameState, target) {
+    const extent = frameState.extent;
+    const resolution = frameState.viewState.resolution;
+    const rotation = frameState.viewState.rotation;
+    const pixelRatio = frameState.pixelRatio;
+    const width = Math.round((getWidth(extent) / resolution) * pixelRatio);
+    const height = Math.round((getHeight(extent) / resolution) * pixelRatio);
+    // set forward and inverse pixel transforms
+    composeTransform(
+      this.pixelTransform,
+      frameState.size[0] / 2,
+      frameState.size[1] / 2,
+      1 / pixelRatio,
+      1 / pixelRatio,
+      rotation,
+      -width / 2,
+      -height / 2,
+    );
+    makeInverse(this.inversePixelTransform, this.pixelTransform);
+
+    const canvasTransform = toTransformString(this.pixelTransform);
+    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+
+    if (!this.containerReused) {
+      const canvas = this.context.canvas;
+      if (canvas.width != width || canvas.height != height) {
+        canvas.width = width;
+        canvas.height = height;
+      } else {
+        this.getRenderContext(frameState).clearRect(0, 0, width, height);
+      }
+      if (canvasTransform !== canvas.style.transform) {
+        canvas.style.transform = canvasTransform;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This pull request moves the container preparation code which is repeated across tile, vector and image canvas layer renderes, as `prepareContainer()` method into the parent class.

The only logic change compared with the previous repeated code is that the canvas width and height is only changed when the container is not reused. This change fixes #15704.