### PR TITLE
Fix getFeatures(pixel) regression

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -15,7 +15,6 @@ import {
   createHitDetectionImageData,
   hitDetect,
 } from '../../render/canvas/hitdetect.js';
-import {apply} from '../../transform.js';
 import {
   buffer,
   containsExtent,
@@ -352,7 +351,6 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
         !this.animatingOrInteracting_
       ) {
         const size = this.frameState.size.slice();
-        apply(this.pixelTransform, size);
         const center = this.renderedCenter_;
         const resolution = this.renderedResolution_;
         const rotation = this.renderedRotation_;

--- a/test/browser/spec/ol/layer/vector.test.js
+++ b/test/browser/spec/ol/layer/vector.test.js
@@ -203,6 +203,59 @@ describe('ol.layer.Vector', function () {
       });
     });
 
+    it('detects features properly on rotated view', function (done) {
+      map.getView().setRotation(Math.PI / 4);
+      map.renderSync();
+      const source = new VectorSource({
+        features: [
+          new Feature({
+            geometry: new Point([-1000000, 0]),
+            name: 'feature1',
+          }),
+          new Feature({
+            geometry: new Point([1000000, 0]),
+            name: 'feature2',
+          }),
+        ],
+      });
+
+      const feature = new Feature({
+        geometry: new Point([-1000000, 0]),
+        name: 'feature with no size',
+      });
+
+      const testImage = new ImageStyle({
+        opacity: 1,
+        displacement: [],
+      });
+
+      testImage.getImageState = () => {};
+      testImage.listenImageChange = () => {};
+      testImage.getImageSize = () => {};
+
+      feature.setStyle([
+        new Style({
+          image: testImage,
+        }),
+      ]);
+
+      source.addFeature(feature);
+
+      const layer = new VectorLayer({
+        source,
+      });
+      map.addLayer(layer);
+      map.renderSync();
+
+      const pixel = map.getPixelFromCoordinate([-1000000, 0]);
+
+      layer.getFeatures(pixel).then(function (features) {
+        expect(features.length).to.equal(1);
+        expect(features[0].get('name')).to.be('feature1');
+        done();
+      });
+    });
+
     it('detects zero opacity images', function (done) {
       const source = new VectorSource({
         features: [


### PR DESCRIPTION
This pull request fixes a regression introduced with #15683, which slipped through the tests. That regression broke `getFeatures(pixel)` hit detection on rotated views and on maps with a pixel ratio other than 1.

I also added another test to avoid such regressions in the future.