### PR TITLE
Use outdoor instead of streets style for site and mapbox-style example

### DIFF
--- a/examples/mapbox-style.js
+++ b/examples/mapbox-style.js
@@ -3,7 +3,7 @@ import olms from 'ol-mapbox-style';
 
 olms(
   'map',
-  'https://api.maptiler.com/maps/streets-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB',
+  'https://api.maptiler.com/maps/outdoor-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB',
 ).then(function (map) {
   map.addControl(new FullScreen());
 });

--- a/site/src/main.js
+++ b/site/src/main.js
@@ -85,7 +85,7 @@ map.addControl(new FullScreen());
 
 apply(
   map,
-  'https://api.maptiler.com/maps/streets-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB',
+  'https://api.maptiler.com/maps/outdoor-v2/style.json?key=get_your_own_D6rA4zTHduk6KOKTXzGB',
 );
 
 container.onmouseover = function () {


### PR DESCRIPTION
Makes the site's top banner map more appealing again, and brings the mapbox-style example closer to what it was before #15725.