### PR TITLE
fix: webgl style regression - force ambiguous match input type to an accepted type

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -874,6 +874,7 @@ function parseMatchArgs(encoded, context, parsedArgs, typeHint) {
         `, got ${typeName(inputType)} instead`,
     );
   }
+  inputType &= expectedInputType;
   if (isType(outputType, NoneType)) {
     throw new Error(
       `Could not find a common output type for the following match operation: ` +

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -1073,6 +1073,28 @@ describe('ol.webgl.styleparser', () => {
     });
   });
 
+  describe('handle ambiguous match input', () => {
+    it('parses a match', () => {
+      const result = parseLiteralStyle({
+        'icon-src':
+          'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==',
+        'icon-color': [
+          'match',
+          ['get', 'foo'],
+          'green',
+          [251, 173, 21, 0.5],
+          'red',
+          [251, 173, 21, 0.5],
+          [251, 173, 21, 0.5],
+        ],
+      });
+
+      expect(result.attributes.foo.callback({get: () => 'green'})).to.be.a(
+        'number',
+      );
+    });
+  });
+
   describe('shader functions', () => {
     it('adds shader functions in the vertex and fragment shaders', () => {
       const result = parseLiteralStyle({


### PR DESCRIPTION
Fix for https://github.com/openlayers/openlayers/issues/15801 , which contains more context
