### PR TITLE
Stop using deprecated search API from EPSG.io

### DIFF
--- a/examples/reprojection-by-code.html
+++ b/examples/reprojection-by-code.html
@@ -1,14 +1,18 @@
 ---
 layout: example.html
-title: Reprojection with EPSG.io Search
+title: Reprojection with coordinate system search
 shortdesc: Demonstrates client-side raster reprojection of OSM to arbitrary projection
 docs: >
   This example shows client-side raster reprojection capabilities from
   OSM (EPSG:3857) to arbitrary projection by searching
-  in <a href="https://epsg.io/">EPSG.io</a> database.
-tags: "reprojection, projection, proj4js, epsg.io, graticule"
+  in <a href="https://docs.maptiler.com/cloud/api/coordinates/">MapTiler Cloud Coordinates API</a>.
+  **Note**: Make sure to get your own API key at https://www.maptiler.com/cloud/ when using this example.
+tags: "reprojection, projection, proj4js, epsg, maptiler, graticule"
 resources:
   - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>
 <form class="row">


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

## Summary

This PR updates a single example demonstrating map reprojection by full-text searching for coordinate systems.
The Coordinate system search API from EPSG.io is going to be deprecated soon and is replaced by the similar API from MapTiler Cloud. (That requires a free key, but the same key from other examples can be used here as well.)

The API is very similar, but some minor changes were required.

### Note
Only the dynamic full-text search (and remote transformation API) is getting deprecated, the `https://epsg.io/${code}.proj4` is still going to work as before, so this code does not require any change: https://github.com/openlayers/openlayers/blob/faccc50f7fe067da656b8965bbdd4280058deb75/src/ol/proj/proj4.js#L95-L98 