### PR TITLE
fix: handle errors in response parsing in xhr loader

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -89,18 +89,10 @@ export function loadFeaturesXhr(
       try {
         /** @type {Document|Node|Object|string|undefined} */
         let source;
-        if (type == 'json') {
-          source = JSON.parse(xhr.responseText);
-        } else if (type == 'text') {
+        if (type == 'text' || type == 'json') {
           source = xhr.responseText;
         } else if (type == 'xml') {
-          source = xhr.responseXML;
-          if (!source) {
-            source = new DOMParser().parseFromString(
-              xhr.responseText,
-              'application/xml',
-            );
-          }
+          source = xhr.responseXML || xhr.responseText;
         } else if (type == 'arraybuffer') {
           source = /** @type {ArrayBuffer} */ (xhr.response);
         }

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -86,35 +86,39 @@ export function loadFeaturesXhr(
     // status will be 0 for file:// urls
     if (!xhr.status || (xhr.status >= 200 && xhr.status < 300)) {
       const type = format.getType();
-      /** @type {Document|Node|Object|string|undefined} */
-      let source;
-      if (type == 'json') {
-        source = JSON.parse(xhr.responseText);
-      } else if (type == 'text') {
-        source = xhr.responseText;
-      } else if (type == 'xml') {
-        source = xhr.responseXML;
-        if (!source) {
-          source = new DOMParser().parseFromString(
-            xhr.responseText,
-            'application/xml',
-          );
+      try {
+        /** @type {Document|Node|Object|string|undefined} */
+        let source;
+        if (type == 'json') {
+          source = JSON.parse(xhr.responseText);
+        } else if (type == 'text') {
+          source = xhr.responseText;
+        } else if (type == 'xml') {
+          source = xhr.responseXML;
+          if (!source) {
+            source = new DOMParser().parseFromString(
+              xhr.responseText,
+              'application/xml',
+            );
+          }
+        } else if (type == 'arraybuffer') {
+          source = /** @type {ArrayBuffer} */ (xhr.response);
         }
-      } else if (type == 'arraybuffer') {
-        source = /** @type {ArrayBuffer} */ (xhr.response);
-      }
-      if (source) {
-        success(
-          /** @type {Array<FeatureType>} */
-          (
-            format.readFeatures(source, {
-              extent: extent,
-              featureProjection: projection,
-            })
-          ),
-          format.readProjection(source),
-        );
-      } else {
+        if (source) {
+          success(
+            /** @type {Array<FeatureType>} */
+            (
+              format.readFeatures(source, {
+                extent: extent,
+                featureProjection: projection,
+              })
+            ),
+            format.readProjection(source),
+          );
+        } else {
+          failure();
+        }
+      } catch {
         failure();
       }
     } else {

--- a/test/browser/spec/ol/data/exceptionreport.json
+++ b/test/browser/spec/ol/data/exceptionreport.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.1.0",
+  "exceptions": [
+    {
+      "code": "noApplicableCode",
+      "locator": "noLocator",
+      "text": "We have had issues trying to flip axis of GEOGCS[\"GCS_WGS_1984\", \n  DATUM[\"D_WGS_1984\", \n    SPHEROID[\"WGS_1984\", 6378137.0, 298.257223563]], \n  PRIMEM[\"Greenwich\", 0.0], \n  UNIT[\"degree\", 0.017453292519943295], \n  AXIS[\"Longitude\", EAST], \n  AXIS[\"Latitude\", NORTH]]\nNo authority was defined for code \"GCS_WGS_1984\". Did you forget \"AUTHORITY:NUMBER\"?"
+    }
+  ]
+}

--- a/test/browser/spec/ol/data/exceptionreport.xml
+++ b/test/browser/spec/ol/data/exceptionreport.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows https://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
+  <ows:Exception exceptionCode="NoApplicableCode">
+    <ows:ExceptionText>We have had issues trying to flip axis of GEOGCS["GCS_WGS_1984", 
+  DATUM["D_WGS_1984", 
+    SPHEROID["WGS_1984", 6378137.0, 298.257223563]], 
+  PRIMEM["Greenwich", 0.0], 
+  UNIT["degree", 0.017453292519943295], 
+  AXIS["Longitude", EAST], 
+  AXIS["Latitude", NORTH]]
+No authority was defined for code "GCS_WGS_1984". Did you forget "AUTHORITY:NUMBER"?</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>

--- a/test/browser/spec/ol/featureloader.test.js
+++ b/test/browser/spec/ol/featureloader.test.js
@@ -59,7 +59,7 @@ describe('ol.featureloader', function () {
       });
     });
 
-    it('it calls the success callback', function (done) {
+    it('calls the success callback', function (done) {
       const errorSpy = sinon.spy();
       loader = xhr(url, format);
       loader.call(
@@ -75,6 +75,17 @@ describe('ol.featureloader', function () {
         },
         errorSpy,
       );
+    });
+
+    it('calls the failure callback when the parsing throws an error', function (done) {
+      const successSpy = sinon.spy();
+      loader = xhr('spec/ol/data/exceptionreport.xml', format);
+      loader.call(source, [], 1, 'EPSG:3857', successSpy, function () {
+        setTimeout(function () {
+          expect(successSpy.callCount).to.be(0);
+          done();
+        }, 0);
+      });
     });
   });
 });

--- a/test/browser/spec/ol/featureloader.test.js
+++ b/test/browser/spec/ol/featureloader.test.js
@@ -77,9 +77,20 @@ describe('ol.featureloader', function () {
       );
     });
 
-    it('calls the failure callback when the parsing throws an error', function (done) {
+    it('calls the failure callback when the parsing throws an error (xml)', function (done) {
       const successSpy = sinon.spy();
       loader = xhr('spec/ol/data/exceptionreport.xml', format);
+      loader.call(source, [], 1, 'EPSG:3857', successSpy, function () {
+        setTimeout(function () {
+          expect(successSpy.callCount).to.be(0);
+          done();
+        }, 0);
+      });
+    });
+
+    it('calls the failure callback when the parsing throws an error (json)', function (done) {
+      const successSpy = sinon.spy();
+      loader = xhr('spec/ol/data/exceptionreport.json', format);
       loader.call(source, [], 1, 'EPSG:3857', successSpy, function () {
         setTimeout(function () {
           expect(successSpy.callCount).to.be(0);


### PR DESCRIPTION
Although I'm not sure if/what the OWS spec says about this, but at least the popular geoserver will return status 200 even when the result is an OWS exception report.

E.g. If I make a WFS call that fails in geoserver. I'll get a status 200 with an ows exception report XML.
e.g.
```xml
<?xml version="1.0" encoding="UTF-8"?><ows:ExceptionReport xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/ows localhost/geoserver/schemas/ows/1.0.0/owsExceptionReport.xsd">
  <ows:Exception exceptionCode="NoApplicableCode">
    <ows:ExceptionText>We have had issues trying to flip axis of GEOGCS["GCS_WGS_1984", ...</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```

The problem is that the xhr loader does not account for this and will throw an uncaught error when trying to parse it as json.
Therefore the failure/success callbacks are never called and the source stays in loading state (and in turn rendercomplete is not called)

This PR tries to solve this by putting wrapping the entire data parsing in a try-catch