### PR TITLE
refactor: remove unneeded '/' for URL construction

### DIFF
--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -111,7 +111,7 @@ export function appendCollectionsQueryParam(tileUrlTemplate, collections) {
   }
 
   // making sure we can always construct a URL instance.
-  const url = new URL(tileUrlTemplate, 'file://');
+  const url = new URL(tileUrlTemplate, 'file:/');
 
   if (url.pathname.split('/').includes('collections')) {
     logError(


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This is a very minor follow up of https://github.com/openlayers/openlayers/pull/15792 that removes the unneeded second `/` when constructing the helper URL instance for appending the collections parameter on OGC API Layers. See also https://github.com/openlayers/openlayers/pull/15792#discussion_r1592822864