### PR TITLE
Resolve NumberType | NumberArrayType ambiguity with a new SizeType

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -134,6 +134,7 @@ export const NumberType = 1 << numTypes++;
 export const StringType = 1 << numTypes++;
 export const ColorType = 1 << numTypes++;
 export const NumberArrayType = 1 << numTypes++;
+export const SizeType = NumberType | NumberArrayType;
 export const AnyType = Math.pow(2, numTypes) - 1;
 
 const typeNames = {

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -134,7 +134,7 @@ export const NumberType = 1 << numTypes++;
 export const StringType = 1 << numTypes++;
 export const ColorType = 1 << numTypes++;
 export const NumberArrayType = 1 << numTypes++;
-export const SizeType = NumberType | NumberArrayType;
+export const SizeType = 1 << numTypes++;
 export const AnyType = Math.pow(2, numTypes) - 1;
 
 const typeNames = {
@@ -143,6 +143,7 @@ const typeNames = {
   [StringType]: 'string',
   [ColorType]: 'color',
   [NumberArrayType]: 'number[]',
+  [SizeType]: 'size',
 };
 
 const namedTypes = Object.keys(typeNames).map(Number).sort(ascending);
@@ -286,7 +287,10 @@ export function parse(encoded, context, typeHint) {
       return new LiteralExpression(BooleanType, encoded);
     }
     case 'number': {
-      return new LiteralExpression(NumberType, encoded);
+      return new LiteralExpression(
+        typeHint === SizeType ? SizeType : NumberType,
+        encoded,
+      );
     }
     case 'string': {
       let type = StringType;
@@ -323,7 +327,9 @@ export function parse(encoded, context, typeHint) {
   }
 
   let type = NumberArrayType;
-  if (encoded.length === 3 || encoded.length === 4) {
+  if (encoded.length === 2) {
+    type |= SizeType;
+  } else if (encoded.length === 3 || encoded.length === 4) {
     type |= ColorType;
   }
   if (typeHint) {
@@ -623,9 +629,11 @@ const parsers = {
   ),
   [Ops.Array]: createParser(
     (parsedArgs) => {
-      return parsedArgs.length === 3 || parsedArgs.length === 4
-        ? NumberArrayType | ColorType
-        : NumberArrayType;
+      return parsedArgs.length === 2
+        ? NumberArrayType | SizeType
+        : parsedArgs.length === 3 || parsedArgs.length === 4
+          ? NumberArrayType | ColorType
+          : NumberArrayType;
     },
     withArgsCount(1, Infinity),
     parseArgsOfType(NumberType),

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -10,6 +10,7 @@ import {
   NumberArrayType,
   NumberType,
   Ops,
+  SizeType,
   StringType,
   computeGeometryType,
   isType,
@@ -19,6 +20,7 @@ import {
 } from './expression.js';
 import {Uniforms} from '../renderer/webgl/TileLayer.js';
 import {asArray} from '../color.js';
+import {toSize} from '../size.js';
 
 /**
  * @param {string} operator Operator
@@ -70,6 +72,16 @@ export function colorToGlsl(color) {
     (array[2] / 255) * alpha,
     alpha,
   ]);
+}
+
+/**
+ * Normalizes and converts a number or array toa `vec2` array compatible with GLSL.
+ * @param {number|import('../size.js').Size} size Size.
+ * @return {string} The color expressed in the `vec4(1.0, 1.0, 1.0, 1.0)` form.
+ */
+export function sizeToGlsl(size) {
+  const array = toSize(size);
+  return arrayToGlsl(array);
 }
 
 /** @type {Object<string, number>} */
@@ -483,6 +495,12 @@ function compile(expression, returnType, context) {
 
   if ((expression.type & NumberArrayType) > 0) {
     return arrayToGlsl(/** @type {Array<number>} */ (expression.value));
+  }
+
+  if ((expression.type & SizeType) > 0) {
+    return sizeToGlsl(
+      /** @type {number|import('../size.js').Size} */ (expression.value),
+    );
   }
 
   throw new Error(

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -7,6 +7,7 @@ import {
   ColorType,
   NumberArrayType,
   NumberType,
+  SizeType,
   StringType,
   newParsingContext,
 } from '../expr/expression.js';
@@ -67,7 +68,7 @@ const UNPACK_COLOR_FN = `vec4 unpackColor(vec2 packedColor) {
  * @return {1|2|3|4} The amount of components for this value
  */
 function getGlslSizeFromType(type) {
-  if (type === ColorType) {
+  if (type === ColorType || type === SizeType) {
     return 2;
   }
   if (type === NumberArrayType) {
@@ -134,7 +135,7 @@ function parseCommonSymbolProperties(style, builder, vertContext, prefix) {
     const scale = expressionToGlsl(
       vertContext,
       style[`${prefix}scale`],
-      NumberType | NumberArrayType,
+      SizeType,
     );
     builder.setSymbolSizeExpression(
       `${builder.getSymbolSizeExpression()} * ${scale}`,
@@ -301,7 +302,7 @@ function parseCircleProperties(
     const scale = expressionToGlsl(
       fragContext,
       style['circle-scale'],
-      NumberType | NumberArrayType,
+      SizeType,
     );
     currentPoint = `coordsPx / ${scale}`;
   }
@@ -420,11 +421,7 @@ function parseShapeProperties(
   // SCALE
   let currentPoint = 'coordsPx';
   if ('shape-scale' in style) {
-    const scale = expressionToGlsl(
-      fragContext,
-      style['shape-scale'],
-      NumberType | NumberArrayType,
-    );
+    const scale = expressionToGlsl(fragContext, style['shape-scale'], SizeType);
     currentPoint = `coordsPx / ${scale}`;
   }
 
@@ -584,11 +581,7 @@ function parseIconProperties(
     );
     let scale = `1.0`;
     if (`icon-scale` in style) {
-      scale = expressionToGlsl(
-        vertContext,
-        style[`icon-scale`],
-        NumberType | NumberArrayType,
-      );
+      scale = expressionToGlsl(vertContext, style[`icon-scale`], SizeType);
     }
     let shiftPx;
     if (

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -1015,7 +1015,7 @@ describe('ol.webgl.styleparser', () => {
       });
       it('adds uniforms to the shader builder', () => {
         expect(parseResult.builder.uniforms_).to.eql([
-          'vec4 u_var_iconSize',
+          'vec2 u_var_iconSize',
           'vec2 u_var_color',
           'float u_var_lineType',
           'float u_var_lineWidth',

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -898,12 +898,12 @@ describe('ol.webgl.styleparser', () => {
           ],
           'circle-radius': 8,
           'circle-fill-color': ['get', 'color'],
-          'circle-scale': ['get', 'iconSize', 'number[]'],
+          'circle-scale': ['get', 'iconSize'],
         });
       });
       it('adds attributes to the shader builder', () => {
         expect(parseResult.builder.attributes_).to.eql([
-          'vec4 a_prop_iconSize',
+          'vec2 a_prop_iconSize',
           'float a_prop_lineType',
           'float a_prop_lineWidth',
           'vec2 a_prop_color',
@@ -915,7 +915,7 @@ describe('ol.webgl.styleparser', () => {
         expect(parseResult.builder.varyings_).to.eql([
           {
             name: 'v_prop_iconSize',
-            type: 'vec4',
+            type: 'vec2',
             expression: 'a_prop_iconSize',
           },
           {
@@ -943,7 +943,7 @@ describe('ol.webgl.styleparser', () => {
       });
       it('returns attributes with their callbacks in the result', () => {
         expect(parseResult.attributes).to.eql({
-          iconSize: {size: 4, callback: {}},
+          iconSize: {size: 2, callback: {}},
           color: {size: 2, callback: {}},
           lineType: {size: 1, callback: {}},
           lineWidth: {size: 1, callback: {}},

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -532,7 +532,10 @@ describe('ol/expr/expression.js', () => {
         type: BooleanType | NumberType | StringType | ColorType,
         name: 'boolean, number, string, or color',
       },
-      {type: AnyType, name: 'boolean, number, string, color, or number[]'},
+      {
+        type: AnyType,
+        name: 'boolean, number, string, color, number[], or size',
+      },
     ];
 
     for (const {type, name} of cases) {

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -6,6 +6,7 @@ import {
   ColorType,
   NumberArrayType,
   NumberType,
+  SizeType,
   StringType,
   newParsingContext,
 } from '../../../../src/ol/expr/expression.js';
@@ -781,7 +782,7 @@ describe('ol/expr/gpu.js', () => {
           expect(context.variables).to.eql({
             fixedSize: {
               name: 'fixedSize',
-              type: NumberArrayType,
+              type: NumberArrayType | SizeType,
             },
             symbolType: {
               name: 'symbolType',
@@ -797,6 +798,24 @@ describe('ol/expr/gpu.js', () => {
             },
           });
         },
+      },
+      {
+        name: 'scale (number)',
+        type: SizeType,
+        expression: 1.5,
+        expected: 'vec2(1.5, 1.5)',
+      },
+      {
+        name: 'scale (constructed array)',
+        type: SizeType,
+        expression: ['array', 1.5, 0.5],
+        expected: 'vec2(1.5, 0.5)',
+      },
+      {
+        name: 'scale (array)',
+        type: SizeType,
+        expression: [1.5, 0.5],
+        expected: 'vec2(1.5, 0.5)',
       },
     ];
 


### PR DESCRIPTION
This pull request removes the only real-life need for type hints in `"get"` call expressions, which was needed due to an ambiguity between `NumberType` and `NumberArrayType` for `-scale` style properties.

With the new `SizeType`, it would also be possible to support styles like `'icon-size': 24` instead of `'icon-size': [24, 24]`, but I did not make this change here.