### PR TITLE
Align getStyle() behavior and documentation

### DIFF
--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -112,7 +112,7 @@ class BaseVectorLayer extends Layer {
 
     /**
      * User provided style.
-     * @type {import("../style/Style.js").StyleLike}
+     * @type {import("../style/Style.js").StyleLike|import("../style/flat.js").FlatStyleLike}
      * @private
      */
     this.style_ = null;
@@ -190,7 +190,7 @@ class BaseVectorLayer extends Layer {
   /**
    * Get the style for features.  This returns whatever was passed to the `style`
    * option at construction or to the `setStyle` method.
-   * @return {import("../style/Style.js").StyleLike|null|undefined} Layer style.
+   * @return {import("../style/Style.js").StyleLike|import("../style/flat.js").FlatStyleLike|null|undefined} Layer style.
    * @api
    */
   getStyle() {
@@ -265,9 +265,10 @@ class BaseVectorLayer extends Layer {
    * @api
    */
   setStyle(style) {
-    this.style_ = toStyleLike(style);
+    this.style_ = style === undefined ? createDefaultStyle : style;
+    const styleLike = toStyleLike(style);
     this.styleFunction_ =
-      style === null ? undefined : toStyleFunction(this.style_);
+      style === null ? undefined : toStyleFunction(styleLike);
     this.changed();
   }
 }

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -174,8 +174,10 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
     it('gives precedence to feature styles over layer styles', function () {
       const spy = sinon.spy(layer.getRenderer(), 'renderFeature');
       map.renderSync();
-      expect(spy.getCall(0).args[2]).to.be(layer.getStyle());
-      expect(spy.getCall(1).args[2]).to.be(feature2.getStyle());
+      expect(spy.getCall(0).args[2]).to.be(layer.getStyleFunction()(feature1));
+      expect(spy.getCall(1).args[2]).to.be(
+        feature2.getStyleFunction()(feature2),
+      );
       spy.restore();
     });
 

--- a/test/node/ol/layer/Vector.test.js
+++ b/test/node/ol/layer/Vector.test.js
@@ -1,7 +1,7 @@
 import Feature from '../../../../src/ol/Feature.js';
 import Fill from '../../../../src/ol/style/Fill.js';
 import Stroke from '../../../../src/ol/style/Stroke.js';
-import Style from '../../../../src/ol/style/Style.js';
+import Style, {createDefaultStyle} from '../../../../src/ol/style/Style.js';
 import Vector from '../../../../src/ol/layer/Vector.js';
 import expect from '../../expect.js';
 
@@ -13,7 +13,7 @@ describe('ol/layer/Vector.js', () => {
         'fill-color': 'red',
       });
 
-      const styleFunction = layer.getStyle();
+      const styleFunction = layer.getStyleFunction();
       expect(styleFunction).to.be.a(Function);
 
       const styles = styleFunction(new Feature(), 1);
@@ -39,7 +39,7 @@ describe('ol/layer/Vector.js', () => {
         },
       ]);
 
-      const styleFunction = layer.getStyle();
+      const styleFunction = layer.getStyleFunction();
       expect(styleFunction).to.be.a(Function);
 
       const styles = styleFunction(new Feature(), 1);
@@ -61,6 +61,43 @@ describe('ol/layer/Vector.js', () => {
       expect(secondStroke).to.be.a(Stroke);
       expect(secondStroke.getColor()).to.be('yellow');
       expect(secondStroke.getWidth()).to.be(5);
+    });
+  });
+
+  describe('getStyle()', () => {
+    it('returns the default style if no style was set', () => {
+      const layer = new Vector();
+      expect(layer.getStyle()).to.be(createDefaultStyle);
+    });
+    it('returns null if null was set', () => {
+      const layer = new Vector();
+      layer.setStyle(null);
+      expect(layer.getStyle()).to.be(null);
+    });
+    it('returns a Style if a Style was set', () => {
+      const layer = new Vector();
+      const style = new Style({
+        fill: new Fill({
+          color: 'red',
+        }),
+      });
+      layer.setStyle(style);
+      expect(layer.getStyle()).to.be(style);
+    });
+    it('returns a flat style if a flat style was set', () => {
+      const layer = new Vector();
+      const style = [
+        {
+          'stroke-color': 'red',
+          'stroke-width': 10,
+        },
+        {
+          'stroke-color': 'yellow',
+          'stroke-width': 5,
+        },
+      ];
+      layer.setStyle(style);
+      expect(layer.getStyle()).to.be(style);
     });
   });
 });


### PR DESCRIPTION
Currently, the documentation for the BaseVector layer's `getStyle()` method says:

> Get the `style` for features. This returns whatever was passed to the `style` option at construction or to the `setStyle` method.

This is not correct:
1. When no style is configured that way, the default style is returned. This is even covered by an existing test for `setStyle()`.
2. When a flat style is configured that way, the style function created for that flat style is returned.

This pull request makes it so that 1. is properly documented, and that for 2., the passed flat style is returned by `getStyle()`, as documented.