### PR TITLE
Fix removal of render features from vector source

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -1116,7 +1116,7 @@ class VectorSource extends Source {
    */
   removeFeatureInternal(feature) {
     const featureKey = getUid(feature);
-    if (!this.uidIndex_.hasOwnProperty(featureKey)) {
+    if (!(featureKey in this.uidIndex_)) {
       return;
     }
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -1129,10 +1129,8 @@ class VectorSource extends Source {
     }
 
     const featureChangeKeys = this.featureChangeKeys_[featureKey];
-    if (featureChangeKeys) {
-      featureChangeKeys.forEach(unlistenByKey);
-      delete this.featureChangeKeys_[featureKey];
-    }
+    featureChangeKeys?.forEach(unlistenByKey);
+    delete this.featureChangeKeys_[featureKey];
 
     const id = feature.getId();
     if (id !== undefined) {

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -366,6 +366,32 @@ describe('ol/source/Vector', function () {
         }
       });
 
+      it('works as expected for renderfeatures', function () {
+        const feature1 = new RenderFeature(
+          'Polygon',
+          [1, 1, 1, 2, 2, 1, 2, 2],
+          [],
+          2,
+          {},
+          'foo',
+        );
+        const feature2 = new RenderFeature(
+          'Polygon',
+          [1, 1, 1, 2, 2, 1, 2, 2],
+          [],
+          2,
+          {},
+          'foo',
+        );
+
+        const vectorSource = new VectorSource({features: [feature1, feature2]});
+        expect(vectorSource.getFeatureById('foo')).to.eql([feature1, feature2]);
+        vectorSource.removeFeature(feature1);
+        expect(vectorSource.getFeatureById('foo')).to.be(feature2);
+        vectorSource.removeFeature(feature2);
+        expect(vectorSource.getFeatureById('foo')).to.be(null);
+      });
+
       it('fires a change event', function () {
         const listener = sinon.spy();
         listen(vectorSource, 'change', listener);


### PR DESCRIPTION
Render features were not fully removed because they don't have change keys and can be arrays.
I look at the uindex now instead of the change keys
