### PR TITLE
Do not make the source type of a vector layer generic

### DIFF
--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -178,7 +178,7 @@ const INTERVALS = [
  * Note that the view projection must define both extent and worldExtent.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @extends {VectorLayer<import("../source/Vector.js").default>}
+ * @extends {VectorLayer<Feature>}
  * @api
  */
 class Graticule extends VectorLayer {

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -8,6 +8,7 @@ import {clamp} from '../math.js';
 import {createCanvasContext2D} from '../dom.js';
 
 /**
+ * @template {import("../Feature.js").FeatureLike} FeatureType
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -33,7 +34,7 @@ import {createCanvasContext2D} from '../dom.js';
  * @property {string|function(import("../Feature.js").default):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
- * @property {import("../source/Vector.js").default} [source] Point source.
+ * @property {import("../source/Vector.js").default<FeatureType>} [source] Point source.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
@@ -61,12 +62,13 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * options means that `title` is observable, and has get/set accessors.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @extends {BaseVector<import("../source/Vector.js").default, WebGLPointsLayerRenderer>}
+ * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @extends {BaseVector<import("../source/Vector.js").default<FeatureType>, WebGLPointsLayerRenderer>}
  * @api
  */
 class Heatmap extends BaseVector {
   /**
-   * @param {Options} [options] Options.
+   * @param {Options<FeatureType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -15,13 +15,13 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../source/Vector.js").default<import('../Feature.js').FeatureLike>} VectorSourceType
- * @extends {BaseVectorLayer<VectorSourceType, CanvasVectorLayerRenderer>}
+ * @template {import('../Feature.js').FeatureLike} FeatureType
+ * @extends {BaseVectorLayer<import("../source/Vector.js").default<FeatureType>, CanvasVectorLayerRenderer>}
  * @api
  */
 class VectorLayer extends BaseVectorLayer {
   /**
-   * @param {import("./BaseVector.js").Options<VectorSourceType>} [options] Options.
+   * @param {import("./BaseVector.js").Options<import("../source/Vector.js").default<FeatureType>>} [options] Options.
    */
   constructor(options) {
     super(options);

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -61,13 +61,13 @@ import CanvasVectorImageLayerRenderer from '../renderer/canvas/VectorImageLayer.
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../source/Vector.js").default} VectorSourceType
- * @extends {BaseVectorLayer<VectorSourceType, CanvasVectorImageLayerRenderer>}
+ * @template {import("../Feature.js").default} FeatureType
+ * @extends {BaseVectorLayer<import("../source/Vector.js").default<FeatureType>, CanvasVectorImageLayerRenderer>}
  * @api
  */
 class VectorImageLayer extends BaseVectorLayer {
   /**
-   * @param {Options<VectorSourceType>} [options] Options.
+   * @param {Options<import("../source/Vector.js").default<FeatureType>>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -91,8 +91,8 @@ import {assert} from '../asserts.js';
  * options means that `title` is observable, and has get/set accessors.
  *
  * @param {Options} [options] Options.
- * @template {import("../source/VectorTile.js").default<import('../Feature').FeatureLike>} VectorTileSourceType
- * @extends {BaseVectorLayer<VectorTileSourceType, CanvasVectorTileLayerRenderer>}
+ * @template {import('../Feature').FeatureLike} FeatureType
+ * @extends {BaseVectorLayer<import("../source/VectorTile.js").default<FeatureType>, CanvasVectorTileLayerRenderer>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
@@ -107,7 +107,7 @@ class VectorTileLayer extends BaseVectorLayer {
     delete baseOptions.useInterimTilesOnError;
 
     super(
-      /** @type {import("./BaseVector.js").Options<VectorTileSourceType>} */ (
+      /** @type {import("./BaseVector.js").Options<import("../source/VectorTile.js").default<FeatureType>>} */ (
         baseOptions
       ),
     );


### PR DESCRIPTION
Fixes #15830.

This pull request changes the TypeScript signature of `ol/layer/Vector`, `ol/layer/VectorImage` and `ol/layer/Heatmap` to accept the feature type instead of the source type as type parameter. This change makes sense because the previous signature was redundant, and did not work in some cases (see #15830).

Example: Previously, we had:
```ts
const layer: VectorLayer<VectorSource<Feature<Geometry>>> = new VectorLayer({
  source: new VectorSource({ // no source type other than VectorSource is accepted anyway
    features: [
      new Feature(new Point([0, 0])) // RenderFeature or Feature with different geometry type are also possible
    ]
  })
});
```
And now we have:
```ts
const layer: VectorLayer<Feature<Geometry>> = new VectorLayer({
  source: new VectorSource({ // no source type other than VectorSource is possible anyway
    features: [
      new Feature(new Point([0, 0])) // RenderFeature or Feature with different geometry type are also possible
    ]
  })
});
```