### PR TITLE
Add rect example

### DIFF
--- a/examples/rectangle.html
+++ b/examples/rectangle.html
@@ -1,0 +1,9 @@
+---
+layout: example.html
+title: Rectangle
+shortdesc: Renders a rectangle on a map.
+docs: >
+  A simple map with an OSM basemap and a rectangular polygon feature (e.g. a bounding box).
+tags: "simple, geometry, rectangle, box, bbox, polygon"
+---
+<div id="map" class="map"></div>

--- a/examples/rectangle.js
+++ b/examples/rectangle.js
@@ -1,0 +1,41 @@
+import Map from '../src/ol/Map.js';
+import OSM from '../src/ol/source/OSM.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import View from '../src/ol/View.js';
+
+import {Vector as VectorLayer} from 'ol/layer.js';
+import {Vector as VectorSource} from 'ol/source.js';
+import Feature from 'ol/Feature.js';
+import Polygon from 'ol/geom/Polygon.js';
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+    new VectorLayer({
+      source: new VectorSource({
+        features: [
+          new Feature(  // expects a Geometry
+            new Polygon(  // expects coordinates as described hereafter
+              [  // array of linear rings
+                [ // the first (and in this case only) linear ring
+                  [-1000000, 5000000],  // actual coordinates...
+                  [ 3000000, 5000000],
+                  [ 3000000, 7000000],
+                  [-1000000, 7000000],
+                  [-1000000, 5000000]   // first coordinate repeated
+                ]
+              ]
+            )
+          )
+        ]
+      }),
+    })
+  ],
+  target: 'map',
+  view: new View({
+    center: [1000000, 6000000],
+    zoom: 4,
+  }),
+});

--- a/examples/rectangle.js
+++ b/examples/rectangle.js
@@ -3,10 +3,10 @@ import OSM from '../src/ol/source/OSM.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
 
-import {Vector as VectorLayer} from 'ol/layer.js';
-import {Vector as VectorSource} from 'ol/source.js';
 import Feature from 'ol/Feature.js';
 import Polygon from 'ol/geom/Polygon.js';
+import {Vector as VectorLayer} from 'ol/layer.js';
+import {Vector as VectorSource} from 'ol/source.js';
 
 const map = new Map({
   layers: [
@@ -16,22 +16,23 @@ const map = new Map({
     new VectorLayer({
       source: new VectorSource({
         features: [
-          new Feature(  // expects a Geometry
-            new Polygon(  // expects coordinates as described hereafter
-              [  // array of linear rings
-                [ // the first (and in this case only) linear ring
-                  [-1000000, 5000000],  // actual coordinates...
-                  [ 3000000, 5000000],
-                  [ 3000000, 7000000],
-                  [-1000000, 7000000],
-                  [-1000000, 5000000]   // first coordinate repeated
-                ]
-              ]
-            )
-          )
-        ]
+          // Feature expects a Geometry
+          new Feature(
+            // Polygon expects coordinates as an array of linear rings
+            new Polygon([
+              // the first (and in this case only) linear ring
+              [
+                [-1000000, 5000000], // actual coordinates...
+                [3000000, 5000000],
+                [3000000, 7000000],
+                [-1000000, 7000000],
+                [-1000000, 5000000], // first coordinate repeated
+              ],
+            ]),
+          ),
+        ],
       }),
-    })
+    }),
   ],
   target: 'map',
   view: new View({

--- a/examples/rectangle.js
+++ b/examples/rectangle.js
@@ -4,9 +4,9 @@ import TileLayer from '../src/ol/layer/Tile.js';
 import View from '../src/ol/View.js';
 
 import Feature from 'ol/Feature.js';
-import Polygon from 'ol/geom/Polygon.js';
 import {Vector as VectorLayer} from 'ol/layer.js';
 import {Vector as VectorSource} from 'ol/source.js';
+import {fromExtent} from 'ol/geom/Polygon.js';
 
 const map = new Map({
   layers: [
@@ -16,19 +16,9 @@ const map = new Map({
     new VectorLayer({
       source: new VectorSource({
         features: [
-          // Feature expects a Geometry
           new Feature(
-            // Polygon expects coordinates as an array of linear rings
-            new Polygon([
-              // the first (and in this case only) linear ring
-              [
-                [-1000000, 5000000], // actual coordinates...
-                [3000000, 5000000],
-                [3000000, 7000000],
-                [-1000000, 7000000],
-                [-1000000, 5000000], // first coordinate repeated
-              ],
-            ]),
+            // Here a `Geometry` is expected, e.g. a `Polygon`, which has a handy function to create a rectangle from bbox coordinates
+            fromExtent([-1000000, 5000000, 3000000, 7000000]), // minX, minY, maxX, maxY
           ),
         ],
       }),


### PR DESCRIPTION
Earlier today I wanted to put a simple rectangle on a map to visualise a bbox, but only found examples that used super advanced functionality like custom polygon styles etc. There seemed to be none that explains this quite common usecase on a very basic level ("you need a Feature that has a Geometry which is in this case a Polygon which expects an array of linear rings which look like this"). So after finishing my tiny application, I thought I could generalise it a little and contribute it here.

Feel free to rename it/edit the description etc.

Possibly it would be nice to add a second Polygon that actually has _multiple_ linear rings to illustrate "how to cut holes into a shape".