### PR TITLE
Avoid throwing error if ClusterSource source is null

### DIFF
--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -71,9 +71,10 @@ import {getUid} from '../util.js';
  */
 class Cluster extends VectorSource {
   /**
-   * @param {Options<FeatureType>} options Cluster options.
+   * @param {Options<FeatureType>} [options] Cluster options.
    */
   constructor(options) {
+    options = options || {};
     super({
       attributions: options.attributions,
       wrapX: options.wrapX,
@@ -180,7 +181,7 @@ class Cluster extends VectorSource {
    * @param {import("../proj/Projection.js").default} projection Projection.
    */
   loadFeatures(extent, resolution, projection) {
-    this.source.loadFeatures(extent, resolution, projection);
+    this.source?.loadFeatures(extent, resolution, projection);
     if (resolution !== this.resolution) {
       this.resolution = resolution;
       this.refresh();


### PR DESCRIPTION
Fixes the runtime error mentioned in https://github.com/openlayers/openlayers/issues/15840#issuecomment-2117715783

Since `source` can be null `options` can be optional.
