### PR TITLE
Use offset from start instead of full coordinate to improve getArea() precision

### DIFF
--- a/src/ol/geom/flat/area.js
+++ b/src/ol/geom/flat/area.js
@@ -11,14 +11,16 @@
  */
 export function linearRing(flatCoordinates, offset, end, stride) {
   let twiceArea = 0;
-  let x1 = flatCoordinates[end - stride];
-  let y1 = flatCoordinates[end - stride + 1];
+  const x0 = flatCoordinates[end - stride];
+  const y0 = flatCoordinates[end - stride + 1];
+  let dx1 = 0;
+  let dy1 = 0;
   for (; offset < end; offset += stride) {
-    const x2 = flatCoordinates[offset];
-    const y2 = flatCoordinates[offset + 1];
-    twiceArea += y1 * x2 - x1 * y2;
-    x1 = x2;
-    y1 = y2;
+    const dx2 = flatCoordinates[offset] - x0;
+    const dy2 = flatCoordinates[offset + 1] - y0;
+    twiceArea += dy1 * dx2 - dx1 * dy2;
+    dx1 = dx2;
+    dy1 = dy2;
   }
   return twiceArea / 2;
 }

--- a/test/node/ol/geom/flat/area.test.js
+++ b/test/node/ol/geom/flat/area.test.js
@@ -12,6 +12,25 @@ describe('ol/geom/flat/area.js', function () {
       const area = linearRing([0, 0, 0, 1, 1, 1, 1, 0], 0, 8, 2);
       expect(area).to.be(1);
     });
+
+    it('calculates with large coordinate values', function () {
+      const area = linearRing(
+        [
+          Number.MAX_SAFE_INTEGER - 1,
+          Number.MAX_SAFE_INTEGER - 1,
+          Number.MAX_SAFE_INTEGER - 1,
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_SAFE_INTEGER,
+          Number.MAX_SAFE_INTEGER - 1,
+        ],
+        0,
+        8,
+        2,
+      );
+      expect(area).to.be(1);
+    });
   });
 
   describe('linearRings', function () {


### PR DESCRIPTION
Fixes #15856

The current method is subject to rounding errors when subtracting the results of multiplying large numbers (especially in wrapped worlds).