### PR TITLE
fix ol.VERSION not available in umd pkg

### DIFF
--- a/tasks/generate-index.js
+++ b/tasks/generate-index.js
@@ -101,6 +101,8 @@ function generateExports(symbols) {
   }
   const defs = ['\nvar ol = {};'].concat(nsdefs, [...new Set(blocks)]);
   const lines = Object.keys(imports).concat(defs.sort());
+  lines.push('', 'ol.VERSION = ol.util.VERSION;');
+  lines.push('', 'ol.getUid = ol.util.getUid;');
   lines.push('', 'export default ol;');
   return lines.join('\n');
 }


### PR DESCRIPTION
fix ol.VERSION not available in umd pkg, In the process of developing some plug-ins, we will use 

```js
import { VERSION } from 'ol'
```
In the packager we will configure external and globals so that we can also use it in the umd class library