### PR TITLE
Consistent generics for vector(tile) layers, sources, formats

### DIFF
--- a/config/tsconfig-lib-check.json
+++ b/config/tsconfig-lib-check.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": false,
+    "skipDefaultLibCheck": true
+ },
+ "include": [
+    "../build/ol/**/*.d.ts"
+ ],
+ "exlude": [
+    "../build/ol/dist/**/*.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "homepage": "https://openlayers.org/",
   "scripts": {
     "lint": "eslint tasks test src/ol examples config",
-    "pretest": "npm run lint && npm run typecheck && npm run typecheck-strict",
+    "pretest": "npm run lint && npm run typecheck && npm run typecheck-strict && npm run build-package",
     "test-rendering": "npm run build-full && node test/rendering/test.js",
     "test-browser": "npm run karma -- --single-run --log-level error",
     "test-node": "mocha --recursive test/node",
@@ -20,7 +20,7 @@
     "start": "npm run serve-examples",
     "serve-examples": "webpack serve --config examples/webpack/config.mjs --mode development",
     "build-examples": "shx rm -rf build/examples && webpack --config examples/webpack/config.mjs --mode production",
-    "build-package": "npm run build-full && npm run copy-css && npm run generate-types && node tasks/prepare-package.js",
+    "build-package": "npm run build-full && npm run copy-css && npm run generate-types && node tasks/prepare-package.js && npm run typecheck-libcheck",
     "build-index": "shx rm -f build/index.js && npm run transpile && node tasks/generate-index.js",
     "build-full": "shx rm -rf build/full && npm run build-index && npx rollup --config config/rollup-full-build.js",
     "copy-css": "shx cp src/ol/ol.css build/ol/ol.css",
@@ -28,6 +28,7 @@
     "transpile": "shx rm -rf build/ol && shx mkdir -p build/ol && shx cp -rf src/ol build && node tasks/serialize-workers.cjs && node tasks/set-version.js",
     "typecheck": "tsc --pretty",
     "typecheck-strict": "tsc --project config/tsconfig-strict.json",
+    "typecheck-libcheck": "tsc --project config/tsconfig-lib-check.json",
     "apidoc-debug": "shx rm -rf build/apidoc && node --inspect-brk=9229 ./node_modules/jsdoc/jsdoc.js --readme config/jsdoc/api/index.md --configure config/jsdoc/api/conf.json --package package.json --destination build/apidoc",
     "apidoc": "shx rm -rf build/apidoc && jsdoc --readme config/jsdoc/api/index.md --configure config/jsdoc/api/conf.json --package package.json --destination build/apidoc"
   },

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -4,12 +4,15 @@
 import Tile from './Tile.js';
 import TileState from './TileState.js';
 
+/**
+ * @template {import('./Feature.js').FeatureLike} FeatureType
+ */
 class VectorTile extends Tile {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
    * @param {string} src Data source url.
-   * @param {import("./format/Feature.js").default<typeof import("./Feature.js").default|typeof import("./render/Feature.js").default>} format Feature format.
+   * @param {import("./format/Feature.js").default<import("./format/Feature.js").FeatureToFeatureClass<FeatureType>>} format Feature format.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
    * @param {import("./Tile.js").Options} [options] Tile options.
    */
@@ -24,19 +27,19 @@ class VectorTile extends Tile {
 
     /**
      * @private
-     * @type {import("./format/Feature.js").default<typeof import("./Feature.js").default|typeof import("./render/Feature.js").default>}
+     * @type {import("./format/Feature.js").default<import("./format/Feature.js").FeatureToFeatureClass<FeatureType>>}
      */
     this.format_ = format;
 
     /**
      * @private
-     * @type {Array<import("./Feature.js").FeatureLike>}
+     * @type {Array<FeatureType>}
      */
     this.features_ = null;
 
     /**
      * @private
-     * @type {import("./featureloader.js").FeatureLoader}
+     * @type {import("./featureloader.js").FeatureLoader<FeatureType>}
      */
     this.loader_;
 
@@ -69,7 +72,7 @@ class VectorTile extends Tile {
 
   /**
    * Get the feature format assigned for reading this tile's features.
-   * @return {import("./format/Feature.js").default<typeof import("./Feature.js").default|typeof import("./render/Feature.js").default>} Feature format.
+   * @return {import("./format/Feature.js").default<import("./format/Feature.js").FeatureToFeatureClass<FeatureType>>} Feature format.
    * @api
    */
   getFormat() {
@@ -78,7 +81,7 @@ class VectorTile extends Tile {
 
   /**
    * Get the features for this tile. Geometries will be in the view projection.
-   * @return {Array<import("./Feature.js").FeatureLike>} Features.
+   * @return {Array<FeatureType>} Features.
    * @api
    */
   getFeatures() {
@@ -100,7 +103,7 @@ class VectorTile extends Tile {
 
   /**
    * Handler for successful tile load.
-   * @param {Array<import("./Feature.js").default>} features The loaded features.
+   * @param {Array<FeatureType>} features The loaded features.
    * @param {import("./proj/Projection.js").default} dataProjection Data projection.
    */
   onLoad(features, dataProjection) {
@@ -117,7 +120,7 @@ class VectorTile extends Tile {
   /**
    * Function for use in an {@link module:ol/source/VectorTile~VectorTile}'s `tileLoadFunction`.
    * Sets the features for the tile.
-   * @param {Array<import("./Feature.js").FeatureLike>} features Features.
+   * @param {Array<FeatureType>} features Features.
    * @api
    */
   setFeatures(features) {
@@ -127,7 +130,7 @@ class VectorTile extends Tile {
 
   /**
    * Set the feature loader for reading this tile's features.
-   * @param {import("./featureloader.js").FeatureLoader} loader Feature loader.
+   * @param {import("./featureloader.js").FeatureLoader<FeatureType>} loader Feature loader.
    * @api
    */
   setLoader(loader) {

--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -26,7 +26,7 @@ let withCredentials = false;
  * source.
  *
  * @template {import("./Feature.js").FeatureLike} [FeatureType=import("./Feature.js").default]
- * @typedef {function(this:(import("./source/Vector").default|import("./VectorTile.js").default),
+ * @typedef {function(this:(import("./source/Vector").default<FeatureType>|import("./VectorTile.js").default),
  *           import("./extent.js").Extent,
  *           number,
  *           import("./proj/Projection.js").default,
@@ -48,9 +48,9 @@ let withCredentials = false;
  */
 
 /**
- * @template {import("./Feature.js").FeatureLike} [FeatureType=import("./Feature.js").FeatureLike]
+ * @template {import("./Feature.js").FeatureLike} [FeatureType=import("./Feature.js").default]
  * @param {string|FeatureUrlFunction} url Feature URL service.
- * @param {import("./format/Feature.js").default<import('./format/Feature.js').FeatureToFeatureClass<FeatureType>>} format Feature format.
+ * @param {import("./format/Feature.js").default<import("./format/Feature.js").FeatureToFeatureClass<FeatureType>>} format Feature format.
  * @param {import("./extent.js").Extent} extent Extent.
  * @param {number} resolution Resolution.
  * @param {import("./proj/Projection.js").default} projection Projection.
@@ -128,9 +128,9 @@ export function loadFeaturesXhr(
  * Create an XHR feature loader for a `url` and `format`. The feature loader
  * loads features (with XHR), parses the features, and adds them to the
  * vector source.
- * @template {import("./Feature.js").FeatureLike} [FeatureType=import("./Feature.js").FeatureLike]
+ * @template {import("./Feature.js").FeatureLike} FeatureType
  * @param {string|FeatureUrlFunction} url Feature URL service.
- * @param {import("./format/Feature.js").default<import('./format/Feature.js').FeatureToFeatureClass<FeatureType>>} format Feature format.
+ * @param {import("./format/Feature.js").default<import("./format/Feature.js").FeatureToFeatureClass<FeatureType>>} format Feature format.
  * @return {FeatureLoader<FeatureType>} The feature loader.
  * @api
  */

--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -95,7 +95,7 @@ import {
  */
 
 /***
- * @template {Feature|RenderFeature} T
+ * @template {import('../Feature.js').FeatureLike} T
  * @typedef {T extends RenderFeature ? typeof RenderFeature : typeof Feature} FeatureToFeatureClass
  */
 
@@ -113,7 +113,7 @@ import {
  * {@link module:ol/Feature~Feature} objects from a variety of commonly used geospatial
  * file formats.  See the documentation for each format for more details.
  *
- * @template {import('../Feature.js').FeatureClass} [T=typeof import('../Feature.js').default]
+ * @template {import('../Feature.js').FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../Feature.js").default>]
  * @abstract
  * @api
  */
@@ -133,9 +133,9 @@ class FeatureFormat {
 
     /**
      * @protected
-     * @type {T}
+     * @type {FeatureClassType}
      */
-    this.featureClass = /** @type {T} */ (Feature);
+    this.featureClass = /** @type {FeatureClassType} */ (Feature);
 
     /**
      * A list media types supported by the format in descending order of preference.
@@ -206,7 +206,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Element|Object|string} source Source.
    * @param {ReadOptions} [options] Read options.
-   * @return {import("../Feature.js").FeatureLike|Array<import("../render/Feature.js").default>} Feature.
+   * @return {FeatureClassToFeature<FeatureClassType>|Array<FeatureClassToFeature<FeatureClassType>>} Feature.
    */
   readFeature(source, options) {
     return abstract();
@@ -218,7 +218,7 @@ class FeatureFormat {
    * @abstract
    * @param {Document|Element|ArrayBuffer|Object|string} source Source.
    * @param {ReadOptions} [options] Read options.
-   * @return {Array<import('../Feature.js').FeatureLike|FeatureClassToFeature<T>>} Features.
+   * @return {Array<FeatureClassToFeature<FeatureClassType>>} Features.
    */
   readFeatures(source, options) {
     return abstract();

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -33,7 +33,7 @@ import {isEmpty} from '../obj.js';
  */
 
 /**
- * @template {import("../Feature.js").FeatureClass} FeatureClassToFeature
+ * @template {import("../Feature.js").FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../Feature.js").default>]
  * @typedef {Object} Options
  *
  * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Default data projection.
@@ -44,7 +44,7 @@ import {isEmpty} from '../obj.js';
  * the geometry_name field in the feature GeoJSON. If set to `true` the GeoJSON reader
  * will look for that field to set the geometry name. If both this field is set to `true`
  * and a `geometryName` is provided, the `geometryName` will take precedence.
- * @property {FeatureClassToFeature} [featureClass] Feature class
+ * @property {FeatureClassType} [featureClass] Feature class
  * to be used when reading features. The default is {@link module:ol/Feature~Feature}. If performance is
  * the primary concern, and features are not going to be modified or round-tripped through the format,
  * consider using {@link module:ol/render/Feature~RenderFeature}
@@ -54,13 +54,13 @@ import {isEmpty} from '../obj.js';
  * @classdesc
  * Feature format for reading and writing data in the GeoJSON format.
  *
- * @template {import('../Feature.js').FeatureClass} [T=typeof Feature]
- * @extends {JSONFeature<T>}
+ * @template {import('../Feature.js').FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../Feature.js").default>]
+ * @extends {JSONFeature<FeatureClassType>}
  * @api
  */
 class GeoJSON extends JSONFeature {
   /**
-   * @param {Options<T>} [options] Options.
+   * @param {Options<FeatureClassType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};
@@ -109,7 +109,7 @@ class GeoJSON extends JSONFeature {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {Feature|RenderFeature|Array<RenderFeature>}.default} Feature.
+   * @return {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Feature.
    */
   readFeatureFromObject(object, options) {
     /**
@@ -128,13 +128,15 @@ class GeoJSON extends JSONFeature {
 
     const geometry = readGeometryInternal(geoJSONFeature['geometry'], options);
     if (this.featureClass === RenderFeature) {
-      return createRenderFeature(
-        {
-          geometry,
-          id: geoJSONFeature['id'],
-          properties: geoJSONFeature['properties'],
-        },
-        options,
+      return /** @type {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} */ (
+        createRenderFeature(
+          {
+            geometry,
+            id: geoJSONFeature['id'],
+            properties: geoJSONFeature['properties'],
+          },
+          options,
+        )
       );
     }
 
@@ -153,18 +155,19 @@ class GeoJSON extends JSONFeature {
     if (geoJSONFeature['properties']) {
       feature.setProperties(geoJSONFeature['properties'], true);
     }
-    return feature;
+    return /** @type {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} */ (
+      feature
+    );
   }
 
   /**
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {Array<Feature|RenderFeature>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Features.
    */
   readFeaturesFromObject(object, options) {
     const geoJSONObject = /** @type {GeoJSONObject} */ (object);
-    /** @type {Array<Feature|RenderFeature|Array<RenderFeature>>} */
     let features = null;
     if (geoJSONObject['type'] === 'FeatureCollection') {
       const geoJSONFeatureCollection = /** @type {GeoJSONFeatureCollection} */ (
@@ -185,7 +188,9 @@ class GeoJSON extends JSONFeature {
     } else {
       features = [this.readFeatureFromObject(object, options)];
     }
-    return features.flat();
+    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} */ (
+      features.flat()
+    );
   }
 
   /**

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -10,8 +10,8 @@ import {abstract} from '../util.js';
  * instantiated in apps.
  * Base class for JSON feature formats.
  *
- * @template {import('../Feature.js').FeatureClass} [T=typeof import('../Feature.js').default]
- * @extends {FeatureFormat<T>}
+ * @template {import('../Feature.js').FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../Feature.js").default>]
+ * @extends {FeatureFormat<FeatureClassType>}
  * @abstract
  */
 class JSONFeature extends FeatureFormat {
@@ -32,15 +32,13 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {import('./Feature.js').FeatureClassToFeature<T>} Feature.
+   * @return {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Feature.
    * @api
    */
   readFeature(source, options) {
-    return /** @type {import('./Feature.js').FeatureClassToFeature<T>} */ (
-      this.readFeatureFromObject(
-        getObject(source),
-        this.getReadOptions(source, options),
-      )
+    return this.readFeatureFromObject(
+      getObject(source),
+      this.getReadOptions(source, options),
     );
   }
 
@@ -50,11 +48,11 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import('./Feature.js').FeatureClassToFeature<T>>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Features.
    * @api
    */
   readFeatures(source, options) {
-    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<T>>} */ (
+    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} */ (
       this.readFeaturesFromObject(
         getObject(source),
         this.getReadOptions(source, options),
@@ -67,7 +65,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {import("../Feature.js").default|import("../render/Feature.js").default|Array<import("../render/Feature.js").default>} Feature.
+   * @return {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Feature.
    */
   readFeatureFromObject(object, options) {
     return abstract();
@@ -78,7 +76,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {Array<import("../Feature.js").default|import("../render/Feature.js").default>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Features.
    */
   readFeaturesFromObject(object, options) {
     return abstract();

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -17,9 +17,9 @@ import {get} from '../proj.js';
 import {inflateEnds} from '../geom/flat/orient.js';
 
 /**
- * @template {import("../Feature.js").FeatureClass} FeatureClassToFeature
+ * @template {import("../Feature.js").FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../render/Feature.js").default>]
  * @typedef {Object} Options
- * @property {FeatureClassToFeature} [featureClass] Class for features returned by
+ * @property {FeatureClassType} [featureClass] Class for features returned by
  * {@link module:ol/format/MVT~MVT#readFeatures}. Set to {@link module:ol/Feature~Feature} to get full editing and geometry
  * support at the cost of decreased rendering performance. The default is
  * {@link module:ol/render/Feature~RenderFeature}, which is optimized for rendering and hit detection.
@@ -34,13 +34,13 @@ import {inflateEnds} from '../geom/flat/orient.js';
  * @classdesc
  * Feature format for reading data in the Mapbox MVT format.
  *
- * @template {import('../Feature.js').FeatureClass} [T=typeof import("../render/Feature.js").default]
- * @extends {FeatureFormat<T>}
+ * @template {import('../Feature.js').FeatureClass} [FeatureClassType=import('./Feature.js').FeatureToFeatureClass<import("../render/Feature.js").default>]
+ * @extends {FeatureFormat<FeatureClassType>}
  * @api
  */
 class MVT extends FeatureFormat {
   /**
-   * @param {Options<T>} [options] Options.
+   * @param {Options<FeatureClassType>} [options] Options.
    */
   constructor(options) {
     super();
@@ -57,7 +57,7 @@ class MVT extends FeatureFormat {
 
     this.featureClass = options.featureClass
       ? options.featureClass
-      : /** @type {T} */ (RenderFeature);
+      : /** @type {FeatureClassType} */ (RenderFeature);
 
     /**
      * @private
@@ -157,7 +157,7 @@ class MVT extends FeatureFormat {
    * @param {PBF} pbf PBF
    * @param {Object} rawFeature Raw Mapbox feature.
    * @param {import("./Feature.js").ReadOptions} options Read options.
-   * @return {import("../Feature.js").FeatureLike|null} Feature.
+   * @return {import('./Feature.js').FeatureClassToFeature<FeatureClassType>|null} Feature.
    */
   createFeature_(pbf, rawFeature, options) {
     const type = rawFeature.type;
@@ -185,14 +185,10 @@ class MVT extends FeatureFormat {
     const geometryType = getGeometryType(type, ends.length);
 
     if (this.featureClass === RenderFeature) {
-      feature = new /** @type {typeof RenderFeature} */ (this.featureClass)(
-        geometryType,
-        flatCoordinates,
-        ends,
-        2,
-        values,
-        id,
-      );
+      feature =
+        new /** @type {import('./Feature.js').FeatureToFeatureClass<RenderFeature>} */ (
+          this.featureClass
+        )(geometryType, flatCoordinates, ends, 2, values, id);
       feature.transform(options.dataProjection);
     } else {
       let geom;
@@ -229,7 +225,9 @@ class MVT extends FeatureFormat {
       feature.setProperties(values, true);
     }
 
-    return feature;
+    return /** @type {import('./Feature.js').FeatureClassToFeature<FeatureClassType>} */ (
+      feature
+    );
   }
 
   /**
@@ -244,7 +242,7 @@ class MVT extends FeatureFormat {
    *
    * @param {ArrayBuffer} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {Array<import('./Feature.js').FeatureClassToFeature<T>>} Features.
+   * @return {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} Features.
    * @api
    */
   readFeatures(source, options) {
@@ -275,7 +273,7 @@ class MVT extends FeatureFormat {
       }
     }
 
-    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<T>>} */ (
+    return /** @type {Array<import('./Feature.js').FeatureClassToFeature<FeatureClassType>>} */ (
       features
     );
   }

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -13,7 +13,8 @@ import {
 } from '../render/canvas/style.js';
 
 /**
- * @template {import("../source/Vector.js").default<import('../Feature').FeatureLike>|import("../source/VectorTile.js").default<import('../Feature').FeatureLike>} VectorSourceType
+ * @template {import('../Feature').FeatureLike} FeatureType
+ * @template {import("../source/Vector.js").default<FeatureType>|import("../source/VectorTile.js").default<FeatureType>} VectorSourceType<FeatureType>
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -77,14 +78,15 @@ const Property = {
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../source/Vector.js").default<import('../Feature').FeatureLike>|import("../source/VectorTile.js").default<import('../Feature').FeatureLike>} VectorSourceType
- * @template {import("../renderer/canvas/VectorLayer.js").default|import("../renderer/canvas/VectorTileLayer.js").default|import("../renderer/canvas/VectorImageLayer.js").default|import("../renderer/webgl/PointsLayer.js").default} RendererType
+ * @template {import('../Feature').FeatureLike} FeatureType
+ * @template {import("../source/Vector.js").default<FeatureType>|import("../source/VectorTile.js").default<FeatureType>} VectorSourceType<FeatureType>
  * @extends {Layer<VectorSourceType, RendererType>}
+ * @template {import("../renderer/canvas/VectorLayer.js").default|import("../renderer/canvas/VectorTileLayer.js").default|import("../renderer/canvas/VectorImageLayer.js").default|import("../renderer/webgl/PointsLayer.js").default} RendererType
  * @api
  */
 class BaseVectorLayer extends Layer {
   /**
-   * @param {Options<VectorSourceType>} [options] Options.
+   * @param {Options<FeatureType, VectorSourceType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -178,7 +178,7 @@ const INTERVALS = [
  * Note that the view projection must define both extent and worldExtent.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @extends {VectorLayer<Feature>}
+ * @extends {VectorLayer<Feature, VectorSource>}
  * @api
  */
 class Graticule extends VectorLayer {

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -8,7 +8,8 @@ import {clamp} from '../math.js';
 import {createCanvasContext2D} from '../dom.js';
 
 /**
- * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -34,7 +35,7 @@ import {createCanvasContext2D} from '../dom.js';
  * @property {string|function(import("../Feature.js").default):number} [weight='weight'] The feature
  * attribute to use for the weight or a function that returns a weight from a feature. Weight values
  * should range from 0 to 1 (and values outside will be clamped to that range).
- * @property {import("../source/Vector.js").default<FeatureType>} [source] Point source.
+ * @property {VectorSourceType} [source] Point source.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  */
 
@@ -62,13 +63,14 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * options means that `title` is observable, and has get/set accessors.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @template {import("../Feature.js").FeatureLike} FeatureType
- * @extends {BaseVector<import("../source/Vector.js").default<FeatureType>, WebGLPointsLayerRenderer>}
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
+ * @extends {BaseVector<FeatureType, VectorSourceType, WebGLPointsLayerRenderer>}
  * @api
  */
 class Heatmap extends BaseVector {
   /**
-   * @param {Options<FeatureType>} [options] Options.
+   * @param {Options<FeatureType, VectorSourceType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/layer/Tile.js
+++ b/src/ol/layer/Tile.js
@@ -12,7 +12,7 @@ import CanvasTileLayerRenderer from '../renderer/canvas/TileLayer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../source/Tile.js").default} TileSourceType
+ * @template {import("../source/Tile.js").default} [TileSourceType=import("../source/Tile.js").default]
  * @extends BaseTileLayer<TileSourceType, CanvasTileLayerRenderer>
  * @api
  */

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -5,7 +5,8 @@ import BaseVectorLayer from './BaseVector.js';
 import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
 
 /**
- * @template {import('../Feature.js').FeatureLike} FeatureType
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=import('../Feature.js').default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -30,7 +31,7 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * @property {number} [renderBuffer=100] The buffer in pixels around the viewport extent used by the
  * renderer when getting features from the vector source for the rendering or hit-detection.
  * Recommended value: the size of the largest symbol, line width or label.
- * @property {import("../source/Vector.js").default<FeatureType>} [source] Source.
+ * @property {VectorSourceType} [source] Source.
  * @property {import("../Map.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
@@ -65,13 +66,14 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import('../Feature.js').FeatureLike} FeatureType
- * @extends {BaseVectorLayer<import("../source/Vector.js").default<FeatureType>, CanvasVectorLayerRenderer>}
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=import('../Feature.js').default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
+ * @extends {BaseVectorLayer<FeatureType, VectorSourceType, CanvasVectorLayerRenderer>}
  * @api
  */
 class VectorLayer extends BaseVectorLayer {
   /**
-   * @param {Options<FeatureType>} [options] Options.
+   * @param {Options<FeatureType, VectorSourceType>} [options] Options.
    */
   constructor(options) {
     super(options);

--- a/src/ol/layer/VectorImage.js
+++ b/src/ol/layer/VectorImage.js
@@ -5,7 +5,8 @@ import BaseVectorLayer from './BaseVector.js';
 import CanvasVectorImageLayerRenderer from '../renderer/canvas/VectorImageLayer.js';
 
 /**
- * @template {import("../source/Vector.js").default} VectorSourceType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -61,13 +62,14 @@ import CanvasVectorImageLayerRenderer from '../renderer/canvas/VectorImageLayer.
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../Feature.js").default} FeatureType
- * @extends {BaseVectorLayer<import("../source/Vector.js").default<FeatureType>, CanvasVectorImageLayerRenderer>}
+ * @template {import("../Feature.js").default} [FeatureType=import("../Feature.js").default]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
+ * @extends {BaseVectorLayer<FeatureType, VectorSourceType, CanvasVectorImageLayerRenderer>}
  * @api
  */
 class VectorImageLayer extends BaseVectorLayer {
   /**
-   * @param {Options<import("../source/Vector.js").default<FeatureType>>} [options] Options.
+   * @param {Options<FeatureType, VectorSourceType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -21,7 +21,8 @@ import {assert} from '../asserts.js';
  */
 
 /**
- * @template {import('../Feature').FeatureLike} FeatureType
+ * @template {import("../Feature").FeatureLike} [FeatureType=import("../render/Feature.js").default]
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<FeatureType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -56,7 +57,7 @@ import {assert} from '../asserts.js';
  *    this mode for improved performance and visual epxerience on vector tile layers with not too many
  *    rendered features (e.g. for highlighting a subset of features of another layer with the same
  *    source).
- * @property {import("../source/VectorTile.js").default<FeatureType>} [source] Source.
+ * @property {VectorTileSourceType} [source] Source.
  * @property {import("../Map.js").default} [map] Sets the layer as overlay on a map. The map will not manage
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
@@ -90,20 +91,19 @@ import {assert} from '../asserts.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import('../Feature').FeatureLike} FeatureType
- * @extends {BaseVectorLayer<import("../source/VectorTile.js").default<FeatureType>, CanvasVectorTileLayerRenderer>}
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<FeatureType>]
+ * @extends {BaseVectorLayer<FeatureType, VectorTileSourceType, CanvasVectorTileLayerRenderer>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
   /**
-   * @param {Options<FeatureType>} [options] Options.
+   * @param {Options<FeatureType, VectorTileSourceType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};
 
-    const baseOptions = /** @type {Options<FeatureType>} */ (
-      Object.assign({}, options)
-    );
+    const baseOptions = Object.assign({}, options);
     delete baseOptions.preload;
     delete baseOptions.useInterimTilesOnError;
 
@@ -159,7 +159,9 @@ class VectorTileLayer extends BaseVectorLayer {
   }
 
   createRenderer() {
-    return new CanvasVectorTileLayerRenderer(this);
+    return new CanvasVectorTileLayerRenderer(
+      /** @type {VectorTileLayer} */ (this),
+    );
   }
 
   /**

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -28,7 +28,7 @@ import {toSize} from '../../size.js';
  * @classdesc
  * Canvas renderer for tile layers.
  * @api
- * @template {import("../../layer/Tile.js").default<import("../../source/Tile.js").default>|import("../../layer/VectorTile.js").default} [LayerType=import("../../layer/Tile.js").default<import("../../source/Tile.js").default>|import("../../layer/VectorTile.js").default]
+ * @template {import("../../layer/Tile.js").default|import("../../layer/VectorTile.js").default} [LayerType=import("../../layer/Tile.js").default<import("../../source/Tile.js").default>|import("../../layer/VectorTile.js").default]
  * @extends {CanvasLayerRenderer<LayerType>}
  */
 class CanvasTileLayerRenderer extends CanvasLayerRenderer {

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -62,7 +62,7 @@ const VECTOR_REPLAYS = {
  * @classdesc
  * Canvas renderer for vector tile layers.
  * @api
- * @extends {CanvasTileLayerRenderer<import("../../layer/VectorTile.js").default>}
+ * @extends {CanvasTileLayerRenderer<import("../../layer/VectorTile.js").default<import('../../Feature.js').FeatureLike, import('../../source/VectorTile.js').default>>}
  */
 class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   /**

--- a/src/ol/source/OGCVectorTile.js
+++ b/src/ol/source/OGCVectorTile.js
@@ -7,12 +7,12 @@ import {getTileSetInfo} from './ogcTileUtil.js';
 import {error as logError} from '../console.js';
 
 /**
- * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
  * @typedef {Object} Options
  * @property {string} url URL to the OGC Vector Tileset endpoint.
  * @property {Object} [context] A lookup of values to use in the tile URL template.  The `{tileMatrix}`
  * (zoom level), `{tileRow}`, and `{tileCol}` variables in the URL will always be provided by the source.
- * @property {import("../format/Feature.js").default<import('../format/Feature.js').FeatureToFeatureClass<FeatureType>>} format Feature parser for tiles.
+ * @property {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>} [format] Feature format for tiles. Used and required by the default.
  * @property {string} [mediaType] The content type for the tiles (e.g. "application/vnd.mapbox-vector-tile").  If not provided,
  * the source will try to find a link with rel="item" that uses a vector type supported by the configured format.
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
@@ -50,7 +50,7 @@ import {error as logError} from '../console.js';
  * which of the advertised media types is used.  If you need to force the use of a particular media type, you can
  * provide the `mediaType` option.
  * @api
- * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
  * @extends {VectorTileSource<FeatureType>}
  */
 class OGCVectorTile extends VectorTileSource {

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -34,27 +34,27 @@ import {xhr} from '../featureloader.js';
  * @classdesc
  * Events emitted by {@link module:ol/source/Vector~VectorSource} instances are instances of this
  * type.
- * @template {import("../Feature.js").FeatureLike} [FeatureClass=import("../Feature.js").default]
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
  */
 export class VectorSourceEvent extends Event {
   /**
    * @param {string} type Type.
-   * @param {FeatureClass} [feature] Feature.
-   * @param {Array<FeatureClass>} [features] Features.
+   * @param {FeatureType} [feature] Feature.
+   * @param {Array<FeatureType>} [features] Features.
    */
   constructor(type, feature, features) {
     super(type);
 
     /**
      * The added or removed feature for the `ADDFEATURE` and `REMOVEFEATURE` events, `undefined` otherwise.
-     * @type {FeatureClass|undefined}
+     * @type {FeatureType|undefined}
      * @api
      */
     this.feature = feature;
 
     /**
      * The loaded features for the `FEATURESLOADED` event, `undefined` otherwise.
-     * @type {Array<FeatureClass>|undefined}
+     * @type {Array<FeatureType>|undefined}
      * @api
      */
     this.features = features;
@@ -77,7 +77,7 @@ export class VectorSourceEvent extends Event {
  */
 
 /**
- * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {Array<FeatureType>|Collection<FeatureType>} [features]
@@ -217,9 +217,9 @@ class VectorSource extends Source {
 
     /**
      * @private
-     * @type {import("../format/Feature.js").default<import('../format/Feature.js').FeatureToFeatureClass<FeatureType>>|undefined}
+     * @type {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>|null}
      */
-    this.format_ = options.format;
+    this.format_ = options.format || null;
 
     /**
      * @private
@@ -448,7 +448,7 @@ class VectorSource extends Source {
     const extents = [];
     /** @type {Array<FeatureType>} */
     const newFeatures = [];
-    /** @type Array<FeatureType> */
+    /** @type {Array<FeatureType>} */
     const geometryFeatures = [];
 
     for (let i = 0, length = features.length; i < length; i++) {
@@ -889,7 +889,7 @@ class VectorSource extends Source {
   /**
    * Get the format associated with this source.
    *
-   * @return {import("../format/Feature.js").default<import('../format/Feature.js').FeatureToFeatureClass<FeatureType>>|undefined} The feature format.
+   * @return {import("../format/Feature.js").default<import("../format/Feature.js").FeatureToFeatureClass<FeatureType>>|null}} The feature format.
    * @api
    */
   getFormat() {

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -22,7 +22,7 @@ import {loadFeaturesXhr} from '../featureloader.js';
 import {toSize} from '../size.js';
 
 /**
- * @template {import("../Feature.js").FeatureLike} FeatureType
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
@@ -491,7 +491,8 @@ export default VectorTile;
 
 /**
  * Sets the loader for a tile.
- * @param {import("../VectorTile.js").default} tile Vector tile.
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
+ * @param {import("../VectorTile.js").default<FeatureType>} tile Vector tile.
  * @param {string} url URL.
  */
 export function defaultLoadFunction(tile, url) {

--- a/test/typescript/cases/cluster-source.ts
+++ b/test/typescript/cases/cluster-source.ts
@@ -5,7 +5,19 @@ import Point from '../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../src/ol/source/Vector.js';
 
-export const layer: VectorLayer<Feature<Geometry>> = new VectorLayer({
+export const layer1: VectorLayer<Feature<Geometry>> = new VectorLayer({
+  source: new ClusterSource({
+    distance: 10,
+    source: new VectorSource({
+      features: [new Feature(new Point([0, 0]))],
+    }),
+  }),
+});
+
+export const layer2: VectorLayer<
+  Feature,
+  ClusterSource<Feature<Point>>
+> = new VectorLayer({
   source: new ClusterSource({
     distance: 10,
     source: new VectorSource({

--- a/test/typescript/cases/vectortile-layer.ts
+++ b/test/typescript/cases/vectortile-layer.ts
@@ -3,6 +3,7 @@ import Point from '../../../src/ol/geom/Point.js';
 import VectorTileLayer from '../../../src/ol/layer/VectorTile.js';
 import VectorTileSource from '../../../src/ol/source/VectorTile.js';
 import {MVT} from '../../../src/ol/format.js';
+import {OGCVectorTile as OGCVectorTileSource} from '../../../src/ol/source.js';
 import {toFeature} from '../../../src/ol/render/Feature.js';
 
 const options = {
@@ -11,14 +12,41 @@ const options = {
   }),
 };
 const layer1 = new VectorTileLayer(options);
-export const feature = toFeature(
-  layer1.getSource().getFeaturesInExtent([0, 0, 1, 1])[0],
-);
+toFeature(layer1.getSource().getFeaturesInExtent([0, 0, 1, 1])[0]);
 
 const layer2: VectorTileLayer<Feature<Point>> = new VectorTileLayer({
   source: new VectorTileSource({
     format: new MVT({featureClass: Feature}),
   }),
 });
-const features = layer2.getSource().getFeaturesInExtent([0, 0, 1, 1]);
-export const coordinates = features[0].getGeometry().getCoordinates();
+layer2
+  .getSource()
+  .getFeaturesInExtent([0, 0, 1, 1])[0]
+  .getGeometry()
+  .getCoordinates();
+
+const layer3: VectorTileLayer<Feature<Point>> = new VectorTileLayer({
+  source: new VectorTileSource({
+    format: new MVT({featureClass: Feature}),
+  }),
+});
+layer3
+  .getSource()
+  .getFeaturesInExtent([0, 0, 1, 1])[0]
+  .getGeometry()
+  .getCoordinates();
+
+const layer4: VectorTileLayer<
+  Feature,
+  OGCVectorTileSource<Feature<Point>>
+> = new VectorTileLayer({
+  source: new OGCVectorTileSource({
+    format: new MVT({featureClass: Feature}),
+    url: 'http://example.com',
+  }),
+});
+layer4
+  .getSource()
+  .getFeaturesInExtent([0, 0, 1, 1])[0]
+  .getGeometry()
+  .getCoordinates();


### PR DESCRIPTION
Fixes #15858

In addition to fixing several type issues, this pull request sets defaults for all type parameters to layers, sources and formats - this way no generics need to be specified any more when the defaults are used.
