### PR TITLE
Extract feature type from the source's type arguments

### DIFF
--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -178,7 +178,7 @@ const INTERVALS = [
  * Note that the view projection must define both extent and worldExtent.
  *
  * @fires import("../render/Event.js").RenderEvent
- * @extends {VectorLayer<Feature, VectorSource>}
+ * @extends {VectorLayer<VectorSource<Feature>>}
  * @api
  */
 class Graticule extends VectorLayer {

--- a/src/ol/layer/Vector.js
+++ b/src/ol/layer/Vector.js
@@ -4,9 +4,14 @@
 import BaseVectorLayer from './BaseVector.js';
 import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
 
+/***
+ * @template T
+ * @typedef {T extends import("../source/Vector.js").default<infer U extends import("../Feature.js").FeatureLike> ? U : never} ExtractedFeatureType
+ */
+
 /**
- * @template {import('../Feature.js').FeatureLike} [FeatureType=import('../Feature.js').default]
- * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorSourceType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -66,14 +71,14 @@ import CanvasVectorLayerRenderer from '../renderer/canvas/VectorLayer.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import('../Feature.js').FeatureLike} [FeatureType=import('../Feature.js').default]
- * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorSourceType>]
  * @extends {BaseVectorLayer<FeatureType, VectorSourceType, CanvasVectorLayerRenderer>}
  * @api
  */
 class VectorLayer extends BaseVectorLayer {
   /**
-   * @param {Options<FeatureType, VectorSourceType>} [options] Options.
+   * @param {Options<VectorSourceType, FeatureType>} [options] Options.
    */
   constructor(options) {
     super(options);

--- a/src/ol/layer/VectorTile.js
+++ b/src/ol/layer/VectorTile.js
@@ -20,9 +20,14 @@ import {assert} from '../asserts.js';
  * @typedef {'hybrid' | 'vector'} VectorTileRenderType
  */
 
+/***
+ * @template T
+ * @typedef {T extends import("../source/VectorTile.js").default<infer U extends import("../Feature.js").FeatureLike> ? U : never} ExtractedFeatureType
+ */
+
 /**
- * @template {import("../Feature").FeatureLike} [FeatureType=import("../render/Feature.js").default]
- * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<FeatureType>]
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<*>]
+ * @template {import("../Feature").FeatureLike} [FeatureType=ExtractedFeatureType<VectorTileSourceType>]
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
@@ -91,14 +96,14 @@ import {assert} from '../asserts.js';
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../render/Feature.js").default]
- * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<FeatureType>]
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<*>]
+ * @template {import("../Feature.js").FeatureLike} [FeatureType=ExtractedFeatureType<VectorTileSourceType>]
  * @extends {BaseVectorLayer<FeatureType, VectorTileSourceType, CanvasVectorTileLayerRenderer>}
  * @api
  */
 class VectorTileLayer extends BaseVectorLayer {
   /**
-   * @param {Options<FeatureType, VectorTileSourceType>} [options] Options.
+   * @param {Options<VectorTileSourceType, FeatureType>} [options] Options.
    */
   constructor(options) {
     options = options ? options : {};

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -62,7 +62,7 @@ const VECTOR_REPLAYS = {
  * @classdesc
  * Canvas renderer for vector tile layers.
  * @api
- * @extends {CanvasTileLayerRenderer<import("../../layer/VectorTile.js").default<import('../../Feature.js').FeatureLike, import('../../source/VectorTile.js').default>>}
+ * @extends {CanvasTileLayerRenderer<import("../../layer/VectorTile.js").default<import('../../source/VectorTile.js').default<import('../../Feature.js').FeatureLike>>>}
  */
 class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   /**

--- a/test/typescript/cases/cluster-source.ts
+++ b/test/typescript/cases/cluster-source.ts
@@ -5,23 +5,22 @@ import Point from '../../../src/ol/geom/Point.js';
 import VectorLayer from '../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../src/ol/source/Vector.js';
 
-export const layer1: VectorLayer<Feature<Geometry>> = new VectorLayer({
-  source: new ClusterSource({
-    distance: 10,
-    source: new VectorSource({
-      features: [new Feature(new Point([0, 0]))],
+export const layer1: VectorLayer<ClusterSource<Feature<Geometry>>> =
+  new VectorLayer({
+    source: new ClusterSource({
+      distance: 10,
+      source: new VectorSource({
+        features: [new Feature(new Point([0, 0]))],
+      }),
     }),
-  }),
-});
+  });
 
-export const layer2: VectorLayer<
-  Feature,
-  ClusterSource<Feature<Point>>
-> = new VectorLayer({
-  source: new ClusterSource({
-    distance: 10,
-    source: new VectorSource({
-      features: [new Feature(new Point([0, 0]))],
+export const layer2: VectorLayer<ClusterSource<Feature<Point>>> =
+  new VectorLayer({
+    source: new ClusterSource({
+      distance: 10,
+      source: new VectorSource({
+        features: [new Feature(new Point([0, 0]))],
+      }),
     }),
-  }),
-});
+  });

--- a/test/typescript/cases/vector-layer.ts
+++ b/test/typescript/cases/vector-layer.ts
@@ -5,21 +5,24 @@ import VectorLayer, {
 } from '../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../src/ol/source/Vector.js';
 
-const options: VectorLayerOptions<Feature<Point>> = {
+const options: VectorLayerOptions<VectorSource<Feature<Point>>> = {
   source: new VectorSource({
     features: [new Feature(new Point([0, 0]))],
   }),
 };
 export const layer1 = new VectorLayer(options);
 
-export const layer2: VectorLayer<Feature<Point>> = new VectorLayer({
-  source: new VectorSource({
-    features: [new Feature(new Point([0, 0]))],
-  }),
-});
+export const layer2: VectorLayer<VectorSource<Feature<Point>>> =
+  new VectorLayer({
+    source: new VectorSource({
+      features: [new Feature(new Point([0, 0]))],
+    }),
+  });
 
-const createLayer = <F extends FeatureLike>(options?: VectorLayerOptions<F>) =>
-  new VectorLayer<F>(options);
+const createLayer = <F extends FeatureLike>(
+  options?: VectorLayerOptions<VectorSource<F>>,
+) => new VectorLayer<VectorSource<F>>(options);
+
 export const layer3 = createLayer({
   source: new VectorSource({
     features: [new Feature(new Point([0, 0]))],

--- a/test/typescript/cases/vectortile-layer.ts
+++ b/test/typescript/cases/vectortile-layer.ts
@@ -14,37 +14,37 @@ const options = {
 const layer1 = new VectorTileLayer(options);
 toFeature(layer1.getSource().getFeaturesInExtent([0, 0, 1, 1])[0]);
 
-const layer2: VectorTileLayer<Feature<Point>> = new VectorTileLayer({
-  source: new VectorTileSource({
-    format: new MVT({featureClass: Feature}),
-  }),
-});
+const layer2: VectorTileLayer<VectorTileSource<Feature<Point>>> =
+  new VectorTileLayer({
+    source: new VectorTileSource({
+      format: new MVT({featureClass: Feature}),
+    }),
+  });
 layer2
   .getSource()
   .getFeaturesInExtent([0, 0, 1, 1])[0]
   .getGeometry()
   .getCoordinates();
 
-const layer3: VectorTileLayer<Feature<Point>> = new VectorTileLayer({
-  source: new VectorTileSource({
-    format: new MVT({featureClass: Feature}),
-  }),
-});
+const layer3: VectorTileLayer<VectorTileSource<Feature<Point>>> =
+  new VectorTileLayer({
+    source: new VectorTileSource({
+      format: new MVT({featureClass: Feature}),
+    }),
+  });
 layer3
   .getSource()
   .getFeaturesInExtent([0, 0, 1, 1])[0]
   .getGeometry()
   .getCoordinates();
 
-const layer4: VectorTileLayer<
-  Feature,
-  OGCVectorTileSource<Feature<Point>>
-> = new VectorTileLayer({
-  source: new OGCVectorTileSource({
-    format: new MVT({featureClass: Feature}),
-    url: 'http://example.com',
-  }),
-});
+const layer4: VectorTileLayer<OGCVectorTileSource<Feature<Point>>> =
+  new VectorTileLayer({
+    source: new OGCVectorTileSource({
+      format: new MVT({featureClass: Feature}),
+      url: 'http://example.com',
+    }),
+  });
 layer4
   .getSource()
   .getFeaturesInExtent([0, 0, 1, 1])[0]


### PR DESCRIPTION
This is a follow-up on #15869, and achieves the following:

**Before:**
```ts
const layer: VectorLayer<Feature<Point>, ClusterSource<Feature<Point>>> = // ...
```
**After:**
```ts
const layer: VectorLayer<ClusterSource<Feature<Point>>> = // ...
```
Same for VectorTile layers.

Addresses https://github.com/openlayers/openlayers/pull/15869#discussion_r1622522940.