### PR TITLE
Make non-string text styles work again

### DIFF
--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -260,7 +260,6 @@ class Executor {
       textState.scale[0] * pixelRatio,
       textState.scale[1] * pixelRatio,
     ];
-    const textIsArray = Array.isArray(text);
     const align = textState.justify
       ? TEXT_ALIGN[textState.justify]
       : horizontalTextAlign(
@@ -270,9 +269,9 @@ class Executor {
     const strokeWidth =
       strokeKey && strokeState.lineWidth ? strokeState.lineWidth : 0;
 
-    const chunks = textIsArray
+    const chunks = Array.isArray(text)
       ? text
-      : text.split('\n').reduce(createTextChunks, []);
+      : String(text).split('\n').reduce(createTextChunks, []);
 
     const {width, height, widths, heights, lineWidths} = getTextDimensions(
       textState,

--- a/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
@@ -193,6 +193,38 @@ describe('ol/renderer/canvas/VectorLayer', function () {
     });
   });
 
+  describe('numeric labels', function () {
+    let map;
+    this.beforeEach(function () {
+      map = new Map({
+        target: createMapDiv(100, 100),
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+    });
+
+    this.afterEach(function () {
+      disposeMap(map);
+    });
+
+    it('supports numbers for texts', function () {
+      const layer = new VectorLayer({
+        source: new VectorSource({
+          features: [new Feature(new Point([0, 0]))],
+        }),
+        style: new Style({
+          text: new Text({
+            text: 5,
+          }),
+        }),
+      });
+      map.addLayer(layer);
+      expect(() => map.renderSync()).to.not.throwException();
+    });
+  });
+
   describe('#forEachFeatureAtCoordinate', function () {
     /** @type {VectorLayer} */ let layer;
     /** @type {CanvasVectorLayerRenderer} */ let renderer;


### PR DESCRIPTION
This pull request restores the text rendering behavior for `null`, `undefined`, `Object` and `number` values from before #13410. Currently, such values throw an error. Before #13410, they resulted in rendering the `String` representation of the respective value.

This change allows us to remove the `to-string` flat style operator (see #15875).