### PR TITLE
Add 2D coordinate comparison option to Modify interaction

### DIFF
--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -236,17 +236,19 @@ export function format(coordinate, template, fractionDigits) {
 /**
  * @param {Coordinate} coordinate1 First coordinate.
  * @param {Coordinate} coordinate2 Second coordinate.
+ * @param {boolean} [compare2D=false] Compare only the first two dimensions. Default is `false`
  * @return {boolean} The two coordinates are equal.
  */
-export function equals(coordinate1, coordinate2) {
-  let equals = true;
-  for (let i = coordinate1.length - 1; i >= 0; --i) {
-    if (coordinate1[i] != coordinate2[i]) {
-      equals = false;
-      break;
-    }
+export function equals(coordinate1, coordinate2, compare2D = false) {
+  if (compare2D) {
+    return (
+      coordinate1[0] === coordinate2[0] && coordinate1[1] === coordinate2[1]
+    );
   }
-  return equals;
+  if (coordinate1.length !== coordinate2.length) {
+    return false;
+  }
+  return coordinate1.every((value, index) => value === coordinate2[index]);
 }
 
 /**

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -129,6 +129,8 @@ const ModifyEventType = {
  * overlay.
  * @property {boolean} [snapToPointer=!hitDetection] The vertex, point or segment being modified snaps to the
  * pointer coordinate when clicked within the `pixelTolerance`.
+ * @property {boolean} [compare2D=false] Perform a 2D only comparison of vertices when determining proximity or equality. This can be useful in scenarios where the
+ * modification operations are purely planar and do not require consideration of height or depth.
  */
 
 /**
@@ -224,6 +226,12 @@ class Modify extends PointerInteraction {
      * @type {import("../events/condition.js").Condition}
      */
     this.condition_ = options.condition ? options.condition : primaryAction;
+
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.compare2D_ = options.compare2D || false;
 
     /**
      * @private
@@ -1019,7 +1027,7 @@ class Modify extends PointerInteraction {
             projection,
           );
           if (
-            coordinatesEqual(closestVertex, vertex) &&
+            coordinatesEqual(closestVertex, vertex, this.compare2D_) &&
             !componentSegments[uid][0]
           ) {
             this.dragSegments_.push([segmentDataMatch, 0]);
@@ -1029,7 +1037,7 @@ class Modify extends PointerInteraction {
         }
 
         if (
-          coordinatesEqual(segment[0], vertex) &&
+          coordinatesEqual(segment[0], vertex, this.compare2D_) &&
           !componentSegments[uid][0]
         ) {
           this.dragSegments_.push([segmentDataMatch, 0]);
@@ -1038,7 +1046,7 @@ class Modify extends PointerInteraction {
         }
 
         if (
-          coordinatesEqual(segment[1], vertex) &&
+          coordinatesEqual(segment[1], vertex, this.compare2D_) &&
           !componentSegments[uid][1]
         ) {
           if (
@@ -1272,10 +1280,26 @@ class Modify extends PointerInteraction {
           for (let i = 1, ii = nodes.length; i < ii; ++i) {
             const segment = nodes[i].segment;
             if (
-              (coordinatesEqual(closestSegment[0], segment[0]) &&
-                coordinatesEqual(closestSegment[1], segment[1])) ||
-              (coordinatesEqual(closestSegment[0], segment[1]) &&
-                coordinatesEqual(closestSegment[1], segment[0]))
+              (coordinatesEqual(
+                closestSegment[0],
+                segment[0],
+                this.compare2D_,
+              ) &&
+                coordinatesEqual(
+                  closestSegment[1],
+                  segment[1],
+                  this.compare2D_,
+                )) ||
+              (coordinatesEqual(
+                closestSegment[0],
+                segment[1],
+                this.compare2D_,
+              ) &&
+                coordinatesEqual(
+                  closestSegment[1],
+                  segment[0],
+                  this.compare2D_,
+                ))
             ) {
               const geometryUid = getUid(nodes[i].geometry);
               if (!(geometryUid in geometries)) {

--- a/test/node/ol/coordinate.test.js
+++ b/test/node/ol/coordinate.test.js
@@ -58,15 +58,19 @@ describe('ol/coordinate.js', function () {
   });
 
   describe('#equals', function () {
-    const cologne = [50.93333, 6.95];
-    const bonn1 = [50.73, 7.1];
-    const bonn2 = [50.73, 7.1];
+    const cologne = [50.93333, 6.95, 0];
+    const bonn1 = [50.73, 7.1, 10];
+    const bonn2 = [50.73, 7.1, 20];
 
     it('compares correctly', function () {
-      const bonnEqualsBonn = coordinatesEqual(bonn1, bonn2);
-      const bonnEqualsCologne = coordinatesEqual(bonn1, cologne);
-      expect(bonnEqualsBonn).to.be(true);
-      expect(bonnEqualsCologne).to.be(false);
+      const bonnEqualsBonn3D = coordinatesEqual(bonn1, bonn2);
+      const bonnEqualsBonn2D = coordinatesEqual(bonn1, bonn2, true);
+      const bonnEqualsCologne3D = coordinatesEqual(bonn1, cologne);
+      const bonnEqualsCologne2D = coordinatesEqual(bonn1, cologne, true);
+      expect(bonnEqualsBonn3D).to.be(false);
+      expect(bonnEqualsBonn2D).to.be(true);
+      expect(bonnEqualsCologne3D).to.be(false);
+      expect(bonnEqualsCologne2D).to.be(false);
     });
   });
 


### PR DESCRIPTION
Updated the `equals` function in `coordinate.js` to support a `compare2D` parameter, enabling comparison of 2D coordinates only. Exposed the `compare2D` option in the Modify interaction, allowing coordinate comparisons to be limited to the first two dimensions when needed.

This update allows users to perform purely planar modifications without considering the z-coordinate or other dimensions. The default behavior remains unchanged, ensuring backward compatibility.