### PR TITLE
Fix polyfills link

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The [ol package](https://npmjs.com/package/ol) includes auto-generated TypeScrip
 
 ## Supported Browsers
 
-OpenLayers runs on all modern browsers (with greater than 1% global usage).  This includes Chrome, Firefox, Safari and Edge. For older browsers, [polyfills](https://polyfill.io/) will likely need to be added.
+OpenLayers runs on all modern browsers (with greater than 1% global usage).  This includes Chrome, Firefox, Safari and Edge. For older browsers, polyfills ([Fastly](https://polyfill-fastly.io) or [Cloudflare](https://cdnjs.cloudflare.com/polyfill)) will likely need to be added.
 
 ## Documentation
 

--- a/site/src/doc/tutorials/background.md
+++ b/site/src/doc/tutorials/background.md
@@ -17,7 +17,7 @@ OpenLayers is available as [`ol` npm package](https://npmjs.com/package/ol), whi
 
 ## Browser Support
 
-OpenLayers runs on all modern browsers (with greater than 1% global usage).  This includes Chrome, Firefox, Safari and Edge. For older browsers, [polyfills](https://polyfill.io/) will likely need to be added.
+OpenLayers runs on all modern browsers (with greater than 1% global usage).  This includes Chrome, Firefox, Safari and Edge. For older browsers, polyfills ([Fastly](https://polyfill-fastly.io) or [Cloudflare](https://cdnjs.cloudflare.com/polyfill)) will likely need to be added.
 
 The library is intended for use on both desktop/laptop and mobile devices, and supports pointer and touch interactions.
 


### PR DESCRIPTION
Hi maintainers,

We noticed the following `polyfill.io` security news today.
https://sansec.io/research/polyfill-supply-chain-attack

And we noticed that there are 2 links in this repository's documents.

This PR replaces the link to safer ones ([Fastly](https://polyfill-fastly.io) or [Cloudflare](https://cdnjs.cloudflare.com/polyfill)), so reviewing this is helpful.