### PR TITLE
Recenter map on overview map click

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -249,15 +249,17 @@ class OverviewMap extends Control {
 
       scope.getMap().getView().setCenterInternal(coordinates);
 
-      window.removeEventListener('mousemove', move);
-      window.removeEventListener('mouseup', endMoving);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', endMoving);
     };
 
     /* Binding */
 
-    overlayBox.addEventListener('mousedown', function () {
-      window.addEventListener('mousemove', move);
-      window.addEventListener('mouseup', endMoving);
+    this.ovmapDiv_.addEventListener('pointerdown', function () {
+      if (event.target === overlayBox) {
+        window.addEventListener('pointermove', move);
+      }
+      window.addEventListener('pointerup', endMoving);
     });
   }
 

--- a/src/ol/ol.css
+++ b/src/ol/ol.css
@@ -348,3 +348,7 @@
 .ol-overviewmap .ol-overviewmap-box:hover {
   cursor: move;
 }
+
+.ol-overviewmap .ol-viewport:hover {
+  cursor: pointer;
+}

--- a/test/browser/spec/ol/control/overviewmap.test.js
+++ b/test/browser/spec/ol/control/overviewmap.test.js
@@ -1,13 +1,19 @@
 import Control from '../../../../../src/ol/control/Control.js';
+import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import OverviewMap from '../../../../../src/ol/control/OverviewMap.js';
+import VectorLayer from '../../../../../src/ol/layer/Vector.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
 import View from '../../../../../src/ol/View.js';
+import {Point} from '../../../../../src/ol/geom.js';
 
 describe('ol.control.OverviewMap', function () {
   let map, target;
 
   beforeEach(function () {
     target = document.createElement('div');
+    target.style.width = '256px';
+    target.style.height = '256px';
     document.body.appendChild(target);
     map = new Map({
       target: target,
@@ -26,6 +32,37 @@ describe('ol.control.OverviewMap', function () {
       const control = new OverviewMap();
       expect(control).to.be.a(OverviewMap);
       expect(control).to.be.a(Control);
+    });
+  });
+
+  describe('recenter', function () {
+    it('recenters main map on overview map click', function () {
+      map.setView(new View({center: [0, 0], resolution: 1}));
+      map.addLayer(
+        new VectorLayer({
+          source: new VectorSource({
+            features: [new Feature(new Point([0, 0]))],
+          }),
+        }),
+      );
+      const control = new OverviewMap({collapsed: false, collapsible: false});
+      control.ovmapDiv_.style.width = '100px';
+      control.ovmapDiv_.style.height = '100px';
+      map.addControl(control);
+      control.getOverviewMap().renderSync();
+      const [x, y] = control.ovmap_.getPixelFromCoordinate([100, 100]);
+      const origin = control.ovmapDiv_.getBoundingClientRect();
+      const down = new PointerEvent('pointerdown', {
+        clientX: origin.left + x,
+        clientY: origin.top + y,
+      });
+      const up = new PointerEvent('pointerup', {
+        clientX: origin.left + x,
+        clientY: origin.top + y,
+      });
+      control.ovmapDiv_.dispatchEvent(down);
+      window.dispatchEvent(up);
+      expect(map.getView().getCenter()).to.eql([100, 100]);
     });
   });
 


### PR DESCRIPTION
This pull request changes the behavior of the overview map. Previously, only dragging the box overlay re-centered the main map. Now, the map is also re-centered to any point clicked on the overview map.