### PR TITLE
Handle a KML icon scale of zero correctly

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -1027,8 +1027,13 @@ function createNameStyleFunction(foundStyle, name) {
   const imageStyle = foundStyle.getImage();
   if (imageStyle) {
     const imageSize = imageStyle.getSize();
-    if (imageSize && imageSize.length == 2) {
-      const imageScale = imageStyle.getScaleArray();
+    const imageScale = imageStyle.getScaleArray();
+    if (
+      imageSize &&
+      imageSize.length == 2 &&
+      imageScale &&
+      imageScale.find((scale) => scale > 0)
+    ) {
       const anchor = imageStyle.getAnchor();
       // Offset the label to be centered to the right of the icon,
       // if there is one.


### PR DESCRIPTION
let the name go through without calculating any anchor or offset, it otherwise leads to a [NaN, NaN] offset and the name isn't displayed.

I have a couple user's KML that have `<Placemark>` with an `<IconStyle>` with only `<scale>0</scale>` in them. (They only want to show a label, without the default yellow pin coming from GoogleEarth). The label style is ignored/mishandled because an offset is calculated on the scale of zero, leading to a [NaN, NaN] result.
I'm trying to fix this issue.

Here's the rendering of the KML on Google Earth
![image](https://github.com/openlayers/openlayers/assets/11540521/6162ac8a-2cc7-4f5e-a19d-9c67720d872f)

Here on current OL
![image](https://github.com/openlayers/openlayers/assets/11540521/ba984df1-be81-4f5d-aeb0-b1424af06af7)

Here with the fix
![image](https://github.com/openlayers/openlayers/assets/11540521/6811b89b-f53d-4c5c-be47-b4f784d481aa)
