### PR TITLE
Fix control/OverviewMap for useGeographic()

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -237,7 +237,7 @@ class OverviewMap extends Control {
 
     const move = function (event) {
       const position = /** @type {?} */ (computeDesiredMousePosition(event));
-      const coordinates = ovmap.getEventCoordinateInternal(
+      const coordinates = ovmap.getEventCoordinate(
         /** @type {MouseEvent} */ (position),
       );
 
@@ -505,7 +505,7 @@ class OverviewMap extends Control {
 
     const overlay = this.boxOverlay_;
     const box = this.boxOverlay_.getElement();
-    const center = view.getCenterInternal();
+    const center = view.getCenter();
     const resolution = view.getResolution();
     const ovresolution = ovview.getResolution();
     const width = (mapSize[0] * resolution) / ovresolution;


### PR DESCRIPTION
When using `control/OverviewMap` with `useGeographic`, the view rectangle in the overview map is not drawn, as shown below.

```js
import Map from 'ol/Map.js';
import OSM from 'ol/source/OSM.js';
import TileLayer from 'ol/layer/Tile.js';
import View from 'ol/View.js';
import {OverviewMap, defaults as defaultControls} from 'ol/control.js';
import {useGeographic} from 'ol/proj.js';

useGeographic();

const source = new OSM();
const overviewMapControl = new OverviewMap({
  layers: [
    new TileLayer({
      source: source,
    }),
  ],
});

const map = new Map({
  controls: defaultControls().extend([overviewMapControl]),
  layers: [
    new TileLayer({
      source: source,
    }),
  ],
  target: 'map',
  view: new View({
    center: [135, 35],
    zoom: 7,
  }),
});
```
![image](https://github.com/openlayers/openlayers/assets/445223/69b3bfd6-f4d2-4174-a92d-6df7224982a1)

This PR fixes the issue.