### PR TITLE
Fix control/OverviewMap for setView()

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -297,10 +297,6 @@ class OverviewMap extends Control {
       const view = map.getView();
       if (view) {
         this.bindView_(view);
-        if (view.isDef()) {
-          this.ovmap_.updateSize();
-          this.resetExtent_();
-        }
       }
 
       if (!this.ovmap_.isRendered()) {
@@ -352,6 +348,11 @@ class OverviewMap extends Control {
     );
     // Sync once with the new view
     this.handleRotationChanged_();
+
+    if (view.isDef()) {
+      this.ovmap_.updateSize();
+      this.resetExtent_();
+    }
   }
 
   /**


### PR DESCRIPTION
When using `OverviewMap` with `collapsed: false` and delayed `setView`, the overview map is not displayed initially, as shown below.

```js
import Map from 'ol/Map.js';
import OSM from 'ol/source/OSM.js';
import TileLayer from 'ol/layer/Tile.js';
import View from 'ol/View.js';
import {OverviewMap, defaults as defaultControls} from 'ol/control.js';

const source = new OSM();
const overviewMapControl = new OverviewMap({
  collapsed: false,
  layers: [
    new TileLayer({
      source: source,
    }),
  ],
});

const map = new Map({
  controls: defaultControls().extend([overviewMapControl]),
  layers: [
    new TileLayer({
      source: source,
    }),
  ],
  target: 'map',
});

map.setView(
  new View({
    center: [500000, 6000000],
    zoom: 7,
  })
);
```
![image](https://github.com/openlayers/openlayers/assets/445223/05dd78ba-0856-4830-a94a-fece00df468e)

This PR resolves the issue.