### PR TITLE
No implicit this

### DIFF
--- a/src/ol/control/OverviewMap.js
+++ b/src/ol/control/OverviewMap.js
@@ -536,11 +536,10 @@ class OverviewMap extends Control {
     this.ovmapPostrenderKey_ = listenOnce(
       this.ovmap_,
       MapEventType.POSTRENDER,
-      function (event) {
+      (event) => {
         delete this.ovmapPostrenderKey_;
         this.updateBox_();
       },
-      this,
     );
   }
 

--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -45,15 +45,17 @@ import {clear} from './obj.js';
  * @return {EventsKey} Unique key for the listener.
  */
 export function listen(target, type, listener, thisArg, once) {
-  if (thisArg && thisArg !== target) {
-    listener = listener.bind(thisArg);
-  }
   if (once) {
     const originalListener = listener;
+    /**
+     * @this {typeof target}
+     */
     listener = function () {
       target.removeEventListener(type, listener);
-      originalListener.apply(this, arguments);
+      originalListener.apply(thisArg ?? this, arguments);
     };
+  } else if (thisArg && thisArg !== target) {
+    listener = listener.bind(thisArg);
   }
   const eventsKey = {
     target: target,

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -2165,6 +2165,7 @@ const PAIR_PARSERS = makeStructureNS(NAMESPACE_URIS, {
 });
 
 /**
+ * @this {KML}
  * @param {Element} node Node.
  * @param {Array<*>} objectStack Object stack.
  */

--- a/src/ol/functions.js
+++ b/src/ol/functions.js
@@ -37,20 +37,21 @@ export function VOID() {}
  * @template ReturnType
  */
 export function memoizeOne(fn) {
-  let called = false;
-
   /** @type {ReturnType} */
   let lastResult;
 
-  /** @type {Array<any>} */
+  /** @type {Array<any>|undefined} */
   let lastArgs;
 
   let lastThis;
 
+  /**
+   * @this {*} Only need to know if `this` changed, don't care what type
+   * @return {ReturnType} Memoized value
+   */
   return function () {
     const nextArgs = Array.prototype.slice.call(arguments);
-    if (!called || this !== lastThis || !arrayEquals(nextArgs, lastArgs)) {
-      called = true;
+    if (!lastArgs || this !== lastThis || !arrayEquals(nextArgs, lastArgs)) {
       lastThis = this;
       lastArgs = nextArgs;
       lastResult = fn.apply(this, arguments);

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -755,7 +755,7 @@ class Draw extends PointerInteraction {
          * @param {import("../proj/Projection.js").default} projection The view projection.
          * @return {import("../geom/SimpleGeometry.js").default} A geometry.
          */
-        geometryFunction = function (coordinates, geometry, projection) {
+        geometryFunction = (coordinates, geometry, projection) => {
           const circle = geometry
             ? /** @type {Circle} */ (geometry)
             : new Circle([NaN, NaN]);
@@ -790,7 +790,7 @@ class Draw extends PointerInteraction {
          * @param {import("../proj/Projection.js").default} projection The view projection.
          * @return {import("../geom/SimpleGeometry.js").default} A geometry.
          */
-        geometryFunction = function (coordinates, geometry, projection) {
+        geometryFunction = (coordinates, geometry, projection) => {
           if (geometry) {
             if (mode === 'Polygon') {
               if (coordinates[0].length) {

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -450,7 +450,7 @@ class Layer extends BaseLayer {
       this.mapPrecomposeKey_ = listen(
         map,
         RenderEventType.PRECOMPOSE,
-        function (evt) {
+        (evt) => {
           const renderEvent =
             /** @type {import("../render/Event.js").default} */ (evt);
           const layerStatesArray = renderEvent.frameState.layerStatesArray;
@@ -463,7 +463,6 @@ class Layer extends BaseLayer {
           );
           layerStatesArray.push(layerState);
         },
-        this,
       );
       this.mapRenderKey_ = listen(this, EventType.CHANGE, map.render, map);
       this.changed();

--- a/src/ol/render/canvas.js
+++ b/src/ol/render/canvas.js
@@ -233,7 +233,8 @@ export const registerFont = (function () {
     for (let i = 0, ii = fonts.length; i < ii; ++i) {
       const font = fonts[i];
       if (checkedFonts.get(font) < retries) {
-        if (isAvailable.apply(this, font.split('\n'))) {
+        const [style, weight, family] = font.split('\n');
+        if (isAvailable(style, weight, family)) {
           clear(textHeights);
           // Make sure that loaded fonts are picked up by Safari
           measureContext = null;

--- a/src/ol/reproj/DataTile.js
+++ b/src/ol/reproj/DataTile.js
@@ -501,26 +501,21 @@ class ReprojDataTile extends DataTile {
       }
       leftToLoad++;
 
-      const sourceListenKey = listen(
-        tile,
-        EventType.CHANGE,
-        function () {
-          const state = tile.getState();
-          if (
-            state == TileState.LOADED ||
-            state == TileState.ERROR ||
-            state == TileState.EMPTY
-          ) {
-            unlistenByKey(sourceListenKey);
-            leftToLoad--;
-            if (leftToLoad === 0) {
-              this.unlistenSources_();
-              this.reproject_();
-            }
+      const sourceListenKey = listen(tile, EventType.CHANGE, () => {
+        const state = tile.getState();
+        if (
+          state == TileState.LOADED ||
+          state == TileState.ERROR ||
+          state == TileState.EMPTY
+        ) {
+          unlistenByKey(sourceListenKey);
+          leftToLoad--;
+          if (leftToLoad === 0) {
+            this.unlistenSources_();
+            this.reproject_();
           }
-        },
-        this,
-      );
+        }
+      });
       this.sourcesListenerKeys_.push(sourceListenKey);
     });
 

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -228,7 +228,7 @@ class ReprojImage extends ImageWrapper {
         this.sourceListenerKey_ = listen(
           this.sourceImage_,
           EventType.CHANGE,
-          function (e) {
+          (e) => {
             const sourceState = this.sourceImage_.getState();
             if (
               sourceState == ImageState.LOADED ||
@@ -238,7 +238,6 @@ class ReprojImage extends ImageWrapper {
               this.reproject_();
             }
           },
-          this,
         );
         this.sourceImage_.load();
       }

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -345,26 +345,21 @@ class ReprojTile extends Tile {
         if (state == TileState.IDLE || state == TileState.LOADING) {
           leftToLoad++;
 
-          const sourceListenKey = listen(
-            tile,
-            EventType.CHANGE,
-            function (e) {
-              const state = tile.getState();
-              if (
-                state == TileState.LOADED ||
-                state == TileState.ERROR ||
-                state == TileState.EMPTY
-              ) {
-                unlistenByKey(sourceListenKey);
-                leftToLoad--;
-                if (leftToLoad === 0) {
-                  this.unlistenSources_();
-                  this.reproject_();
-                }
+          const sourceListenKey = listen(tile, EventType.CHANGE, (e) => {
+            const state = tile.getState();
+            if (
+              state == TileState.LOADED ||
+              state == TileState.ERROR ||
+              state == TileState.EMPTY
+            ) {
+              unlistenByKey(sourceListenKey);
+              leftToLoad--;
+              if (leftToLoad === 0) {
+                this.unlistenSources_();
+                this.reproject_();
               }
-            },
-            this,
-          );
+            }
+          });
           this.sourcesListenerKeys_.push(sourceListenKey);
         }
       });

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -136,14 +136,9 @@ export class CustomTile extends Tile {
   forDataAtCoordinate(coordinate, callback, request) {
     if (this.state == TileState.EMPTY && request === true) {
       this.state = TileState.IDLE;
-      listenOnce(
-        this,
-        EventType.CHANGE,
-        function (e) {
-          callback(this.getData(coordinate));
-        },
-        this,
-      );
+      listenOnce(this, EventType.CHANGE, (e) => {
+        callback(this.getData(coordinate));
+      });
       this.loadInternal_();
     } else {
       if (request === true) {

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -281,7 +281,7 @@ class IconImage extends EventTarget {
         ) {
           resolve();
         } else {
-          this.addEventListener(EventType.CHANGE, function onChange() {
+          const onChange = () => {
             if (
               this.imageState_ === ImageState.LOADED ||
               this.imageState_ === ImageState.ERROR
@@ -289,7 +289,8 @@ class IconImage extends EventTarget {
               this.removeEventListener(EventType.CHANGE, onChange);
               resolve();
             }
-          });
+          };
+          this.addEventListener(EventType.CHANGE, onChange);
         }
       });
     }

--- a/src/ol/xml.js
+++ b/src/ol/xml.js
@@ -115,13 +115,10 @@ export function makeArrayExtender(valueReader, thisArg) {
     /**
      * @param {Node} node Node.
      * @param {Array<*>} objectStack Object stack.
+     * @this {*}
      */
     function (node, objectStack) {
-      const value = valueReader.call(
-        thisArg !== undefined ? thisArg : this,
-        node,
-        objectStack,
-      );
+      const value = valueReader.call(thisArg ?? this, node, objectStack);
       if (value !== undefined) {
         const array = /** @type {Array<*>} */ (
           objectStack[objectStack.length - 1]
@@ -145,13 +142,10 @@ export function makeArrayPusher(valueReader, thisArg) {
     /**
      * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
+     * @this {*}
      */
     function (node, objectStack) {
-      const value = valueReader.call(
-        thisArg !== undefined ? thisArg : this,
-        node,
-        objectStack,
-      );
+      const value = valueReader.call(thisArg ?? this, node, objectStack);
       if (value !== undefined) {
         const array = /** @type {Array<*>} */ (
           objectStack[objectStack.length - 1]
@@ -175,13 +169,10 @@ export function makeReplacer(valueReader, thisArg) {
     /**
      * @param {Node} node Node.
      * @param {Array<*>} objectStack Object stack.
+     * @this {*}
      */
     function (node, objectStack) {
-      const value = valueReader.call(
-        thisArg !== undefined ? thisArg : this,
-        node,
-        objectStack,
-      );
+      const value = valueReader.call(thisArg ?? this, node, objectStack);
       if (value !== undefined) {
         objectStack[objectStack.length - 1] = value;
       }
@@ -203,13 +194,10 @@ export function makeObjectPropertyPusher(valueReader, property, thisArg) {
     /**
      * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
+     * @this {*}
      */
     function (node, objectStack) {
-      const value = valueReader.call(
-        thisArg !== undefined ? thisArg : this,
-        node,
-        objectStack,
-      );
+      const value = valueReader.call(thisArg ?? this, node, objectStack);
       if (value !== undefined) {
         const object = /** @type {!Object} */ (
           objectStack[objectStack.length - 1]
@@ -241,13 +229,10 @@ export function makeObjectPropertySetter(valueReader, property, thisArg) {
     /**
      * @param {Element} node Node.
      * @param {Array<*>} objectStack Object stack.
+     * @this {*}
      */
     function (node, objectStack) {
-      const value = valueReader.call(
-        thisArg !== undefined ? thisArg : this,
-        node,
-        objectStack,
-      );
+      const value = valueReader.call(thisArg ?? this, node, objectStack);
       if (value !== undefined) {
         const object = /** @type {!Object} */ (
           objectStack[objectStack.length - 1]
@@ -269,19 +254,22 @@ export function makeObjectPropertySetter(valueReader, property, thisArg) {
  * @template T, V
  */
 export function makeChildAppender(nodeWriter, thisArg) {
-  return function (node, value, objectStack) {
-    nodeWriter.call(
-      thisArg !== undefined ? thisArg : this,
-      node,
-      value,
-      objectStack,
-    );
-    const parent = /** @type {NodeStackItem} */ (
-      objectStack[objectStack.length - 1]
-    );
-    const parentNode = parent.node;
-    parentNode.appendChild(node);
-  };
+  return (
+    /**
+     * @param {Element} node Node.
+     * @param {*} value Value to be written.
+     * @param {Array<*>} objectStack Object stack.
+     * @this {*}
+     */
+    function (node, value, objectStack) {
+      nodeWriter.call(thisArg ?? this, node, value, objectStack);
+      const parent = /** @type {NodeStackItem} */ (
+        objectStack[objectStack.length - 1]
+      );
+      const parentNode = parent.node;
+      parentNode.appendChild(node);
+    }
+  );
 }
 
 /**
@@ -470,7 +458,7 @@ export function serialize(
     value = values[i];
     if (value !== undefined) {
       node = nodeFactory.call(
-        thisArg !== undefined ? thisArg : this,
+        thisArg,
         value,
         objectStack,
         keys !== undefined ? keys[i] : undefined,

--- a/test/node/ol/events.test.js
+++ b/test/node/ol/events.test.js
@@ -58,6 +58,14 @@ describe('ol/events.js', function () {
       target.dispatchEvent('foo');
       expect(listener.callCount).to.be(2);
     });
+    it('is called with the provided this argument', () => {
+      const listener = sinon.spy();
+      const target = new EventTarget();
+      const that = {};
+      listenOnce(target, 'bar', listener, that);
+      target.dispatchEvent('bar');
+      expect(listener.thisValues[0]).to.be(that);
+    });
   });
 
   describe('unlistenByKey()', function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    "noImplicitThis": true,                   /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */


### PR DESCRIPTION
This fixes all typescript implicit-this warnings. Most were straight-forward, in `xml.js` it could by any of the `XMLFormat` sub-classes, not sure if something else., but also in the affected methods it doesn't really matter because the this-type is just passed through. so just annotate them as `*`.

Two small improvements:
- remove the `called` variable in `memoizeOne`, it has been called if `lastArgs` is not `undefined`
- remove the call to `bind` in `listen` when `once` is `true`