### PR TITLE
Fix Raster source attributions bugs

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -191,22 +191,15 @@ class Attribution extends Control {
    * @private
    */
   collectSourceAttributions_(frameState) {
+    const layers = this.getMap().getAllLayers();
     const visibleAttributions = Array.from(
-      new Set(
-        this.getMap()
-          .getAllLayers()
-          .flatMap((layer) => layer.getAttributions(frameState)),
-      ),
+      new Set(layers.flatMap((layer) => layer.getAttributions(frameState))),
     );
 
-    const collapsible = !this.getMap()
-      .getAllLayers()
-      .some(
-        (layer) =>
-          layer.getSource() &&
-          layer.getSource().getAttributionsCollapsible() === false,
-      );
     if (!this.overrideCollapsible_) {
+      const collapsible = !layers.some(
+        (layer) => layer.getSource()?.getAttributionsCollapsible() === false,
+      );
       this.setCollapsible(collapsible);
     }
     return visibleAttributions;

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -339,11 +339,7 @@ class Layer extends BaseLayer {
     if (!this.isVisible(view)) {
       return [];
     }
-    let getAttributions;
-    const source = this.getSource();
-    if (source) {
-      getAttributions = source.getAttributions();
-    }
+    const getAttributions = this.getSource()?.getAttributions();
     if (!getAttributions) {
       return [];
     }

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -631,12 +631,8 @@ class RasterSource extends ImageSource {
     this.setAttributions(function (frameState) {
       /** @type {Array<string>} */
       const attributions = [];
-      for (
-        let index = 0, iMax = options.sources.length;
-        index < iMax;
-        ++index
-      ) {
-        const sourceOrLayer = options.sources[index];
+      for (let i = 0, iMax = options.sources.length; i < iMax; ++i) {
+        const sourceOrLayer = options.sources[i];
         const source =
           sourceOrLayer instanceof Source
             ? sourceOrLayer
@@ -644,14 +640,11 @@ class RasterSource extends ImageSource {
         if (!source) {
           continue;
         }
-        const attributionGetter = source.getAttributions();
-        if (typeof attributionGetter === 'function') {
-          const sourceAttributions = attributionGetter(frameState);
-          if (typeof sourceAttributions === 'string') {
-            attributions.push(sourceAttributions);
-          } else {
-            attributions.push(...sourceAttributions);
-          }
+        const sourceAttributions = source.getAttributions()?.(frameState);
+        if (typeof sourceAttributions === 'string') {
+          attributions.push(sourceAttributions);
+        } else if (sourceAttributions !== undefined) {
+          attributions.push(...sourceAttributions);
         }
       }
       return attributions;

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -649,7 +649,7 @@ class RasterSource extends ImageSource {
           attributions.push.apply(attributions, sourceAttribution);
         }
       }
-      return attributions.length !== 0 ? attributions : null;
+      return attributions;
     });
 
     if (options.operation !== undefined) {

--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -629,6 +629,7 @@ class RasterSource extends ImageSource {
     };
 
     this.setAttributions(function (frameState) {
+      /** @type {Array<string>} */
       const attributions = [];
       for (
         let index = 0, iMax = options.sources.length;
@@ -645,8 +646,12 @@ class RasterSource extends ImageSource {
         }
         const attributionGetter = source.getAttributions();
         if (typeof attributionGetter === 'function') {
-          const sourceAttribution = attributionGetter(frameState);
-          attributions.push.apply(attributions, sourceAttribution);
+          const sourceAttributions = attributionGetter(frameState);
+          if (typeof sourceAttributions === 'string') {
+            attributions.push(sourceAttributions);
+          } else {
+            attributions.push(...sourceAttributions);
+          }
         }
       }
       return attributions;

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -71,10 +71,7 @@ class Source extends BaseObject {
      * @private
      * @type {boolean}
      */
-    this.attributionsCollapsible_ =
-      options.attributionsCollapsible !== undefined
-        ? options.attributionsCollapsible
-        : true;
+    this.attributionsCollapsible_ = options.attributionsCollapsible ?? true;
 
     /**
      * This source is currently loading data. Sources that defer loading to the
@@ -227,19 +224,13 @@ function adaptAttributions(attributionLike) {
   if (!attributionLike) {
     return null;
   }
-  if (Array.isArray(attributionLike)) {
-    return function (frameState) {
-      return attributionLike;
-    };
-  }
-
   if (typeof attributionLike === 'function') {
     return attributionLike;
   }
-
-  return function (frameState) {
-    return [attributionLike];
-  };
+  if (!Array.isArray(attributionLike)) {
+    attributionLike = [attributionLike];
+  }
+  return (frameState) => attributionLike;
 }
 
 export default Source;

--- a/test/browser/spec/ol/source/raster.test.js
+++ b/test/browser/spec/ol/source/raster.test.js
@@ -47,7 +47,7 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
     greenSource = new Static({
       url: green,
       imageExtent: extent,
-      attributions: ['green raster source'],
+      attributions: (frameState) => 'green raster source',
     });
 
     blueSource = new VectorImageLayer({
@@ -238,7 +238,7 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
         },
       });
       const blueAttributions = blue.getAttributions();
-      expect(blueAttributions()).to.be(null);
+      expect(blueAttributions()).to.eql([]);
     });
 
     it('shows single attributions', function () {


### PR DESCRIPTION
Two bugs with Raster source attributions.

- when attributsions is configured as a function returning a string there was an error
- when the combined attributions array of the raster source is empty it returned `null` which was converted to an array with null as its only element here:
https://github.com/openlayers/openlayers/blob/5cfa6a7ab5e1b7872570b0800ba6754e1c37400b/src/ol/layer/Layer.js#L352-L356