### PR TITLE
Remove last remaining `@inheritDoc`

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -162,13 +162,6 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
-   * @inheritDoc
-   */
-  getTileImage(tile) {
-    return tile.getImage(this.getLayer());
-  }
-
-  /**
    * Determine whether render should be called.
    * @param {import("../../Map.js").FrameState} frameState Frame state.
    * @return {boolean} Layer is ready to be rendered.


### PR DESCRIPTION
One instance of `@inheritDoc` survived #10840

Overriding the method in src/ol/renderer/canvas/TileLayer.js is not needed as the `getImage` method does not accept any arguments.