### PR TITLE
Improve listen calls

### DIFF
--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -446,23 +446,30 @@ class Layer extends BaseLayer {
       this.mapPrecomposeKey_ = listen(
         map,
         RenderEventType.PRECOMPOSE,
-        (evt) => {
-          const renderEvent =
-            /** @type {import("../render/Event.js").default} */ (evt);
-          const layerStatesArray = renderEvent.frameState.layerStatesArray;
-          const layerState = this.getLayerState(false);
-          assert(
-            !layerStatesArray.some(function (arrayLayerState) {
-              return arrayLayerState.layer === layerState.layer;
-            }),
-            'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both.',
-          );
-          layerStatesArray.push(layerState);
-        },
+        this.handlePrecompose_,
+        this,
       );
       this.mapRenderKey_ = listen(this, EventType.CHANGE, map.render, map);
       this.changed();
     }
+  }
+
+  /**
+   * @param {import("../events/Event.js").default} renderEvent Render event
+   * @private
+   */
+  handlePrecompose_(renderEvent) {
+    const layerStatesArray =
+      /** @type {import("../render/Event.js").default} */ (renderEvent)
+        .frameState.layerStatesArray;
+    const layerState = this.getLayerState(false);
+    assert(
+      !layerStatesArray.some(
+        (arrayLayerState) => arrayLayerState.layer === layerState.layer,
+      ),
+      'A layer can only be added to the map once. Use either `layer.setMap()` or `map.addLayer()`, not both.',
+    );
+    layerStatesArray.push(layerState);
   }
 
   /**

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -31,7 +31,8 @@ class CompositeMapRenderer extends MapRenderer {
     this.fontChangeListenerKey_ = listen(
       checkedFonts,
       ObjectEventType.PROPERTYCHANGE,
-      map.redrawText.bind(map),
+      map.redrawText,
+      map,
     );
 
     /**

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -196,7 +196,6 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
         source,
         VectorEventType.ADDFEATURE,
         this.handleSourceFeatureAdded_.bind(this, projectionTransform),
-        this,
       ),
       listen(
         source,


### PR DESCRIPTION
@ahocevar In most cases the listen call is made with a class method and therefore the bind step cannot be skipped.
Not quite sure which style is better
- storing an arrow function for each instance of a class in the constructor with addEventListener
- a private method with storing the keys returned by listen
- a private method, storing a bound function in the constructor with addEventListener

Besides these changes I only found some in src/ol/reproj, though I'm curious in [`ol/repoj/Image`](https://github.com/openlayers/openlayers/blob/main/src/ol/reproj/Image.js) the listeners are removed on dispose
https://github.com/openlayers/openlayers/blob/c201f4c62d4367bdde2fd2bc828f366faedb9544/src/ol/reproj/Image.js#L162-L164
In [`src/ol/reproj/DataTile`](https://github.com/openlayers/openlayers/blob/main/src/ol/reproj/DataTile.js) and [`ol/reproj/Tile`](https://github.com/openlayers/openlayers/blob/main/src/ol/reproj/Tile.js) this is not done. Should it be added here?
I assume this skips the expensive reproject step in case the tile is no longer needed.