### PR TITLE
Only reset an existing renderer in `setStyle()`

### DIFF
--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -473,15 +473,17 @@ class WebGLTileLayer extends BaseTileLayer {
   setStyle(style) {
     this.styleVariables_ = style.variables || {};
     this.style_ = style;
-    const parsedStyle = parseStyle(this.style_, this.getSourceBandCount_());
-    const renderer = this.getRenderer();
-    renderer.reset({
-      vertexShader: parsedStyle.vertexShader,
-      fragmentShader: parsedStyle.fragmentShader,
-      uniforms: parsedStyle.uniforms,
-      paletteTextures: parsedStyle.paletteTextures,
-    });
-    this.changed();
+    if (this.hasRenderer()) {
+      const parsedStyle = parseStyle(this.style_, this.getSourceBandCount_());
+      const renderer = this.getRenderer();
+      renderer.reset({
+        vertexShader: parsedStyle.vertexShader,
+        fragmentShader: parsedStyle.fragmentShader,
+        uniforms: parsedStyle.uniforms,
+        paletteTextures: parsedStyle.paletteTextures,
+      });
+      this.changed();
+    }
   }
 
   /**

--- a/test/rendering/cases/cog-stats/main.js
+++ b/test/rendering/cases/cog-stats/main.js
@@ -7,12 +7,16 @@ const source = new GeoTIFF({
   transition: 0,
 });
 
+const layer = new TileLayer({
+  source: source,
+});
+
+layer.setStyle({
+  color: ['array', ['band', 1], ['band', 1], ['band', 1], ['band', 2]],
+});
+
 new Map({
-  layers: [
-    new TileLayer({
-      source: source,
-    }),
-  ],
+  layers: [layer],
   target: 'map',
   view: source.getView(),
 });


### PR DESCRIPTION
Fixes #16000

I updated an existing rendering test which previously would have failed if `setStyle()` had been used,
