### PR TITLE
Fix cluster geometryFunction return type

### DIFF
--- a/src/ol/source/Cluster.js
+++ b/src/ol/source/Cluster.js
@@ -27,7 +27,7 @@ import {getUid} from '../util.js';
  * By default no minimum distance is guaranteed. This config can be used to avoid
  * overlapping icons. As a tradoff, the cluster feature's position will no longer be
  * the center of all its features.
- * @property {function(FeatureType):(Point)} [geometryFunction]
+ * @property {function(FeatureType):(Point|null)} [geometryFunction]
  * Function that takes a {@link module:ol/Feature~Feature} as argument and returns a
  * {@link module:ol/geom/Point~Point} as cluster calculation point for the feature. When a
  * feature should not be considered for clustering, the function should return


### PR DESCRIPTION
The geometryFunction can return `null` if a feature should not be considered.

Fixes #16020 

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
