### PR TITLE
Add v9.2.4 to the API version selector and bump 8.1.0 to 8.2.0.

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -51,7 +51,8 @@
             </a>
             <div class="dropdown-menu dropdown-menu-end mb-3" aria-labelledby="apidropdown">
               <a class="dropdown-item" href="/en/latest/apidoc/"><i class="fa fa-sitemap fa-fw me-2 fa-lg"></i>{{ version }} (latest)</a>
-              <a class="dropdown-item" href="/en/v8.1.0/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v8.1.0</a>
+              <a class="dropdown-item" href="/en/v9.2.4/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v9.2.4</a>
+              <a class="dropdown-item" href="/en/v8.2.0/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v8.2.0</a>
               <a class="dropdown-item" href="/en/v7.5.2/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v7.5.2</a>
               <a class="dropdown-item" href="/en/v6.15.1/apidoc/"><i class="fa fa-sitemap a-fw me-2 fa-lg"></i>v6.15.1</a>
               <a class="dropdown-item" href="/en/v5.3.0/apidoc/"><i class="fa fa-sitemap fa-fw me-2 fa-lg"></i>v5.3.0</a>

--- a/site/src/index.hbs
+++ b/site/src/index.hbs
@@ -95,7 +95,8 @@ head:
     <div class='col-sm-12'>
       <p>In case you are not ready (yet) for the latest version of OpenLayers, we provide links to selected resources of older major versions of the software.</p>
       <ul>
-        <li>Latest v8: <a href="https://github.com/openlayers/openlayers/releases/tag/v8.1.0">v8.1.0</a> released 2023-09-07 &mdash; <a href="/en/v8.1.0/apidoc/">API</a> &amp;  <a href="/en/v8.1.0/examples/">examples</a></li>
+        <li>Latest v9: <a href="https://github.com/openlayers/openlayers/releases/tag/v9.2.4">v9.2.4</a> released 2024-05-27 &mdash; <a href="/en/v9.2.4/apidoc/">API</a> &amp;  <a href="/en/v9.2.4/examples/">examples</a></li>
+        <li>Latest v8: <a href="https://github.com/openlayers/openlayers/releases/tag/v8.2.0">v8.2.0</a> released 2023-11-14 &mdash; <a href="/en/v8.2.0/apidoc/">API</a> &amp;  <a href="/en/v8.2.0/examples/">examples</a></li>
         <li>Latest v7: <a href="https://github.com/openlayers/openlayers/releases/tag/v7.5.2">v7.5.2</a> released 2023-08-31 &mdash; <a href="/en/v7.5.2/apidoc/">API</a> &amp;  <a href="/en/v7.5.2/examples/">examples</a></li>
         <li>Latest v6: <a href="https://github.com/openlayers/openlayers/releases/tag/v6.15.1">v6.15.1</a> released 2022-07-18 &mdash; <a href="/en/v6.15.1/doc/">docs</a>, <a href="/en/v6.15.1/apidoc/">API</a> &amp;  <a href="/en/v6.15.1/examples/">examples</a></li>
         <li>Latest v5: <a href="https://github.com/openlayers/openlayers/releases/tag/v5.3.0">v5.3.0</a> released 2018-11-06 &mdash; <a href="/en/v5.3.0/doc/">docs</a>, <a href="/en/v5.3.0/apidoc/">API</a> &amp;  <a href="/en/v5.3.0/examples/">examples</a></li>


### PR DESCRIPTION
Documentation update.

Updating "latest" to version 10 left version 9 orphaned in the UI so entries to the version 9.2.4 API were added. During this work, it was found that the latest version 8 reference was to version 8.1.0, so that was bumped to 8.2.0 as well.