### PR TITLE
Fix flashing on the WebGL vector example

### DIFF
--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -527,12 +527,8 @@ class WebGLHelper extends Disposable {
    * @param {import("./Buffer.js").default} buf Buffer.
    */
   deleteBuffer(buf) {
-    const gl = this.gl_;
     const bufferKey = getUid(buf);
-    const bufferCacheEntry = this.bufferCache_[bufferKey];
-    if (bufferCacheEntry && !gl.isContextLost()) {
-      gl.deleteBuffer(bufferCacheEntry.webGlBuffer);
-    }
+    // Note: gl.deleteBuffer is not called here since we let WebGL garbage collect it automatically
     delete this.bufferCache_[bufferKey];
   }
 


### PR DESCRIPTION
This fixes #16039 and is an alternative to #16054

Calling `gl.deleteBuffer` was marking the buffer for deleting which caused INVALID_OPERATION errors, see: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/bindBuffer#exceptions

We can omit the call safely as the buffers are garbage collected automatically once they are not bound anymore.