### PR TITLE
WebGL / fix flaky tests relying on patterns

### DIFF
--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -12,14 +12,13 @@ import {
   newParsingContext,
 } from '../expr/expression.js';
 import {ShaderBuilder} from './ShaderBuilder.js';
+import {asArray} from '../color.js';
 import {
-  arrayToGlsl,
   buildExpression,
   getStringNumberEquivalent,
   stringToGlsl,
   uniformNameForVariable,
 } from '../expr/gpu.js';
-import {asArray} from '../color.js';
 
 /**
  * Recursively parses a style expression and outputs a GLSL-compatible string. Takes in a compilation context that
@@ -202,23 +201,19 @@ function getColorFromDistanceField(
  */
 function parseImageProperties(style, builder, uniforms, prefix, textureId) {
   const image = new Image();
-  let size;
   image.crossOrigin =
     style[`${prefix}cross-origin`] === undefined
       ? 'anonymous'
       : style[`${prefix}cross-origin`];
   image.src = style[`${prefix}src`];
 
-  if (image.complete && image.width && image.height) {
-    size = arrayToGlsl([image.width, image.height]);
-  } else {
-    // the size is provided asynchronously using a uniform
-    uniforms[`u_texture${textureId}_size`] = () => {
-      return image.complete ? [image.width, image.height] : [0, 0];
-    };
-    builder.addUniform(`vec2 u_texture${textureId}_size`);
-    size = `u_texture${textureId}_size`;
-  }
+  // the size is provided asynchronously using a uniform
+  uniforms[`u_texture${textureId}_size`] = () => {
+    return image.complete ? [image.width, image.height] : [0, 0];
+  };
+  builder.addUniform(`vec2 u_texture${textureId}_size`);
+  const size = `u_texture${textureId}_size`;
+
   uniforms[`u_texture${textureId}`] = image;
   builder.addUniform(`sampler2D u_texture${textureId}`);
   return size;

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -328,6 +328,7 @@ describe('ol/webgl/styleparser', () => {
         });
         it('sets up builder accordingly', () => {
           expect(result.builder.uniforms_).to.eql([
+            `vec2 u_texture${uid}_size`,
             `sampler2D u_texture${uid}`,
           ]);
           expect(result.builder.attributes_).to.eql([
@@ -352,14 +353,15 @@ describe('ol/webgl/styleparser', () => {
             'vec2(-2.0, 1.0)',
           );
           expect(result.builder.texCoordExpression_).to.eql(
-            '(vec4((vec2(a_prop_attr1, 20.0)).xyxy) + vec4(0., 0., vec2(30.0, 40.0))) / (vec2(1.0, 1.0)).xyxy',
+            `(vec4((vec2(a_prop_attr1, 20.0)).xyxy) + vec4(0., 0., vec2(30.0, 40.0))) / (u_texture${uid}_size).xyxy`,
           );
           expect(result.builder.symbolRotateWithView_).to.eql(true);
           expect(Object.keys(result.attributes).length).to.eql(3);
           expect(result.attributes).to.have.property('attr1');
           expect(result.attributes).to.have.property('heading');
           expect(result.attributes).to.have.property('color1');
-          expect(Object.keys(result.uniforms).length).to.eql(1);
+          expect(Object.keys(result.uniforms).length).to.eql(2);
+          expect(result.uniforms).to.have.property(`u_texture${uid}_size`);
           expect(result.uniforms).to.have.property(`u_texture${uid}`);
         });
         it('uses the provided Image', () => {
@@ -764,7 +766,7 @@ describe('ol/webgl/styleparser', () => {
             'vec4 sampleStrokePattern',
           );
           expect(result.builder.strokeColorExpression_).to.eql(
-            `vec4(1.0, 0.0, 0.0, 1.0) * sampleStrokePattern(u_texture${uid}, vec2(1.0, 1.0), vec2(0., vec2(1.0, 1.0).y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), (2.0 * 10.0), currentLengthPx, currentRadiusRatio, v_width)`,
+            `vec4(1.0, 0.0, 0.0, 1.0) * sampleStrokePattern(u_texture${uid}, u_texture${uid}_size, vec2(0., u_texture${uid}_size.y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), (2.0 * 10.0), currentLengthPx, currentRadiusRatio, v_width)`,
           );
         });
       });
@@ -871,7 +873,7 @@ describe('ol/webgl/styleparser', () => {
             'vec4 sampleFillPattern',
           );
           expect(result.builder.fillColorExpression_).to.eql(
-            `vec4(1.0, 0.0, 0.0, 1.0) * sampleFillPattern(u_texture${uid}, vec2(1.0, 1.0), vec2(0., vec2(1.0, 1.0).y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), pxOrigin, pxPos)`,
+            `vec4(1.0, 0.0, 0.0, 1.0) * sampleFillPattern(u_texture${uid}, u_texture${uid}_size, vec2(0., u_texture${uid}_size.y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), pxOrigin, pxPos)`,
           );
         });
       });


### PR DESCRIPTION
This PR make it so that image sizes will always be provided asynchronously using a uniform in WebGL shaders.

Fixes #15942 

The previous logic was not using a uniform if an image was be ready synchronously. This would happen in very rare cases and in an unreliable way; if we don't want to make the style parsing asynchronous we have to always use a uniform for the image size.

This logic was probably an insignificant optimization anyway, as uniforms are not costly in shaders.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
