### PR TITLE
Add a coordinate tile source

### DIFF
--- a/config/tsconfig-strict.json
+++ b/config/tsconfig-strict.json
@@ -211,6 +211,7 @@
     "../src/ol/source/BingMaps.js",
     "../src/ol/source/CartoDB.js",
     "../src/ol/source/Cluster.js",
+    "../src/ol/source/CoordinateTile.js",
     "../src/ol/source/DataTile.js",
     "../src/ol/source/GeoTIFF.js",
     "../src/ol/source/Google.js",

--- a/examples/coordinate-tile-source.html
+++ b/examples/coordinate-tile-source.html
@@ -1,0 +1,12 @@
+---
+layout: example.html
+title: CoordinateTile source (Earth's shadow)
+shortdesc: Example of using a coordinate tile source with a WebGL style function to draw Earth's shadow.
+docs: >
+  This example shows how to use the coordinate tile source with the WebGL style function.
+tags: "coordinatetile, night, shadow, webgl, osm, tile, style"
+---
+<div id="map" class="map"></div>
+
+Date:
+<input type="datetime-local" id="datetime" />

--- a/examples/coordinate-tile-source.js
+++ b/examples/coordinate-tile-source.js
@@ -1,0 +1,101 @@
+import CoordinateTile from '../src/ol/source/CoordinateTile.js';
+import Map from '../src/ol/Map.js';
+import OSM from '../src/ol/source/OSM.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import View from '../src/ol/View.js';
+
+function getSubsolarPoint(t) {
+  const N = Math.floor(
+    (new Date(t).getTime() - Date.UTC(new Date(t).getUTCFullYear(), 0, 0)) /
+      86400000,
+  );
+
+  const n = (2 * Math.PI) / 365.24;
+  const declination = Math.asin(
+    -0.39777249434045 * // sin(-23.44°)
+      Math.cos(n * (N + 10) + 2 * 0.0167 * Math.sin(n * (N - 2))),
+  );
+  const latitude = (declination * 180) / Math.PI;
+
+  const UTC_H =
+    new Date(t).getUTCHours() +
+    new Date(t).getUTCMinutes() / 60 +
+    new Date(t).getUTCSeconds() / 3600;
+  const longitude = 180 - UTC_H * 15;
+
+  return {
+    subsolarLng: longitude,
+    subsolarLat: latitude,
+  };
+}
+
+// ---- Earth's shadow calculation
+const radians = (x) => ['/', ['*', x, Math.PI], 180];
+const degrees = (x) => ['*', ['/', x, Math.PI], 180];
+const arcsin = (x) => ['atan', ['/', x, ['sqrt', ['-', 1, ['*', x, x]]]]];
+
+const subsolarLng = radians(['var', 'subsolarLng']);
+const subsolarLat = radians(['var', 'subsolarLat']);
+const observerLng = radians(['band', 1]);
+const observerLat = radians(['band', 2]);
+
+const Sz = [
+  '+',
+  ['*', ['sin', observerLat], ['sin', subsolarLat]],
+  [
+    '*',
+    ['cos', observerLat],
+    ['cos', subsolarLat],
+    ['cos', ['-', subsolarLng, observerLng]],
+  ],
+];
+const sunAltitude = degrees(arcsin(Sz));
+
+// shadow config
+const twilightStartDegrees = 0;
+const twilightStepDegrees = 6;
+const twilightSteps = 0;
+const twilightAttenuation = 0.5;
+
+let twilightLevel = [
+  '/',
+  ['-', ['-', 0, sunAltitude], twilightStartDegrees],
+  twilightStepDegrees,
+];
+if (twilightSteps > 0) {
+  twilightLevel = ['ceil', ['clamp', twilightLevel, 0, twilightSteps]];
+}
+
+const brightness = ['clamp', ['^', twilightAttenuation, twilightLevel], 0, 1];
+const darkness = ['-', 1, brightness];
+
+const color = ['color', 0, 0, 0, darkness];
+// ----
+
+const shadowLayer = new TileLayer({
+  source: new CoordinateTile(),
+  style: {
+    color,
+    variables: getSubsolarPoint(Date.now()),
+  },
+});
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+    shadowLayer,
+  ],
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 2,
+  }),
+});
+
+const datetime = document.getElementById('datetime');
+datetime.addEventListener('change', () => {
+  const t = datetime.value || new Date();
+  shadowLayer.updateStyleVariables(getSubsolarPoint(t));
+});

--- a/src/ol/source.js
+++ b/src/ol/source.js
@@ -8,6 +8,7 @@ import {getIntersection} from './extent.js';
 export {default as BingMaps} from './source/BingMaps.js';
 export {default as CartoDB} from './source/CartoDB.js';
 export {default as Cluster} from './source/Cluster.js';
+export {default as CoordinateTile} from './source/CoordinateTile.js';
 export {default as DataTile} from './source/DataTile.js';
 export {default as GeoTIFF} from './source/GeoTIFF.js';
 export {default as Google} from './source/Google.js';

--- a/src/ol/source/CoordinateTile.js
+++ b/src/ol/source/CoordinateTile.js
@@ -1,0 +1,121 @@
+/**
+ * @module ol/source/CoordinateTile
+ */
+
+import DataTileSource from './DataTile.js';
+import {get as getProjection, getTransform} from '../proj.js';
+import {toSize} from '../size.js';
+
+/**
+ * @typedef {Object} Options
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
+ * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
+ * @property {number} [maxZoom=42] Optional max zoom level. Not used if `tileGrid` is provided.
+ * @property {number} [minZoom=0] Optional min zoom level. Not used if `tileGrid` is provided.
+ * @property {number|import("../size.js").Size} [tileSize] The pixel width and height of the source tiles.
+ * This may be different than the rendered pixel size if a `tileGrid` is provided.
+ * @property {number} [maxResolution] Optional tile grid resolution at level zero. Not used if `tileGrid` is provided.
+ * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Tile projection.
+ * @property {import("../proj.js").ProjectionLike} [dataProjection='EPSG:4326'] Data projection.
+ * @property {import("../tilegrid/TileGrid.js").default} [tileGrid] Tile grid.
+ * @property {import("./Source.js").State} [state] The source state.
+ * @property {boolean} [wrapX=false] Render tiles beyond the antimeridian.
+ * @property {number} [transition] Transition time when fading in new tiles (in milliseconds).
+ * @property {boolean} [interpolate=false] Use interpolated values when resampling.  By default,
+ * the nearest neighbor is used when resampling.
+ * @property {string} [key] Key for use in caching tiles.
+ * @property {number} [padding=0] padding for reversing the gutter.
+ */
+
+/**
+ * @classdesc
+ * A source for coordinate data tiles.
+ *
+ * @extends DataTileSource<import("../DataTile.js").default>
+ * @fires import("./Tile.js").TileSourceEvent
+ * @api
+ */
+class CoordinateTileSource extends DataTileSource {
+  /**
+   * @param {Options} [options] options.
+   */
+  constructor(options) {
+    options = options || {};
+    super({
+      loader: (z, x, y) => this.loadTileData_(z, x, y),
+      maxZoom: options.maxZoom,
+      minZoom: options.minZoom,
+      tileSize: options.tileSize,
+      maxResolution: options.maxResolution,
+      projection: options.projection,
+      tileGrid: options.tileGrid,
+      state: options.state,
+      wrapX: options.wrapX !== false,
+      transition: options.transition,
+      interpolate: options.interpolate !== false,
+      bandCount: 2,
+    });
+
+    const dataProjection = getProjection(options.dataProjection || 'EPSG:4326');
+    this.setKey(
+      `coordinate/${dataProjection.getCode()}/${this.getProjection().getCode()}/${options.key || ''}`,
+    );
+
+    this.transform_ = getTransform(this.getProjection(), dataProjection);
+
+    this.padding_ = options.padding || 0;
+
+    const [width, height] = toSize(options.tileSize ?? 256);
+    this.tmpCoord_ = new Array(width * height * 2);
+    this.tmpPoint_ = new Array(width * height * 2);
+  }
+
+  /**
+   * @param {Array<number>} tileCoord Tile coordinate
+   * @return {Promise<Float32Array>} data
+   */
+  async loadTileData_(...tileCoord) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const [z] = tileCoord;
+    const [width, height] = this.getTileSize(z);
+    const grid = this.getTileGrid();
+    const tileSize = toSize(grid.getTileSize(z));
+
+    const scale_x = (tileSize[0] + this.padding_ * 2) / tileSize[0];
+    const scale_y = (tileSize[1] + this.padding_ * 2) / tileSize[1];
+
+    const extent = grid.getTileCoordExtent(tileCoord);
+
+    // scale around center for padding
+    const deltaX = ((extent[2] - extent[0]) / 2) * (scale_x - 1);
+    const deltaY = ((extent[3] - extent[1]) / 2) * (scale_y - 1);
+    extent[0] -= deltaX;
+    extent[2] += deltaX;
+    extent[1] -= deltaY;
+    extent[3] += deltaY;
+
+    const coord = this.tmpCoord_;
+    const point = this.tmpPoint_;
+
+    let idx = 0;
+    const resolution_x = (extent[2] - extent[0]) / width;
+    const resolution_y = (extent[3] - extent[1]) / height;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        coord[idx++] = extent[0] + resolution_x * x;
+        coord[idx++] = extent[3] - resolution_y * y;
+      }
+    }
+
+    this.transform_(coord, point, 2);
+
+    return new Float32Array(point);
+  }
+
+  getPadding() {
+    return this.padding_;
+  }
+}
+
+export default CoordinateTileSource;


### PR DESCRIPTION
Add a new source, `CoordinateTileSource`, to provide coordinate information (not limited to latitude and longitude) for every pixel within a tile.
This floating-point tile is intended to be accessed via the `band` operator of the `EncodedExpression` in the `WebGLTileLayer` and styled accordingly.

The most notable application is drawing the "Earth's shadow", which is demonstrated in the example.
It calculates the Sun's altitude for every geographic location of each pixel, rendering it as a tile with an alpha channel, allowing it to be overlaid on a map.

This was part of #16028, but I've separated it to simplify things.