### PR TITLE
expression: has

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -115,7 +115,8 @@ function compileExpression(expression, context) {
       return compileAssertionExpression(expression, context);
     }
     case Ops.Get:
-    case Ops.Var: {
+    case Ops.Var:
+    case Ops.Has: {
       return compileAccessorExpression(expression, context);
     }
     case Ops.Id: {
@@ -255,6 +256,25 @@ function compileAccessorExpression(expression, context) {
     }
     case Ops.Var: {
       return (context) => context.variables[name];
+    }
+    case Ops.Has: {
+      return (context) => {
+        const args = expression.args;
+        let value = context.properties[name];
+        let has = value !== undefined && value !== null;
+        if (has && args.length > 1) {
+          for (let i = 1, ii = args.length; i < ii; ++i) {
+            const keyExpression = /** @type {LiteralExpression} */ (args[i]);
+            const key = /** @type {string|number} */ (keyExpression.value);
+            value = value[key];
+            has = value !== undefined && value !== null;
+            if (!has) {
+              break;
+            }
+          }
+        }
+        return has;
+      };
     }
     default: {
       throw new Error(`Unsupported accessor operator ${expression.operator}`);

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -260,20 +260,19 @@ function compileAccessorExpression(expression, context) {
     case Ops.Has: {
       return (context) => {
         const args = expression.args;
-        let value = context.properties[name];
-        let has = value !== undefined && value !== null;
-        if (has && args.length > 1) {
-          for (let i = 1, ii = args.length; i < ii; ++i) {
-            const keyExpression = /** @type {LiteralExpression} */ (args[i]);
-            const key = /** @type {string|number} */ (keyExpression.value);
-            value = value[key];
-            has = value !== undefined && value !== null;
-            if (!has) {
-              break;
-            }
-          }
+        if (!(name in context.properties)) {
+          return false;
         }
-        return has;
+        let value = context.properties[name];
+        for (let i = 1, ii = args.length; i < ii; ++i) {
+          const keyExpression = /** @type {LiteralExpression} */ (args[i]);
+          const key = /** @type {string|number} */ (keyExpression.value);
+          if (!value || !Object.hasOwn(value, key)) {
+            return false;
+          }
+          value = value[key];
+        }
+        return true;
       };
     }
     default: {

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -91,6 +91,8 @@ import {toSize} from '../size.js';
  *   * `['!', value1]` returns `false` if `value1` is `true` or greater than `0`, or `true` otherwise.
  *   * `['all', value1, value2, ...]` returns `true` if all the inputs are `true`, `false` otherwise.
  *   * `['any', value1, value2, ...]` returns `true` if any of the inputs are `true`, `false` otherwise.
+ *   * `['has', attributeName, keyOrArrayIndex, ...]` returns `true` if feature properties include the (nested) key `attributeName`,
+ *     `false` otherwise.
  *   * `['between', value1, value2, value3]` returns `true` if `value1` is contained between `value2` and `value3`
  *     (inclusively), or `false` otherwise.
  *   * `['in', needle, haystack]` returns `true` if `needle` is found in `haystack`, and
@@ -414,6 +416,7 @@ export const Ops = {
   Band: 'band',
   Palette: 'palette',
   ToString: 'to-string',
+  Has: 'has',
 };
 
 /**
@@ -428,6 +431,7 @@ export const Ops = {
 const parsers = {
   [Ops.Get]: createCallExpressionParser(hasArgsCount(1, Infinity), withGetArgs),
   [Ops.Var]: createCallExpressionParser(hasArgsCount(1, 1), withVarArgs),
+  [Ops.Has]: createCallExpressionParser(hasArgsCount(1, Infinity), withGetArgs),
   [Ops.Id]: createCallExpressionParser(usesFeatureId, withNoArgs),
   [Ops.Concat]: createCallExpressionParser(
     hasArgsCount(2, Infinity),

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -716,6 +716,62 @@ describe('ol/expr/cpu.js', () => {
         expression: ['between', 3, 4, 5],
         expected: false,
       },
+      {
+        name: 'has (true)',
+        context: {
+          properties: {
+            property: 42,
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'property'],
+        expected: true,
+      },
+      {
+        name: 'has (false)',
+        context: {
+          properties: {
+            property: 42,
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'notProperty'],
+        expected: false,
+      },
+      {
+        name: 'has (false - null)',
+        context: {
+          properties: {
+            property: 42,
+            notProperty: null,
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'notProperty'],
+        expected: false,
+      },
+      {
+        name: 'has (nested array true)',
+        context: {
+          properties: {
+            property: [42, {foo: 'bar'}],
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'property', 1, 'foo'],
+        expected: true,
+      },
+      {
+        name: 'has (nested array false)',
+        context: {
+          properties: {
+            property: [42, {foo: 'bar'}],
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'property', 0, 'foo'],
+        expected: false,
+      },
     ];
 
     for (const c of cases) {

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -739,15 +739,47 @@ describe('ol/expr/cpu.js', () => {
         expected: false,
       },
       {
-        name: 'has (false - null)',
+        name: 'has (true - null)',
         context: {
           properties: {
-            property: 42,
-            notProperty: null,
+            property: null,
           },
         },
         type: BooleanType,
-        expression: ['has', 'notProperty'],
+        expression: ['has', 'property'],
+        expected: true,
+      },
+      {
+        name: 'has (true - undefined)',
+        context: {
+          properties: {
+            property: undefined,
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'property'],
+        expected: true,
+      },
+      {
+        name: 'has (nested object true)',
+        context: {
+          properties: {
+            deeply: {nested: {property: true}},
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'deeply', 'nested', 'property'],
+        expected: true,
+      },
+      {
+        name: 'has (nested object false)',
+        context: {
+          properties: {
+            deeply: {nested: {property: true}},
+          },
+        },
+        type: BooleanType,
+        expression: ['has', 'deeply', 'not', 'property'],
         expected: false,
       },
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "ES2017",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": ["es2019", "dom", "webworker"],                 /* Specify library files to be included in the compilation. */
+    "lib": ["es2022", "dom", "webworker"],                 /* Specify library files to be included in the compilation. */
     "allowJs": true,                          /* Allow javascript files to be compiled. */
     "checkJs": true,                          /* Report errors in .js files. */
     "skipLibCheck": true,


### PR DESCRIPTION
# `has` expression

This PR provides a `has` expression to ol/expr which returns a boolean based on the context properties having a certain key (or nested key).

## Reasoning

It is not trivial to get a `has` or `defined` operation with the current expressions. Things like `["any", ["get", "bar"], ["==", ["get", "bar"], ""], ["==", ["get", "bar"], false], ["==", ["get", "bar"], 0]]` would work, but aren't very convenient.

## Solution

Similar to [mapbox has](https://docs.mapbox.com/style-spec/reference/expressions/#has) this expression will return `true` if the key was found in the properites, making the above expression reduce to `["has", "bar"]`. The syntax is identical to the `get` expression, where you can provide more then one key for nested properties.
