### PR TITLE
Clear the RenderBox when the DragBox is removed from the Map

### DIFF
--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -231,8 +231,6 @@ class DragBox extends PointerInteraction {
       return false;
     }
 
-    this.box_.setMap(null);
-
     const completeBox = this.boxEndCondition_(
       mapBrowserEvent,
       this.startPixel_,
@@ -248,6 +246,10 @@ class DragBox extends PointerInteraction {
         mapBrowserEvent,
       ),
     );
+
+    this.box_.setMap(null);
+    this.startPixel_ = null;
+
     return false;
   }
 

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -137,7 +137,7 @@ class DragBox extends PointerInteraction {
      */
     this.un;
 
-    options = options ? options : {};
+    options = options ?? {};
 
     /**
      * @type {import("../render/Box.js").default}
@@ -149,7 +149,7 @@ class DragBox extends PointerInteraction {
      * @type {number}
      * @private
      */
-    this.minArea_ = options.minArea !== undefined ? options.minArea : 64;
+    this.minArea_ = options.minArea ?? 64;
 
     if (options.onBoxEnd) {
       this.onBoxEnd = options.onBoxEnd;
@@ -165,15 +165,14 @@ class DragBox extends PointerInteraction {
      * @private
      * @type {import("../events/condition.js").Condition}
      */
-    this.condition_ = options.condition ? options.condition : mouseActionButton;
+    this.condition_ = options.condition ?? mouseActionButton;
 
     /**
      * @private
      * @type {EndCondition}
      */
-    this.boxEndCondition_ = options.boxEndCondition
-      ? options.boxEndCondition
-      : this.defaultBoxEndCondition;
+    this.boxEndCondition_ =
+      options.boxEndCondition ?? this.defaultBoxEndCondition;
   }
 
   /**

--- a/src/ol/interaction/DragBox.js
+++ b/src/ol/interaction/DragBox.js
@@ -300,6 +300,27 @@ class DragBox extends PointerInteraction {
 
     super.setActive(active);
   }
+
+  /**
+   * @param {import("../Map.js").default|null} map Map.
+   * @override
+   */
+  setMap(map) {
+    const oldMap = this.getMap();
+
+    if (oldMap) {
+      this.box_.setMap(null);
+
+      if (this.startPixel_) {
+        this.dispatchEvent(
+          new DragBoxEvent(DragBoxEventType.BOXCANCEL, this.startPixel_, null),
+        );
+        this.startPixel_ = null;
+      }
+    }
+
+    super.setMap(map);
+  }
 }
 
 export default DragBox;

--- a/test/browser/spec/ol/interaction/DragBox.test.js
+++ b/test/browser/spec/ol/interaction/DragBox.test.js
@@ -1,0 +1,76 @@
+import DragBox from '../../../../../src/ol/interaction/DragBox.js';
+import Map from '../../../../../src/ol/Map.js';
+import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
+import View from '../../../../../src/ol/View.js';
+import {always} from '../../../../../src/ol/events/condition.js';
+
+describe('ol/interaction/DragBox', () => {
+  let dragBox, map;
+
+  const width = 100;
+  const height = 100;
+
+  /**
+   * Simulates a browser event on the map viewport.  The client x/y location
+   * will be adjusted as if the map were centered at 0,0.
+   * @param {string} type Event type.
+   * @param {number} x Horizontal offset from map center.
+   * @param {number} y Vertical offset from map center.
+   * @param {boolean} [opt_shiftKey] Shift key is pressed.
+   * @param {boolean} [opt_pointerId] Pointer id.
+   * @return {module:ol/MapBrowserEvent} The simulated event.
+   */
+  function simulateEvent(type, x, y, opt_shiftKey, opt_pointerId = 0) {
+    const viewport = map.getViewport();
+    // calculated in case body has top < 0 (test runner with small window)
+    const position = viewport.getBoundingClientRect();
+    const shiftKey = opt_shiftKey !== undefined ? opt_shiftKey : false;
+    const event = {};
+    event.type = type;
+    event.target = viewport.firstChild;
+    event.clientX = position.left + x + width / 2;
+    event.clientY = position.top + y + height / 2;
+    event.shiftKey = shiftKey;
+    event.preventDefault = function () {};
+    event.pointerType = 'mouse';
+    event.pointerId = opt_pointerId;
+    const simulatedEvent = new MapBrowserEvent(type, map, event);
+    map.handleMapBrowserEvent(simulatedEvent);
+    return simulatedEvent;
+  }
+
+  beforeEach((done) => {
+    dragBox = new DragBox({
+      condition: always,
+    });
+    map = new Map({
+      target: createMapDiv(width, height),
+      interactions: [],
+      constrols: [],
+      view: new View({
+        center: [0, 0],
+        zoom: 0,
+      }),
+    });
+    map.once('rendercomplete', () => done());
+  });
+
+  afterEach(() => {
+    disposeMap(map);
+  });
+
+  it('clears the drag box', (done) => {
+    try {
+      map.addInteraction(dragBox);
+      simulateEvent('pointermove', 10, 10);
+      simulateEvent('pointerdown', 10, 10);
+      simulateEvent('pointerdrag', 20, 20);
+      expect(dragBox.box_.map_).to.be(map);
+      map.removeInteraction(dragBox);
+      expect(dragBox.box_.map_).to.be(null);
+      done();
+    } catch (error) {
+      done(error);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #16072

DragBox interaction calls setMap when it is removed from the map. So I added code to clean up the RenderBox at that time. Additionally, if the box was being drawn, I also dispatched a cancel event.