### PR TITLE
Add BaseEvent export from event.js entry file

### DIFF
--- a/src/ol/events.js
+++ b/src/ol/events.js
@@ -29,6 +29,8 @@ import {clear} from './obj.js';
  * @typedef {ListenerFunction|ListenerObject} Listener
  */
 
+export {default as BaseEvent } from './events/Event.js';
+
 /**
  * Registers an event listener on an event target. Inspired by
  * https://google.github.io/closure-library/api/source/closure/goog/events/events.js.src.html


### PR DESCRIPTION
In order to fix some issues related to jest test runner that is not able to find the BaseEvent when imported from it's definition file for some reason.