### PR TITLE
WebGL / Ensure that `['geometry-type']` is correctly interpreted in expressions

### DIFF
--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -973,24 +973,21 @@ export function parseLiteralStyle(style) {
   const attributes = {};
   for (const propName in vertContext.properties) {
     const property = vertContext.properties[propName];
-    let callback;
-    if (property.evaluator) {
-      callback = property.evaluator;
-    } else {
-      callback = (feature) => {
-        const value = feature.get(property.name);
-        if (property.type === ColorType) {
-          return packColor([...asArray(value || '#eee')]);
-        }
-        if (typeof value === 'string') {
-          return getStringNumberEquivalent(value);
-        }
-        if (typeof value === 'boolean') {
-          return value ? 1 : 0;
-        }
-        return value;
-      };
-    }
+    const callback = (feature) => {
+      const value = property.evaluator
+        ? property.evaluator(feature)
+        : feature.get(property.name);
+      if (property.type === ColorType) {
+        return packColor([...asArray(value || '#eee')]);
+      }
+      if (typeof value === 'string') {
+        return getStringNumberEquivalent(value);
+      }
+      if (typeof value === 'boolean') {
+        return value ? 1 : 0;
+      }
+      return value;
+    };
 
     attributes[property.name] = {
       size: getGlslSizeFromType(property.type),


### PR DESCRIPTION
The GeometryType property had a custom evaluator function resulting to a string, but its result was not correctly converted to a number equivalent, meaning it was simply unusable in shaders.

The tests for that were missing in styleparser.

Fixes https://github.com/openlayers/openlayers/issues/15805

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
