### PR TITLE
Focus for maps placed in ShadowRoot in custom HTML elements

### DIFF
--- a/examples/es2015-custom-element-a11y.css
+++ b/examples/es2015-custom-element-a11y.css
@@ -1,0 +1,3 @@
+#map:focus {
+  outline: 0.15em solid #4A74A8;
+}

--- a/examples/es2015-custom-element-a11y.html
+++ b/examples/es2015-custom-element-a11y.html
@@ -1,0 +1,11 @@
+---
+layout: example.html
+title: Custom map element with accessible map
+shortdesc: Example of a custom element with an accessible map, which can gain focus and allows keyboard based navigation.
+docs: >
+  The example creates and registers a custom element, `ol-map`, which contains an accessible OpenLayers map. Therefore the `ol-map` element has its `tabindex` attribute set to `"0"`.
+  So the map can gain the focus and thus allows map navigation with the keyboard. Use the + and - keys to zoom in and out and the arrow keys to pan the map.
+  **Note:** Only works in browsers that supports `ShadowRoot`.
+tags: "es2015, web-component, custom-element, shadow-dom, accessibility, tabindex"
+---
+<ol-map id="map" class="map" tabindex="0"></ol-map>

--- a/examples/es2015-custom-element-a11y.js
+++ b/examples/es2015-custom-element-a11y.js
@@ -1,0 +1,42 @@
+import Map from '../src/ol/Map.js';
+import OSM from '../src/ol/source/OSM.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import View from '../src/ol/View.js';
+
+let map;
+class OLComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.shadow = this.attachShadow({mode: 'open'});
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'stylesheet');
+    link.setAttribute('href', 'theme/ol.css');
+    this.shadow.appendChild(link);
+    const style = document.createElement('style');
+    style.innerText = `
+      :host {
+        display: block;
+      }
+    `;
+    this.shadow.appendChild(style);
+    const mapTarget = document.createElement('div');
+    mapTarget.style.width = '100%';
+    mapTarget.style.height = '100%';
+    this.shadow.appendChild(mapTarget);
+
+    this.map = new Map({
+      target: mapTarget,
+      layers: [
+        new TileLayer({
+          source: new OSM(),
+        }),
+      ],
+      view: new View({
+        center: [0, 0],
+        zoom: 2,
+      }),
+    });
+  }
+}
+
+customElements.define('ol-map', OLComponent);

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -148,6 +148,9 @@ import {warn} from './console.js';
  * element itself or the `id` of the element. If not specified at construction
  * time, {@link module:ol/Map~Map#setTarget} must be called for the map to be
  * rendered. If passed by element, the container can be in a secondary document.
+ * In case your `target` element is inside a Shadow DOM you have to ensure that
+ * a possible `tabindex` attribute has to be placed on the target's host
+ * element, so it can be focused for key events to be emitted.
  * **Note:** CSS `transform` support for the target element is limited to `scale`.
  * @property {View|Promise<import("./View.js").ViewOptions>} [view] The map's view.  No layer sources will be
  * fetched unless this is specified at construction time or through
@@ -1668,6 +1671,9 @@ class Map extends BaseObject {
 
   /**
    * Set the target element to render this map into.
+   * In case the given `target` is inside a Shadow DOM you have to
+   * ensure that a possible `tabindex` attribute has to be placed on the
+   * target's host element, so it can be focused for key events to be emitted.
    * @param {HTMLElement|string} [target] The Element or id of the Element
    *     that the map is rendered in.
    * @observable

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1129,6 +1129,14 @@ class Map extends BaseObject {
         : doc;
       const target = /** @type {Node} */ (originalEvent.target);
 
+      const currentDoc =
+        rootNode instanceof ShadowRoot
+          ? rootNode.host === target
+            ? rootNode.host.ownerDocument
+            : rootNode
+          : rootNode === doc
+            ? doc.documentElement
+            : rootNode;
       if (
         // Abort if the target is a child of the container for elements whose events are not meant
         // to be handled by map interactions.
@@ -1137,12 +1145,7 @@ class Map extends BaseObject {
         // It's possible for the target to no longer be in the page if it has been removed in an
         // event listener, this might happen in a Control that recreates it's content based on
         // user interaction either manually or via a render in something like https://reactjs.org/
-        // skip check for maps place in ShadowRoot element structures
-        !(rootNode instanceof ShadowRoot)
-          ? !(rootNode === doc ? doc.documentElement : rootNode).contains(
-              target,
-            )
-          : false
+        !currentDoc.contains(target)
       ) {
         return;
       }

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1671,9 +1671,9 @@ class Map extends BaseObject {
 
   /**
    * Set the target element to render this map into.
-   * In case the given `target` is inside a Shadow DOM you have to
-   * ensure that a possible `tabindex` attribute has to be placed on the
-   * target's host element, so it can be focused for key events to be emitted.
+   * For accessibility (focus and keyboard events for map navigation), the `target` element must have a
+   *  properly configured `tabindex` attribute. If the `target` element is inside a Shadow DOM, the
+   *  `tabindex` atribute must be set on the custom element's host element.
    * @param {HTMLElement|string} [target] The Element or id of the Element
    *     that the map is rendered in.
    * @observable

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1128,6 +1128,7 @@ class Map extends BaseObject {
         ? this.viewport_.getRootNode()
         : doc;
       const target = /** @type {Node} */ (originalEvent.target);
+
       if (
         // Abort if the target is a child of the container for elements whose events are not meant
         // to be handled by map interactions.
@@ -1136,7 +1137,12 @@ class Map extends BaseObject {
         // It's possible for the target to no longer be in the page if it has been removed in an
         // event listener, this might happen in a Control that recreates it's content based on
         // user interaction either manually or via a render in something like https://reactjs.org/
-        !(rootNode === doc ? doc.documentElement : rootNode).contains(target)
+        // skip check for maps place in ShadowRoot element structures
+        !(rootNode instanceof ShadowRoot)
+          ? !(rootNode === doc ? doc.documentElement : rootNode).contains(
+              target,
+            )
+          : false
       ) {
         return;
       }
@@ -1313,9 +1319,17 @@ class Map extends BaseObject {
         PASSIVE_EVENT_LISTENERS ? {passive: false} : false,
       );
 
-      const keyboardEventTarget = !this.keyboardEventTarget_
-        ? targetElement
-        : this.keyboardEventTarget_;
+      let keyboardEventTarget;
+      if (!this.keyboardEventTarget_) {
+        // check if map target is in shadowDOM, if yes use host element as target
+        const targetRoot = targetElement.getRootNode();
+        const targetCandidate =
+          targetRoot instanceof ShadowRoot ? targetRoot.host : targetElement;
+        keyboardEventTarget = targetCandidate;
+      } else {
+        keyboardEventTarget = this.keyboardEventTarget_;
+      }
+
       this.targetChangeHandlerKeys_ = [
         listen(
           keyboardEventTarget,

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -148,9 +148,9 @@ import {warn} from './console.js';
  * element itself or the `id` of the element. If not specified at construction
  * time, {@link module:ol/Map~Map#setTarget} must be called for the map to be
  * rendered. If passed by element, the container can be in a secondary document.
- * In case your `target` element is inside a Shadow DOM you have to ensure that
- * a possible `tabindex` attribute has to be placed on the target's host
- * element, so it can be focused for key events to be emitted.
+ * For accessibility (focus and keyboard events for map navigation), the `target` element must have a
+ *  properly configured `tabindex` attribute. If the `target` element is inside a Shadow DOM, the
+ *  `tabindex` atribute must be set on the custom element's host element.
  * **Note:** CSS `transform` support for the target element is limited to `scale`.
  * @property {View|Promise<import("./View.js").ViewOptions>} [view] The map's view.  No layer sources will be
  * fetched unless this is specified at construction time or through

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -84,8 +84,12 @@ export const altShiftKeysOnly = function (mapBrowserEvent) {
  */
 export const focus = function (event) {
   const targetElement = event.map.getTargetElement();
+  const rootNode = targetElement.getRootNode();
   const activeElement = event.map.getOwnerDocument().activeElement;
-  return targetElement.contains(activeElement);
+
+  return rootNode instanceof ShadowRoot
+    ? rootNode.host.contains(activeElement)
+    : targetElement.contains(activeElement);
 };
 
 /**
@@ -95,9 +99,12 @@ export const focus = function (event) {
  * @return {boolean} The map container has the focus or no 'tabindex' attribute.
  */
 export const focusWithTabindex = function (event) {
-  return event.map.getTargetElement().hasAttribute('tabindex')
-    ? focus(event)
-    : true;
+  const targetElement = event.map.getTargetElement();
+  const rootNode = targetElement.getRootNode();
+  const tabIndexCandidate =
+    rootNode instanceof ShadowRoot ? rootNode.host : targetElement;
+
+  return tabIndexCandidate.hasAttribute('tabindex') ? focus(event) : true;
 };
 
 /**

--- a/test/browser/.eslintrc
+++ b/test/browser/.eslintrc
@@ -5,6 +5,7 @@
   "globals": {
     "afterLoadText": false,
     "createMapDiv": true,
+    "defineCustomMapEl": true,
     "disposeMap": true,
     "expect": false,
     "proj4": false,

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1309,6 +1309,9 @@ describe('ol/Map', function () {
               contains: function () {
                 return hasFocus;
               },
+              getRootNode: function () {
+                return {};
+              },
             };
           },
           getOwnerDocument: function () {

--- a/test/browser/spec/ol/interaction/keyboardpan.test.js
+++ b/test/browser/spec/ol/interaction/keyboardpan.test.js
@@ -54,4 +54,79 @@ describe('ol.interaction.KeyboardPan', function () {
       view.animateInternal.restore();
     });
   });
+
+  describe('handleEvent with map in ShadowRoot', function () {
+    let olMap;
+    let customMapEl;
+    const options = {
+      altShiftDragRotate: false,
+      doubleClickZoom: false,
+      keyboard: true,
+      mouseWheelZoom: false,
+      shiftDragZoom: false,
+      dragPan: false,
+      pinchRotate: false,
+      pinchZoom: false,
+      onFocusOnly: true,
+    };
+
+    defineCustomMapEl({interactionOpts: options});
+
+    beforeEach(function () {
+      // create custom ol-map element and add to body
+      customMapEl = document.createElement('ol-map');
+      customMapEl.setAttribute('tabindex', '0');
+      customMapEl.style.position = 'absolute';
+      customMapEl.style.left = '-1000px';
+      customMapEl.style.top = '-1000px';
+      customMapEl.style.width = '100px';
+      customMapEl.style.height = '100px';
+      document.body.appendChild(customMapEl);
+
+      olMap = customMapEl.map;
+      olMap.renderSync();
+    });
+
+    afterEach(() => {
+      disposeMap(olMap);
+      customMapEl.remove();
+    });
+
+    it('pans on arrow keys', function (done) {
+      // we have to wait until the map is rendered
+      olMap.on('rendercomplete', () => {
+        const view = olMap.getView();
+        const spy = sinon.spy(view, 'animateInternal');
+        const event = new MapBrowserEvent('keydown', olMap, {
+          type: 'keydown',
+          target: customMapEl,
+          preventDefault: Event.prototype.preventDefault,
+        });
+
+        event.originalEvent.key = 'ArrowDown';
+        olMap.handleMapBrowserEvent(event);
+        expect(spy.getCall(0).args[0].center).to.eql([0, -128]);
+        view.setCenter([0, 0]);
+
+        event.originalEvent.key = 'ArrowUp';
+        map.handleMapBrowserEvent(event);
+        expect(spy.getCall(1).args[0].center).to.eql([0, 128]);
+        view.setCenter([0, 0]);
+
+        event.originalEvent.key = 'ArrowLeft';
+        map.handleMapBrowserEvent(event);
+        expect(spy.getCall(2).args[0].center).to.eql([-128, 0]);
+        view.setCenter([0, 0]);
+
+        event.originalEvent.key = 'ArrowRight';
+        map.handleMapBrowserEvent(event);
+        expect(spy.getCall(3).args[0].center).to.eql([128, 0]);
+        view.setCenter([0, 0]);
+
+        view.animateInternal.restore();
+
+        done();
+      });
+    });
+  });
 });

--- a/test/browser/spec/ol/interaction/keyboardzoom.test.js
+++ b/test/browser/spec/ol/interaction/keyboardzoom.test.js
@@ -78,4 +78,69 @@ describe('ol.interaction.KeyboardZoom', function () {
       expect(spy.called).to.be(false);
     });
   });
+
+  describe('handleEvent with map in ShadowRoot', function () {
+    let olMap;
+    let customMapEl;
+    const options = {
+      altShiftDragRotate: false,
+      doubleClickZoom: false,
+      keyboard: true,
+      mouseWheelZoom: false,
+      shiftDragZoom: false,
+      dragPan: false,
+      pinchRotate: false,
+      pinchZoom: false,
+      onFocusOnly: true,
+    };
+
+    defineCustomMapEl({interactionOpts: options});
+
+    beforeEach(function () {
+      // create custom ol-map element and add to body
+      customMapEl = document.createElement('ol-map');
+      customMapEl.setAttribute('tabindex', '0');
+      customMapEl.style.position = 'absolute';
+      customMapEl.style.left = '-1000px';
+      customMapEl.style.top = '-1000px';
+      customMapEl.style.width = '100px';
+      customMapEl.style.height = '100px';
+      document.body.appendChild(customMapEl);
+
+      olMap = customMapEl.map;
+      olMap.renderSync();
+    });
+
+    afterEach(() => {
+      disposeMap(olMap);
+      customMapEl.remove();
+    });
+
+    it('zooms on +/- keys', function (done) {
+      // we have to wait until the map is rendered
+      olMap.on('rendercomplete', () => {
+        const view = map.getView();
+        const spy = sinon.spy(view, 'animateInternal');
+        const event = new MapBrowserEvent('keydown', map, {
+          type: 'keydown',
+          target: customMapEl,
+          preventDefault: Event.prototype.preventDefault,
+        });
+
+        event.originalEvent.key = '+';
+        olMap.handleMapBrowserEvent(event);
+        expect(spy.getCall(0).args[0].resolution).to.eql(1);
+        view.setResolution(2);
+
+        event.originalEvent.key = '-';
+        olMap.handleMapBrowserEvent(event);
+        expect(spy.getCall(1).args[0].resolution).to.eql(4);
+        view.setResolution(2);
+
+        view.animateInternal.restore();
+
+        done();
+      });
+    });
+  });
 });

--- a/test/browser/test-extensions.js
+++ b/test/browser/test-extensions.js
@@ -1,3 +1,6 @@
+import Map from '../../src/ol/Map.js';
+import View from '../../src/ol/View.js';
+import {defaults as defaultInteractions} from '../../src/ol/interaction.js';
 import {setLevel as setLogLevel} from '../../src/ol/console.js';
 
 setLogLevel('error');
@@ -419,4 +422,47 @@ setLogLevel('error');
       throw new Error('Found extra <div> elements in the body');
     }
   });
+
+  /**
+   * Defines and registers a custom HTML element `ol-map`.
+   *
+   * @param {Object} options Object holding different options used in
+   *  constructor of OLComponent. Currently 'interactionOpts' can be set as
+   *  child property.
+   */
+  global.defineCustomMapEl = function (options) {
+    // custom HTML element holding the OL map
+    class OLComponent extends HTMLElement {
+      constructor() {
+        super();
+        const shadow = this.attachShadow({mode: 'open'});
+
+        const style = document.createElement('style');
+        style.innerText = `
+          :host {
+            display: block;
+          }
+        `;
+        shadow.appendChild(style);
+
+        const target = document.createElement('div');
+        target.style.width = '100%';
+        target.style.height = '100%';
+        shadow.appendChild(target);
+
+        this.map = new Map({
+          target: target,
+          interactions: defaultInteractions(options.interactionOpts),
+          view: new View({
+            center: [0, 0],
+            resolutions: [1],
+            zoom: 8,
+          }),
+        });
+      }
+    }
+    if (customElements.get('ol-map') === undefined) {
+      customElements.define('ol-map', OLComponent);
+    }
+  };
 })(window);


### PR DESCRIPTION
This ensures that focus detection and keyboard navigation for maps placed inside a `ShadowRoot` is working properly. So in case of having a custom HTML element holding an OpenLayers map inside its ShadowRoot, the `tabindex` attribute can be placed on the custom element itself and the keyboard-based interactions (and all others of course) are still working:

`<ol-map tabindex="0" id="map" class="map"></ol-map>`

Therefore the `focusWithTabindex` and `focus` conditions were extended and the `MapBrowserEvent` propagation in the `Map` component is adapted accordingly by allwoing the host of the custom HTML element to be the `keyboardEventTarget_`. Also added an example and some tests.

The code for the changeset in `src/ol/events/condition.js` was provided by @ahocevar in [#16076](https://github.com/openlayers/openlayers/issues/16076#issuecomment-2286387515). Thanks for this :+1: 

Closes #16076 
