### PR TITLE
Fix canvas group changes on webgl layers (revised)

### DIFF
--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -110,8 +110,9 @@ class VectorStyleRenderer {
   constructor(styleOrShaders, helper, enableHitDetection) {
     /**
      * @private
+     * @type {import('../../webgl/Helper.js').default}
      */
-    this.helper_ = helper;
+    this.helper_;
 
     /**
      * @private
@@ -133,6 +134,24 @@ class VectorStyleRenderer {
     }
 
     /**
+     * @private
+     * @type {WebGLProgram}
+     */
+    this.fillProgram_;
+
+    /**
+     * @private
+     * @type {WebGLProgram}
+     */
+    this.strokeProgram_;
+
+    /**
+     * @private
+     * @type {WebGLProgram}
+     */
+    this.symbolProgram_;
+
+    /**
      * @type {boolean}
      * @private
      */
@@ -146,13 +165,6 @@ class VectorStyleRenderer {
        * @private
        */
       this.fillFragmentShader_ = shaders.builder.getFillFragmentShader();
-      /**
-       * @private
-       */
-      this.fillProgram_ = this.helper_.getProgram(
-        this.fillFragmentShader_,
-        this.fillVertexShader_,
-      );
     }
 
     /**
@@ -169,13 +181,6 @@ class VectorStyleRenderer {
        * @private
        */
       this.strokeFragmentShader_ = shaders.builder.getStrokeFragmentShader();
-      /**
-       * @private
-       */
-      this.strokeProgram_ = this.helper_.getProgram(
-        this.strokeFragmentShader_,
-        this.strokeVertexShader_,
-      );
     }
 
     /**
@@ -192,13 +197,6 @@ class VectorStyleRenderer {
        * @private
        */
       this.symbolFragmentShader_ = shaders.builder.getSymbolFragmentShader();
-      /**
-       * @private
-       */
-      this.symbolProgram_ = this.helper_.getProgram(
-        this.symbolFragmentShader_,
-        this.symbolVertexShader_,
-      );
     }
 
     const hitDetectionAttributes = this.hitDetectionEnabled_
@@ -304,9 +302,7 @@ class VectorStyleRenderer {
       ...customAttributesDesc,
     ];
 
-    if (shaders.uniforms) {
-      this.helper_.addUniforms(shaders.uniforms);
-    }
+    this.setHelper(helper);
   }
 
   /**
@@ -533,6 +529,49 @@ class VectorStyleRenderer {
     this.helper_.enableAttributes(attributes);
     preRenderCallback();
     this.helper_.drawElements(0, renderCount);
+  }
+
+  /**
+   * @param {import('../../webgl/Helper.js').default} helper Helper
+   * @param {WebGLBuffers} buffers WebGL Buffers to reload if any
+   */
+  setHelper(helper, buffers = null) {
+    this.helper_ = helper;
+
+    if (this.hasFill_) {
+      this.fillProgram_ = this.helper_.getProgram(
+        this.fillFragmentShader_,
+        this.fillVertexShader_,
+      );
+    }
+    if (this.hasStroke_) {
+      this.strokeProgram_ = this.helper_.getProgram(
+        this.strokeFragmentShader_,
+        this.strokeVertexShader_,
+      );
+    }
+    if (this.hasSymbol_) {
+      this.symbolProgram_ = this.helper_.getProgram(
+        this.symbolFragmentShader_,
+        this.symbolVertexShader_,
+      );
+    }
+    this.helper_.addUniforms(this.uniforms_);
+
+    if (buffers) {
+      if (buffers.polygonBuffers) {
+        this.helper_.flushBufferData(buffers.polygonBuffers[0]);
+        this.helper_.flushBufferData(buffers.polygonBuffers[1]);
+      }
+      if (buffers.lineStringBuffers) {
+        this.helper_.flushBufferData(buffers.lineStringBuffers[0]);
+        this.helper_.flushBufferData(buffers.lineStringBuffers[1]);
+      }
+      if (buffers.pointBuffers) {
+        this.helper_.flushBufferData(buffers.pointBuffers[0]);
+        this.helper_.flushBufferData(buffers.pointBuffers[1]);
+      }
+    }
   }
 }
 

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -367,7 +367,13 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       this.hitRenderTarget_ = new WebGLRenderTarget(this.helper);
     }
 
-    this.getLayer().getSource().changed();
+    // upload buffers again if any
+    if (this.verticesBuffer_.getArray()) {
+      this.helper.flushBufferData(this.verticesBuffer_);
+    }
+    if (this.indicesBuffer_.getArray()) {
+      this.helper.flushBufferData(this.indicesBuffer_);
+    }
   }
 
   /**

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -255,11 +255,18 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    * @override
    */
   afterHelperCreated() {
-    this.createRenderers_();
+    if (this.styleRenderers_.length) {
+      // To reuse buffers
+      this.styleRenderers_.forEach((renderer, i) =>
+        renderer.setHelper(this.helper, this.buffers_[i]),
+      );
+    } else {
+      this.createRenderers_();
+    }
+
     if (this.hitDetectionEnabled_) {
       this.hitRenderTarget_ = new WebGLRenderTarget(this.helper);
     }
-    this.getLayer().getSource().changed();
   }
 
   /**


### PR DESCRIPTION
This is a follow-up PR for #16051.

It properly fixes `WebGLVectorLayerRenderer` and `WebGLPointsLayerRenderer` by re-uploading their buffers, instead of triggering a source change event.
This resolves the flickering on group changes that occurred as a result of the mitigation.