### PR TITLE
Upload all palette textures before binding tile textures

### DIFF
--- a/src/ol/renderer/webgl/TileLayer.js
+++ b/src/ol/renderer/webgl/TileLayer.js
@@ -146,6 +146,11 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
         this.fragmentShader_,
         this.vertexShader_,
       );
+      const gl = this.helper.getGL();
+      for (const paletteTexture of this.paletteTextures_) {
+        // upload the texture data
+        paletteTexture.getTexture(gl);
+      }
     }
   }
 
@@ -154,6 +159,12 @@ class WebGLTileLayerRenderer extends WebGLBaseTileLayerRenderer {
    */
   afterHelperCreated() {
     super.afterHelperCreated();
+
+    const gl = this.helper.getGL();
+    for (const paletteTexture of this.paletteTextures_) {
+      // upload the texture data
+      paletteTexture.getTexture(gl);
+    }
 
     this.program_ = this.helper.getProgram(
       this.fragmentShader_,

--- a/test/rendering/cases/webgl-palette/main.js
+++ b/test/rendering/cases/webgl-palette/main.js
@@ -32,6 +32,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         loader: function () {
           const data = new Float32Array(size * size);
           const numColors = colors.length;


### PR DESCRIPTION
Currently, if you use `transition: 0` on a data tile source where the layer uses the `palette` operator, on the first render of the first tile, the palette is not used correctly.  This change fixes that by uploading data for all palettes before binding and rendering tile textures.

The `webgl-palette` rendering test demonstrates the issue if `transition: 0` is added.  This animation shows what that test looks like before and after the fix.

![palette-fix](https://github.com/user-attachments/assets/00c86a8c-01cd-45bc-9f01-f56778a57eab)
(the first render of the first tile (top-left) doesn't use the palette)

Fixes #15471.