### PR TITLE
Mark the type of InteractionOptions.handleEvent as optional

### DIFF
--- a/src/ol/interaction/Interaction.js
+++ b/src/ol/interaction/Interaction.js
@@ -17,7 +17,7 @@ import {easeOut, linear} from '../easing.js';
 /**
  * Object literal with config options for interactions.
  * @typedef {Object} InteractionOptions
- * @property {function(import("../MapBrowserEvent.js").default):boolean} handleEvent
+ * @property {function(import("../MapBrowserEvent.js").default):boolean} [handleEvent]
  * Method called by the map to notify the interaction that a browser event was
  * dispatched to the map. If the function returns a falsy value, propagation of
  * the event to other interactions in the map's interactions chain will be


### PR DESCRIPTION
A small change to mark `handleEvent` as optional. The property is optional based on its usage in `Interaction` as well as in the `MouseWheelZoom` subclass.

I ran into this while implementing a custom `MouseWheelZoom` interaction in typescript (working around this bug: https://github.com/openlayers/openlayers/issues/16122). 