### PR TITLE
transform function type regression

### DIFF
--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -96,6 +96,7 @@ import {warn} from './console.js';
  * @param {number} [dimension]
  * @param {number} [stride]
  * @return {Array<number>}
+ *
  * @api
  */
 

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -90,7 +90,12 @@ import {warn} from './console.js';
  * transforms the input coordinate values, populates the output array, and
  * returns the output array.
  *
- * @typedef {function(Array<number>, Array<number>=, number=, number=): Array<number>} TransformFunction
+ * @callback TransformFunction
+ * @param {Array<number>} input
+ * @param {Array<number>} [output]
+ * @param {number} [dimension]
+ * @param {number} [stride]
+ * @return {Array<number>}
  * @api
  */
 


### PR DESCRIPTION
# Issue

As of 10.1 there is a type regression in `TransformFunction`, introduced with 1b81b364e08950589bdff9609fcaf23852db3324. With a minor version upgrade, transformation now expect 4 instead of 3 parameters. The generated type was not _correct_ prior to this commit either, but stable for the last couple of major versions.

# Solution

Correctly typed `TransformFunction` with all the optional parameters correctly defined as optional. The newly genertated type now resolves to: 

```ts
export type TransformFunction =  (input: Array<number>, output?: number[] | undefined, dimension?: number | undefined, stride?: number | undefined) => Array<number>;
```

instead of
```ts
export type TransformFunction = (arg0: Array<number>, arg1: Array<number> | undefined, arg2: number | undefined, arg3: number | undefined) => Array<number>;
```
This is backward compatible with the type generated prior to 1b81b364e08950589bdff9609fcaf23852db3324 and reflects the actual type of `TransformFunction`.