### PR TITLE
Dispose of expired tiles

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -172,6 +172,15 @@ class ImageTile extends Tile {
       this.unlisten_ = null;
     }
   }
+
+  /**
+   * @override
+   */
+  disposeInternal() {
+    this.unlistenImage_();
+    this.image_ = null;
+    super.disposeInternal();
+  }
 }
 
 /**

--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -241,6 +241,14 @@ class Tile extends EventTarget {
       this.transitionStarts_[id] = -1;
     }
   }
+
+  /**
+   * @override
+   */
+  disposeInternal() {
+    this.release();
+    super.disposeInternal();
+  }
 }
 
 export default Tile;

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -145,9 +145,11 @@ class VectorRenderTile extends Tile {
    * @override
    */
   release() {
-    releaseCanvas(this.context_);
-    canvasPool.push(this.context_.canvas);
-    this.context_ = null;
+    if (this.context_) {
+      releaseCanvas(this.context_);
+      canvasPool.push(this.context_.canvas);
+      this.context_ = null;
+    }
     super.release();
   }
 }

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -88,9 +88,10 @@ class VectorRenderTile extends Tile {
     this.getSourceTiles = getSourceTiles.bind(undefined, this);
 
     /**
-     * @type {!function():void}
+     * @type {!function(VectorRenderTile):void}
+     * @private
      */
-    this.removeSourceTiles = removeSourceTiles.bind(undefined, this);
+    this.removeSourceTiles_ = removeSourceTiles;
 
     /**
      * @type {import("./tilecoord.js").TileCoord}
@@ -161,7 +162,7 @@ class VectorRenderTile extends Tile {
       canvasPool.push(this.context_.canvas);
       this.context_ = null;
     }
-    this.removeSourceTiles();
+    this.removeSourceTiles_(this);
     this.sourceTiles.length = 0;
     super.release();
   }

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -26,10 +26,16 @@ class VectorRenderTile extends Tile {
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
    * @param {import("./tilecoord.js").TileCoord} urlTileCoord Wrapped tile coordinate for source urls.
-   * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function
-   * to get source tiles for this tile.
+   * @param {function(VectorRenderTile):Array<import("./VectorTile").default>} getSourceTiles Function.
+   * @param {function(VectorRenderTile):void} removeSourceTiles Function.
    */
-  constructor(tileCoord, state, urlTileCoord, getSourceTiles) {
+  constructor(
+    tileCoord,
+    state,
+    urlTileCoord,
+    getSourceTiles,
+    removeSourceTiles,
+  ) {
     super(tileCoord, state, {transition: 0});
 
     /**
@@ -80,6 +86,11 @@ class VectorRenderTile extends Tile {
      * @type {!function():Array<import("./VectorTile.js").default>}
      */
     this.getSourceTiles = getSourceTiles.bind(undefined, this);
+
+    /**
+     * @type {!function():void}
+     */
+    this.removeSourceTiles = removeSourceTiles.bind(undefined, this);
 
     /**
      * @type {import("./tilecoord.js").TileCoord}
@@ -150,6 +161,8 @@ class VectorRenderTile extends Tile {
       canvasPool.push(this.context_.canvas);
       this.context_ = null;
     }
+    this.removeSourceTiles();
+    this.sourceTiles.length = 0;
     super.release();
   }
 }

--- a/src/ol/VectorTile.js
+++ b/src/ol/VectorTile.js
@@ -71,6 +71,13 @@ class VectorTile extends Tile {
   }
 
   /**
+   * @return {string} Tile url.
+   */
+  getTileUrl() {
+    return this.url_;
+  }
+
+  /**
    * Get the feature format assigned for reading this tile's features.
    * @return {import("./format/Feature.js").default<FeatureType>} Feature format.
    * @api

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -848,7 +848,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     }
     context.imageSmoothingEnabled = true;
 
-    // TODO: let the renderers manage their own cache instead of managing the source cache
     /**
      * Here we unconditionally expire the source cache since the renderer maintains
      * its own cache.

--- a/src/ol/structs/LRUCache.js
+++ b/src/ol/structs/LRUCache.js
@@ -2,6 +2,7 @@
  * @module ol/structs/LRUCache
  */
 
+import Disposable from '../Disposable.js';
 import {assert} from '../asserts.js';
 
 /**
@@ -66,12 +67,16 @@ class LRUCache {
   }
 
   /**
-   * Expire the cache.
+   * Expire the cache. When the cache entry is a {@link module:ol/Disposable~Disposable},
+   * the entry will be disposed.
    * @param {!Object<string, boolean>} [keep] Keys to keep. To be implemented by subclasses.
    */
   expireCache(keep) {
     while (this.canExpireCache()) {
-      this.pop();
+      const entry = this.pop();
+      if (entry instanceof Disposable) {
+        entry.dispose();
+      }
     }
   }
 

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -374,9 +374,15 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       sourceTile.getImage = function () {
         return document.createElement('canvas');
       };
-      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], function () {
-        return sourceTile;
-      });
+      const tile = new VectorRenderTile(
+        [0, 0, 0],
+        1,
+        [0, 0, 0],
+        function () {
+          return sourceTile;
+        },
+        () => {},
+      );
       tile.transition_ = 0;
       tile.setState(TileState.LOADED);
       layer.getSource().getTile = function () {
@@ -429,9 +435,15 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
         return document.createElement('canvas');
       };
       layer.getSource().getSourceTiles = () => [sourceTile];
-      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], function () {
-        return sourceTile;
-      });
+      const tile = new VectorRenderTile(
+        [0, 0, 0],
+        1,
+        [0, 0, 0],
+        function () {
+          return sourceTile;
+        },
+        () => {},
+      );
       tile.transition_ = 0;
       tile.replayState_[getUid(layer)] = [{dirty: true}];
       tile.setState(TileState.LOADED);
@@ -511,9 +523,15 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
         return document.createElement('canvas');
       };
       layer.getSource().getSourceTiles = () => [sourceTile];
-      const tile = new VectorRenderTile([0, 0, 0], 1, [0, 0, 0], function () {
-        return sourceTile;
-      });
+      const tile = new VectorRenderTile(
+        [0, 0, 0],
+        1,
+        [0, 0, 0],
+        function () {
+          return sourceTile;
+        },
+        () => {},
+      );
       tile.transition_ = 0;
       tile.replayState_[getUid(layer)] = [{dirty: true}];
       tile.setState(TileState.LOADED);
@@ -608,7 +626,7 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
         tileClass: TileClass,
         tileGrid: createXYZ(),
       });
-      source.sourceTileCache_.set('0/0/0.mvt', sourceTile);
+      source.sourceTiles_['0/0/0.mvt'] = sourceTile;
       executorGroup = {};
       executorGroup.forEachFeatureAtCoordinate = function (
         coordinate,

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -246,6 +246,7 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
           TileState.LOADING,
           [0, 0, 0],
           () => sourceTile,
+          () => {},
         ),
         grid,
         helper: renderer.helper,

--- a/test/browser/spec/ol/source/VectorTile.test.js
+++ b/test/browser/spec/ol/source/VectorTile.test.js
@@ -71,6 +71,23 @@ describe('ol/source/VectorTile', function () {
       });
     });
 
+    it('unreferences source tiles that are no longer used', () => {
+      const source = new VectorTileSource({
+        format: new GeoJSON(),
+        url: 'spec/ol/data/point.json',
+      });
+      const tile = source.getTile(0, 0, 0, 1, source.getProjection());
+
+      tile.load();
+      expect(Object.keys(source.sourceTiles_).length).to.be(1);
+      expect(source.tileKeysBySourceTileUrl_).to.eql({
+        'spec/ol/data/point.json': ['spec/ol/data/point.json/0,0,0'],
+      });
+      tile.dispose();
+      expect(Object.keys(source.sourceTiles_).length).to.be(0);
+      expect(source.tileKeysBySourceTileUrl_).to.eql({});
+    });
+
     it('handles empty tiles', function () {
       const source = new VectorTileSource({
         format: new GeoJSON(),

--- a/test/browser/spec/ol/webgl/TileGeometry.test.js
+++ b/test/browser/spec/ol/webgl/TileGeometry.test.js
@@ -28,7 +28,13 @@ describe('ol/webgl/TileGeometry', function () {
   let helper;
 
   beforeEach(function () {
-    tile = new VectorRenderTile([3, 2, 1], TileState.IDLE, [3, 2, 1], () => []);
+    tile = new VectorRenderTile(
+      [3, 2, 1],
+      TileState.IDLE,
+      [3, 2, 1],
+      () => [],
+      () => {},
+    );
     styleRenderers = [new MockRenderer(), new MockRenderer()];
     helper = new WebGLHelper();
 
@@ -90,6 +96,7 @@ describe('ol/webgl/TileGeometry', function () {
         TileState.LOADED,
         [3, 2, 1],
         () => [sourceTile],
+        () => {},
       );
 
       sinon.spy(tileGeometry.batch_, 'clear');


### PR DESCRIPTION
Fixes #16156.

By nullifying tile images when we expire tiles from the cache, we encourage the garbage collector to get rid of the detached `HTMLImageElement`s.

For vector tiles, we get rid of the `sourceTileCache` and unreference source tiles when they are not used any more by any render tile. Because `expireCache()` is no longer called on the source, the cleanup is now triggered by the tile's `release()` method.