### PR TITLE
Fix getData() on reprojected tile layers

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -323,7 +323,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
        * @type {import('../../DataTile.js').ImageLike}
        */
       let image;
-      if (tile instanceof ImageTile) {
+      if (tile instanceof ImageTile || tile instanceof ReprojTile) {
         image = tile.getImage();
       } else if (tile instanceof DataTile) {
         image = asImageLike(tile.getData());

--- a/test/browser/spec/ol/layer/Tile.test.js
+++ b/test/browser/spec/ol/layer/Tile.test.js
@@ -69,6 +69,33 @@ describe('ol/layer/Tile', function () {
       expect(data[3]).to.be(255);
     });
 
+    it('gets reprojected pixel data', (done) => {
+      layer.setSource(
+        new XYZ({
+          url: 'spec/ol/data/osm-0-0-0.png',
+          maxZoom: 0,
+          interpolate: false,
+        }),
+      );
+      map.setView(
+        new View({
+          center: [0, 0],
+          zoom: 1,
+          projection: 'EPSG:4326',
+        }),
+      );
+      map.once('rendercomplete', () => {
+        const data = layer.getData([50, 50]);
+        expect(data).to.be.a(Uint8ClampedArray);
+        expect(data.length).to.be(4);
+        expect(data[0]).to.be(181);
+        expect(data[1]).to.be(208);
+        expect(data[2]).to.be(208);
+        expect(data[3]).to.be(255);
+        done();
+      });
+    });
+
     it('gets pixel data', () => {
       layer.setVisible(false);
       map.renderSync();


### PR DESCRIPTION
`getData()` is not working on reprojected canvas tile layers since version 10.0.0.

ReprojTile is not a subclass of ImageTile (unlike ReprojDataTile and DataTile) so both must compared when checking for tile type.