### PR TITLE
Allow MouseWheelZoom by any integer value with constrainResolution

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -273,8 +273,8 @@ class MouseWheelZoom extends Interaction {
         this.maxDelta_ * this.deltaPerZoom_,
       ) / this.deltaPerZoom_;
     if (view.getConstrainResolution() || this.constrainResolution_) {
-      // view has a zoom constraint, zoom by 1
-      delta = delta ? (delta > 0 ? 1 : -1) : 0;
+      // view has a zoom constraint, zoom by integer
+      delta = delta ? (delta > 0 ? Math.ceil(delta) : Math.floor(delta)) : 0;
     }
     zoomByDelta(
       view,


### PR DESCRIPTION
As noted in #16177 there should be no reason why MouseWheelZoom should only use a zoom delta of 1 when `constrainResolution` is set, if `maxZoom` is large enough it should be possible to use any integer value.
