### PR TITLE
Fix getFeaturesInExtent()

### DIFF
--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -520,8 +520,12 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     if (tileCache.getCount() === 0) {
       return features;
     }
-    const tileGrid = this.getLayer().getSource().tileGrid;
+    const source = this.getLayer().getSource();
+    const tileGrid = source.getTileGridForProjection(
+      this.frameState.viewState.projection,
+    );
     const z = tileGrid.getZForResolution(this.renderedResolution);
+    const visitedSourceTiles = {};
     tileCache.forEach((tile) => {
       if (tile.tileCoord[0] !== z || tile.getState() !== TileState.LOADED) {
         return;
@@ -529,6 +533,11 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       const sourceTiles = tile.getSourceTiles();
       for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
         const sourceTile = sourceTiles[i];
+        const key = sourceTile.getKey();
+        if (key in visitedSourceTiles) {
+          continue;
+        }
+        visitedSourceTiles[key] = true;
         const tileCoord = sourceTile.tileCoord;
         if (intersects(extent, tileGrid.getTileCoordExtent(tileCoord))) {
           const tileFeatures = sourceTile.getFeatures();

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -88,6 +88,7 @@ class TileSource extends Source {
 
     /**
      * @type {import("../tilegrid/TileGrid.js").default|null}
+     * @protected
      */
     this.tileGrid = options.tileGrid !== undefined ? options.tileGrid : null;
 

--- a/test/browser/spec/ol/layer/vectortile.test.js
+++ b/test/browser/spec/ol/layer/vectortile.test.js
@@ -185,6 +185,7 @@ describe('ol.layer.VectorTile', function () {
             .getTileGrid()
             .getTileCoordExtent(tile.tileCoord);
           const feature = new Feature(fromExtent(extent));
+          feature.setId(tile.tileCoord.toString());
           feature.set('z', tile.tileCoord[0]);
           tile.setFeatures([feature]);
         },
@@ -221,13 +222,22 @@ describe('ol.layer.VectorTile', function () {
         const extent = map.getView().calculateExtent(map.getSize());
         const features = layer.getFeaturesInExtent(extent);
         expect(features.length).to.be(4);
-        expect(features[0].get('z')).to.be(15);
+        const keys = {};
+        features.forEach((feature) => {
+          expect(feature.get('z')).to.be(15);
+          expect(feature.getId() in keys).to.be(false);
+          keys[feature.getId()] = true;
+        });
         map.getView().setZoom(0);
         map.once('rendercomplete', function () {
           const extent = map.getView().calculateExtent(map.getSize());
           const features = layer.getFeaturesInExtent(extent);
           expect(features.length).to.be(1);
-          expect(features[0].get('z')).to.be(0);
+          features.forEach((feature) => {
+            expect(feature.get('z')).to.be(0);
+            expect(feature.getId() in keys).to.be(false);
+            keys[feature.getId()] = true;
+          });
           done();
         });
       });


### PR DESCRIPTION
* Do not add features from an already visited source tile again
* Use renderer tile grid instead of source tile grid to look up tiles in the renderer tile grid

Fixes #16189