### PR TITLE
Update major revision of jsdoc-plugin-typescript

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -23,9 +23,6 @@
     "config/jsdoc/plugins/api.cjs",
     "config/jsdoc/plugins/default-export.cjs"
   ],
-  "typescript": {
-    "moduleRoot": "src"
-  },
   "templates": {
     "cleverLinks": true,
     "monospaceLinks": true,

--- a/config/jsdoc/info/conf.json
+++ b/config/jsdoc/info/conf.json
@@ -15,8 +15,5 @@
     "config/jsdoc/plugins/define-plugin.cjs",
     "config/jsdoc/plugins/virtual-plugin.cjs",
     "config/jsdoc/plugins/default-export.cjs"
-  ],
-  "typescript": {
-    "moduleRoot": "src"
-  }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "jquery": "3.7.1",
         "jsdoc": "4.0.3",
         "jsdoc-plugin-intersection": "^1.0.4",
-        "jsdoc-plugin-typescript": "^2.3.0",
+        "jsdoc-plugin-typescript": "^3.0.0",
         "jstransformer-handlebars": "^1.2.0",
         "karma": "^6.3.8",
         "karma-chrome-launcher": "^3.1.0",
@@ -6287,9 +6287,9 @@
       "dev": true
     },
     "node_modules/jsdoc-plugin-typescript": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-2.3.0.tgz",
-      "integrity": "sha512-Cl7UIuFHJBVjUt7Kt0rKh4l8yUVG/z/SezBm39csIaxFUnWP4fbcYtXwj/WMuyZDPakKu4DXyf2MrvdhxNGWxQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-plugin-typescript/-/jsdoc-plugin-typescript-3.0.0.tgz",
+      "integrity": "sha512-/4dvpIxTqpOJkEdGtLA0p3yJcVjgpcvAvxy6wr2zuGHPo7N5k2ValhJNdIQYja2nOs0HFAepm2ii5uGQ3bXkpw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "jquery": "3.7.1",
     "jsdoc": "4.0.3",
     "jsdoc-plugin-intersection": "^1.0.4",
-    "jsdoc-plugin-typescript": "^2.3.0",
+    "jsdoc-plugin-typescript": "^3.0.0",
     "jstransformer-handlebars": "^1.2.0",
     "karma": "^6.3.8",
     "karma-chrome-launcher": "^3.1.0",


### PR DESCRIPTION
Removes the no longer needed `typescript` section in the JSDoc config.