### PR TITLE
No double caching, distinct tile keys for queue

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -250,6 +250,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         y,
         frameState.pixelRatio,
         frameState.viewState.projection,
+        true,
       );
       if (!tile) {
         return null;

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -250,7 +250,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         y,
         frameState.pixelRatio,
         frameState.viewState.projection,
-        true,
       );
       if (!tile) {
         return null;

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -294,10 +294,6 @@ class DataTileSource extends TileSource {
     }
 
     const size = this.getTileSize(z);
-    const tileCoordKey = getKeyZXY(z, x, y);
-    if (this.tileCache.containsKey(tileCoordKey)) {
-      return this.tileCache.get(tileCoordKey);
-    }
 
     const sourceLoader = this.loader_;
 
@@ -344,7 +340,6 @@ class DataTileSource extends TileSource {
     tile.key = this.getKey();
     tile.addEventListener(EventType.CHANGE, this.handleTileChange_);
 
-    this.tileCache.set(tileCoordKey, tile);
     return tile;
   }
 
@@ -423,7 +418,7 @@ class DataTileSource extends TileSource {
   getTileCacheForProjection(projection) {
     const thisProj = this.getProjection();
     if (!thisProj || equivalent(thisProj, projection)) {
-      return this.tileCache;
+      return super.getTileCacheForProjection(projection);
     }
 
     const projKey = getUid(projection);
@@ -441,9 +436,6 @@ class DataTileSource extends TileSource {
   expireCache(projection, usedTiles) {
     const usedTileCache = this.getTileCacheForProjection(projection);
 
-    this.tileCache.expireCache(
-      this.tileCache == usedTileCache ? usedTiles : {},
-    );
     for (const id in this.tileCacheForProjection_) {
       const tileCache = this.tileCacheForProjection_[id];
       tileCache.expireCache(tileCache == usedTileCache ? usedTiles : {});

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -3,7 +3,6 @@
  */
 import Event from '../events/Event.js';
 import Source from './Source.js';
-import TileCache from '../TileCache.js';
 import {abstract, getUid} from '../util.js';
 import {assert} from '../asserts.js';
 import {equivalent} from '../proj.js';
@@ -99,12 +98,6 @@ class TileSource extends Source {
 
     /**
      * @protected
-     * @type {import("../TileCache.js").default}
-     */
-    this.tileCache = new TileCache(options.cacheSize || 0);
-
-    /**
-     * @protected
      * @type {import("../size.js").Size}
      */
     this.tmpSize = [0, 0];
@@ -138,7 +131,7 @@ class TileSource extends Source {
    * @return {boolean} Can expire cache.
    */
   canExpireCache() {
-    return this.tileCache.canExpireCache();
+    return false;
   }
 
   /**
@@ -202,10 +195,9 @@ class TileSource extends Source {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} projection Projection.
-   * @param {boolean} [omitCache] Do not use the tile cache.
    * @return {TileType|null} Tile.
    */
-  getTile(z, x, y, pixelRatio, projection, omitCache) {
+  getTile(z, x, y, pixelRatio, projection) {
     return abstract();
   }
 
@@ -238,9 +230,9 @@ class TileSource extends Source {
     const sourceProjection = this.getProjection();
     assert(
       sourceProjection === null || equivalent(sourceProjection, projection),
-      'A VectorTile source can only be rendered if it has a projection compatible with the view projection.',
+      "Use the renderer's tile cache when not reprojecting.",
     );
-    return this.tileCache;
+    return null;
   }
 
   /**
@@ -289,12 +281,10 @@ class TileSource extends Source {
   }
 
   /**
-   * Remove all cached tiles from the source. The next render cycle will fetch new tiles.
+   * Remove all cached reprojected tiles from the source. The next render cycle will create new tiles.
    * @api
    */
-  clear() {
-    this.tileCache.clear();
-  }
+  clear() {}
 
   /**
    * @override
@@ -303,16 +293,6 @@ class TileSource extends Source {
     this.clear();
     super.refresh();
   }
-
-  /**
-   * Marks a tile coord as being used, without triggering a load.
-   * @abstract
-   * @param {number} z Tile coordinate z.
-   * @param {number} x Tile coordinate x.
-   * @param {number} y Tile coordinate y.
-   * @param {import("../proj/Projection.js").default} projection Projection.
-   */
-  useTile(z, x, y, projection) {}
 }
 
 /**

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -4,7 +4,7 @@
 import Event from '../events/Event.js';
 import Source from './Source.js';
 import TileCache from '../TileCache.js';
-import {abstract} from '../util.js';
+import {abstract, getUid} from '../util.js';
 import {assert} from '../asserts.js';
 import {equivalent} from '../proj.js';
 import {
@@ -113,7 +113,7 @@ class TileSource extends Source {
      * @private
      * @type {string}
      */
-    this.key_ = options.key || '';
+    this.key_ = options.key || getUid(this);
 
     /**
      * @protected

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -202,9 +202,10 @@ class TileSource extends Source {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {boolean} [omitCache] Do not use the tile cache.
    * @return {TileType|null} Tile.
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, pixelRatio, projection, omitCache) {
     return abstract();
   }
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -274,10 +274,11 @@ class TileImage extends UrlTile {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {boolean} [omitCache] Do not use the tile cache.
    * @return {!(ImageTile|ReprojTile)} Tile.
    * @override
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, pixelRatio, projection, omitCache) {
     const sourceProjection = this.getProjection();
     if (
       !sourceProjection ||
@@ -290,6 +291,7 @@ class TileImage extends UrlTile {
         y,
         pixelRatio,
         sourceProjection || projection,
+        omitCache,
       );
     }
     const cache = this.getTileCacheForProjection(projection);
@@ -319,7 +321,7 @@ class TileImage extends UrlTile {
       this.getTilePixelRatio(pixelRatio),
       this.getGutter(),
       (z, x, y, pixelRatio) =>
-        this.getTileInternal(z, x, y, pixelRatio, sourceProjection),
+        this.getTileInternal(z, x, y, pixelRatio, sourceProjection, omitCache),
       this.reprojectionErrorThreshold_,
       this.renderReprojectionEdges_,
       this.tileOptions,
@@ -340,12 +342,17 @@ class TileImage extends UrlTile {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {!import("../proj/Projection.js").default} projection Projection.
+   * @param {boolean} [omitCache] Do not use the tile cache.
    * @return {!ImageTile} Tile.
    * @protected
    */
-  getTileInternal(z, x, y, pixelRatio, projection) {
+  getTileInternal(z, x, y, pixelRatio, projection, omitCache) {
     const tileCoordKey = getKeyZXY(z, x, y);
     const key = this.getKey();
+    if (omitCache) {
+      return this.createTile_(z, x, y, pixelRatio, projection, key);
+    }
+
     if (!this.tileCache.containsKey(tileCoordKey)) {
       const tile = this.createTile_(z, x, y, pixelRatio, projection, key);
       this.tileCache.set(tileCoordKey, tile);
@@ -357,6 +364,7 @@ class TileImage extends UrlTile {
       tile = this.createTile_(z, x, y, pixelRatio, projection, key);
       this.tileCache.replace(tileCoordKey, tile);
     }
+
     return tile;
   }
 

--- a/src/ol/source/UTFGrid.js
+++ b/src/ol/source/UTFGrid.js
@@ -9,7 +9,6 @@ import TileState from '../TileState.js';
 import {applyTransform, intersects} from '../extent.js';
 import {createFromTemplates, nullTileUrlFunction} from '../tileurlfunction.js';
 import {createXYZ, extentFromProjection} from '../tilegrid.js';
-import {getKeyZXY} from '../tilecoord.js';
 import {get as getProjection, getTransformFromProjections} from '../proj.js';
 import {listenOnce} from '../events.js';
 import {jsonp as requestJSONP} from '../net.js';
@@ -473,10 +472,6 @@ class UTFGrid extends TileSource {
    * @override
    */
   getTile(z, x, y, pixelRatio, projection) {
-    const tileCoordKey = getKeyZXY(z, x, y);
-    if (this.tileCache.containsKey(tileCoordKey)) {
-      return this.tileCache.get(tileCoordKey);
-    }
     const tileCoord = [z, x, y];
     const urlTileCoord = this.getTileCoordForTileUrlFunction(
       tileCoord,
@@ -491,22 +486,7 @@ class UTFGrid extends TileSource {
       this.preemptive_,
       this.jsonp_,
     );
-    this.tileCache.set(tileCoordKey, tile);
     return tile;
-  }
-
-  /**
-   * Marks a tile coord as being used, without triggering a load.
-   * @param {number} z Tile coordinate z.
-   * @param {number} x Tile coordinate x.
-   * @param {number} y Tile coordinate y.
-   * @override
-   */
-  useTile(z, x, y) {
-    const tileCoordKey = getKeyZXY(z, x, y);
-    if (this.tileCache.containsKey(tileCoordKey)) {
-      this.tileCache.get(tileCoordKey);
-    }
   }
 }
 

--- a/src/ol/source/UrlTile.js
+++ b/src/ol/source/UrlTile.js
@@ -6,7 +6,6 @@ import TileSource, {TileSourceEvent} from './Tile.js';
 import TileState from '../TileState.js';
 import {createFromTemplates} from '../tileurlfunction.js';
 import {expandUrl} from '../uri.js';
-import {getKeyZXY} from '../tilecoord.js';
 import {getUid} from '../util.js';
 
 /**
@@ -160,7 +159,6 @@ class UrlTile extends TileSource {
    * @api
    */
   setTileLoadFunction(tileLoadFunction) {
-    this.tileCache.clear();
     this.tileLoadFunction = tileLoadFunction;
     this.changed();
   }
@@ -174,7 +172,6 @@ class UrlTile extends TileSource {
    */
   setTileUrlFunction(tileUrlFunction, key) {
     this.tileUrlFunction = tileUrlFunction;
-    this.tileCache.pruneExceptNewestZ();
     if (typeof key !== 'undefined') {
       this.setKey(key);
     } else {
@@ -217,20 +214,6 @@ class UrlTile extends TileSource {
    */
   tileUrlFunction(tileCoord, pixelRatio, projection) {
     return undefined;
-  }
-
-  /**
-   * Marks a tile coord as being used, without triggering a load.
-   * @param {number} z Tile coordinate z.
-   * @param {number} x Tile coordinate x.
-   * @param {number} y Tile coordinate y.
-   * @override
-   */
-  useTile(z, x, y) {
-    const tileCoordKey = getKeyZXY(z, x, y);
-    if (this.tileCache.containsKey(tileCoordKey)) {
-      this.tileCache.get(tileCoordKey);
-    }
   }
 }
 

--- a/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
@@ -32,7 +32,7 @@ describe('ol/renderer/canvas/TileLayer', function () {
       layer.getSource().zDirection = 1;
       map.getView().setZoom(5.8); // would lead to z6 tile request with the default zDirection
       map.once('rendercomplete', function () {
-        const tileCache = layer.getSource().tileCache;
+        const tileCache = layer.getRenderer().tileCache_;
         const keys = tileCache.getKeys();
         expect(keys.some((key) => key.startsWith('6/'))).to.be(false);
         done();

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -71,8 +71,7 @@ describe('ol/renderer/webgl/TileLayer', function () {
     map.dispose();
   });
 
-  it('maintains a cache on the renderer instead of the source', function () {
-    expect(tileLayer.getSource().tileCache.highWaterMark).to.be(0.1);
+  it('maintains a cache on the renderer', function () {
     expect(renderer.tileRepresentationCache.highWaterMark).to.be(512);
   });
 

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -121,10 +121,10 @@ describe('ol/renderer/webgl/TileLayer', function () {
       const wantedTiles = frameState.wantedTiles[sourceKey];
 
       const expected = {
-        '/10,511,511': true,
-        '/10,511,512': true,
-        '/10,512,511': true,
-        '/10,512,512': true,
+        [sourceKey + '/10,511,511']: true,
+        [sourceKey + '/10,511,512']: true,
+        [sourceKey + '/10,512,511']: true,
+        [sourceKey + '/10,512,512']: true,
       };
       expect(wantedTiles).to.eql(expected);
     });
@@ -148,18 +148,18 @@ describe('ol/renderer/webgl/TileLayer', function () {
       const wantedTiles = frameState.wantedTiles[sourceKey];
 
       const expected = {
-        '/10,511,511': true,
-        '/10,511,512': true,
-        '/10,512,511': true,
-        '/10,512,512': true,
-        '/9,255,255': true,
-        '/9,255,256': true,
-        '/9,256,255': true,
-        '/9,256,256': true,
-        '/8,127,127': true,
-        '/8,127,128': true,
-        '/8,128,127': true,
-        '/8,128,128': true,
+        [sourceKey + '/10,511,511']: true,
+        [sourceKey + '/10,511,512']: true,
+        [sourceKey + '/10,512,511']: true,
+        [sourceKey + '/10,512,512']: true,
+        [sourceKey + '/9,255,255']: true,
+        [sourceKey + '/9,255,256']: true,
+        [sourceKey + '/9,256,255']: true,
+        [sourceKey + '/9,256,256']: true,
+        [sourceKey + '/8,127,127']: true,
+        [sourceKey + '/8,127,128']: true,
+        [sourceKey + '/8,128,127']: true,
+        [sourceKey + '/8,128,128']: true,
       };
       expect(wantedTiles).to.eql(expected);
     });
@@ -184,14 +184,14 @@ describe('ol/renderer/webgl/TileLayer', function () {
       const wantedTiles = frameState.wantedTiles[sourceKey];
 
       const expected = {
-        '/10,511,511': true,
-        '/10,511,512': true,
-        '/10,512,511': true,
-        '/10,512,512': true,
-        '/9,255,255': true,
-        '/9,255,256': true,
-        '/9,256,255': true,
-        '/9,256,256': true,
+        [sourceKey + '/10,511,511']: true,
+        [sourceKey + '/10,511,512']: true,
+        [sourceKey + '/10,512,511']: true,
+        [sourceKey + '/10,512,512']: true,
+        [sourceKey + '/9,255,255']: true,
+        [sourceKey + '/9,255,256']: true,
+        [sourceKey + '/9,256,255']: true,
+        [sourceKey + '/9,256,256']: true,
       };
       expect(wantedTiles).to.eql(expected);
     });
@@ -219,18 +219,18 @@ describe('ol/renderer/webgl/TileLayer', function () {
       const wantedTiles = frameState.wantedTiles[sourceKey];
 
       const expected = {
-        '/10,511,511': true,
-        '/10,511,512': true,
-        '/10,512,511': true,
-        '/10,512,512': true,
-        '/9,255,255': true,
-        '/9,255,256': true,
-        '/9,256,255': true,
-        '/9,256,256': true,
-        '/8,127,127': true,
-        '/8,127,128': true,
-        '/8,128,127': true,
-        '/8,128,128': true,
+        [sourceKey + '/10,511,511']: true,
+        [sourceKey + '/10,511,512']: true,
+        [sourceKey + '/10,512,511']: true,
+        [sourceKey + '/10,512,512']: true,
+        [sourceKey + '/9,255,255']: true,
+        [sourceKey + '/9,255,256']: true,
+        [sourceKey + '/9,256,255']: true,
+        [sourceKey + '/9,256,256']: true,
+        [sourceKey + '/8,127,127']: true,
+        [sourceKey + '/8,127,128']: true,
+        [sourceKey + '/8,128,127']: true,
+        [sourceKey + '/8,128,128']: true,
       };
       expect(wantedTiles).to.eql(expected);
     });

--- a/test/browser/spec/ol/source/Tile.test.js
+++ b/test/browser/spec/ol/source/Tile.test.js
@@ -5,6 +5,7 @@ import TileGrid from '../../../../../src/ol/tilegrid/TileGrid.js';
 import TileSource from '../../../../../src/ol/source/Tile.js';
 import {getKeyZXY} from '../../../../../src/ol/tilecoord.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
+import {getUid} from '../../../../../src/ol/util.js';
 
 /**
  * Tile source for tests that uses a EPSG:4326 based grid with 4 resolutions and
@@ -70,7 +71,7 @@ describe('ol/source/Tile', function () {
   describe('#setKey()', function () {
     it('sets the source key', function () {
       const source = new TileSource({});
-      expect(source.getKey()).to.equal('');
+      expect(source.getKey()).to.equal(getUid(source));
 
       const key = 'foo';
       source.setKey(key);

--- a/test/browser/spec/ol/source/TileImage.test.js
+++ b/test/browser/spec/ol/source/TileImage.test.js
@@ -15,6 +15,7 @@ import {
 } from '../../../../../src/ol/tilegrid.js';
 import {createFromTemplate} from '../../../../../src/ol/tileurlfunction.js';
 import {getKeyZXY} from '../../../../../src/ol/tilecoord.js';
+import {getUid} from '../../../../../src/ol/util.js';
 import {listen} from '../../../../../src/ol/events.js';
 import {register} from '../../../../../src/ol/proj/proj4.js';
 
@@ -105,7 +106,7 @@ describe('ol/source/TileImage', function () {
 
     beforeEach(function () {
       source = createSource();
-      expect(source.getKey()).to.be('');
+      expect(source.getKey()).to.be(getUid(source));
       source.getTileInternal(0, 0, 0, 1, getProjection('EPSG:3857'));
       expect(source.tileCache.getCount()).to.be(1);
       tile = source.tileCache.get(getKeyZXY(0, 0, 0));

--- a/test/browser/spec/ol/source/Zoomify.test.js
+++ b/test/browser/spec/ol/source/Zoomify.test.js
@@ -2,7 +2,6 @@ import Projection from '../../../../../src/ol/proj/Projection.js';
 import TileGrid from '../../../../../src/ol/tilegrid/TileGrid.js';
 import Zoomify, {CustomTile} from '../../../../../src/ol/source/Zoomify.js';
 import {DEFAULT_TILE_SIZE} from '../../../../../src/ol/tilegrid/common.js';
-import {listen} from '../../../../../src/ol/events.js';
 
 describe('ol/source/Zoomify', function () {
   const w = 1024;
@@ -332,40 +331,6 @@ describe('ol/source/Zoomify', function () {
       const source = getZoomifySource();
       const tile = source.getTile(0, 0, 0, 1, proj);
       expect(tile).to.be.a(CustomTile);
-    });
-
-    it('"tile.getImage" returns and caches an unloaded image', function () {
-      const source = getZoomifySource();
-
-      const tile = source.getTile(0, 0, 0, 1, proj);
-      const img = tile.getImage();
-
-      const tile2 = source.getTile(0, 0, 0, 1, proj);
-      const img2 = tile2.getImage();
-
-      expect(img).to.be.a(HTMLImageElement);
-      expect(img).to.be(img2);
-    });
-
-    it('"tile.getImage" returns and caches a loaded canvas', function (done) {
-      const source = getZoomifySource();
-
-      const tile = source.getTile(0, 0, 0, 1, proj);
-
-      listen(tile, 'change', function () {
-        if (tile.getState() == 2) {
-          // LOADED
-          const img = tile.getImage();
-          expect(img).to.be.a(HTMLCanvasElement);
-
-          const tile2 = source.getTile(0, 0, 0, 1, proj);
-          expect(tile2.getState()).to.be(2); // LOADED
-          const img2 = tile2.getImage();
-          expect(img).to.be(img2);
-          done();
-        }
-      });
-      tile.load();
     });
   });
 });

--- a/test/browser/spec/ol/source/raster.test.js
+++ b/test/browser/spec/ol/source/raster.test.js
@@ -472,7 +472,7 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
         ],
       });
 
-      const tileCache = source.tileCache;
+      const tileCache = raster.layers_[0].getRenderer().tileCache_;
 
       expect(tileCache.getCount()).to.equal(0);
 


### PR DESCRIPTION
This pull request fixes two issues with tile rendering with the new TileLayer renderer:
* When using an `ol/source/TileImage`, tiles were cached by the source and the renderer. This resulted in disposed tiles being returned from the source cache - tiles that were disposed when expiring the renderer cache. The result was that when the queue tried to load such an expired tile, there was an error setting the src on the removed image. This pull request makes it so the source cache is bypassed in this case.
* When using multiple layers with `ol/source/TileImage`, the tile keys were the same for the same tile coordinate in each source. This caused the TileQueue to not queue tiles from subsequent layers. This pull request adds the source's uid as default prefix to the tile key to make it unique.

Fixes #16205
