### PR TITLE
Fix getResolutionsForZoom() for views with only one resolution

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1310,9 +1310,9 @@ class View extends BaseObject {
    * @api
    */
   getResolutionForZoom(zoom) {
-    if (this.resolutions_) {
-      if (this.resolutions_.length <= 1) {
-        return 0;
+    if (this.resolutions_?.length) {
+      if (this.resolutions_.length === 1) {
+        return this.resolutions_[0];
       }
       const baseLevel = clamp(
         Math.floor(zoom),

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -1573,6 +1573,16 @@ describe('ol/View', function () {
       expect(view.getResolutionForZoom(5)).to.be(2);
     });
 
+    it('returns correct zoom levels for views with a single configured resolution', () => {
+      const view = new View({
+        resolutions: [10],
+      });
+
+      expect(view.getResolutionForZoom(-1)).to.be(10);
+      expect(view.getResolutionForZoom(0)).to.be(10);
+      expect(view.getResolutionForZoom(5)).to.be(10);
+    });
+
     it('returns correct zoom levels for resolutions with variable zoom levels', function () {
       const view = new View({
         resolutions: [50, 10, 5, 2.5, 1.25, 0.625],


### PR DESCRIPTION
On a map with a view with just a single resolution configured, nothing will be rendered for tile layers. See https://codesandbox.io/p/sandbox/x529ls:
```js
  new View({
    center: [0, 0],
    zoom: 0,
    resolutions: [39135.75848201024],
  }),
```
This pull request fixes the `View#getResolutionsForZoom()` method, which is responsible for this problem, because it returns `0` in this case, which is not a resolution the `enqueueTiles()` method in the TileLayer renderer can work with.