### PR TITLE
Get rid of reprojection tile caches

### DIFF
--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -39,11 +39,6 @@ export const Uniforms = {
 };
 
 /**
- * @type {Object<string, boolean>}
- */
-const empty = {};
-
-/**
  * Transform a zoom level into a depth value; zoom level zero has a depth value of 0.5, and increasing values
  * have a depth trending towards 0
  * @param {number} z A zoom level.
@@ -720,19 +715,6 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
       const tileRepresentation = tileRepresentationCache.pop();
       tileRepresentation.dispose();
     }
-
-    // TODO: let the renderers manage their own cache instead of managing the source cache
-    /**
-     * Here we unconditionally expire the source cache since the renderer maintains
-     * its own cache.
-     * @param {import("../../Map.js").default} map Map.
-     * @param {import("../../Map.js").FrameState} frameState Frame state.
-     */
-    const postRenderFunction = function (map, frameState) {
-      tileSource.expireCache(frameState.viewState.projection, empty);
-    };
-
-    frameState.postRenderFunctions.push(postRenderFunction);
 
     this.postRender(gl, frameState);
     return canvas;

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -4,8 +4,6 @@
 import Event from '../events/Event.js';
 import Source from './Source.js';
 import {abstract, getUid} from '../util.js';
-import {assert} from '../asserts.js';
-import {equivalent} from '../proj.js';
 import {
   getForProjection as getTileGridForProjection,
   wrapX,
@@ -128,24 +126,6 @@ class TileSource extends Source {
   }
 
   /**
-   * @return {boolean} Can expire cache.
-   */
-  canExpireCache() {
-    return false;
-  }
-
-  /**
-   * @param {import("../proj/Projection.js").default} projection Projection.
-   * @param {!Object<string, boolean>} usedTiles Used tiles.
-   */
-  expireCache(projection, usedTiles) {
-    const tileCache = this.getTileCacheForProjection(projection);
-    if (tileCache) {
-      tileCache.expireCache(usedTiles);
-    }
-  }
-
-  /**
    * @param {import("../proj/Projection.js").default} projection Projection.
    * @return {number} Gutter.
    */
@@ -219,20 +199,6 @@ class TileSource extends Source {
       return getTileGridForProjection(projection);
     }
     return this.tileGrid;
-  }
-
-  /**
-   * @param {import("../proj/Projection.js").default} projection Projection.
-   * @return {import("../TileCache.js").default} Tile cache.
-   * @protected
-   */
-  getTileCacheForProjection(projection) {
-    const sourceProjection = this.getProjection();
-    assert(
-      sourceProjection === null || equivalent(sourceProjection, projection),
-      "Use the renderer's tile cache when not reprojecting.",
-    );
-    return null;
   }
 
   /**

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -616,17 +616,6 @@ describe('ol/layer/WebGLTile', function () {
     map.render();
   });
 
-  it('tries to expire the source tile cache', (done) => {
-    const source = layer.getSource();
-    const expire = sinon.spy(source, 'expireCache');
-
-    layer.updateStyleVariables({r: 1, g: 2, b: 3});
-    map.once('rendercomplete', () => {
-      expect(expire.called).to.be(true);
-      done();
-    });
-  });
-
   it('throws on incorrect style configs', function () {
     function incorrectStyle() {
       layer.style_ = {

--- a/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
@@ -81,6 +81,24 @@ describe('ol/renderer/canvas/TileLayer', function () {
           expect(tiles[i].disposed).to.be(true);
         }
       });
+
+      it('caches tiles and clears the cache when the source is refreshed', async () => {
+        const source = new OSM();
+        const layer = new TileLayer({source: source});
+        const tiles = [];
+        source.on('tileloadend', (event) => {
+          tiles.push(event.tile);
+        });
+        map.addLayer(layer);
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(tiles.length).to.be(2);
+        map.render();
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(tiles.length).to.be(2);
+        source.refresh();
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(tiles.length).to.be(4);
+      });
     });
   });
 });

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -97,7 +97,6 @@ describe('ol/renderer/webgl/TileLayer', function () {
     expect(rendered).to.be.a(HTMLCanvasElement);
     expect(frameState.tileQueue.getCount()).to.be(1);
     expect(Object.keys(frameState.wantedTiles).length).to.be(1);
-    expect(frameState.postRenderFunctions.length).to.be(1); // clear source cache (use renderer cache)
     expect(renderer.tileRepresentationCache.count_).to.be(1);
   });
 

--- a/test/browser/spec/ol/source/TileImage.test.js
+++ b/test/browser/spec/ol/source/TileImage.test.js
@@ -43,19 +43,6 @@ describe('ol/source/TileImage', function () {
     });
   });
 
-  describe('#getTileCacheForProjection', function () {
-    it('uses 512 as cache size', function () {
-      const source = createSource(undefined, undefined);
-      const tileCache = source.getTileCacheForProjection(
-        getProjection('EPSG:4326'),
-      );
-      expect(tileCache.highWaterMark).to.be(512);
-      expect(tileCache).to.not.equal(
-        source.getTileCacheForProjection(source.getProjection()),
-      );
-    });
-  });
-
   describe('#setTileGridForProjection', function () {
     it('uses the tilegrid for given projection', function () {
       const source = createSource();
@@ -65,23 +52,6 @@ describe('ol/source/TileImage', function () {
         getProjection('EPSG:4326'),
       );
       expect(retrieved).to.be(tileGrid);
-    });
-  });
-
-  describe('#refresh', function () {
-    it('refreshes the source when raster reprojection is used', function () {
-      const source = createSource();
-      let loaded = 0;
-      source.setTileLoadFunction(() => ++loaded);
-      source.getTile(0, 0, 0, 1, getProjection('EPSG:4326')).load();
-      expect(loaded).to.be(16384);
-      source.getTile(0, 0, 0, 1, getProjection('EPSG:4326')).load();
-      expect(loaded).to.be(16384);
-      const revision = source.getRevision();
-      source.refresh();
-      expect(source.getRevision()).to.be(revision + 1);
-      source.getTile(0, 0, 0, 1, getProjection('EPSG:4326')).load();
-      expect(loaded).to.be(16384 * 2);
     });
   });
 


### PR DESCRIPTION
With the renderer responsible for caching tiles, we don't need projection specific tile caches on the sources any more.

Fixes #16218.