### PR TITLE
Add `zDirection` option to ol/source/ImageTile

### DIFF
--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -60,6 +60,9 @@ import {toSize} from '../size.js';
  * the nearest neighbor is used when resampling.
  * @property {CrossOriginAttribute} [crossOrigin='anonymous'] The crossOrigin property to pass to loaders for image data.
  * @property {string} [key] Key for use in caching tiles.
+ * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
+ * Choose whether to use tiles with a higher or lower zoom level when between integer
+ * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
  */
 
 /**
@@ -101,6 +104,7 @@ class DataTileSource extends TileSource {
       transition: options.transition,
       interpolate: options.interpolate,
       key: options.key,
+      zDirection: options.zDirection,
     });
 
     /**

--- a/src/ol/source/ImageTile.js
+++ b/src/ol/source/ImageTile.js
@@ -44,6 +44,9 @@ import {expandUrl, pickUrl, renderXYZTemplate} from '../uri.js';
  * @property {number} [transition] Transition time when fading in new tiles (in miliseconds).
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.
  * @property {import('./DataTile.js').CrossOriginAttribute} [crossOrigin='anonymous'] The crossOrigin property to pass to loaders for image data.
+ * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
+ * Choose whether to use tiles with a higher or lower zoom level when between integer
+ * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
  */
 
 const loadError = new Error('Image failed to load');
@@ -186,6 +189,7 @@ class ImageTileSource extends DataTileSource {
       transition: options.transition,
       interpolate: options.interpolate !== false,
       crossOrigin: options.crossOrigin,
+      zDirection: options.zDirection,
     });
   }
 


### PR DESCRIPTION
Adds the `zDirection` option to `ol/source/ImageTile` (passed via `ol/source/DataTile`) to make it more consistent with `ol/source/XYZ` where a custom `zDirection` function can be used to change tile zoom levels at view zooms z.5 instead of the OpenLayers default of z.415.

This is also a prerequisite for #16228
