### PR TITLE
Only track pointers as touches if they have fired a POINTERDOWN event

### DIFF
--- a/src/ol/MapBrowserEventHandler.js
+++ b/src/ol/MapBrowserEventHandler.js
@@ -186,7 +186,8 @@ class MapBrowserEventHandler extends Target {
       }
     } else if (
       event.type == MapBrowserEventType.POINTERDOWN ||
-      event.type == MapBrowserEventType.POINTERMOVE
+      (id in this.trackedTouches_ &&
+        event.type == MapBrowserEventType.POINTERMOVE)
     ) {
       this.trackedTouches_[id] = event;
     }


### PR DESCRIPTION
This fixes #16225. Drag interactions now work on iPad without interference from the pencil hover-pointer.

I'm not sure about the comment above:

    Some platforms assign a new pointerId when the target changes.

This might constitute a case where we want to track a pointermove without a preceding pointerdown as a touch. Is there a known platform we can use to test against a possible regression?