### PR TITLE
Add setters for the `overlaps` option

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -1184,6 +1184,14 @@ class VectorSource extends Source {
     this.url_ = url;
     this.setLoader(xhr(url, this.format_));
   }
+
+  /**
+   * @param {boolean} overlaps The source can have overlapping geometries.
+   */
+  setOverlaps(overlaps) {
+    this.overlaps_ = overlaps;
+    this.changed();
+  }
 }
 
 export default VectorSource;

--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -416,6 +416,14 @@ class VectorTile extends UrlTile {
       Math.round(tileSize[1] * pixelRatio),
     ];
   }
+
+  /**
+   * @param {boolean} overlaps The source has overlapping geometries.
+   */
+  setOverlaps(overlaps) {
+    this.overlaps_ = overlaps;
+    this.changed();
+  }
 }
 
 export default VectorTile;


### PR DESCRIPTION
I find it useful to be able to change the `overlaps` option on a Vector or VectorTile source, e.g. to add optimizations to sources that were auto-created, e.g. by ol-mapbox-style.

This pull request simply adds setters for the `overlaps` option.