### PR TITLE
Make TileDebug a subclass of ImageTile instead of XYZ

### DIFF
--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -2,9 +2,9 @@
  * @module ol/source/TileDebug
  */
 
-import XYZ from './XYZ.js';
+import ImageTile from './ImageTile.js';
 import {createCanvasContext2D} from '../dom.js';
-import {toSize} from '../size.js';
+import {renderXYZTemplate} from '../uri.js';
 
 /**
  * @typedef {Object} Options
@@ -26,7 +26,7 @@ import {toSize} from '../size.js';
  * each tile. See examples/canvas-tiles for an example.
  * @api
  */
-class TileDebug extends XYZ {
+class TileDebug extends ImageTile {
   /**
    * @param {Options} [options] Debug tile options.
    */
@@ -35,16 +35,16 @@ class TileDebug extends XYZ {
      * @type {Options}
      */
     options = options || {};
+    const template = options.template || 'z:{z} x:{x} y:{y}';
 
     super({
       projection: options.projection,
       tileGrid: options.tileGrid,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,
       zDirection: options.zDirection,
-      url: options.template || 'z:{z} x:{x} y:{y}',
-      tileLoadFunction: (tile, text) => {
-        const z = tile.getTileCoord()[0];
-        const tileSize = toSize(this.tileGrid.getTileSize(z));
+      loader: (z, x, y, loaderOptions) => {
+        const text = renderXYZTemplate(template, z, x, y, loaderOptions.maxY);
+        const tileSize = this.getTileSize(z);
         const context = createCanvasContext2D(tileSize[0], tileSize[1]);
 
         context.strokeStyle = 'grey';
@@ -58,10 +58,7 @@ class TileDebug extends XYZ {
         context.lineWidth = 4;
         context.strokeText(text, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
         context.fillText(text, tileSize[0] / 2, tileSize[1] / 2, tileSize[0]);
-
-        /** @type {import("../ImageTile.js").default} */ (tile).setImage(
-          context.canvas,
-        );
+        return context.canvas;
       },
     });
   }


### PR DESCRIPTION
Fixes #16228

Making TileDebug a subclass of ImageTile source will use the more efficient reprojection introduced in #15860, and will also allow easy support for any new options which might be added to DataTile source subclasses such as ModelTransformation support.

Although not included in this PR if #16227 is merged it would be easy to support debugging tile grid with transform matrix by providing a new TileDebug option and a getter for the GeoTIFF source

```
  view: cogSource.getView().then((viewConfig) => {
    viewConfig.projection = 'SR-ORG:97019';
    map.addLayer(
      new TileLayer({
        source: new TileDebug({
          projection: viewConfig.projection,
          tileGrid: cogSource.getTileGrid(),
          transformMatrix: cogSource.getTransformMtatrix(),
        }),
      })
    );
    return viewConfig;
  }),
```

![image](https://github.com/user-attachments/assets/9324dcce-618c-4c19-9e7c-49ca02d18555)
