### PR TITLE
Let isVisible() return false for layers that are not yet rendered

### DIFF
--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -319,6 +319,9 @@ class Layer extends BaseLayer {
       layerState = frameState.layerStatesArray.find(
         (layerState) => layerState.layer === this,
       );
+      if (!layerState) {
+        return false;
+      }
     } else {
       layerState = this.getLayerState();
     }


### PR DESCRIPTION
Fixes #15913
Fixes #16259 

The problem is this: when a layer is added to the map in a `moveend` listener, it will not be rendered yet when the Attribution control - also in a `moveend` listener - checks if the layer is visible. So because it is not rendered, it won't appear in the `layerStates` array.

This pull request makes it so the `isVisible()` function returns an early `false` in this case.