### PR TITLE
Do not call postrender functions when there is no frameState

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1229,8 +1229,10 @@ class Map extends BaseObject {
     }
 
     const postRenderFunctions = this.postRenderFunctions_;
-    for (let i = 0, ii = postRenderFunctions.length; i < ii; ++i) {
-      postRenderFunctions[i](this, frameState);
+    if (frameState) {
+      for (let i = 0, ii = postRenderFunctions.length; i < ii; ++i) {
+        postRenderFunctions[i](this, frameState);
+      }
     }
     postRenderFunctions.length = 0;
   }


### PR DESCRIPTION
When the map has no size, the `renderFrame()` method does not do much. In this case, the `frameState` will be `null`. At the end of the  `renderFrame()` method, postrender functions are called. These functions expect the `frameState` as 2nd argument. If nothing was rendered, and if there is no frame state, I think we can safely say that we do not want to call postrender functions.

Fixes #16266.