### PR TITLE
Accept a CRS object with a URI string in tile matrix set

### DIFF
--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -48,9 +48,16 @@ import {error as logError} from '../console.js';
 /**
  * @typedef {Object} TileMatrixSet
  * @property {string} id The tile matrix set identifier.
- * @property {string} crs The coordinate reference system.
+ * @property {string|CRSObject} crs The coordinate reference system.
  * @property {Array<string>} [orderedAxes] Axis order.
  * @property {Array<TileMatrix>} tileMatrices Array of tile matrices.
+ */
+
+/**
+ * @typedef {Object} CRSObject
+ * @property {string} uri Reference to one coordinate reference system (CRS).
+ * @property {Object} wkt An object defining the CRS using the JSON encoding for Well-known text representation of coordinate reference systems 2.0.
+ * @property {Object} referenceSystem A reference system data structure as defined in the MD_ReferenceSystem of the ISO 19115.
  */
 
 /**
@@ -249,9 +256,13 @@ function parseTileMatrixSet(
 ) {
   let projection = sourceInfo.projection;
   if (!projection) {
-    projection = getProjection(tileMatrixSet.crs);
+    if (typeof tileMatrixSet.crs === 'string') {
+      projection = getProjection(tileMatrixSet.crs);
+    } else if ('uri' in tileMatrixSet.crs) {
+      projection = getProjection(tileMatrixSet.crs.uri);
+    }
     if (!projection) {
-      throw new Error(`Unsupported CRS: ${tileMatrixSet.crs}`);
+      throw new Error(`Unsupported CRS: ${JSON.stringify(tileMatrixSet.crs)}`);
     }
   }
   const orderedAxes = tileMatrixSet.orderedAxes;

--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -48,16 +48,24 @@ import {error as logError} from '../console.js';
 /**
  * @typedef {Object} TileMatrixSet
  * @property {string} id The tile matrix set identifier.
- * @property {string|CRSObject} crs The coordinate reference system.
+ * @property {string|CrsUri|CrsWkt|CrsReferenceSystem} crs The coordinate reference system.
  * @property {Array<string>} [orderedAxes] Axis order.
  * @property {Array<TileMatrix>} tileMatrices Array of tile matrices.
  */
 
 /**
- * @typedef {Object} CRSObject
+ * @typedef {Object} CrsUri
  * @property {string} uri Reference to one coordinate reference system (CRS).
- * @property {Object} wkt An object defining the CRS using the JSON encoding for Well-known text representation of coordinate reference systems 2.0.
- * @property {Object} referenceSystem A reference system data structure as defined in the MD_ReferenceSystem of the ISO 19115.
+ */
+
+/**
+ * @typedef {Object} CrsWkt
+ * @property {Object} wkt JSON encoding for WKT representation of CRS 2.0.
+ */
+
+/**
+ * @typedef {Object} CrsReferenceSystem
+ * @property {Object} referenceSystem Data structure as defined in the MD_ReferenceSystem of the ISO 19115.
  */
 
 /**

--- a/test/node/ol/source/data/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectCRS.json
+++ b/test/node/ol/source/data/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectCRS.json
@@ -1,0 +1,88 @@
+{
+  "title" : "blueMarble",
+  "tileMatrixSetURI" : "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs" : "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "dataType" : "map",
+  "tileMatrixSetLimits" : [
+     { "tileMatrix" : "0", "minTileRow" : 0, "maxTileRow" : 0, "minTileCol" : 0, "maxTileCol" : 0 },
+     { "tileMatrix" : "1", "minTileRow" : 0, "maxTileRow" : 1, "minTileCol" : 0, "maxTileCol" : 1 },
+     { "tileMatrix" : "2", "minTileRow" : 0, "maxTileRow" : 3, "minTileCol" : 0, "maxTileCol" : 3 },
+     { "tileMatrix" : "3", "minTileRow" : 0, "maxTileRow" : 7, "minTileCol" : 0, "maxTileCol" : 7 },
+     { "tileMatrix" : "4", "minTileRow" : 0, "maxTileRow" : 15, "minTileCol" : 0, "maxTileCol" : 15 },
+     { "tileMatrix" : "5", "minTileRow" : 0, "maxTileRow" : 31, "minTileCol" : 0, "maxTileCol" : 31 },
+     { "tileMatrix" : "6", "minTileRow" : 0, "maxTileRow" : 63, "minTileCol" : 0, "maxTileCol" : 63 },
+     { "tileMatrix" : "7", "minTileRow" : 0, "maxTileRow" : 127, "minTileCol" : 0, "maxTileCol" : 127 },
+     { "tileMatrix" : "8", "minTileRow" : 0, "maxTileRow" : 255, "minTileCol" : 0, "maxTileCol" : 255 },
+     { "tileMatrix" : "9", "minTileRow" : 0, "maxTileRow" : 511, "minTileCol" : 0, "maxTileCol" : 511 }
+  ],
+  "links" : [
+     {
+        "rel" : "self",
+        "type" : "application/json",
+        "title" : "The JSON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=json"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "text/plain",
+        "title" : "The ECON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=econ"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "text/html",
+        "title" : "The HTML representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?=html"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "application/json+tile",
+        "title" : "The TileJSON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=tilejson"
+     },
+     {
+        "rel" : "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+        "type" : "application/json",
+        "title" : "WebMercatorQuadTileMatrixSet definition (as JSON)",
+        "href" : "/ogcapi/tileMatrixSets/WebMercatorQuadObjectCRS"
+     },
+     {
+        "rel" : "http://www.opengis.net/def/rel/ogc/1.0/geodata",
+        "href" : "/ogcapi/collections/blueMarble"
+     },
+     {
+        "rel" : "item",
+        "type" : "application/vnd.gnosis-map-tile",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as GNOSIS Map Tiles)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.gmt",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/png",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as PNG)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.png",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/jpeg",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as JPG)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.jpg",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/tiff; application=geotiff",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as GeoTIFF)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.tif",
+        "templated" : true
+     }
+  ],
+  "centerPoint" : {
+     "coordinates" : [ 0, 0 ],
+     "tileMatrix" : "4",
+     "scaleDenominator" : 34942641.501794859767,
+     "cellSize" : 9783.9396205025605
+  }
+}

--- a/test/node/ol/source/data/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectWKT.json
+++ b/test/node/ol/source/data/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectWKT.json
@@ -1,0 +1,88 @@
+{
+  "title" : "blueMarble",
+  "tileMatrixSetURI" : "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs" : "http://www.opengis.net/def/crs/EPSG/0/3857",
+  "dataType" : "map",
+  "tileMatrixSetLimits" : [
+     { "tileMatrix" : "0", "minTileRow" : 0, "maxTileRow" : 0, "minTileCol" : 0, "maxTileCol" : 0 },
+     { "tileMatrix" : "1", "minTileRow" : 0, "maxTileRow" : 1, "minTileCol" : 0, "maxTileCol" : 1 },
+     { "tileMatrix" : "2", "minTileRow" : 0, "maxTileRow" : 3, "minTileCol" : 0, "maxTileCol" : 3 },
+     { "tileMatrix" : "3", "minTileRow" : 0, "maxTileRow" : 7, "minTileCol" : 0, "maxTileCol" : 7 },
+     { "tileMatrix" : "4", "minTileRow" : 0, "maxTileRow" : 15, "minTileCol" : 0, "maxTileCol" : 15 },
+     { "tileMatrix" : "5", "minTileRow" : 0, "maxTileRow" : 31, "minTileCol" : 0, "maxTileCol" : 31 },
+     { "tileMatrix" : "6", "minTileRow" : 0, "maxTileRow" : 63, "minTileCol" : 0, "maxTileCol" : 63 },
+     { "tileMatrix" : "7", "minTileRow" : 0, "maxTileRow" : 127, "minTileCol" : 0, "maxTileCol" : 127 },
+     { "tileMatrix" : "8", "minTileRow" : 0, "maxTileRow" : 255, "minTileCol" : 0, "maxTileCol" : 255 },
+     { "tileMatrix" : "9", "minTileRow" : 0, "maxTileRow" : 511, "minTileCol" : 0, "maxTileCol" : 511 }
+  ],
+  "links" : [
+     {
+        "rel" : "self",
+        "type" : "application/json",
+        "title" : "The JSON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=json"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "text/plain",
+        "title" : "The ECON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=econ"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "text/html",
+        "title" : "The HTML representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?=html"
+     },
+     {
+        "rel" : "alternate",
+        "type" : "application/json+tile",
+        "title" : "The TileJSON representation of the WebMercatorQuad map tileset for blueMarble",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad?f=tilejson"
+     },
+     {
+        "rel" : "http://www.opengis.net/def/rel/ogc/1.0/tiling-scheme",
+        "type" : "application/json",
+        "title" : "WebMercatorQuadTileMatrixSet definition (as JSON)",
+        "href" : "/ogcapi/tileMatrixSets/WebMercatorQuadObjectWKT"
+     },
+     {
+        "rel" : "http://www.opengis.net/def/rel/ogc/1.0/geodata",
+        "href" : "/ogcapi/collections/blueMarble"
+     },
+     {
+        "rel" : "item",
+        "type" : "application/vnd.gnosis-map-tile",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as GNOSIS Map Tiles)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.gmt",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/png",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as PNG)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.png",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/jpeg",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as JPG)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.jpg",
+        "templated" : true
+     },
+     {
+        "rel" : "item",
+        "type" : "image/tiff; application=geotiff",
+        "title" : "WebMercatorQuad map tiles for blueMarble (as GeoTIFF)",
+        "href" : "/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}.tif",
+        "templated" : true
+     }
+  ],
+  "centerPoint" : {
+     "coordinates" : [ 0, 0 ],
+     "tileMatrix" : "4",
+     "scaleDenominator" : 34942641.501794859767,
+     "cellSize" : 9783.9396205025605
+  }
+}

--- a/test/node/ol/source/data/ogcapi/tileMatrixSets/WebMercatorQuadObjectCRS.json
+++ b/test/node/ol/source/data/ogcapi/tileMatrixSets/WebMercatorQuadObjectCRS.json
@@ -1,0 +1,435 @@
+{
+  "id": "WebMercatorQuad",
+  "title": "WebMercatorQuad",
+  "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs": {
+    "uri": "http://www.opengis.net/def/crs/EPSG/0/3857"
+  },
+  "orderedAxes": [
+    "E",
+    "N"
+  ],
+  "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+  "tileMatrices": [
+    {
+      "id": "0",
+      "scaleDenominator": 559082264.0287177562714,
+      "cellSize": 156543.033928040968,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1,
+      "matrixHeight": 1,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "1",
+      "scaleDenominator": 279541132.0143588781357,
+      "cellSize": 78271.516964020484,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2,
+      "matrixHeight": 2,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "2",
+      "scaleDenominator": 139770566.0071794390678,
+      "cellSize": 39135.758482010242,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4,
+      "matrixHeight": 4,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "3",
+      "scaleDenominator": 69885283.0035897195339,
+      "cellSize": 19567.879241005121,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8,
+      "matrixHeight": 8,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "4",
+      "scaleDenominator": 34942641.501794859767,
+      "cellSize": 9783.9396205025605,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16,
+      "matrixHeight": 16,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "5",
+      "scaleDenominator": 17471320.7508974298835,
+      "cellSize": 4891.9698102512803,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 32,
+      "matrixHeight": 32,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "6",
+      "scaleDenominator": 8735660.3754487149417,
+      "cellSize": 2445.9849051256401,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 64,
+      "matrixHeight": 64,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "7",
+      "scaleDenominator": 4367830.1877243574709,
+      "cellSize": 1222.9924525628201,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 128,
+      "matrixHeight": 128,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "8",
+      "scaleDenominator": 2183915.0938621787354,
+      "cellSize": 611.49622628141,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 256,
+      "matrixHeight": 256,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "9",
+      "scaleDenominator": 1091957.5469310893677,
+      "cellSize": 305.748113140705,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 512,
+      "matrixHeight": 512,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "10",
+      "scaleDenominator": 545978.7734655446839,
+      "cellSize": 152.8740565703525,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1024,
+      "matrixHeight": 1024,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "11",
+      "scaleDenominator": 272989.3867327723419,
+      "cellSize": 76.4370282851763,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2048,
+      "matrixHeight": 2048,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "12",
+      "scaleDenominator": 136494.693366386171,
+      "cellSize": 38.2185141425881,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4096,
+      "matrixHeight": 4096,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "13",
+      "scaleDenominator": 68247.3466831930855,
+      "cellSize": 19.1092570712941,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8192,
+      "matrixHeight": 8192,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "14",
+      "scaleDenominator": 34123.6733415965427,
+      "cellSize": 9.554628535647,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16384,
+      "matrixHeight": 16384,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "15",
+      "scaleDenominator": 17061.8366707982714,
+      "cellSize": 4.7773142678235,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 32768,
+      "matrixHeight": 32768,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "16",
+      "scaleDenominator": 8530.9183353991357,
+      "cellSize": 2.3886571339118,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 65536,
+      "matrixHeight": 65536,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "17",
+      "scaleDenominator": 4265.4591676995678,
+      "cellSize": 1.1943285669559,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 131072,
+      "matrixHeight": 131072,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "18",
+      "scaleDenominator": 2132.7295838497839,
+      "cellSize": 0.5971642834779,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 262144,
+      "matrixHeight": 262144,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "19",
+      "scaleDenominator": 1066.364791924892,
+      "cellSize": 0.298582141739,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 524288,
+      "matrixHeight": 524288,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "20",
+      "scaleDenominator": 533.182395962446,
+      "cellSize": 0.1492910708695,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1048576,
+      "matrixHeight": 1048576,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "21",
+      "scaleDenominator": 266.591197981223,
+      "cellSize": 0.0746455354347,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2097152,
+      "matrixHeight": 2097152,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "22",
+      "scaleDenominator": 133.2955989906115,
+      "cellSize": 0.0373227677174,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4194304,
+      "matrixHeight": 4194304,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "23",
+      "scaleDenominator": 66.6477994953057,
+      "cellSize": 0.0186613838587,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8388608,
+      "matrixHeight": 8388608,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "24",
+      "scaleDenominator": 33.3238997476529,
+      "cellSize": 0.0093306919293,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16777216,
+      "matrixHeight": 16777216,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "25",
+      "scaleDenominator": 16.6619498738264,
+      "cellSize": 0.0046653459647,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 33554432,
+      "matrixHeight": 33554432,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "26",
+      "scaleDenominator": 8.3309749369132,
+      "cellSize": 0.0023326729823,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 67108864,
+      "matrixHeight": 67108864,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "27",
+      "scaleDenominator": 4.1654874684566,
+      "cellSize": 0.0011663364912,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 134217728,
+      "matrixHeight": 134217728,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "28",
+      "scaleDenominator": 2.0827437342283,
+      "cellSize": 0.0005831682456,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 268435456,
+      "matrixHeight": 268435456,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "29",
+      "scaleDenominator": 1.0413718671142,
+      "cellSize": 0.0002915841228,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 536870912,
+      "matrixHeight": 536870912,
+      "tileWidth": 256,
+      "tileHeight": 256
+    }
+  ]
+}

--- a/test/node/ol/source/data/ogcapi/tileMatrixSets/WebMercatorQuadObjectWKT.json
+++ b/test/node/ol/source/data/ogcapi/tileMatrixSets/WebMercatorQuadObjectWKT.json
@@ -1,0 +1,437 @@
+{
+  "id": "WebMercatorQuad",
+  "title": "WebMercatorQuad",
+  "uri": "http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad",
+  "crs": {
+    "wkt": {
+      "supported": false
+    }
+  },
+  "orderedAxes": [
+    "E",
+    "N"
+  ],
+  "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleMapsCompatible",
+  "tileMatrices": [
+    {
+      "id": "0",
+      "scaleDenominator": 559082264.0287177562714,
+      "cellSize": 156543.033928040968,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1,
+      "matrixHeight": 1,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "1",
+      "scaleDenominator": 279541132.0143588781357,
+      "cellSize": 78271.516964020484,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2,
+      "matrixHeight": 2,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "2",
+      "scaleDenominator": 139770566.0071794390678,
+      "cellSize": 39135.758482010242,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4,
+      "matrixHeight": 4,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "3",
+      "scaleDenominator": 69885283.0035897195339,
+      "cellSize": 19567.879241005121,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8,
+      "matrixHeight": 8,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "4",
+      "scaleDenominator": 34942641.501794859767,
+      "cellSize": 9783.9396205025605,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16,
+      "matrixHeight": 16,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "5",
+      "scaleDenominator": 17471320.7508974298835,
+      "cellSize": 4891.9698102512803,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 32,
+      "matrixHeight": 32,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "6",
+      "scaleDenominator": 8735660.3754487149417,
+      "cellSize": 2445.9849051256401,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 64,
+      "matrixHeight": 64,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "7",
+      "scaleDenominator": 4367830.1877243574709,
+      "cellSize": 1222.9924525628201,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 128,
+      "matrixHeight": 128,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "8",
+      "scaleDenominator": 2183915.0938621787354,
+      "cellSize": 611.49622628141,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 256,
+      "matrixHeight": 256,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "9",
+      "scaleDenominator": 1091957.5469310893677,
+      "cellSize": 305.748113140705,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 512,
+      "matrixHeight": 512,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "10",
+      "scaleDenominator": 545978.7734655446839,
+      "cellSize": 152.8740565703525,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1024,
+      "matrixHeight": 1024,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "11",
+      "scaleDenominator": 272989.3867327723419,
+      "cellSize": 76.4370282851763,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2048,
+      "matrixHeight": 2048,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "12",
+      "scaleDenominator": 136494.693366386171,
+      "cellSize": 38.2185141425881,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4096,
+      "matrixHeight": 4096,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "13",
+      "scaleDenominator": 68247.3466831930855,
+      "cellSize": 19.1092570712941,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8192,
+      "matrixHeight": 8192,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "14",
+      "scaleDenominator": 34123.6733415965427,
+      "cellSize": 9.554628535647,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16384,
+      "matrixHeight": 16384,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "15",
+      "scaleDenominator": 17061.8366707982714,
+      "cellSize": 4.7773142678235,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 32768,
+      "matrixHeight": 32768,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "16",
+      "scaleDenominator": 8530.9183353991357,
+      "cellSize": 2.3886571339118,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 65536,
+      "matrixHeight": 65536,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "17",
+      "scaleDenominator": 4265.4591676995678,
+      "cellSize": 1.1943285669559,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 131072,
+      "matrixHeight": 131072,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "18",
+      "scaleDenominator": 2132.7295838497839,
+      "cellSize": 0.5971642834779,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 262144,
+      "matrixHeight": 262144,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "19",
+      "scaleDenominator": 1066.364791924892,
+      "cellSize": 0.298582141739,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 524288,
+      "matrixHeight": 524288,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "20",
+      "scaleDenominator": 533.182395962446,
+      "cellSize": 0.1492910708695,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 1048576,
+      "matrixHeight": 1048576,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "21",
+      "scaleDenominator": 266.591197981223,
+      "cellSize": 0.0746455354347,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 2097152,
+      "matrixHeight": 2097152,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "22",
+      "scaleDenominator": 133.2955989906115,
+      "cellSize": 0.0373227677174,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 4194304,
+      "matrixHeight": 4194304,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "23",
+      "scaleDenominator": 66.6477994953057,
+      "cellSize": 0.0186613838587,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 8388608,
+      "matrixHeight": 8388608,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "24",
+      "scaleDenominator": 33.3238997476529,
+      "cellSize": 0.0093306919293,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 16777216,
+      "matrixHeight": 16777216,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "25",
+      "scaleDenominator": 16.6619498738264,
+      "cellSize": 0.0046653459647,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 33554432,
+      "matrixHeight": 33554432,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "26",
+      "scaleDenominator": 8.3309749369132,
+      "cellSize": 0.0023326729823,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 67108864,
+      "matrixHeight": 67108864,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "27",
+      "scaleDenominator": 4.1654874684566,
+      "cellSize": 0.0011663364912,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 134217728,
+      "matrixHeight": 134217728,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "28",
+      "scaleDenominator": 2.0827437342283,
+      "cellSize": 0.0005831682456,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 268435456,
+      "matrixHeight": 268435456,
+      "tileWidth": 256,
+      "tileHeight": 256
+    },
+    {
+      "id": "29",
+      "scaleDenominator": 1.0413718671142,
+      "cellSize": 0.0002915841228,
+      "cornerOfOrigin": "topLeft",
+      "pointOfOrigin": [
+        -20037508.3427892439067,
+        20037508.3427892439067
+      ],
+      "matrixWidth": 536870912,
+      "matrixHeight": 536870912,
+      "tileWidth": 256,
+      "tileHeight": 256
+    }
+  ]
+}

--- a/test/node/ol/source/ogcTileUtil.test.js
+++ b/test/node/ol/source/ogcTileUtil.test.js
@@ -212,6 +212,33 @@ describe('ol/source/ogcTileUtil.js', () => {
         'https://maps.ecere.com/ogcapi/collections/NaturalEarth:cultural:ne_10m_admin_0_countries/tiles/WebMercatorQuad/3/1/2.json',
       );
     });
+
+    it('works with a tile matrix set that uses a crs object with uri string', async () => {
+      baseUrl = 'https://maps.ecere.com/';
+      const sourceInfo = {
+        url: 'https://maps.ecere.com/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectCRS',
+      };
+      const tileInfo = await getTileSetInfo(sourceInfo);
+      expect(tileInfo).to.be.an(Object);
+    });
+
+    it('fails with a tile matrix set that uses a crs object with a wkt object', async () => {
+      baseUrl = 'https://maps.ecere.com/';
+      const sourceInfo = {
+        url: 'https://maps.ecere.com/ogcapi/collections/blueMarble/map/tiles/WebMercatorQuadObjectWKT',
+      };
+
+      let error;
+      try {
+        await getTileSetInfo(sourceInfo);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      expect(error.message).to.be(
+        'Unsupported CRS: {"wkt":{"supported":false}}',
+      );
+    });
   });
 
   describe('getVectorTileUrlTemplate()', () => {


### PR DESCRIPTION
The OGC Tiles spec depends on the TMS 2 spec. In TMS 2, the [crs](https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/2.0.0/schemas/tms/2.0/json/crs.json) for a [tile matrix set](https://github.com/opengeospatial/2D-Tile-Matrix-Set/blob/2.0.0/schemas/tms/2.0/json/tileMatrixSet.json) can be an object or a string. Previously, we only supported a string. This change adds support for an object with a `uri` property as well.

Fixes #16287.