### PR TITLE
Set source projection from OGC TileMatrixSet crs

### DIFF
--- a/src/ol/source/OGCMapTile.js
+++ b/src/ol/source/OGCMapTile.js
@@ -83,6 +83,7 @@ class OGCMapTile extends TileImage {
    */
   handleTileSetInfo_(tileSetInfo) {
     this.tileGrid = tileSetInfo.grid;
+    this.projection = tileSetInfo.projection;
     this.setTileUrlFunction(tileSetInfo.urlFunction, tileSetInfo.urlTemplate);
     this.setState('ready');
   }

--- a/src/ol/source/OGCVectorTile.js
+++ b/src/ol/source/OGCVectorTile.js
@@ -92,6 +92,7 @@ class OGCVectorTile extends VectorTileSource {
    */
   handleTileSetInfo_(tileSetInfo) {
     this.tileGrid = tileSetInfo.grid;
+    this.projection = tileSetInfo.projection;
     this.setTileUrlFunction(tileSetInfo.urlFunction, tileSetInfo.urlTemplate);
     this.setState('ready');
   }

--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -101,6 +101,7 @@ const knownVectorMediaTypes = {
 /**
  * @typedef {Object} TileSetInfo
  * @property {string} urlTemplate The tile URL template.
+ * @property {import("../proj/Projection.js").default} projection The source projection.
  * @property {import("../tilegrid/TileGrid.js").default} grid The tile grid.
  * @property {import("../Tile.js").UrlFunction} urlFunction The tile URL function.
  */
@@ -409,6 +410,7 @@ function parseTileMatrixSet(
 
   return {
     grid: tileGrid,
+    projection: projection,
     urlTemplate: tileUrlTemplate,
     urlFunction: tileUrlFunction,
   };


### PR DESCRIPTION
Propagate the projection from TileMatrixSet projection to the Source.
Users can still override the projection using the Source `projection` option.

Fixes https://github.com/openlayers/openlayers/issues/16292