### PR TITLE
Improve the Modify interaction's API for programmatic actions

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -89,6 +89,10 @@ const ModifyEventType = {
  */
 
 /**
+ * @typedef {[SegmentData, number]} DragSegment
+ */
+
+/**
  * @typedef {Object} Options
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
@@ -110,7 +114,8 @@ const ModifyEventType = {
  * Style used for the modification point or vertex. For linestrings and polygons, this will
  * be the affected vertex, for circles a point along the circle, and for points the actual
  * point. If not configured, the default edit style is used (see {@link module:ol/style/Style~Style}).
- * When using a style function, the point feature passed to the function will have a `features`
+ * When using a style function, the point feature passed to the function will have an `existing` property -
+ * indicating whether there is an existing vertex underneath or not, a `features`
  * property - an array whose entries are the features that are being modified, and a `geometries`
  * property - an array whose entries are the geometries that are being modified. Both arrays are
  * in the same order. The `geometries` are only useful when modifying geometry collections, where
@@ -313,7 +318,7 @@ class Modify extends PointerInteraction {
     this.changingFeature_ = false;
 
     /**
-     * @type {Array}
+     * @type {Array<DragSegment>}
      * @private
      */
     this.dragSegments_ = [];
@@ -439,14 +444,14 @@ class Modify extends PointerInteraction {
     }
     const map = this.getMap();
     if (map && map.isRendered() && this.getActive()) {
-      this.handlePointerAtPixel_(this.lastPixel_, map);
+      this.handlePointerAtPixel_(map.getCoordinateFromPixel(this.lastPixel_));
     }
     feature.addEventListener(EventType.CHANGE, this.boundHandleFeatureChange_);
   }
 
   /**
    * @param {import("../MapBrowserEvent.js").default} evt Map browser event.
-   * @param {Array<Array<SegmentData>>} segments The segments subject to modification.
+   * @param {Array<SegmentData>} segments The segments subject to modification.
    * @private
    */
   willModifyFeatures_(evt, segments) {
@@ -454,12 +459,9 @@ class Modify extends PointerInteraction {
       this.featuresBeingModified_ = new Collection();
       const features = this.featuresBeingModified_.getArray();
       for (let i = 0, ii = segments.length; i < ii; ++i) {
-        const segment = segments[i];
-        for (let s = 0, ss = segment.length; s < ss; ++s) {
-          const feature = segment[s].feature;
-          if (feature && !features.includes(feature)) {
-            this.featuresBeingModified_.push(feature);
-          }
+        const feature = segments[i].feature;
+        if (feature && !features.includes(feature)) {
+          this.featuresBeingModified_.push(feature);
         }
       }
       if (this.featuresBeingModified_.getLength() === 0) {
@@ -818,10 +820,11 @@ class Modify extends PointerInteraction {
    * @param {import("../coordinate.js").Coordinate} coordinates Coordinates.
    * @param {Array<Feature>} features The features being modified.
    * @param {Array<import("../geom/SimpleGeometry.js").default>} geometries The geometries being modified.
+   * @param {boolean} existing The vertex represents an existing vertex.
    * @return {Feature} Vertex feature.
    * @private
    */
-  createOrUpdateVertexFeature_(coordinates, features, geometries) {
+  createOrUpdateVertexFeature_(coordinates, features, geometries, existing) {
     let vertexFeature = this.vertexFeature_;
     if (!vertexFeature) {
       vertexFeature = new Feature(new Point(coordinates));
@@ -833,6 +836,7 @@ class Modify extends PointerInteraction {
     }
     vertexFeature.set('features', features);
     vertexFeature.set('geometries', geometries);
+    vertexFeature.set('existing', existing);
     return vertexFeature;
   }
 
@@ -874,6 +878,102 @@ class Modify extends PointerInteraction {
     return super.handleEvent(mapBrowserEvent) && !handled;
   }
 
+  findInsertVerticesAndUpdateDragSegments_(pixelCoordinate) {
+    this.handlePointerAtPixel_(pixelCoordinate);
+    this.dragSegments_.length = 0;
+    this.featuresBeingModified_ = null;
+    const vertexFeature = this.vertexFeature_;
+    if (!vertexFeature) {
+      return;
+    }
+
+    const projection = this.getMap().getView().getProjection();
+    const insertVertices = [];
+    const vertex = vertexFeature.getGeometry().getCoordinates();
+    const vertexExtent = boundingExtent([vertex]);
+    const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
+    const componentSegments = {};
+    segmentDataMatches.sort(compareIndexes);
+    for (let i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
+      const segmentDataMatch = segmentDataMatches[i];
+      const segment = segmentDataMatch.segment;
+      let uid = getUid(segmentDataMatch.geometry);
+      const depth = segmentDataMatch.depth;
+      if (depth) {
+        uid += '-' + depth.join('-'); // separate feature components
+      }
+      if (!componentSegments[uid]) {
+        componentSegments[uid] = new Array(2);
+      }
+
+      if (
+        segmentDataMatch.geometry.getType() === 'Circle' &&
+        segmentDataMatch.index === CIRCLE_CIRCUMFERENCE_INDEX
+      ) {
+        const closestVertex = closestOnSegmentData(
+          pixelCoordinate,
+          segmentDataMatch,
+          projection,
+        );
+        if (
+          coordinatesEqual(closestVertex, vertex) &&
+          !componentSegments[uid][0]
+        ) {
+          this.dragSegments_.push([segmentDataMatch, 0]);
+          componentSegments[uid][0] = segmentDataMatch;
+        }
+        continue;
+      }
+
+      if (coordinatesEqual(segment[0], vertex) && !componentSegments[uid][0]) {
+        this.dragSegments_.push([segmentDataMatch, 0]);
+        componentSegments[uid][0] = segmentDataMatch;
+        continue;
+      }
+
+      if (coordinatesEqual(segment[1], vertex) && !componentSegments[uid][1]) {
+        if (
+          componentSegments[uid][0] &&
+          componentSegments[uid][0].index === 0
+        ) {
+          let coordinates = segmentDataMatch.geometry.getCoordinates();
+          switch (segmentDataMatch.geometry.getType()) {
+            // prevent dragging closed linestrings by the connecting node
+            case 'LineString':
+            case 'MultiLineString':
+              continue;
+            // if dragging the first vertex of a polygon, ensure the other segment
+            // belongs to the closing vertex of the linear ring
+            case 'MultiPolygon':
+              coordinates = coordinates[depth[1]];
+            /* falls through */
+            case 'Polygon':
+              if (segmentDataMatch.index !== coordinates[depth[0]].length - 2) {
+                continue;
+              }
+              break;
+            default:
+            // pass
+          }
+        }
+
+        this.dragSegments_.push([segmentDataMatch, 1]);
+        componentSegments[uid][1] = segmentDataMatch;
+        continue;
+      }
+
+      if (
+        getUid(segment) in this.vertexSegments_ &&
+        !componentSegments[uid][0] &&
+        !componentSegments[uid][1]
+      ) {
+        insertVertices.push(segmentDataMatch);
+      }
+    }
+
+    return insertVertices;
+  }
+
   /**
    * Handle pointer drag events.
    * @param {import("../MapBrowserEvent.js").default} evt Event.
@@ -881,7 +981,10 @@ class Modify extends PointerInteraction {
    */
   handleDragEvent(evt) {
     this.ignoreNextSingleClick_ = false;
-    this.willModifyFeatures_(evt, this.dragSegments_);
+    this.willModifyFeatures_(
+      evt,
+      this.dragSegments_.map(([segment]) => segment),
+    );
 
     const vertex = [
       evt.coordinate[0] + this.delta_[0],
@@ -942,23 +1045,26 @@ class Modify extends PointerInteraction {
           segment[index] = vertex;
           break;
         case 'Circle':
+          const circle = /** @type {import("../geom/Circle.js").default} */ (
+            geometry
+          );
           segment[0] = vertex;
           segment[1] = vertex;
           if (segmentData.index === CIRCLE_CENTER_INDEX) {
             this.changingFeature_ = true;
-            geometry.setCenter(vertex);
+            circle.setCenter(vertex);
             this.changingFeature_ = false;
           } else {
             // We're dragging the circle's circumference:
             this.changingFeature_ = true;
             const projection = evt.map.getView().getProjection();
             let radius = coordinateDistance(
-              fromUserCoordinate(geometry.getCenter(), projection),
+              fromUserCoordinate(circle.getCenter(), projection),
               fromUserCoordinate(vertex, projection),
             );
             const userProjection = getUserProjection();
             if (userProjection) {
-              const circleGeometry = geometry
+              const circleGeometry = circle
                 .clone()
                 .transform(userProjection, projection);
               circleGeometry.setRadius(radius);
@@ -966,7 +1072,7 @@ class Modify extends PointerInteraction {
                 .transform(projection, userProjection)
                 .getRadius();
             }
-            geometry.setRadius(radius);
+            circle.setRadius(radius);
             this.changingFeature_ = false;
           }
           break;
@@ -978,7 +1084,7 @@ class Modify extends PointerInteraction {
         this.setGeometryCoordinates_(geometry, coordinates);
       }
     }
-    this.createOrUpdateVertexFeature_(vertex, features, geometries);
+    this.createOrUpdateVertexFeature_(vertex, features, geometries, true);
   }
 
   /**
@@ -992,113 +1098,21 @@ class Modify extends PointerInteraction {
       return false;
     }
     const pixelCoordinate = evt.coordinate;
-    this.handlePointerAtPixel_(evt.pixel, evt.map, pixelCoordinate);
-    this.dragSegments_.length = 0;
-    this.featuresBeingModified_ = null;
-    const vertexFeature = this.vertexFeature_;
-    if (vertexFeature) {
-      const projection = evt.map.getView().getProjection();
-      const insertVertices = [];
-      const vertex = vertexFeature.getGeometry().getCoordinates();
-      const vertexExtent = boundingExtent([vertex]);
-      const segmentDataMatches = this.rBush_.getInExtent(vertexExtent);
-      const componentSegments = {};
-      segmentDataMatches.sort(compareIndexes);
-      for (let i = 0, ii = segmentDataMatches.length; i < ii; ++i) {
-        const segmentDataMatch = segmentDataMatches[i];
-        const segment = segmentDataMatch.segment;
-        let uid = getUid(segmentDataMatch.geometry);
-        const depth = segmentDataMatch.depth;
-        if (depth) {
-          uid += '-' + depth.join('-'); // separate feature components
+    const insertVertices =
+      this.findInsertVerticesAndUpdateDragSegments_(pixelCoordinate);
+
+    if (insertVertices?.length && this.insertVertexCondition_(evt)) {
+      this.willModifyFeatures_(evt, insertVertices);
+
+      if (this.vertexFeature_) {
+        const vertex = this.vertexFeature_.getGeometry().getCoordinates();
+        for (let j = insertVertices.length - 1; j >= 0; --j) {
+          this.insertVertex_(insertVertices[j], vertex);
         }
-        if (!componentSegments[uid]) {
-          componentSegments[uid] = new Array(2);
-        }
-
-        if (
-          segmentDataMatch.geometry.getType() === 'Circle' &&
-          segmentDataMatch.index === CIRCLE_CIRCUMFERENCE_INDEX
-        ) {
-          const closestVertex = closestOnSegmentData(
-            pixelCoordinate,
-            segmentDataMatch,
-            projection,
-          );
-          if (
-            coordinatesEqual(closestVertex, vertex) &&
-            !componentSegments[uid][0]
-          ) {
-            this.dragSegments_.push([segmentDataMatch, 0]);
-            componentSegments[uid][0] = segmentDataMatch;
-          }
-          continue;
-        }
-
-        if (
-          coordinatesEqual(segment[0], vertex) &&
-          !componentSegments[uid][0]
-        ) {
-          this.dragSegments_.push([segmentDataMatch, 0]);
-          componentSegments[uid][0] = segmentDataMatch;
-          continue;
-        }
-
-        if (
-          coordinatesEqual(segment[1], vertex) &&
-          !componentSegments[uid][1]
-        ) {
-          if (
-            componentSegments[uid][0] &&
-            componentSegments[uid][0].index === 0
-          ) {
-            let coordinates = segmentDataMatch.geometry.getCoordinates();
-            switch (segmentDataMatch.geometry.getType()) {
-              // prevent dragging closed linestrings by the connecting node
-              case 'LineString':
-              case 'MultiLineString':
-                continue;
-              // if dragging the first vertex of a polygon, ensure the other segment
-              // belongs to the closing vertex of the linear ring
-              case 'MultiPolygon':
-                coordinates = coordinates[depth[1]];
-              /* falls through */
-              case 'Polygon':
-                if (
-                  segmentDataMatch.index !==
-                  coordinates[depth[0]].length - 2
-                ) {
-                  continue;
-                }
-                break;
-              default:
-              // pass
-            }
-          }
-
-          this.dragSegments_.push([segmentDataMatch, 1]);
-          componentSegments[uid][1] = segmentDataMatch;
-          continue;
-        }
-
-        if (
-          getUid(segment) in this.vertexSegments_ &&
-          !componentSegments[uid][0] &&
-          !componentSegments[uid][1] &&
-          this.insertVertexCondition_(evt)
-        ) {
-          insertVertices.push(segmentDataMatch);
-        }
-      }
-
-      if (insertVertices.length) {
-        this.willModifyFeatures_(evt, [insertVertices]);
-      }
-
-      for (let j = insertVertices.length - 1; j >= 0; --j) {
-        this.insertVertex_(insertVertices[j], vertex);
+        this.ignoreNextSingleClick_ = true;
       }
     }
+
     return !!this.vertexFeature_;
   }
 
@@ -1113,8 +1127,11 @@ class Modify extends PointerInteraction {
       const segmentData = this.dragSegments_[i][0];
       const geometry = segmentData.geometry;
       if (geometry.getType() === 'Circle') {
+        const circle = /** @type {import("../geom/Circle.js").default} */ (
+          geometry
+        );
         // Update a circle object in the R* bush:
-        const coordinates = geometry.getCenter();
+        const coordinates = circle.getCenter();
         const centerSegmentData = segmentData.featureSegments[0];
         const circumferenceSegmentData = segmentData.featureSegments[1];
         centerSegmentData.segment[0] = coordinates;
@@ -1122,7 +1139,8 @@ class Modify extends PointerInteraction {
         circumferenceSegmentData.segment[0] = coordinates;
         circumferenceSegmentData.segment[1] = coordinates;
         this.rBush_.update(createExtent(coordinates), centerSegmentData);
-        let circleGeometry = geometry;
+        /** @type {import("../geom/Circle.js").default | import("../geom/Polygon.js").default} */
+        let circleGeometry = circle;
         const userProjection = getUserProjection();
         if (userProjection) {
           const projection = evt.map.getView().getProjection();
@@ -1161,17 +1179,16 @@ class Modify extends PointerInteraction {
    */
   handlePointerMove_(evt) {
     this.lastPixel_ = evt.pixel;
-    this.handlePointerAtPixel_(evt.pixel, evt.map, evt.coordinate);
+    this.handlePointerAtPixel_(evt.coordinate);
   }
 
   /**
-   * @param {import("../pixel.js").Pixel} pixel Pixel
-   * @param {import("../Map.js").default} map Map.
-   * @param {import("../coordinate.js").Coordinate} [coordinate] The pixel Coordinate.
+   * @param {import("../coordinate.js").Coordinate} pixelCoordinate The pixel Coordinate.
    * @private
    */
-  handlePointerAtPixel_(pixel, map, coordinate) {
-    const pixelCoordinate = coordinate || map.getCoordinateFromPixel(pixel);
+  handlePointerAtPixel_(pixelCoordinate) {
+    const map = this.getMap();
+    const pixel = map.getPixelFromCoordinate(pixelCoordinate);
     const projection = map.getView().getProjection();
     const sortByDistance = function (a, b) {
       return (
@@ -1256,6 +1273,7 @@ class Modify extends PointerInteraction {
             vertex,
             [node.feature],
             [node.geometry],
+            this.snappedToVertex_,
           );
         } else {
           const pixel1 = map.getPixelFromCoordinate(closestSegment[0]);
@@ -1274,6 +1292,7 @@ class Modify extends PointerInteraction {
             vertex,
             [node.feature],
             [node.geometry],
+            this.snappedToVertex_,
           );
           const geometries = {};
           geometries[getUid(node.geometry)] = true;
@@ -1309,6 +1328,7 @@ class Modify extends PointerInteraction {
   /**
    * @param {SegmentData} segmentData Segment data.
    * @param {import("../coordinate.js").Coordinate} vertex Vertex.
+   * @return {boolean} A vertex was inserted.
    * @private
    */
   insertVertex_(segmentData, vertex) {
@@ -1341,7 +1361,7 @@ class Modify extends PointerInteraction {
         coordinates.splice(index + 1, 0, vertex);
         break;
       default:
-        return;
+        return false;
     }
 
     this.setGeometryCoordinates_(geometry, coordinates);
@@ -1372,21 +1392,86 @@ class Modify extends PointerInteraction {
 
     rTree.insert(boundingExtent(newSegmentData2.segment), newSegmentData2);
     this.dragSegments_.push([newSegmentData2, 0]);
-    this.ignoreNextSingleClick_ = true;
+    return true;
+  }
+
+  updatePointer_(coordinate) {
+    if (coordinate) {
+      this.findInsertVerticesAndUpdateDragSegments_(coordinate);
+    }
+    return this.vertexFeature_?.getGeometry().getCoordinates();
   }
 
   /**
-   * Removes the vertex currently being pointed.
+   * Get the current pointer position.
+   * @return {import("../coordinate.js").Coordinate | null} The current pointer coordinate.
+   */
+  getPoint() {
+    const coordinate = this.vertexFeature_?.getGeometry().getCoordinates();
+    if (!coordinate) {
+      return null;
+    }
+    return toUserCoordinate(
+      coordinate,
+      this.getMap().getView().getProjection(),
+    );
+  }
+
+  /**
+   * Check if a point can be removed from the current linestring or polygon at the current
+   * pointer position.
+   * @return {boolean} A point can be deleted at the current pointer position.
+   * @api
+   */
+  canRemovePoint() {
+    if (!this.vertexFeature_) {
+      return false;
+    }
+    if (
+      this.vertexFeature_
+        .get('geometries')
+        .every(
+          (geometry) =>
+            geometry.getType() === 'Circle' ||
+            geometry.getType().endsWith('Point'),
+        )
+    ) {
+      return false;
+    }
+    const coordinate = this.vertexFeature_.getGeometry().getCoordinates();
+    const segments = this.rBush_.getInExtent(boundingExtent([coordinate]));
+    return segments.some(
+      ({segment}) =>
+        coordinatesEqual(segment[0], coordinate) ||
+        coordinatesEqual(segment[1], coordinate),
+    );
+  }
+
+  /**
+   * Removes the vertex currently being pointed from the current linestring or polygon.
+   * @param {import('../coordinate.js').Coordinate} [coordinate] If provided, the pointer
+   * will be set to the provided coordinate. If not, the current pointer coordinate will be used.
    * @return {boolean} True when a vertex was removed.
    * @api
    */
-  removePoint() {
+  removePoint(coordinate) {
+    if (coordinate) {
+      coordinate = fromUserCoordinate(
+        coordinate,
+        this.getMap().getView().getProjection(),
+      );
+      this.updatePointer_(coordinate);
+    }
     if (
-      this.lastPointerEvent_ &&
-      this.lastPointerEvent_.type != MapBrowserEventType.POINTERDRAG
+      !this.lastPointerEvent_ ||
+      (this.lastPointerEvent_ &&
+        this.lastPointerEvent_.type != MapBrowserEventType.POINTERDRAG)
     ) {
       const evt = this.lastPointerEvent_;
-      this.willModifyFeatures_(evt, this.dragSegments_);
+      this.willModifyFeatures_(
+        evt,
+        this.dragSegments_.map(([segment]) => segment),
+      );
       const removed = this.removeVertex_();
       if (this.featuresBeingModified_) {
         this.dispatchEvent(
@@ -1522,6 +1607,61 @@ class Modify extends PointerInteraction {
       }
     }
     return deleted;
+  }
+
+  /**
+   * Check if a point can be inserted to the current linestring or polygon at the current
+   * pointer position.
+   * @return {boolean} A point can be inserted at the current pointer position.
+   * @api
+   */
+  canInsertPoint() {
+    if (!this.vertexFeature_) {
+      return false;
+    }
+    if (
+      this.vertexFeature_
+        .get('geometries')
+        .every(
+          (geometry) =>
+            geometry.getType() === 'Circle' ||
+            geometry.getType().endsWith('Point'),
+        )
+    ) {
+      return false;
+    }
+    const coordinate = this.vertexFeature_.getGeometry().getCoordinates();
+    const segments = this.rBush_.getInExtent(boundingExtent([coordinate]));
+    return segments.some(
+      ({segment}) =>
+        !(
+          coordinatesEqual(segment[0], coordinate) ||
+          coordinatesEqual(segment[1], coordinate)
+        ),
+    );
+  }
+
+  /**
+   * Inserts the vertex currently being pointed to the current linestring or polygon.
+   * @param {import('../coordinate.js').Coordinate} [coordinate] If provided, the pointer
+   * will be set to the provided coordinate. If not, the current pointer coordinate will be used.
+   * @return {boolean} A vertex was inserted.
+   * @api
+   */
+  insertPoint(coordinate) {
+    const pixelCoordinate = coordinate
+      ? fromUserCoordinate(coordinate, this.getMap().getView().getProjection())
+      : this.vertexFeature_?.getGeometry().getCoordinates();
+    if (!pixelCoordinate) {
+      return false;
+    }
+    const insertVertices =
+      this.findInsertVerticesAndUpdateDragSegments_(pixelCoordinate);
+    return insertVertices.reduce(
+      (prev, segmentData) =>
+        prev || this.insertVertex_(segmentData, pixelCoordinate),
+      false,
+    );
   }
 
   /**


### PR DESCRIPTION
This pull request improves the API of the Modify interaction for use cases that involve UI elements like e.g. a context menu, where uses can select actions like "Remove vertex" or "Insert vertex" when modifying linestrings or polygons:

* The existing `removePoint()` method now takes an optional `coordinate` as argument. In combination with the new `getPoint()` method, this can be used to remove a point later, without an immediate pointer action that matches the `deleteCondition`.
* A new `insertPoint()` method which takes an optional `coordinate` can be used to programmatically insert a vertex to a linestring or polygon, without an immediate pointer action that matches the `insertVertexCondition`.
* New `canInsertPoint()` and `canRemovePoint()` methods can be used to decide whether additional actions to insert or remove a vertex should be offered e.g. in a context menu.