### PR TITLE
Correct annotation for render events

### DIFF
--- a/src/ol/layer/Flow.js
+++ b/src/ol/layer/Flow.js
@@ -400,7 +400,8 @@ const sources = [];
  * Experimental layer that renders particles moving through a vector field.
  *
  * @extends BaseTileLayer<SourceType, FlowLayerRenderer>
- * @fires import("../render/Event.js").RenderEvent
+ * @fires import("../render/Event.js").RenderEvent#prerender
+ * @fires import("../render/Event.js").RenderEvent#postrender
  */
 class FlowLayer extends BaseTileLayer {
   /**

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -177,7 +177,8 @@ const INTERVALS = [
  * Layer that renders a grid for a coordinate system (currently only EPSG:4326 is supported).
  * Note that the view projection must define both extent and worldExtent.
  *
- * @fires import("../render/Event.js").RenderEvent
+ * @fires import("../render/Event.js").RenderEvent#prerender
+ * @fires import("../render/Event.js").RenderEvent#postrender
  * @extends {VectorLayer<VectorSource<Feature>>}
  * @api
  */

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -62,7 +62,8 @@ const DEFAULT_GRADIENT = ['#00f', '#0ff', '#0f0', '#ff0', '#f00'];
  * property on the layer object; for example, setting `title: 'My Title'` in the
  * options means that `title` is observable, and has get/set accessors.
  *
- * @fires import("../render/Event.js").RenderEvent
+ * @fires import("../render/Event.js").RenderEvent#prerender
+ * @fires import("../render/Event.js").RenderEvent#postrender
  * @template {import("../Feature.js").FeatureLike} [FeatureType=import("../Feature.js").default]
  * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<FeatureType>]
  * @extends {BaseVector<FeatureType, VectorSourceType, WebGLPointsLayerRenderer>}

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -64,7 +64,8 @@ import {parseLiteralStyle} from '../webgl/styleparser.js';
  *
  * @template {import("../source/Vector.js").default<import('../Feature').FeatureLike>} VectorSourceType
  * @extends {Layer<VectorSourceType, WebGLPointsLayerRenderer>}
- * @fires import("../render/Event.js").RenderEvent
+ * @fires import("../render/Event.js").RenderEvent#prerender
+ * @fires import("../render/Event.js").RenderEvent#postrender
  */
 class WebGLPointsLayer extends Layer {
   /**

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -279,7 +279,8 @@ function parseStyle(style, bandCount) {
  * options means that `title` is observable, and has get/set accessors.
  *
  * @extends BaseTileLayer<SourceType, WebGLTileLayerRenderer>
- * @fires import("../render/Event.js").RenderEvent
+ * @fires import("../render/Event.js").RenderEvent#prerender
+ * @fires import("../render/Event.js").RenderEvent#postrender
  * @api
  */
 class WebGLTileLayer extends BaseTileLayer {


### PR DESCRIPTION
This updates the `@fires` annotation for a few layers. Previously, the docs made it look like these layers fired the `rendercomplete` event. After this change, the docs show that they fire `prerender` and `postrender` events instead.

Thanks @ahocevar for pointing out the fix (see https://github.com/openlayers/openlayers/issues/16300#issuecomment-2419701370).