### PR TITLE
Add text-keep-upright to flat style attributes

### DIFF
--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -541,6 +541,12 @@ function buildText(flatStyle, context) {
     context,
   );
 
+  const evaluateKeepUpright = booleanEvaluator(
+    flatStyle,
+    prefix + 'keep-upright',
+    context,
+  );
+
   const evaluatePadding = numberArrayEvaluator(
     flatStyle,
     prefix + 'padding',
@@ -660,6 +666,10 @@ function buildText(flatStyle, context) {
 
     if (evaluatePadding) {
       text.setPadding(evaluatePadding(context));
+    }
+
+    if (evaluateKeepUpright) {
+      text.setKeepUpright(evaluateKeepUpright(context));
     }
 
     return text;


### PR DESCRIPTION
This is a followup to #16302, as I realized additional code is needed to make the attribute available to the "flat style" mode of style definition. 