### PR TITLE
Pass the transformed coordinates

### DIFF
--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -322,7 +322,7 @@ class Geometry extends BaseObject {
               0,
               0,
             );
-            transform2D(
+            const transformed = transform2D(
               inCoordinates,
               0,
               inCoordinates.length,
@@ -331,8 +331,8 @@ class Geometry extends BaseObject {
               outCoordinates,
             );
             return getTransform(sourceProj, destination)(
-              inCoordinates,
-              outCoordinates,
+              transformed,
+              transformed,
               stride,
             );
           }


### PR DESCRIPTION
When working with projections using `tile-pixels` units, we first apply an affine transform before calling the projection transform function. While it isn't really currently a bug, things only work for simple geometries where the `applyTransform` function passes [the same input and output arrays](https://github.com/openlayers/openlayers/blob/38845b778d2c054bf192f6d6b7bac39918d44b1b/src/ol/geom/SimpleGeometry.js#L211-L212). This change updates the `transform` implementation so it would work if `applyTransform` didn't use the same input and output arrays.