### PR TITLE
Turn off transition for rendering tests

### DIFF
--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -38,6 +38,7 @@ class TileDebug extends ImageTile {
     const template = options.template || 'z:{z} x:{x} y:{y}';
 
     super({
+      transition: 0,
       projection: options.projection,
       tileGrid: options.tileGrid,
       wrapX: options.wrapX !== undefined ? options.wrapX : true,

--- a/test/rendering/cases/layer-tile-reset-projection/main.js
+++ b/test/rendering/cases/layer-tile-reset-projection/main.js
@@ -7,6 +7,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new XYZ({
+        transition: 0,
         minZoom: 0,
         maxZoom: 0,
         url: '/data/tiles/osm/{z}/{x}/{y}.png',


### PR DESCRIPTION
The rendering tests periodically fail due to tile source transitions.

Here is the output from an [example failed test](https://github.com/openlayers/openlayers/actions/runs/11561981570/job/32182175141?pr=16325):

![actual](https://github.com/user-attachments/assets/30a42074-5654-4c27-8d6b-0507e08b4715)
