### PR TITLE
Support for UTM transforms

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -1,5 +1,11 @@
 ## Upgrade notes
 
+### Next Release
+
+#### The `transform` function throws for unknown projections
+
+Previously, the `transform()` function from the `ol/proj` module would apply the identity transform if either the source or the destination projections were unrecognized. Now this function will throw an error if it cannot perform the transform. You can check whether a projection is registered by calling the `get()` function from `ol/proj` - this function returns `null` if the projection definition for a provided identifier is not known.
+
 ### 10.2.0
 
 No changes should be needed to update to this release.  See the release changelog for new features and fixes.

--- a/config/jsdoc/api/template/static/styles/jaguar.css
+++ b/config/jsdoc/api/template/static/styles/jaguar.css
@@ -451,14 +451,18 @@ span.type-signature.static {
   font-size: 0.95em;
   margin-bottom: 10px;
 }
+.main header ol,
 .main article ol,
+.main header ul,
 .main article ul {
   margin-left: 25px;
 }
+.main header ol > li,
 .main article ol > li {
   list-style-type: decimal;
   margin-bottom: 5px;
 }
+.main header ul > li,
 .main article ul > li {
   margin-bottom: 5px;
   list-style-type: disc;

--- a/config/tsconfig-strict.json
+++ b/config/tsconfig-strict.json
@@ -161,6 +161,7 @@
     "../src/ol/proj/Projection.js",
     "../src/ol/proj/projections.js",
     "../src/ol/proj/transforms.js",
+    "../src/ol/proj/utm.js",
     "../src/ol/render.js",
     "../src/ol/render/Box.js",
     "../src/ol/render/canvas.js",

--- a/examples/geotiff-reprojection.css
+++ b/examples/geotiff-reprojection.css
@@ -1,6 +1,0 @@
-.controls {
-  display: grid;
-  grid-template-columns: auto auto 1fr;
-  align-items: baseline;
-  gap: 0 1em;
-}

--- a/examples/geotiff-reprojection.html
+++ b/examples/geotiff-reprojection.html
@@ -1,43 +1,39 @@
 ---
 layout: example.html
 title: GeoTIFF Reprojection
-shortdesc: GeoTIFF Reprojection
+shortdesc: Demonstrates how a GeoTIFF can be rendered in a different projection.
 docs: >
-  Example of reprojection of an EPSG:4326 GeoTIFF source with 20 bytes of raw values per pixel to EPSG:3857.
-tags: "cog, webgl, style, reprojection"
+  <p>
+    This example demonstrates how data from a GeoTIFF in one projection can be displayed on a map with a
+    different projection. For other source types, it is necessary to specify the source projection when
+    it differs from the map view projection. In this example, information about the source projection is
+    included in the GeoTIFF metadata, so it doesn't need to be specified in the application code.
+  </p>
+  <p>
+    The <code>source.getView()</code> method returns a promise that resolves after the GeoTIFF metadata has
+    been fetched. This can be used to get the image projection information along with the image extent and
+    center coordinates. The <code>transform()</code> function is used to transform the source imagery center
+    coordinate when updating the view.
+  </p>
+  <p>
+    OpenLayers has built-in reprojection support for sources in Universal Transverse Mercator (UTM)
+    projections. Since the source data shown here is in UTM Zone 36 N, no additional configuration is needed
+    to reproject the data to the map projection (Spherical Mercator).
+  </p>
+  <p>
+    See these other examples for details on the following:
+    <ul>
+      <li>
+        <a href="./reprojection.html">Reprojection with Proj4js</a>
+        &mdash; using the Proj4js library to reproject raster sources between a variety of projections.
+      </li>
+      <li>
+        <a href="./cog-projection.html">Projection Lookup</a>
+        &mdash; using an external service to look up projection configuration information.
+      </li>
+    </ul>
+  </p>
+
+tags: "cog, geotiff, reprojection, utm"
 ---
 <div id="map" class="map"></div>
-<div class="controls">
-  <label for="red">Red channel</label>
-  <select id="red">
-    <option value="1" selected>visible red</option>
-    <option value="2">visible green</option>
-    <option value="3">visible blue</option>
-    <option value="4">near infrared</option>
-  </select>
-  <label>max
-    <input type="range" id="redMax" value="3000" min="2000" max="5000">
-  </label>
-
-  <label for="green">Green channel</label>
-  <select id="green">
-    <option value="1">visible red</option>
-    <option value="2" selected>visible green</option>
-    <option value="3">visible blue</option>
-    <option value="4">near infrared</option>
-  </select>
-  <label>max
-    <input type="range" id="greenMax" value="3000" min="2000" max="5000">
-  </label>
-
-  <label for="blue">Blue channel</label>
-  <select id="blue">
-    <option value="1">visible red</option>
-    <option value="2">visible green</option>
-    <option value="3" selected>visible blue</option>
-    <option value="4">near infrared</option>
-  </select>
-  <label>max
-    <input type="range" id="blueMax" value="3000" min="2000" max="5000">
-  </label>
-</div>

--- a/examples/geotiff-reprojection.js
+++ b/examples/geotiff-reprojection.js
@@ -2,61 +2,36 @@ import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
+import {transform} from '../src/ol/proj.js';
 
-const channels = ['red', 'green', 'blue'];
-for (const channel of channels) {
-  const selector = document.getElementById(channel);
-  selector.addEventListener('change', update);
-
-  const input = document.getElementById(`${channel}Max`);
-  input.addEventListener('input', update);
-}
-
-function getVariables() {
-  const variables = {};
-  for (const channel of channels) {
-    const selector = document.getElementById(channel);
-    variables[channel] = parseInt(selector.value, 10);
-
-    const inputId = `${channel}Max`;
-    const input = document.getElementById(inputId);
-    variables[inputId] = parseInt(input.value, 10);
-  }
-  return variables;
-}
-
-const layer = new TileLayer({
-  style: {
-    variables: getVariables(),
-    color: [
-      'array',
-      ['/', ['band', ['var', 'red']], ['var', 'redMax']],
-      ['/', ['band', ['var', 'green']], ['var', 'greenMax']],
-      ['/', ['band', ['var', 'blue']], ['var', 'blueMax']],
-      1,
-    ],
-  },
-  source: new GeoTIFF({
-    normalize: false,
-    sources: [
-      {
-        url: 'https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif',
-      },
-    ],
-    wrapX: true,
-  }),
+const source = new GeoTIFF({
+  sources: [
+    {
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/TCI.tif',
+    },
+  ],
 });
-
-function update() {
-  layer.updateStyleVariables(getVariables());
-}
 
 const map = new Map({
   target: 'map',
-  layers: [layer],
+  layers: [new TileLayer({source})],
   view: new View({
     center: [0, 0],
-    zoom: 2,
-    maxZoom: 6,
+    zoom: 12,
   }),
+});
+
+// after GeoTIFF metadata has been read, recenter the map to show the image
+source.getView().then(async (sourceView) => {
+  const view = map.getView();
+
+  // transform the image center to view coorindates
+  const center = transform(
+    sourceView.center,
+    sourceView.projection,
+    view.getProjection(),
+  );
+
+  // update the view to show the image
+  view.setCenter(center);
 });

--- a/site/src/doc/tutorials/raster-reprojection.md
+++ b/site/src/doc/tutorials/raster-reprojection.md
@@ -5,13 +5,24 @@ layout: default.hbs
 
 # Raster Reprojection
 
-OpenLayers has an ability to display raster data from WMS, WMTS, static images and many other sources in a different coordinate system than delivered from the server.
+OpenLayers can display raster data from WMS, WMTS, static images, and many other sources in a different coordinate system than delivered from the server. In cases where the source projection differs from the map view projection, source data can be reprojected on the client (in the browser).
+
+OpenLayers comes with built-in support for transforming coordinates (and reprojecting rasters) between a handful of projections or coordinate reference systems.
+
+The built-in reprojection support applies to the following projections:
+
+ * WGS 84 / Geographic (`EPSG:4326`)
+ * WGS 84 / Web or Spherical Mercator (`EPSG:3857`)
+ * WGS 84 / Universal Transverse Mercator (`EPSG:32601` through `EPSG:32660` and `EPSG:32701` through `EPSG:32760`)
+
+For transforms between other, non-built-in projections, the Proj4js library can be used.
+
 Transformation of the map projections of the image happens directly in a web browser.
 The view in any Proj4js supported coordinate reference system is possible and previously incompatible layers can now be combined and overlaid.
 
 # Usage
 
-The API usage is very simple. Just specify proper projection (e.g. using [EPSG](https://epsg.io) code) on `ol/View`:
+The API usage for built-in projection support involves specifying the projection identifier on the source and the view. String [EPSG codes](https://epsg.io) can be used to identify the projections:
 
 ```js
 import Map from 'ol/Map.js';
@@ -51,7 +62,7 @@ If a source (based on `ol/source/TileImage` or `ol/source/Image`) has a projecti
 
 ### Custom projection
 
-The easiest way to use a custom projection is to add the [Proj4js](http://proj4js.org/) library to your project and then define the projection using a proj4 definition string. It can be installed with
+The easiest way to use a custom projection (one that doesn't have built-in support) is to add the [Proj4js](http://proj4js.org/) library to your project and then define the projection using a proj4 definition string. It can be installed with
 
     npm install proj4
 

--- a/src/ol/geom/Geometry.js
+++ b/src/ol/geom/Geometry.js
@@ -330,11 +330,11 @@ class Geometry extends BaseObject {
               tmpTransform,
               outCoordinates,
             );
-            return getTransform(sourceProj, destination)(
-              transformed,
-              transformed,
-              stride,
-            );
+            const projTransform = getTransform(sourceProj, destination);
+            if (projTransform) {
+              return projTransform(transformed, transformed, stride);
+            }
+            return transformed;
           }
         : getTransform(sourceProj, destination);
     this.applyTransform(transformFn);

--- a/src/ol/math.js
+++ b/src/ol/math.js
@@ -197,3 +197,18 @@ export function floor(n, decimals) {
 export function ceil(n, decimals) {
   return Math.ceil(toFixed(n, decimals));
 }
+
+/**
+ * Wraps a number between some minimum and maximum values.
+ * @param {number} n The number to wrap.
+ * @param {number} min The minimum of the range (inclusive).
+ * @param {number} max The maximum of the range (exclusive).
+ * @return {number} The wrapped number.
+ */
+export function wrap(n, min, max) {
+  if (n >= min && n < max) {
+    return n;
+  }
+  const range = max - min;
+  return ((((n - min) % range) + range) % range) + min;
+}

--- a/src/ol/proj.js
+++ b/src/ol/proj.js
@@ -75,6 +75,10 @@ import {applyTransform, getWidth} from './extent.js';
 import {clamp, modulo} from './math.js';
 import {equals, getWorldsAway} from './coordinate.js';
 import {getDistance} from './sphere.js';
+import {
+  makeProjection as makeUTMProjection,
+  makeTransforms as makeUTMTransforms,
+} from './proj/utm.js';
 import {warn} from './console.js';
 
 /**
@@ -83,6 +87,22 @@ import {warn} from './console.js';
  * @typedef {Projection|string|undefined} ProjectionLike
  * @api
  */
+
+/**
+ * @typedef {Object} Transforms
+ * @property {TransformFunction} forward The forward transform (from geographic).
+ * @property {TransformFunction} inverse The inverse transform (to geographic).
+ */
+
+/**
+ * @type {Array<function(Projection): Transforms|null>}
+ */
+const transformFactories = [makeUTMTransforms];
+
+/**
+ * @type {Array<function(string): Projection|null>}
+ */
+const projectionFactories = [makeUTMProjection];
 
 /**
  * A transform function accepts an array of input coordinate values, an optional
@@ -176,9 +196,20 @@ export function addProjections(projections) {
  * @api
  */
 export function get(projectionLike) {
-  return typeof projectionLike === 'string'
-    ? getProj(/** @type {string} */ (projectionLike))
-    : /** @type {Projection} */ (projectionLike) || null;
+  if (!(typeof projectionLike === 'string')) {
+    return projectionLike;
+  }
+  const projection = getProj(projectionLike);
+  if (projection) {
+    return projection;
+  }
+  for (const makeProjection of projectionFactories) {
+    const projection = makeProjection(projectionLike);
+    if (projection) {
+      return projection;
+    }
+  }
+  return null;
 }
 
 /**
@@ -226,7 +257,7 @@ export function getPointResolution(projection, resolution, point, units) {
         projection,
         get('EPSG:4326'),
       );
-      if (toEPSG4326 === identityTransform && projUnits !== 'degrees') {
+      if (!toEPSG4326 && projUnits !== 'degrees') {
         // no transform is available
         pointResolution = resolution * projection.getMetersPerUnit();
       } else {
@@ -460,22 +491,86 @@ export function equivalent(projection1, projection2) {
  * Searches in the list of transform functions for the function for converting
  * coordinates from the source projection to the destination projection.
  *
- * @param {Projection} sourceProjection Source Projection object.
- * @param {Projection} destinationProjection Destination Projection
+ * @param {Projection} source Source Projection object.
+ * @param {Projection} destination Destination Projection
  *     object.
- * @return {TransformFunction} Transform function.
+ * @return {TransformFunction|null} Transform function.
  */
-export function getTransformFromProjections(
-  sourceProjection,
-  destinationProjection,
-) {
-  const sourceCode = sourceProjection.getCode();
-  const destinationCode = destinationProjection.getCode();
+export function getTransformFromProjections(source, destination) {
+  const sourceCode = source.getCode();
+  const destinationCode = destination.getCode();
   let transformFunc = getTransformFunc(sourceCode, destinationCode);
-  if (!transformFunc) {
-    transformFunc = identityTransform;
+  if (transformFunc) {
+    return transformFunc;
   }
+
+  /**
+   * @type {Transforms|null}
+   */
+  let sourceTransforms = null;
+
+  /**
+   * @type {Transforms|null}
+   */
+  let destinationTransforms = null;
+
+  // lazily add projections if we have supported transforms
+  for (const makeTransforms of transformFactories) {
+    if (!sourceTransforms) {
+      sourceTransforms = makeTransforms(source);
+    }
+    if (!destinationTransforms) {
+      destinationTransforms = makeTransforms(destination);
+    }
+  }
+
+  if (!sourceTransforms && !destinationTransforms) {
+    return null;
+  }
+
+  const intermediateCode = 'EPSG:4326';
+  if (!destinationTransforms) {
+    const toDestination = getTransformFunc(intermediateCode, destinationCode);
+    if (toDestination) {
+      transformFunc = composeTransformFuncs(
+        sourceTransforms.inverse,
+        toDestination,
+      );
+    }
+  } else if (!sourceTransforms) {
+    const fromSource = getTransformFunc(sourceCode, intermediateCode);
+    if (fromSource) {
+      transformFunc = composeTransformFuncs(
+        fromSource,
+        destinationTransforms.forward,
+      );
+    }
+  } else {
+    transformFunc = composeTransformFuncs(
+      sourceTransforms.inverse,
+      destinationTransforms.forward,
+    );
+  }
+
+  if (transformFunc) {
+    addProjection(source);
+    addProjection(destination);
+    addTransformFunc(source, destination, transformFunc);
+  }
+
   return transformFunc;
+}
+
+/**
+ * @param {TransformFunction} t1 The first transform function.
+ * @param {TransformFunction} t2 The second transform function.
+ * @return {TransformFunction} The composed transform function.
+ */
+function composeTransformFuncs(t1, t2) {
+  return function (input, output, dimensions, stride) {
+    output = t1(input, output, dimensions, stride);
+    return t2(output, output, dimensions, stride);
+  };
 }
 
 /**
@@ -496,7 +591,9 @@ export function getTransform(source, destination) {
 
 /**
  * Transforms a coordinate from source projection to destination projection.
- * This returns a new coordinate (and does not modify the original).
+ * This returns a new coordinate (and does not modify the original). If there
+ * is no available transform between the two projection, the function will throw
+ * an error.
  *
  * See {@link module:ol/proj.transformExtent} for extent transformation.
  * See the transform method of {@link module:ol/geom/Geometry~Geometry} and its
@@ -510,6 +607,13 @@ export function getTransform(source, destination) {
  */
 export function transform(coordinate, source, destination) {
   const transformFunc = getTransform(source, destination);
+  if (!transformFunc) {
+    const sourceCode = get(source).getCode();
+    const destinationCode = get(destination).getCode();
+    throw new Error(
+      `No transform available between ${sourceCode} and ${destinationCode}`,
+    );
+  }
   return transformFunc(coordinate, undefined, coordinate.length);
 }
 

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -24,28 +24,30 @@ import {METERS_PER_UNIT} from './Units.js';
 
 /**
  * @classdesc
- * Projection definition class. One of these is created for each projection
- * supported in the application and stored in the {@link module:ol/proj} namespace.
- * You can use these in applications, but this is not required, as API params
- * and options use {@link module:ol/proj~ProjectionLike} which means the simple string
- * code will suffice.
+ * In most cases, you should not need to create instances of this class.
+ * Instead, where projection information is required, you can use a string
+ * projection code or identifier (e.g. `EPSG:4326`) instead of a projection
+ * instance.
  *
- * You can use {@link module:ol/proj.get} to retrieve the object for a particular
- * projection.
+ * The library includes support for transforming coordinates between the following
+ * projections:
  *
- * The library includes definitions for `EPSG:4326` and `EPSG:3857`, together
- * with the following aliases:
- * * `EPSG:4326`: CRS:84, urn:ogc:def:crs:EPSG:6.6:4326,
- *     urn:ogc:def:crs:OGC:1.3:CRS84, urn:ogc:def:crs:OGC:2:84,
- *     http://www.opengis.net/gml/srs/epsg.xml#4326,
- *     urn:x-ogc:def:crs:EPSG:4326
- * * `EPSG:3857`: EPSG:102100, EPSG:102113, EPSG:900913,
- *     urn:ogc:def:crs:EPSG:6.18:3:3857,
- *     http://www.opengis.net/gml/srs/epsg.xml#3857
+ *  * WGS 84 / Geographic - Using codes `EPSG:4326`, `CRS:84`, `urn:ogc:def:crs:EPSG:6.6:4326`,
+ *    `urn:ogc:def:crs:OGC:1.3:CRS84`, `urn:ogc:def:crs:OGC:2:84`, `http://www.opengis.net/gml/srs/epsg.xml#4326`,
+ *    or `urn:x-ogc:def:crs:EPSG:4326`
+ *  * WGS 84 / Spherical Mercator - Using codes `EPSG:3857`, `EPSG:102100`, `EPSG:102113`, `EPSG:900913`,
+ *    `urn:ogc:def:crs:EPSG:6.18:3:3857`, or `http://www.opengis.net/gml/srs/epsg.xml#3857`
+ *  * WGS 84 / UTM zones - Using codes `EPSG:32601` through `EPSG:32660` for northern zones
+ *    and `EPSG:32701` through `EPSG:32760` for southern zones. Note that the built-in UTM transforms
+ *    are lower accuracy (with errors on the order of 0.1 m) than those that you might get in a
+ *    library like [proj4js](https://github.com/proj4js/proj4js).
  *
- * If you use [proj4js](https://github.com/proj4js/proj4js), aliases can
- * be added using `proj4.defs()`. After all required projection definitions are
- * added, call the {@link module:ol/proj/proj4.register} function.
+ * For additional projection support, or to use higher accuracy transforms than the built-in ones, you can use
+ * the [proj4js](https://github.com/proj4js/proj4js) library. With `proj4js`, after adding any new projection
+ * definitions, call the {@link module:ol/proj/proj4.register} function.
+ *
+ * You can use the {@link module:ol/proj.get} function to retrieve a projection instance
+ * for one of the registered projections.
  *
  * @api
  */

--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -7,8 +7,8 @@ import {
   addEquivalentProjections,
   addProjection,
   createSafeCoordinateTransform,
-  get,
 } from '../proj.js';
+import {get as getCachedProjection} from './projections.js';
 import {get as getTransform} from './transforms.js';
 
 /**
@@ -49,7 +49,7 @@ export function register(proj4) {
   let i, j;
   for (i = 0; i < len; ++i) {
     const code = projCodes[i];
-    if (!get(code)) {
+    if (!getCachedProjection(code)) {
       const def = proj4.defs(code);
       let units = /** @type {import("./Units.js").Units} */ (def.units);
       if (!units && def.projName === 'longlat') {
@@ -67,10 +67,10 @@ export function register(proj4) {
   }
   for (i = 0; i < len; ++i) {
     const code1 = projCodes[i];
-    const proj1 = get(code1);
+    const proj1 = getCachedProjection(code1);
     for (j = 0; j < len; ++j) {
       const code2 = projCodes[j];
-      const proj2 = get(code2);
+      const proj2 = getCachedProjection(code2);
       if (!getTransform(code1, code2)) {
         if (proj4.defs[code1] === proj4.defs[code2]) {
           addEquivalentProjections([proj1, proj2]);
@@ -148,13 +148,13 @@ export async function fromEPSGCode(code) {
 
   const epsgCode = 'EPSG:' + code;
   if (proj4.defs(epsgCode)) {
-    return get(epsgCode);
+    return getCachedProjection(epsgCode);
   }
 
   proj4.defs(epsgCode, await epsgLookup(code));
   register(proj4);
 
-  return get(epsgCode);
+  return getCachedProjection(epsgCode);
 }
 
 /**

--- a/src/ol/proj/projections.js
+++ b/src/ol/proj/projections.js
@@ -17,7 +17,7 @@ export function clear() {
 /**
  * Get a cached projection by code.
  * @param {string} code The code for the projection.
- * @return {import("./Projection.js").default} The projection (if cached).
+ * @return {import("./Projection.js").default|null} The projection (if cached).
  */
 export function get(code) {
   return (

--- a/src/ol/proj/transforms.js
+++ b/src/ol/proj/transforms.js
@@ -57,12 +57,11 @@ export function remove(source, destination) {
  * Get a transform given a source code and a destination code.
  * @param {string} sourceCode The code for the source projection.
  * @param {string} destinationCode The code for the destination projection.
- * @return {import("../proj.js").TransformFunction|undefined} The transform function (if found).
+ * @return {import("../proj.js").TransformFunction|null} The transform function (if found).
  */
 export function get(sourceCode, destinationCode) {
-  let transform;
   if (sourceCode in transforms && destinationCode in transforms[sourceCode]) {
-    transform = transforms[sourceCode][destinationCode];
+    return transforms[sourceCode][destinationCode];
   }
-  return transform;
+  return null;
 }

--- a/src/ol/proj/utm.js
+++ b/src/ol/proj/utm.js
@@ -1,0 +1,292 @@
+/**
+ * @module ol/proj/utm
+ */
+
+/**
+ * Adapted from https://github.com/Turbo87/utm
+ * Copyright (c) 2012-2017 Tobias Bieniek
+ *
+ * The functions here provide approximate transforms to and from UTM.
+ * They are not appropriate for use beyond the validity extend of a UTM
+ * zone, and the accuracy of the transform decreases toward the zone
+ * edges.
+ */
+
+import Projection from './Projection.js';
+import {toDegrees, toRadians, wrap} from '../math.js';
+
+/**
+ * @typedef {Object} UTMZone
+ * @property {number} number The zone number (1 - 60).
+ * @property {boolean} north The northern hemisphere.
+ */
+
+const K0 = 0.9996;
+
+const E = 0.00669438;
+const E2 = E * E;
+const E3 = E2 * E;
+const E_P2 = E / (1 - E);
+
+const SQRT_E = Math.sqrt(1 - E);
+const _E = (1 - SQRT_E) / (1 + SQRT_E);
+const _E2 = _E * _E;
+const _E3 = _E2 * _E;
+const _E4 = _E3 * _E;
+const _E5 = _E4 * _E;
+
+const M1 = 1 - E / 4 - (3 * E2) / 64 - (5 * E3) / 256;
+const M2 = (3 * E) / 8 + (3 * E2) / 32 + (45 * E3) / 1024;
+const M3 = (15 * E2) / 256 + (45 * E3) / 1024;
+const M4 = (35 * E3) / 3072;
+
+const P2 = (3 / 2) * _E - (27 / 32) * _E3 + (269 / 512) * _E5;
+const P3 = (21 / 16) * _E2 - (55 / 32) * _E4;
+const P4 = (151 / 96) * _E3 - (417 / 128) * _E5;
+const P5 = (1097 / 512) * _E4;
+
+const R = 6378137;
+
+/**
+ * @param {number} easting Easting value of coordinate.
+ * @param {number} northing Northing value of coordinate.
+ * @param {UTMZone} zone The UTM zone.
+ * @return {import("../coordinate.js").Coordinate} The transformed coordinate.
+ */
+function toLonLat(easting, northing, zone) {
+  const x = easting - 500000;
+  const y = zone.north ? northing : northing - 10000000;
+
+  const m = y / K0;
+  const mu = m / (R * M1);
+
+  const pRad =
+    mu +
+    P2 * Math.sin(2 * mu) +
+    P3 * Math.sin(4 * mu) +
+    P4 * Math.sin(6 * mu) +
+    P5 * Math.sin(8 * mu);
+
+  const pSin = Math.sin(pRad);
+  const pSin2 = pSin * pSin;
+
+  const pCos = Math.cos(pRad);
+
+  const pTan = pSin / pCos;
+  const pTan2 = pTan * pTan;
+  const pTan4 = pTan2 * pTan2;
+
+  const epSin = 1 - E * pSin2;
+  const epSinSqrt = Math.sqrt(1 - E * pSin2);
+
+  const n = R / epSinSqrt;
+  const r = (1 - E) / epSin;
+
+  const c = E_P2 * pCos ** 2;
+  const c2 = c * c;
+
+  const d = x / (n * K0);
+  const d2 = d * d;
+  const d3 = d2 * d;
+  const d4 = d3 * d;
+  const d5 = d4 * d;
+  const d6 = d5 * d;
+
+  const latitude =
+    pRad -
+    (pTan / r) *
+      (d2 / 2 - (d4 / 24) * (5 + 3 * pTan2 + 10 * c - 4 * c2 - 9 * E_P2)) +
+    (d6 / 720) * (61 + 90 * pTan2 + 298 * c + 45 * pTan4 - 252 * E_P2 - 3 * c2);
+
+  let longitude =
+    (d -
+      (d3 / 6) * (1 + 2 * pTan2 + c) +
+      (d5 / 120) * (5 - 2 * c + 28 * pTan2 - 3 * c2 + 8 * E_P2 + 24 * pTan4)) /
+    pCos;
+
+  longitude = wrap(
+    longitude + toRadians(zoneToCentralLongitude(zone.number)),
+    -Math.PI,
+    Math.PI,
+  );
+
+  return [toDegrees(longitude), toDegrees(latitude)];
+}
+
+const MIN_LATITUDE = -80;
+const MAX_LATITUDE = 84;
+const MIN_LONGITUDE = -180;
+const MAX_LONGITUDE = 180;
+
+/**
+ * @param {number} longitude The longitude.
+ * @param {number} latitude The latitude.
+ * @param {UTMZone} zone The UTM zone.
+ * @return {import('../coordinate.js').Coordinate} The UTM coordinate.
+ */
+function fromLonLat(longitude, latitude, zone) {
+  longitude = wrap(longitude, MIN_LONGITUDE, MAX_LONGITUDE);
+
+  if (latitude < MIN_LATITUDE) {
+    latitude = MIN_LATITUDE;
+  } else if (latitude > MAX_LATITUDE) {
+    latitude = MAX_LATITUDE;
+  }
+
+  const latRad = toRadians(latitude);
+  const latSin = Math.sin(latRad);
+  const latCos = Math.cos(latRad);
+
+  const latTan = latSin / latCos;
+  const latTan2 = latTan * latTan;
+  const latTan4 = latTan2 * latTan2;
+
+  const lonRad = toRadians(longitude);
+  const centralLon = zoneToCentralLongitude(zone.number);
+  const centralLonRad = toRadians(centralLon);
+
+  const n = R / Math.sqrt(1 - E * latSin ** 2);
+  const c = E_P2 * latCos ** 2;
+
+  const a = latCos * wrap(lonRad - centralLonRad, -Math.PI, Math.PI);
+  const a2 = a * a;
+  const a3 = a2 * a;
+  const a4 = a3 * a;
+  const a5 = a4 * a;
+  const a6 = a5 * a;
+
+  const m =
+    R *
+    (M1 * latRad -
+      M2 * Math.sin(2 * latRad) +
+      M3 * Math.sin(4 * latRad) -
+      M4 * Math.sin(6 * latRad));
+
+  const easting =
+    K0 *
+      n *
+      (a +
+        (a3 / 6) * (1 - latTan2 + c) +
+        (a5 / 120) * (5 - 18 * latTan2 + latTan4 + 72 * c - 58 * E_P2)) +
+    500000;
+
+  let northing =
+    K0 *
+    (m +
+      n *
+        latTan *
+        (a2 / 2 +
+          (a4 / 24) * (5 - latTan2 + 9 * c + 4 * c ** 2) +
+          (a6 / 720) * (61 - 58 * latTan2 + latTan4 + 600 * c - 330 * E_P2)));
+
+  if (!zone.north) {
+    northing += 10000000;
+  }
+
+  return [easting, northing];
+}
+
+/**
+ * @param {number} zone The zone number.
+ * @return {number} The central longitude in degrees.
+ */
+function zoneToCentralLongitude(zone) {
+  return (zone - 1) * 6 - 180 + 3;
+}
+
+/**
+ * @type {Array<RegExp>}
+ */
+const epsgRegExes = [
+  /^EPSG:(\d+)$/,
+  /^urn:ogc:def:crs:EPSG::(\d+)$/,
+  /^http:\/\/www\.opengis\.net\/def\/crs\/EPSG\/0\/(\d+)$/,
+];
+
+/**
+ * @param {string} code The projection code.
+ * @return {UTMZone|null} The UTM zone info (or null if not UTM).
+ */
+export function zoneFromCode(code) {
+  let epsgId = 0;
+  for (const re of epsgRegExes) {
+    const match = code.match(re);
+    if (match) {
+      epsgId = parseInt(match[1]);
+      break;
+    }
+  }
+  if (!epsgId) {
+    return null;
+  }
+
+  let number = 0;
+  let north = false;
+  if (epsgId > 32700 && epsgId < 32761) {
+    number = epsgId - 32700;
+  } else if (epsgId > 32600 && epsgId < 32661) {
+    north = true;
+    number = epsgId - 32600;
+  }
+  if (!number) {
+    return null;
+  }
+
+  return {number, north};
+}
+
+/**
+ * @param {function(number, number, UTMZone): import('../coordinate.js').Coordinate} transformer The transformer.
+ * @param {UTMZone} zone The UTM zone.
+ * @return {import('../proj.js').TransformFunction} The transform function.
+ */
+function makeTransformFunction(transformer, zone) {
+  return function (input, output, dimension, stride) {
+    const length = input.length;
+    dimension = dimension > 1 ? dimension : 2;
+    stride = stride ?? dimension;
+    if (!output) {
+      if (dimension > 2) {
+        output = input.slice();
+      } else {
+        output = new Array(length);
+      }
+    }
+    for (let i = 0; i < length; i += stride) {
+      const x = input[i];
+      const y = input[i + 1];
+      const coord = transformer(x, y, zone);
+      output[i] = coord[0];
+      output[i + 1] = coord[1];
+    }
+    return output;
+  };
+}
+
+/**
+ * @param {string} code The projection code.
+ * @return {import('./Projection.js').default|null} A projection or null if unable to create one.
+ */
+export function makeProjection(code) {
+  const zone = zoneFromCode(code);
+  if (!zone) {
+    return null;
+  }
+  return new Projection({code, units: 'm'});
+}
+
+/**
+ * @param {import('./Projection.js').default} projection The projection.
+ * @return {import('../proj.js').Transforms|null} The transforms lookup or null if unable to handle projection.
+ */
+export function makeTransforms(projection) {
+  const zone = zoneFromCode(projection.getCode());
+  if (!zone) {
+    return null;
+  }
+
+  return {
+    forward: makeTransformFunction(fromLonLat, zone),
+    inverse: makeTransformFunction(toLonLat, zone),
+  };
+}

--- a/test/browser/spec/ol/proj/transforms.test.js
+++ b/test/browser/spec/ol/proj/transforms.test.js
@@ -1,7 +1,7 @@
-import * as transforms from '../../../../../src/ol/proj/transforms.js';
 import Projection from '../../../../../src/ol/proj/Projection.js';
+import {add, get, remove} from '../../../../../src/ol/proj/transforms.js';
 
-describe('transforms.remove()', function () {
+describe('ol/proj/transforms.js', function () {
   const extent = [180, -90, 180, 90];
   const units = 'degrees';
 
@@ -19,11 +19,11 @@ describe('transforms.remove()', function () {
     const transform = function (input, output, dimension) {
       return input;
     };
-    transforms.add(foo, bar, transform);
-    expect(transforms.get('foo', 'bar')).to.be(transform);
+    add(foo, bar, transform);
+    expect(get('foo', 'bar')).to.be(transform);
 
-    const removed = transforms.remove(foo, bar);
+    const removed = remove(foo, bar);
     expect(removed).to.be(transform);
-    expect(transforms.get('foo', 'bar')).to.be(undefined);
+    expect(get('foo', 'bar')).to.be(null);
   });
 });

--- a/test/node/ol/math.test.js
+++ b/test/node/ol/math.test.js
@@ -10,6 +10,7 @@ import {
   toDegrees,
   toFixed,
   toRadians,
+  wrap,
 } from '../../../src/ol/math.js';
 
 describe('ol/math.js', () => {
@@ -191,6 +192,66 @@ describe('ol/math.js', () => {
     for (const c of cases) {
       it(`works for ceil(${c[0]}, ${c[1]})`, () => {
         expect(ceil(c[0], c[1])).to.be(c[2]);
+      });
+    }
+  });
+
+  describe('wrap', () => {
+    const cases = [
+      {
+        value: 0,
+        min: -180,
+        max: 180,
+        wrapped: 0,
+      },
+      {
+        value: 181,
+        min: -180,
+        max: 180,
+        wrapped: -179,
+      },
+      {
+        value: 180,
+        min: -180,
+        max: 180,
+        wrapped: -180,
+      },
+      {
+        value: -181,
+        min: -180,
+        max: 180,
+        wrapped: 179,
+      },
+      {
+        value: 181 + 360 * 5,
+        min: -180,
+        max: 180,
+        wrapped: -179,
+      },
+      {
+        value: -181 - 360 * 5,
+        min: -180,
+        max: 180,
+        wrapped: 179,
+      },
+      {
+        value: Math.PI / 4,
+        min: -Math.PI,
+        max: Math.PI,
+        wrapped: Math.PI / 4,
+      },
+      {
+        value: Math.PI / 4 + 4 * Math.PI,
+        min: -Math.PI,
+        max: Math.PI,
+        wrapped: Math.PI / 4,
+      },
+    ];
+
+    for (const c of cases) {
+      it(`works for wrap(${c.value}, ${c.min}, ${c.max})`, () => {
+        const wrapped = wrap(c.value, c.min, c.max);
+        expect(wrapped).to.roughlyEqual(c.wrapped, 1e-6);
       });
     }
   });

--- a/test/node/ol/proj/utm.test.js
+++ b/test/node/ol/proj/utm.test.js
@@ -1,0 +1,48 @@
+import expect from '../../expect.js';
+import {zoneFromCode} from '../../../../src/ol/proj/utm.js';
+
+describe('ol/proj/utm.js', () => {
+  describe('zoneFromCode', () => {
+    const cases = [
+      {
+        code: 'EPSG:32721',
+        zone: {number: 21, north: false},
+      },
+      {
+        code: 'EPSG:32612',
+        zone: {number: 12, north: true},
+      },
+      {
+        code: 'urn:ogc:def:crs:EPSG::32740',
+        zone: {number: 40, north: false},
+      },
+      {
+        code: 'http://www.opengis.net/def/crs/EPSG/0/32742',
+        zone: {number: 42, north: false},
+      },
+      {
+        code: 'urn:ogc:def:crs:EPSG::4326',
+        zone: null,
+      },
+      {
+        code: 'http://www.opengis.net/def/crs/EPSG/0/4326',
+        zone: null,
+      },
+      {
+        code: 'EPSG:4326',
+        zone: null,
+      },
+      {
+        code: 'EPSG:foo',
+        zone: null,
+      },
+    ];
+
+    for (const c of cases) {
+      it(`works for ${c.code}`, () => {
+        const zone = zoneFromCode(c.code);
+        expect(zone).to.eql(c.zone);
+      });
+    }
+  });
+});

--- a/test/rendering/cases/cog-rotation/main.js
+++ b/test/rendering/cases/cog-rotation/main.js
@@ -4,6 +4,12 @@ import proj4 from 'proj4';
 import {GeoTIFF, TileDebug} from '../../../../src/ol/source.js';
 import {register} from '../../../../src/ol/proj/proj4.js';
 
+proj4.defs(
+  'EPSG:32759',
+  '+proj=utm +zone=59 +south +datum=WGS84 +units=m +no_defs',
+);
+register(proj4);
+
 const source = new GeoTIFF({
   sources: [
     {
@@ -24,14 +30,7 @@ new Map({
     }),
   ],
   target: 'map',
-  view: source.getView().then((viewConfig) => {
-    proj4.defs(
-      'EPSG:32759',
-      '+proj=utm +zone=59 +south +datum=WGS84 +units=m +no_defs',
-    );
-    register(proj4);
-    return viewConfig;
-  }),
+  view: source.getView(),
 });
 
 render({


### PR DESCRIPTION
This adds built-in support for transforming coordinates to and from WGS 84 / UTM zones. As with `EPSG:4326` and `EPSG:3857` transforms, with the changes in this branch nothing else is required to support raster reprojection or coordinate transforms using UTM.

The forward and inverse UTM transforms here are approximations that are not as accurate as those provided by PROJ. The tests use an epsilon of 0.1 m when comparing values to those from PROJ. For higher precision, Proj4js can be used.

In contrast with the existing built-in projection support, transforms for all 120 zones are not preemptively registered. Instead, when calling a transform function, if the supplied source or destination projection is UTM, the projection and transform functions are registered lazily.

I also changed the old behavior that used the identity transform when calling `transform` using an unknown source or destination projection. I found this behavior surprising, and instead think it makes more sense to throw an error if the user tries to transform between unsupported projections.

Fixes #16326.
Replaces #16314.