### PR TITLE
Turn off transition in more rendering tests

### DIFF
--- a/test/rendering/cases/reproj-tile-dateline-merc/main.js
+++ b/test/rendering/cases/reproj-tile-dateline-merc/main.js
@@ -20,6 +20,7 @@ const source = new XYZ({
   minZoom: 0,
   maxZoom: 0,
   url: '/data/tiles/4326/{z}/{x}/{y}.png',
+  transition: 0,
 });
 
 new Map({

--- a/test/rendering/cases/reproj-tile-none-square/main.js
+++ b/test/rendering/cases/reproj-tile-none-square/main.js
@@ -15,6 +15,7 @@ const source = new XYZ({
   maxZoom: 5,
   url: '/data/tiles/512x256/{z}/{x}/{y}.png',
   tileSize: [512, 256],
+  transition: 0,
 });
 
 new Map({

--- a/test/rendering/cases/reproj-tile-northpole/main.js
+++ b/test/rendering/cases/reproj-tile-northpole/main.js
@@ -23,6 +23,7 @@ const source = new XYZ({
   maxZoom: 0,
   projection: 'EPSG:4326',
   url: '/data/tiles/4326/{z}/{x}/{y}.png',
+  transition: 0,
 });
 
 new Map({

--- a/test/rendering/cases/source-raster-webgl-alpha/main.js
+++ b/test/rendering/cases/source-raster-webgl-alpha/main.js
@@ -24,18 +24,21 @@ const raster = new RasterSource({
       source: new DataTile({
         maxZoom: 0,
         loader: () => data0,
+        transition: 0,
       }),
     }),
     new TileLayer({
       source: new DataTile({
         maxZoom: 0,
         loader: () => data1,
+        transition: 0,
       }),
     }),
     new TileLayer({
       source: new DataTile({
         maxZoom: 0,
         loader: () => data2,
+        transition: 0,
       }),
     }),
   ],

--- a/test/rendering/cases/source-raster-webgl/main.js
+++ b/test/rendering/cases/source-raster-webgl/main.js
@@ -21,6 +21,7 @@ const raster = new RasterSource({
         maxZoom: 0,
         interpolate: true,
         loader: () => data,
+        transition: 0,
       }),
     }),
   ],

--- a/test/rendering/cases/source-tms/main.js
+++ b/test/rendering/cases/source-tms/main.js
@@ -10,6 +10,7 @@ new Map({
     new TileLayer({
       source: new ImageTile({
         url: '/data/tiles/nyc/{z}/{x}/{-y}.jpg',
+        transition: 0,
       }),
     }),
     new TileLayer({

--- a/test/rendering/cases/webgl-data-tile-3-band/main.js
+++ b/test/rendering/cases/webgl-data-tile-3-band/main.js
@@ -20,6 +20,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         loader: function (z, x, y) {
           const halfWidth = size[0] / 2;
           const halfHeight = size[1] / 2;

--- a/test/rendering/cases/webgl-data-tile-6-band/main.js
+++ b/test/rendering/cases/webgl-data-tile-6-band/main.js
@@ -20,6 +20,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         tileSize: size,
         bandCount: 6,
         loader: function (z, x, y) {

--- a/test/rendering/cases/webgl-data-tile-8-band/main.js
+++ b/test/rendering/cases/webgl-data-tile-8-band/main.js
@@ -20,6 +20,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         tileSize: size,
         bandCount: 8,
         loader: function (z, x, y) {

--- a/test/rendering/cases/webgl-data-tile-interpolate-false/main.js
+++ b/test/rendering/cases/webgl-data-tile-interpolate-false/main.js
@@ -19,6 +19,7 @@ new Map({
       source: new DataTile({
         maxZoom: 0,
         loader: () => data,
+        transition: 0,
       }),
     }),
   ],

--- a/test/rendering/cases/webgl-data-tile-interpolate-gutter/main.js
+++ b/test/rendering/cases/webgl-data-tile-interpolate-gutter/main.js
@@ -17,6 +17,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         maxZoom: 1,
         interpolate: true,
         loader: () => data,

--- a/test/rendering/cases/webgl-data-tile-interpolate-true/main.js
+++ b/test/rendering/cases/webgl-data-tile-interpolate-true/main.js
@@ -17,6 +17,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         maxZoom: 0,
         interpolate: true,
         loader: () => data,

--- a/test/rendering/cases/webgl-data-tile-loosely-packed/main.js
+++ b/test/rendering/cases/webgl-data-tile-loosely-packed/main.js
@@ -20,6 +20,7 @@ new Map({
   layers: [
     new TileLayer({
       source: new DataTile({
+        transition: 0,
         tileSize: size,
         loader: function (z, x, y) {
           const halfW = size[0] / 2;

--- a/test/rendering/cases/webgl-data-tile-reset-source/main.js
+++ b/test/rendering/cases/webgl-data-tile-reset-source/main.js
@@ -29,6 +29,7 @@ const sourceRed = new DataTile({
     return context.getImageData(0, 0, size[0], size[1]).data;
   },
   tileSize: size,
+  transition: 0,
 });
 
 const sourceBlue = new DataTile({
@@ -45,6 +46,7 @@ const sourceBlue = new DataTile({
     return context.getImageData(0, 0, size[0], size[1]).data;
   },
   tileSize: size,
+  transition: 0,
 });
 
 const layer = new TileLayer({

--- a/test/rendering/cases/webgl-data-tile-tilepixelratio2/main.js
+++ b/test/rendering/cases/webgl-data-tile-tilepixelratio2/main.js
@@ -22,6 +22,7 @@ new Map({
         tileGrid: createXYZ({maxZoom: 0}),
         maxZoom: 0,
         loader: () => data,
+        transition: 0,
       }),
     }),
   ],

--- a/test/rendering/cases/webgl-tile-range/main.js
+++ b/test/rendering/cases/webgl-tile-range/main.js
@@ -47,6 +47,7 @@ new Map({
         maxZoom: 1,
         tileSize: size,
         loader: () => data,
+        transition: 0,
       }),
     }),
     new TileLayer({

--- a/test/rendering/cases/webgl-tile-reset-projection/main.js
+++ b/test/rendering/cases/webgl-tile-reset-projection/main.js
@@ -7,6 +7,7 @@ const map = new Map({
   layers: [
     new TileLayer({
       source: new XYZ({
+        transition: 0,
         minZoom: 0,
         maxZoom: 0,
         url: '/data/tiles/osm/{z}/{x}/{y}.png',


### PR DESCRIPTION
Following on from #16326 several other tests are potentially affected by the same problem, as many are closely related and based on others, e.g. `layer-tile-reset-projection` was based on `webgl-tile-reset-projection`.  I found several such chains and updated each (unless transition was explicitly set to a non-zero value).  This may not be an exhaustive list.