### PR TITLE
Example showing image tiles from a PMTiles archive

### DIFF
--- a/examples/pmtiles-elevation.html
+++ b/examples/pmtiles-elevation.html
@@ -5,8 +5,6 @@ shortdesc: Elevation data from PMTiles.
 docs: >
   This example shows a shaded relief rendering of elevation data from
   a [PMTiles](https://github.com/protomaps/PMTiles) source.
-resources:
-  - https://unpkg.com/pmtiles@2.4.0/dist/index.js
 tags: "pmtiles, elevation, data tiles"
 ---
 <div id="map" class="map"></div>

--- a/examples/pmtiles-elevation.js
+++ b/examples/pmtiles-elevation.js
@@ -1,13 +1,13 @@
-/* global pmtiles */
 import DataTile from '../src/ol/source/DataTile.js';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import View from '../src/ol/View.js';
+import {PMTiles} from 'pmtiles';
 import {useGeographic} from '../src/ol/proj.js';
 
 useGeographic();
 
-const tiles = new pmtiles.PMTiles(
+const tiles = new PMTiles(
   'https://pub-9288c68512ed46eca46ddcade307709b.r2.dev/protomaps-sample-datasets/terrarium_z9.pmtiles',
 );
 
@@ -20,8 +20,8 @@ function loadImage(src) {
   });
 }
 
-async function loader(z, x, y) {
-  const response = await tiles.getZxy(z, x, y);
+async function loader(z, x, y, {signal}) {
+  const response = await tiles.getZxy(z, x, y, signal);
   const blob = new Blob([response.data]);
   const src = URL.createObjectURL(blob);
   const image = await loadImage(src);

--- a/examples/pmtiles-image.html
+++ b/examples/pmtiles-image.html
@@ -1,0 +1,16 @@
+---
+layout: example.html
+title: PMTiles Image Tiles
+shortdesc: Displaying image tiles from a PMTiles archive.
+docs: >
+  This example shows image tiles from a [PMTiles](https://github.com/protomaps/PMTiles) source.
+  A PMTiles archive can contain tiled data in a variety of formats. In this example, the PMTiles
+  archive contains image-encoded tiles. The [PMTiles JavaScript API](https://pmtiles.io/typedoc/)
+  is used to issue range requests for tile data given tile z, x, y coordinates. The `ImageTile`
+  source is configured with a `loader` that returns a promise for a loaded image. The loader
+  in this example converts the PMTiles response data into a [data URL](https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data)
+  and then uses the browser's built-in image decoder to turn the data URL into an image.
+
+tags: "pmtiles, raster, image tiles"
+---
+<div id="map" class="map"></div>

--- a/examples/pmtiles-image.js
+++ b/examples/pmtiles-image.js
@@ -1,0 +1,48 @@
+import Layer from '../src/ol/layer/WebGLTile.js';
+import Map from '../src/ol/Map.js';
+import Source from '../src/ol/source/ImageTile.js';
+import View from '../src/ol/View.js';
+import {PMTiles} from 'pmtiles';
+import {useGeographic} from '../src/ol/proj.js';
+
+useGeographic();
+
+const tiles = new PMTiles(
+  'https://pmtiles.io/stamen_toner(raster)CC-BY+ODbL_z3.pmtiles',
+);
+
+/**
+ * @param {string} src The image source URL.
+ * @return {Promise<HTMLImageElement>} Resolves with the loaded image.
+ */
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener('load', () => resolve(img));
+    img.addEventListener('error', () => reject(new Error('load failed')));
+    img.src = src;
+  });
+}
+
+const source = new Source({
+  async loader(z, x, y, {signal}) {
+    const response = await tiles.getZxy(z, x, y, signal);
+    const blob = new Blob([response.data]);
+    const src = URL.createObjectURL(blob);
+    const image = await loadImage(src);
+    URL.revokeObjectURL(src);
+    return image;
+  },
+  attributions:
+    'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/4.0">CC BY 4.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
+});
+
+const map = new Map({
+  layers: [new Layer({source})],
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 2,
+    maxZoom: 4,
+  }),
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "ol-mapbox-style": "^12.3.1",
         "ol-stac": "^1.0.0-beta.8",
         "pixelmatch": "^6.0.0",
+        "pmtiles": "^3.2.1",
         "pngjs": "^7.0.0",
         "proj4": "2.12.1",
         "puppeteer": "23.6.0",
@@ -1833,6 +1834,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.14.tgz",
+      "integrity": "sha512-sx2q6MDJaajwhKeVgPSvqXd8rhNJSTA3tMidQGduZn9S6WBYxDkCpSpV5xXEmSg7Cgdk/5vJGhVF1kMYLzauBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
@@ -7999,6 +8010,16 @@
         "ol": ">=7.3.0"
       }
     },
+    "node_modules/ol-pmtiles/node_modules/pmtiles": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.11.0.tgz",
+      "integrity": "sha512-dU9SzzaqmCGpdEuTnIba6bDHT6j09ZJFIXxwGpvkiEnce3ZnBB1VKt6+EOmJGueriweaZLAMTUmKVElU2CBe0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fflate": "^0.8.0"
+      }
+    },
     "node_modules/ol-stac": {
       "version": "1.0.0-beta.10",
       "resolved": "https://registry.npmjs.org/ol-stac/-/ol-stac-1.0.0-beta.10.tgz",
@@ -8434,11 +8455,13 @@
       }
     },
     "node_modules/pmtiles": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.11.0.tgz",
-      "integrity": "sha512-dU9SzzaqmCGpdEuTnIba6bDHT6j09ZJFIXxwGpvkiEnce3ZnBB1VKt6+EOmJGueriweaZLAMTUmKVElU2CBe0g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz",
+      "integrity": "sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
+        "@types/leaflet": "^1.9.8",
         "fflate": "^0.8.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -79,8 +79,8 @@
     "chaikin-smooth": "^1.0.4",
     "chroma-js": "^3.1.1",
     "clean-css-cli": "5.6.3",
-    "colormap": "^2.3.2",
     "codemirror": "^6.0.1",
+    "colormap": "^2.3.2",
     "copy-webpack-plugin": "^12.0.1",
     "d3-array": "^3.2.4",
     "d3-fetch": "^3.0.1",
@@ -121,6 +121,7 @@
     "ol-mapbox-style": "^12.3.1",
     "ol-stac": "^1.0.0-beta.8",
     "pixelmatch": "^6.0.0",
+    "pmtiles": "^3.2.1",
     "pngjs": "^7.0.0",
     "proj4": "2.12.1",
     "puppeteer": "23.6.0",
@@ -155,7 +156,8 @@
         "error",
         {
           "ignore": [
-            "@octokit/rest"
+            "@octokit/rest",
+            "pmtiles"
           ]
         }
       ],


### PR DESCRIPTION
This adds [an example](https://deploy-preview-16335--ol-site.netlify.app/en/latest/examples/pmtiles-image.html) using an `ImageTile` source to load image tiles from a PMTiles archive.