### PR TITLE
Update deprecated applyStyle syntax in Vector tiles in EPSG:4326 example

### DIFF
--- a/examples/vector-tiles-4326.js
+++ b/examples/vector-tiles-4326.js
@@ -22,7 +22,7 @@ const layer = new VectorTileLayer({
     tileGrid: tileGrid,
   }),
 });
-applyStyle(layer, url, '', {resolutions: tileGrid.getResolutions()});
+applyStyle(layer, url, {resolutions: tileGrid.getResolutions()});
 applyBackground(layer, url);
 
 const map = new Map({


### PR DESCRIPTION
The ol-mapbox-style documentation describes the 4th parameter to `applyStyle` as deprecated as the 3rd parameter can be used for options.  https://deploy-preview-16350--ol-site.netlify.app/en/latest/examples/vector-tiles-4326.html
