### PR TITLE
Expire cache only when not loading tiles

### DIFF
--- a/test/browser/spec/ol/renderer/canvas/Layer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/Layer.test.js
@@ -16,7 +16,7 @@ describe('ol/renderer/canvas/Layer', function () {
       layers: [
         new TileLayer({
           source: new XYZ({
-            url: 'spec/ol/data/osm/{z}-{x}-{y}.png',
+            url: 'spec/ol/data/osm-{z}-{x}-{y}.png',
           }),
         }),
         new VectorLayer({

--- a/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
@@ -58,8 +58,12 @@ describe('ol/renderer/canvas/TileLayer', function () {
         const spy = sinon.spy(layer.getRenderer(), 'updateCacheSize');
         map.addLayer(layer);
         map.once('rendercomplete', () => {
-          expect(spy.called).to.be(true);
-          done();
+          // rendercomplete triggers before the postrender functions with the cleanup are run,
+          // so wait another cycle
+          setTimeout(() => {
+            expect(spy.called).to.be(true);
+            done();
+          }, 0);
         });
       });
       it('expires the tile cache, which disposes unused tiles', async () => {


### PR DESCRIPTION
In the old canvas tile renderer, we only expired tiles that were not listed in `frameState.usedTiles`. Since we don't check that any more, we should only expire the cache when no tiles are loading, which is the case when the `renderComplete` flag is true. This avoids the case that loading tiles are expired, which is the reason for the problem reported in #16364.

Fixes #16364.