### PR TITLE
Include `background` in `ol/layer/Tile` options

### DIFF
--- a/src/ol/layer/BaseTile.js
+++ b/src/ol/layer/BaseTile.js
@@ -41,6 +41,8 @@ import TileProperty from './TileProperty.js';
  * this layer in its layers collection, and the layer will be rendered on top. This is useful for
  * temporary layers. The standard way to add a layer to a map and have it managed by the map is to
  * use {@link import("../Map.js").default#addLayer map.addLayer()}.
+ * @property {import("./Base.js").BackgroundColor} [background] Background color for the layer. If not specified, no background
+ * will be rendered.
  * @property {boolean} [useInterimTilesOnError=true] Deprecated.  Use interim tiles on error.
  * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
  * @property {number} [cacheSize=512] The internal tile cache size.  This needs to be large enough to render


### PR DESCRIPTION
Fixes the documentation omission described in #16369 (does not add support for `background` in any other layer types).
