### PR TITLE
Fix forcing of CORS for all image tile fetches

### DIFF
--- a/src/ol/ImageTile.js
+++ b/src/ol/ImageTile.js
@@ -5,13 +5,14 @@ import Tile from './Tile.js';
 import TileState from './TileState.js';
 import {createCanvasContext2D} from './dom.js';
 import {listenImage} from './Image.js';
+import {setCrossOrigin} from './cors.js';
 
 class ImageTile extends Tile {
   /**
    * @param {import("./tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("./TileState.js").default} state State.
    * @param {string} src Image source URI.
-   * @param {?string} crossOrigin Cross origin.
+   * @param {import("./cors.js").CrossOriginOption} crossOrigin Cross origin.
    * @param {import("./Tile.js").LoadFunction} tileLoadFunction Tile load function.
    * @param {import("./Tile.js").Options} [options] Tile options.
    */
@@ -20,9 +21,9 @@ class ImageTile extends Tile {
 
     /**
      * @private
-     * @type {?string}
+     * @type {import("./cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ = crossOrigin;
+    this.crossOrigin_ = crossOrigin ?? 'no-cors';
 
     /**
      * Image URI
@@ -39,9 +40,7 @@ class ImageTile extends Tile {
      * @type {HTMLImageElement|HTMLCanvasElement}
      */
     this.image_ = new Image();
-    if (crossOrigin !== null) {
-      this.image_.crossOrigin = crossOrigin;
-    }
+    setCrossOrigin(this.image_, this.crossOrigin_);
 
     /**
      * @private
@@ -145,9 +144,7 @@ class ImageTile extends Tile {
     if (this.state == TileState.ERROR) {
       this.state = TileState.IDLE;
       this.image_ = new Image();
-      if (this.crossOrigin_ !== null) {
-        this.image_.crossOrigin = this.crossOrigin_;
-      }
+      setCrossOrigin(this.image_, this.crossOrigin_);
     }
     if (this.state == TileState.IDLE) {
       this.state = TileState.LOADING;

--- a/src/ol/cors.js
+++ b/src/ol/cors.js
@@ -1,0 +1,39 @@
+/**
+ * @module ol/cors
+ */
+
+/**
+ * Value to use for 'crossOrigin' attribute of images and media.
+ *
+ * The placeholder value 'no-cors' will mean the attribute should not be set,
+ * and any fetch will occur without CORS. Use 'anonymous' or 'use-credentials'
+ * to fetch using CORS, which is a requirement to for example access data from
+ * a canvas object containing any image from a different origin.
+ *
+ * For more, see:
+ * <https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image>
+ * <https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin>
+ * <https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin>
+ *
+ * @typedef {'anonymous'|'use-credentials'|'no-cors'} CrossOriginAttribute
+ */
+
+/**
+ * Value to use for 'crossOrigin' attribute, or null to default.
+ *
+ * @typedef {CrossOriginAttribute|null} CrossOriginOption
+ */
+
+/**
+ * Set the 'crossOrigin' attribute of an image or media element.
+ *
+ * The element attribute remains unset if 'no-cors' is the value.
+ *
+ * @param {HTMLImageElement|HTMLMediaElement} element HTML element to configure for cors.
+ * @param {CrossOriginAttribute} crossOrigin The cors mode to use.
+ */
+export function setCrossOrigin(element, crossOrigin) {
+  if (crossOrigin !== 'no-cors') {
+    element.crossOrigin = crossOrigin;
+  }
+}

--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -416,7 +416,7 @@ function defaultIconUrlFunction(href) {
  * @property {Array<Style>} [defaultStyle] Default style. The
  * default default style is the same as Google Earth.
  * @property {boolean} [writeStyles=true] Write styles into KML.
- * @property {null|string} [crossOrigin='anonymous'] The `crossOrigin` attribute for loaded images. Note that you must provide a
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin='anonymous'] The `crossOrigin` attribute for loaded images. Note that you must provide a
  * `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * @property {IconUrlFunction} [iconUrlFunction] Function that takes a url string and returns a url string.
  * Might be used to change an icon path or to substitute a data url obtained from a KMZ array buffer.
@@ -488,10 +488,9 @@ class KML extends XMLFeature {
       options.showPointNames !== undefined ? options.showPointNames : true;
 
     /**
-     * @type {null|string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ =
-      options.crossOrigin !== undefined ? options.crossOrigin : 'anonymous';
+    this.crossOrigin_ = options.crossOrigin ?? 'anonymous';
 
     /**
      * @type {IconUrlFunction}

--- a/src/ol/render/canvas/style.js
+++ b/src/ol/render/canvas/style.js
@@ -757,7 +757,7 @@ function buildIcon(flatStyle, context) {
     prefix + 'anchor-y-units',
   );
   const color = optionalColorLike(flatStyle, prefix + 'color');
-  const crossOrigin = optionalString(flatStyle, prefix + 'cross-origin');
+  const crossOrigin = optionalCrossOrigin(flatStyle, prefix + 'cross-origin');
   const offset = optionalNumberArray(flatStyle, prefix + 'offset');
   const offsetOrigin = optionalIconOrigin(flatStyle, prefix + 'offset-origin');
   const width = optionalNumber(flatStyle, prefix + 'width');
@@ -1168,15 +1168,15 @@ function optionalSize(flatStyle, property) {
 /**
  * @param {FlatStyle} flatStyle The flat style.
  * @param {string} property The symbolizer property.
- * @return {string|undefined} A string or undefined.
+ * @return {import("../../cors.js").CrossOriginAttribute} A crossOrigin attribute or undefined.
  */
-function optionalString(flatStyle, property) {
+function optionalCrossOrigin(flatStyle, property) {
   const encoded = flatStyle[property];
   if (encoded === undefined) {
     return undefined;
   }
-  if (typeof encoded !== 'string') {
-    throw new Error(`Expected a string for ${property}`);
+  if (!{'no-cors': true, 'anonymous': true, 'use-credentials': true}[encoded]) {
+    throw new Error(`Expected a valid cross-origin string for ${property}`);
   }
   return encoded;
 }

--- a/src/ol/source/CartoDB.js
+++ b/src/ol/source/CartoDB.js
@@ -8,7 +8,7 @@ import XYZ from './XYZ.js';
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {import("../proj.js").ProjectionLike} [projection='EPSG:3857'] Projection.

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -18,13 +18,9 @@ import {toPromise} from '../functions.js';
 import {toSize} from '../size.js';
 
 /**
- * @typedef {'anonymous'|'use-credentials'} CrossOriginAttribute
- */
-
-/**
  * @typedef {Object} LoaderOptions
  * @property {AbortSignal} signal An abort controller signal.
- * @property {CrossOriginAttribute} [crossOrigin] The cross-origin attribute for images.
+ * @property {import("../cors.js").CrossOriginAttribute} [crossOrigin] The cross-origin attribute for images.
  * @property {number} [maxY] The maximum y coordinate at the given z level.  Will be undefined if the
  * underlying tile grid does not have a known extent.
  */
@@ -58,7 +54,7 @@ import {toSize} from '../size.js';
  * @property {number} [bandCount=4] Number of bands represented in the data.
  * @property {boolean} [interpolate=false] Use interpolated values when resampling.  By default,
  * the nearest neighbor is used when resampling.
- * @property {CrossOriginAttribute} [crossOrigin='anonymous'] The crossOrigin property to pass to loaders for image data.
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin='anonymous'] The crossOrigin property to pass to loaders for image data.
  * @property {string} [key] Key for use in caching tiles.
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
  * Choose whether to use tiles with a higher or lower zoom level when between integer
@@ -154,9 +150,9 @@ class DataTileSource extends TileSource {
 
     /**
      * @private
-     * @type {CrossOriginAttribute}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ = options.crossOrigin || 'anonymous';
+    this.crossOrigin_ = options.crossOrigin ?? 'anonymous';
 
     /**
      * @protected

--- a/src/ol/source/IIIF.js
+++ b/src/ol/source/IIIF.js
@@ -16,7 +16,7 @@ import {toSize} from '../size.js';
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The value for the crossOrigin option of the request.
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The value for the crossOrigin option of the request.
  * @property {import("../extent.js").Extent} [extent=[0, -height, width, 0]] The extent.
  * @property {string} [format='jpg'] Requested image format.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -9,7 +9,7 @@ import {decode} from '../Image.js';
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting the image from
@@ -63,10 +63,9 @@ class ImageArcGISRest extends ImageSource {
 
     /**
      * @private
-     * @type {?string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    this.crossOrigin_ = options.crossOrigin ?? 'no-cors';
 
     /**
      * @private

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -9,7 +9,7 @@ import {decode} from '../Image.js';
 /**
  * @typedef {Object} Options
  * @property {string} [url] The mapagent url.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {number} [displayDpi=96] The display resolution.
@@ -48,10 +48,9 @@ class ImageMapGuide extends ImageSource {
 
     /**
      * @private
-     * @type {?string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    this.crossOrigin_ = options.crossOrigin ?? 'no-cors';
 
     /**
      * @private

--- a/src/ol/source/ImageStatic.js
+++ b/src/ol/source/ImageStatic.js
@@ -12,7 +12,7 @@ import {intersects} from '../extent.js';
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {import("../extent.js").Extent} imageExtent Extent of the image in map coordinates.
@@ -34,8 +34,7 @@ class Static extends ImageSource {
    * @param {Options} options ImageStatic options.
    */
   constructor(options) {
-    const crossOrigin =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    const crossOrigin = options.crossOrigin ?? 'no-cors';
 
     const /** @type {import("../Image.js").LoadFunction} */ imageLoadFunction =
         options.imageLoadFunction !== undefined

--- a/src/ol/source/ImageTile.js
+++ b/src/ol/source/ImageTile.js
@@ -3,6 +3,7 @@
  */
 import DataTileSource from './DataTile.js';
 import {expandUrl, pickUrl, renderXYZTemplate} from '../uri.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * Image tile loading function.  The function is called with z, x, and y tile coordinates and
@@ -43,7 +44,7 @@ import {expandUrl, pickUrl, renderXYZTemplate} from '../uri.js';
  * @property {boolean} [wrapX=true] Render tiles beyond the antimeridian.
  * @property {number} [transition] Transition time when fading in new tiles (in miliseconds).
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.
- * @property {import('./DataTile.js').CrossOriginAttribute} [crossOrigin='anonymous'] The crossOrigin property to pass to loaders for image data.
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin='no-cors'] The crossOrigin property to pass to loaders for image data.
  * @property {number|import("../array.js").NearestDirectionFunction} [zDirection=0]
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
@@ -62,7 +63,7 @@ const loadError = new Error('Image failed to load');
 function loadImage(template, z, x, y, options) {
   return new Promise((resolve, reject) => {
     const image = new Image();
-    image.crossOrigin = options.crossOrigin ?? null;
+    setCrossOrigin(image, options.crossOrigin ?? 'no-cors');
     image.addEventListener('load', () => resolve(image));
     image.addEventListener('error', () => reject(loadError));
     image.src = renderXYZTemplate(template, z, x, y, options.maxY);

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -11,7 +11,7 @@ import {get as getProjection, transform} from '../proj.js';
 /**
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
@@ -57,10 +57,9 @@ class ImageWMS extends ImageSource {
 
     /**
      * @private
-     * @type {?string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    this.crossOrigin_ = options.crossOrigin ?? 'no-cors';
 
     /**
      * @private

--- a/src/ol/source/OGCMapTile.js
+++ b/src/ol/source/OGCMapTile.js
@@ -17,7 +17,7 @@ import {error as logError} from '../console.js';
  * a projection to the constructor.
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/OSM.js
+++ b/src/ol/source/OSM.js
@@ -20,7 +20,7 @@ export const ATTRIBUTION =
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin='anonymous'] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin='anonymous'] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
@@ -63,8 +63,7 @@ class OSM extends XYZ {
       attributions = [ATTRIBUTION];
     }
 
-    const crossOrigin =
-      options.crossOrigin !== undefined ? options.crossOrigin : 'anonymous';
+    const crossOrigin = options.crossOrigin ?? 'anonymous';
 
     const url =
       options.url !== undefined

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -13,7 +13,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -15,7 +15,7 @@ import {getUid} from '../util.js';
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
@@ -90,10 +90,9 @@ class TileImage extends UrlTile {
 
     /**
      * @protected
-     * @type {?string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    this.crossOrigin = options.crossOrigin ?? 'no-cors';
 
     /**
      * @protected

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -35,7 +35,7 @@ import {jsonp as requestJSONP} from '../net.js';
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -17,7 +17,7 @@ import {hash as tileCoordHash} from '../tilecoord.js';
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -19,7 +19,7 @@ import {equivalent, get as getProjection, transformExtent} from '../proj.js';
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
@@ -356,7 +356,7 @@ export default WMTS;
  *  - style - {string} The name of the style
  *  - format - {string} Image format for the layer. Default is the first
  *       format returned in the GetCapabilities response.
- *  - crossOrigin - {string|null|undefined} Cross origin. Default is `undefined`.
+ *  - crossOrigin - {import("../cors.js").CrossOriginOption} Cross origin.
  * @return {Options|null} WMTS source options object or `null` if the layer was not found.
  * @api
  */

--- a/src/ol/source/XYZ.js
+++ b/src/ol/source/XYZ.js
@@ -10,7 +10,7 @@ import {createXYZ, extentFromProjection} from '../tilegrid.js';
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {boolean} [attributionsCollapsible=true] Attributions are collapsible.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/Zoomify.js
+++ b/src/ol/source/Zoomify.js
@@ -23,7 +23,7 @@ export class CustomTile extends ImageTile {
    * @param {import("../tilecoord.js").TileCoord} tileCoord Tile coordinate.
    * @param {import("../TileState.js").default} state State.
    * @param {string} src Image source URI.
-   * @param {?string} crossOrigin Cross origin.
+   * @param {import("../cors.js").CrossOriginOption} crossOrigin Cross origin.
    * @param {import("../Tile.js").LoadFunction} tileLoadFunction Tile load function.
    * @param {import("../Tile.js").Options} [options] Tile options.
    */
@@ -80,7 +80,7 @@ export class CustomTile extends ImageTile {
  * @typedef {Object} Options
  * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {number} [cacheSize] Deprecated.  Use the cacheSize option on the layer instead.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value  you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,

--- a/src/ol/source/arcgisRest.js
+++ b/src/ol/source/arcgisRest.js
@@ -9,6 +9,7 @@ import {getHeight, getWidth} from '../extent.js';
 import {get as getProjection} from '../proj.js';
 import {getRequestExtent} from './Image.js';
 import {round} from '../math.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * @param {string} baseUrl Base URL for the ArcGIS Rest service.
@@ -58,7 +59,7 @@ export function getRequestUrl(
 
 /**
  * @typedef {Object} LoaderOptions
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting the image from
@@ -91,7 +92,7 @@ export function createLoader(options) {
   const load = options.load ? options.load : decode;
   const projection = getProjection(options.projection || 'EPSG:3857');
   const ratio = options.ratio ?? 1.5;
-  const crossOrigin = options.crossOrigin ?? null;
+  const crossOrigin = options.crossOrigin ?? 'no-cors';
 
   /** @type {import('../Image.js').ImageObjectPromiseLoader} */
   return function (extent, resolution, pixelRatio) {
@@ -116,7 +117,7 @@ export function createLoader(options) {
     );
 
     const image = new Image();
-    image.crossOrigin = crossOrigin;
+    setCrossOrigin(image, crossOrigin);
 
     return load(image, src).then((image) => {
       // Update resolution, because the server may return a smaller size than requested

--- a/src/ol/source/mapguide.js
+++ b/src/ol/source/mapguide.js
@@ -6,11 +6,12 @@ import {appendParams} from '../uri.js';
 import {decode} from '../Image.js';
 import {getCenter, getHeight, getWidth} from '../extent.js';
 import {getRequestExtent} from './Image.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * @typedef {Object} LoaderOptions
  * @property {string} url The mapagent url.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {number} [displayDpi=96] The display resolution.
@@ -95,12 +96,12 @@ export function createLoader(options) {
   const metersPerUnit = options.metersPerUnit || 1;
   const displayDpi = options.displayDpi || 96;
   const ratio = options.ratio ?? 1;
-  const crossOrigin = options.crossOrigin ?? null;
+  const crossOrigin = options.crossOrigin ?? 'no-cors';
 
   /** @type {import('../Image.js').ImageObjectPromiseLoader} */
   return function (extent, resolution, pixelRatio) {
     const image = new Image();
-    image.crossOrigin = crossOrigin;
+    setCrossOrigin(image, crossOrigin);
     extent = getRequestExtent(extent, resolution, pixelRatio, ratio);
     const width = getWidth(extent) / resolution;
     const height = getHeight(extent) / resolution;

--- a/src/ol/source/static.js
+++ b/src/ol/source/static.js
@@ -4,10 +4,11 @@
 
 import {decode} from '../Image.js';
 import {getHeight, getWidth} from '../extent.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * @typedef {Object} LoaderOptions
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {import("../extent.js").Extent} imageExtent Extent of the image in map coordinates.
@@ -28,11 +29,11 @@ import {getHeight, getWidth} from '../extent.js';
 export function createLoader(options) {
   const load = options.load || decode;
   const extent = options.imageExtent;
-  const crossOrigin = options.crossOrigin ?? null;
+  const crossOrigin = options.crossOrigin ?? 'no-cors';
 
   return () => {
     const image = new Image();
-    image.crossOrigin = crossOrigin;
+    setCrossOrigin(image, crossOrigin);
     return load(image, options.url).then((image) => {
       const resolutionX = getWidth(extent) / image.width;
       const resolutionY = getHeight(extent) / image.height;

--- a/src/ol/source/wms.js
+++ b/src/ol/source/wms.js
@@ -10,6 +10,7 @@ import {floor, round} from '../math.js';
 import {getForViewAndSize, getHeight, getWidth} from '../extent.js';
 import {get as getProjection} from '../proj.js';
 import {getRequestExtent} from './Image.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * Default WMS version.
@@ -132,7 +133,7 @@ export function getRequestParams(params, request) {
 
 /**
  * @typedef {Object} LoaderOptions
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images.  Note that
  * you must provide a `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting
@@ -164,7 +165,7 @@ export function createLoader(options) {
   const projection = getProjection(options.projection || 'EPSG:3857');
   const ratio = options.ratio || 1.5;
   const load = options.load || decode;
-  const crossOrigin = options.crossOrigin ?? null;
+  const crossOrigin = options.crossOrigin ?? 'no-cors';
 
   /**
    * @type {import("../Image.js").Loader}
@@ -184,7 +185,7 @@ export function createLoader(options) {
       options.serverType,
     );
     const image = new Image();
-    image.crossOrigin = crossOrigin;
+    setCrossOrigin(image, crossOrigin);
     return load(image, src).then((image) => ({image, extent, pixelRatio}));
   };
 }

--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -32,7 +32,7 @@ import {getUid} from '../util.js';
  * the y value in pixels.
  * @property {import("../color.js").Color|string} [color] Color to tint the icon. If not specified,
  * the icon will be left as is.
- * @property {null|string} [crossOrigin] The `crossOrigin` attribute for loaded images. Note that you must provide a
+ * @property {import("../cors.js").CrossOriginOption} [crossOrigin] The `crossOrigin` attribute for loaded images. Note that you must provide a
  * `crossOrigin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {HTMLImageElement|HTMLCanvasElement|ImageBitmap} [img] Image object for the icon.
@@ -152,10 +152,9 @@ class Icon extends ImageStyle {
 
     /**
      * @private
-     * @type {?string}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ =
-      options.crossOrigin !== undefined ? options.crossOrigin : null;
+    this.crossOrigin_ = options.crossOrigin ?? 'no-cors';
 
     const image = options.img !== undefined ? options.img : null;
 

--- a/src/ol/style/IconImage.js
+++ b/src/ol/style/IconImage.js
@@ -9,6 +9,7 @@ import {asString} from '../color.js';
 import {createCanvasContext2D} from '../dom.js';
 import {decodeFallback} from '../Image.js';
 import {shared as iconImageCache} from './IconImageCache.js';
+import {setCrossOrigin} from '../cors.js';
 
 /**
  * @type {CanvasRenderingContext2D}
@@ -19,7 +20,7 @@ class IconImage extends EventTarget {
   /**
    * @param {HTMLImageElement|HTMLCanvasElement|ImageBitmap|null} image Image.
    * @param {string|undefined} src Src.
-   * @param {?string} crossOrigin Cross origin.
+   * @param {import("../cors.js").CrossOriginOption} crossOrigin Cross origin.
    * @param {import("../ImageState.js").default|undefined} imageState Image state.
    * @param {import("../color.js").Color|string|null} color Color.
    */
@@ -40,9 +41,9 @@ class IconImage extends EventTarget {
 
     /**
      * @private
-     * @type {string|null}
+     * @type {import("../cors.js").CrossOriginAttribute}
      */
-    this.crossOrigin_ = crossOrigin;
+    this.crossOrigin_ = crossOrigin ?? 'no-cors';
 
     /**
      * @private
@@ -92,9 +93,7 @@ class IconImage extends EventTarget {
    */
   initializeImage_() {
     this.image_ = new Image();
-    if (this.crossOrigin_ !== null) {
-      this.image_.crossOrigin = this.crossOrigin_;
-    }
+    setCrossOrigin(this.image_, this.crossOrigin_);
   }
 
   /**
@@ -302,7 +301,7 @@ class IconImage extends EventTarget {
 /**
  * @param {HTMLImageElement|HTMLCanvasElement|ImageBitmap|null} image Image.
  * @param {string|undefined} cacheKey Src.
- * @param {?string} crossOrigin Cross origin.
+ * @param {import("../cors.js").CrossOriginOption} crossOrigin Cross origin.
  * @param {import("../ImageState.js").default|undefined} imageState Image state.
  * @param {import("../color.js").Color|string|null} color Color.
  * @param {boolean} [pattern] Also cache a `repeat` pattern with the icon image.

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -188,7 +188,7 @@
  * the y value in pixels.
  * @property {import("../color.js").Color|string} [icon-color] Color to tint the icon. If not specified,
  * the icon will be left as is.
- * @property {null|string} [icon-cross-origin] The `crossOrigin` attribute for loaded images. Note that you must provide a
+ * @property {import("../cors.js").CrossOriginOption} [icon-cross-origin] The `crossOrigin` attribute for loaded images. Note that you must provide a
  * `icon-cross-origin` value if you want to access pixel data with the Canvas renderer.
  * See https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image for more detail.
  * @property {Array<number>} [icon-offset=[0, 0]] Offset, which, together with the size and the offset origin, define the

--- a/src/ol/webgl/BaseTileRepresentation.js
+++ b/src/ol/webgl/BaseTileRepresentation.js
@@ -75,6 +75,7 @@ class BaseTileRepresentation extends EventTarget {
       } else {
         if (tile instanceof ImageTile) {
           const image = tile.getImage();
+          // TODO: Explain why this is forcing a cross origin fetch here.
           if (image instanceof Image && !image.crossOrigin) {
             image.crossOrigin = 'anonymous';
           }


### PR DESCRIPTION
> [!NOTE]  
> This fixes a regression that's prevented us upgrading to the latest openlayers version.

Recent tile source changes regressed the ability to fetch image tiles without requiring cors requests. `DataTile` wants to default to the 'anonymous' option, but `ImageTile` which derives uses `null` to indicate not setting the attribute.

Introduce an explict 'no-cors' value for sources that wish to have a default behaviour of fetching without cors, while enabling others to select 'anonymous' as the default.

All setting of the `crossOrigin` attribute uses the new helper `setCrossOrigin()` which handles the three states.

Enum types for the cross origin options are now propagated up through the various dependent interfaces, which may mean updating types for client code as well.



It would be possible to land this without disrupting the typing quite so much, which may be worth it as a transitional measure - though I'm unsure on how best to type-refine within internal code in the context of the doc annotations style openlayers uses.

Nitpicking names etc also welcome.