### PR TITLE
More representative z-index for the layer-vectortile-z-index test.

### DIFF
--- a/test/rendering/cases/layer-vectortile-z-index/main.js
+++ b/test/rendering/cases/layer-vectortile-z-index/main.js
@@ -45,11 +45,11 @@ const vectorTileLayer = new VectorTileLayer({
     }),
     new Style({
       image: new Circle({radius: 40, fill: new Fill({color: '#0f0'})}),
-      zIndex: 2,
+      zIndex: 1,
     }),
     new Style({
       image: new Circle({radius: 30, fill: new Fill({color: '#00f'})}),
-      zIndex: 4,
+      zIndex: 2,
     }),
   ],
 });


### PR DESCRIPTION
The indices [0, 2, 4] will not reproduce the problem when casting to a string of group indices: ["0", "12", "24"]. And the indices [0, 1, 2] will reproduce: ["0", "12", "6"].
