### PR TITLE
Introduce a WebGLVectorLayer class & change the style variables API

### DIFF
--- a/config/tsconfig-strict.json
+++ b/config/tsconfig-strict.json
@@ -144,6 +144,7 @@
     "../src/ol/layer/VectorImage.js",
     "../src/ol/layer/VectorTile.js",
     "../src/ol/layer/WebGLPoints.js",
+    "../src/ol/layer/WebGLVector.js",
     "../src/ol/layer/WebGLTile.js",
     "../src/ol/loadingstrategy.js",
     "../src/ol/Map.js",

--- a/examples/filter-webgl-line.js
+++ b/examples/filter-webgl-line.js
@@ -1,15 +1,11 @@
 import IGC from '../src/ol/format/IGC.js';
-import Layer from '../src/ol/layer/Layer.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../src/ol/layer/WebGLVector.js';
 import {OSM, Vector as VectorSource} from '../src/ol/source.js';
 import {Tile as TileLayer} from '../src/ol/layer.js';
 
 const lineStyle = {
-  variables: {
-    timestamp: 1303240000,
-  },
   'stroke-width': 4,
   'stroke-color': [
     'interpolate',
@@ -22,15 +18,6 @@ const lineStyle = {
   ],
   filter: ['<=', ['line-metric'], ['var', 'timestamp']],
 };
-
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      className: this.getClassName(),
-      style: lineStyle,
-    });
-  }
-}
 
 const igcUrls = [
   'data/igc/Clement-Latour.igc',
@@ -56,8 +43,13 @@ for (let i = 0; i < igcUrls.length; ++i) {
     });
 }
 
-const vectorLayer = new WebGLLayer({
+let timestamp = 1303240000;
+const vectorLayer = new WebGLVectorLayer({
   source,
+  style: lineStyle,
+  variables: {
+    timestamp,
+  },
 });
 
 const map = new Map({
@@ -75,11 +67,12 @@ const map = new Map({
 });
 
 function showTime() {
-  const time = new Date(lineStyle.variables.timestamp * 1000);
-  document.getElementById('time-value').textContent = time.toUTCString();
+  const dateTime = new Date(timestamp * 1000);
+  document.getElementById('time-value').textContent = dateTime.toUTCString();
 }
 document.getElementById('time-input').addEventListener('input', (event) => {
-  lineStyle.variables.timestamp = parseFloat(event.target.value);
+  timestamp = parseFloat(event.target.value);
+  vectorLayer.updateStyleVariables({timestamp});
   showTime();
   map.render();
 });

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -56,13 +56,7 @@ const displayFeatureInfo = function (pixel) {
     info.innerHTML = '&nbsp;';
   }
 
-  if (!feature) {
-    highlightedId = -1;
-    vectorLayer.updateStyleVariables({highlightedId});
-    return;
-  }
-
-  const id = feature.getId();
+  const id = feature ? feature.getId() : -1;
   if (id !== highlightedId) {
     highlightedId = id;
     vectorLayer.updateStyleVariables({highlightedId});

--- a/examples/webgl-vector-layer.js
+++ b/examples/webgl-vector-layer.js
@@ -1,37 +1,37 @@
 import GeoJSON from '../src/ol/format/GeoJSON.js';
-import Layer from '../src/ol/layer/Layer.js';
 import Map from '../src/ol/Map.js';
 import OSM from '../src/ol/source/OSM.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../src/ol/layer/WebGLVector.js';
 
 /** @type {import('../src/ol/style/webgl.js').WebGLStyle} */
 const style = {
-  'stroke-color': ['*', ['get', 'COLOR'], [220, 220, 220]],
-  'stroke-width': 2,
+  'stroke-color': [
+    'case',
+    ['==', ['var', 'highlightedId'], ['id']],
+    'white',
+    ['*', ['get', 'COLOR'], [220, 220, 220]],
+  ],
+  'stroke-width': ['case', ['==', ['var', 'highlightedId'], ['id']], 3, 2],
   'stroke-offset': -1,
   'fill-color': ['*', ['get', 'COLOR'], [255, 255, 255, 0.6]],
 };
-
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
 
 const osm = new TileLayer({
   source: new OSM(),
 });
 
-const vectorLayer = new WebGLLayer({
+const vectorLayer = new WebGLVectorLayer({
   source: new VectorSource({
     url: 'https://openlayers.org/data/vector/ecoregions.json',
     format: new GeoJSON(),
   }),
+  style,
+  variables: {
+    highlightedId: -1,
+  },
 });
 
 const map = new Map({
@@ -43,16 +43,7 @@ const map = new Map({
   }),
 });
 
-const featureOverlay = new WebGLLayer({
-  source: new VectorSource(),
-  map: map,
-  style: {
-    'stroke-color': 'rgba(255, 255, 255, 0.7)',
-    'stroke-width': 1,
-  },
-});
-
-let highlight;
+let highlightedId = -1;
 const displayFeatureInfo = function (pixel) {
   const feature = map.forEachFeatureAtPixel(pixel, function (feature) {
     return feature;
@@ -65,14 +56,16 @@ const displayFeatureInfo = function (pixel) {
     info.innerHTML = '&nbsp;';
   }
 
-  if (feature !== highlight) {
-    if (highlight) {
-      featureOverlay.getSource().removeFeature(highlight);
-    }
-    if (feature) {
-      featureOverlay.getSource().addFeature(feature);
-    }
-    highlight = feature;
+  if (!feature) {
+    highlightedId = -1;
+    vectorLayer.updateStyleVariables({highlightedId});
+    return;
+  }
+
+  const id = feature.getId();
+  if (id !== highlightedId) {
+    highlightedId = id;
+    vectorLayer.updateStyleVariables({highlightedId});
   }
 };
 

--- a/examples/wind.js
+++ b/examples/wind.js
@@ -1,11 +1,10 @@
 import DataTileSource from '../src/ol/source/DataTile.js';
 import Flow from '../src/ol/layer/Flow.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
-import Layer from '../src/ol/layer/Layer.js';
 import Map from '../src/ol/Map.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import View from '../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../src/ol/layer/WebGLVector.js';
 import colormap from 'colormap';
 import {createXYZ, wrapX} from '../src/ol/tilegrid.js';
 import {get as getProjection, transform} from '../src/ol/proj.js';
@@ -135,16 +134,6 @@ const wind = new DataTileSource({
   },
 });
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style: {
-        'fill-color': '#555555',
-      },
-    });
-  }
-}
-
 const maxSpeed = 20;
 const colors = colormap({
   colormap: 'viridis',
@@ -162,11 +151,14 @@ const map = new Map({
   target: 'map',
   pixelRatio: 2,
   layers: [
-    new WebGLLayer({
+    new WebGLVectorLayer({
       source: new VectorSource({
         url: 'https://openlayers.org/data/vector/ocean.json',
         format: new GeoJSON(),
       }),
+      style: {
+        'fill-color': '#555555',
+      },
     }),
     new Flow({
       source: wind,

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -166,6 +166,8 @@ const GET_BAND_VALUE_FUNC = 'getBandValue';
 
 export const PALETTE_TEXTURE_ARRAY = 'u_paletteTextures';
 
+export const FEATURE_ID_PROPERTY_NAME = 'OL_FEATURE_ID';
+
 /**
  * @typedef {string} CompiledExpression
  */
@@ -223,6 +225,24 @@ const compilers = {
     }
     const prefix = context.inFragmentShader ? 'v_prop_' : 'a_prop_';
     return prefix + propName;
+  },
+  [Ops.Id]: (context) => {
+    const isExisting = FEATURE_ID_PROPERTY_NAME in context.properties;
+    if (!isExisting) {
+      context.properties[FEATURE_ID_PROPERTY_NAME] = {
+        name: FEATURE_ID_PROPERTY_NAME,
+        type: NumberType | StringType,
+        evaluator: (feature) => {
+          const id = feature.getId();
+          if (id !== undefined) {
+            return id;
+          }
+          return null;
+        },
+      };
+    }
+    const prefix = context.inFragmentShader ? 'v_prop_' : 'a_prop_';
+    return prefix + FEATURE_ID_PROPERTY_NAME;
   },
   [Ops.GeometryType]: (context, expression, type) => {
     const propName = 'geometryType';

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -232,13 +232,7 @@ const compilers = {
       context.properties[FEATURE_ID_PROPERTY_NAME] = {
         name: FEATURE_ID_PROPERTY_NAME,
         type: NumberType | StringType,
-        evaluator: (feature) => {
-          const id = feature.getId();
-          if (id !== undefined) {
-            return id;
-          }
-          return null;
-        },
+        evaluator: (feature) => feature.getId() ?? null,
       };
     }
     const prefix = context.inFragmentShader ? 'v_prop_' : 'a_prop_';

--- a/src/ol/layer/Heatmap.js
+++ b/src/ol/layer/Heatmap.js
@@ -189,13 +189,13 @@ class Heatmap extends BaseVector {
    */
   createRenderer() {
     const builder = new ShaderBuilder()
-      .addAttribute('float a_prop_weight')
-      .addVarying('v_prop_weight', 'float', 'a_prop_weight')
+      .addAttribute('float a_weight')
+      .addVarying('v_weight', 'float', 'a_weight')
       .addUniform('float u_size')
       .addUniform('float u_blurSlope')
       .setSymbolSizeExpression('vec2(u_size)')
       .setSymbolColorExpression(
-        'vec4(smoothstep(0., 1., (1. - length(coordsPx * 2. / v_quadSizePx)) * u_blurSlope) * v_prop_weight)',
+        'vec4(smoothstep(0., 1., (1. - length(coordsPx * 2. / v_quadSizePx)) * u_blurSlope) * v_weight)',
       );
 
     return new WebGLPointsLayerRenderer(this, {

--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -516,15 +516,21 @@ class Layer extends BaseLayer {
   }
 
   /**
-   * Clean up.
-   * @override
+   * This will clear the renderer so that a new one can be created next time it is needed
    */
-  disposeInternal() {
+  clearRenderer() {
     if (this.renderer_) {
       this.renderer_.dispose();
       delete this.renderer_;
     }
+  }
 
+  /**
+   * Clean up.
+   * @override
+   */
+  disposeInternal() {
+    this.clearRenderer();
     this.setSource(null);
     super.disposeInternal();
   }

--- a/src/ol/layer/WebGLPoints.js
+++ b/src/ol/layer/WebGLPoints.js
@@ -9,6 +9,10 @@ import {parseLiteralStyle} from '../webgl/styleparser.js';
  * @template {import("../source/Vector.js").default<import('../Feature').FeatureLike>} VectorSourceType
  * @typedef {Object} Options
  * @property {import('../style/webgl.js').WebGLStyle} style Literal style to apply to the layer features.
+ * @property {import('../style/flat.js').StyleVariables} [variables] Style variables. Each variable must hold a literal value (not
+ * an expression). These variables can be used as {@link import("../expr/expression.js").ExpressionValue expressions} in the styles properties
+ * using the `['var', 'varName']` operator.
+ * To update style variables, use the {@link import("./WebGLPoints.js").default#updateStyleVariables} method.
  * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
  * @property {number} [opacity=1] Opacity (0, 1).
  * @property {boolean} [visible=true] Visibility.
@@ -77,16 +81,16 @@ class WebGLPointsLayer extends Layer {
     super(baseOptions);
 
     /**
+     * @type {import('../style/flat.js').StyleVariables}
+     * @private
+     */
+    this.styleVariables_ = options.variables || {};
+
+    /**
      * @private
      * @type {import('../webgl/styleparser.js').StyleParseResult}
      */
-    this.parseResult_ = parseLiteralStyle(options.style);
-
-    /**
-     * @type {Object<string, (string|number|Array<number>|boolean)>}
-     * @private
-     */
-    this.styleVariables_ = options.style.variables || {};
+    this.parseResult_ = parseLiteralStyle(options.style, this.styleVariables_);
 
     /**
      * @private

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -123,7 +123,6 @@ function parseStyle(style, bandCount) {
     ...newCompilationContext(),
     inFragmentShader: true,
     bandCount: bandCount,
-    style: style,
   };
 
   const pipeline = [];

--- a/src/ol/layer/WebGLVector.js
+++ b/src/ol/layer/WebGLVector.js
@@ -1,0 +1,120 @@
+/**
+ * @module ol/layer/WebGLVector
+ */
+import Layer from './Layer.js';
+import WebGLVectorLayerRenderer from '../renderer/webgl/VectorLayer.js';
+
+/***
+ * @template T
+ * @typedef {T extends import("../source/Vector.js").default<infer U extends import("../Feature.js").FeatureLike> ? U : never} ExtractedFeatureType
+ */
+
+/**
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorSourceType>]
+ * @typedef {Object} Options
+ * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
+ * @property {number} [opacity=1] Opacity (0, 1).
+ * @property {boolean} [visible=true] Visibility.
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * rendered outside of this extent.
+ * FIXME: not supported yet
+ * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
+ * for layers that are added to the map's `layers` collection, or `Infinity` when the layer's `setMap()`
+ * method was used.
+ * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
+ * visible.
+ * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
+ * be visible.
+ * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will be
+ * visible.
+ * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
+ * be visible.
+ * @property {VectorSourceType} [source] Source.
+ * @property {import('../style/webgl.js').WebGLStyle} style Layer style.
+ * @property {import('../style/flat.js').StyleVariables} [variables] Style variables. Each variable must hold a literal value (not
+ * an expression). These variables can be used as {@link import("../expr/expression.js").ExpressionValue expressions} in the styles properties
+ * using the `['var', 'varName']` operator.
+ * To update style variables, use the {@link import("./WebGLVector.js").default#updateStyleVariables} method.
+ * @property {import("./Base.js").BackgroundColor} [background] Background color for the layer. If not specified, no background
+ * will be rendered.
+ * FIXME: not supported yet
+ * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
+ * prevent all hit detection on the layer.
+ * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
+ */
+
+/**
+ * @classdesc
+ * Layer optimized for rendering large vector datasets.
+ *
+ * **Important: a `WebGLVector` layer must be manually disposed when removed, otherwise the underlying WebGL context
+ * will not be garbage collected.**
+ *
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * property on the layer object; for example, setting `title: 'My Title'` in the
+ * options means that `title` is observable, and has get/set accessors.
+ *
+ * @template {import("../source/Vector.js").default<FeatureType>} [VectorSourceType=import("../source/Vector.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorSourceType>]
+ * @extends {Layer<VectorSourceType, WebGLVectorLayerRenderer>}
+ */
+class WebGLVectorLayer extends Layer {
+  /**
+   * @param {Options<VectorSourceType, FeatureType>} [options] Options.
+   */
+  constructor(options) {
+    const baseOptions = Object.assign({}, options);
+
+    super(baseOptions);
+
+    /**
+     * @type {import('../style/flat.js').StyleVariables}
+     * @private
+     */
+    this.styleVariables_ = options.variables || {};
+
+    /**
+     * @private
+     */
+    this.style = options.style;
+
+    /**
+     * @private
+     */
+    this.hitDetectionDisabled = !!options.disableHitDetection;
+  }
+
+  /**
+   * @override
+   */
+  createRenderer() {
+    return new WebGLVectorLayerRenderer(this, {
+      style: this.style,
+      variables: this.styleVariables_,
+      disableHitDetection: this.hitDetectionDisabled,
+    });
+  }
+
+  /**
+   * Update any variables used by the layer style and trigger a re-render.
+   * @param {import('../style/flat.js').StyleVariables} variables Variables to update.
+   */
+  updateStyleVariables(variables) {
+    Object.assign(this.styleVariables_, variables);
+    this.changed();
+  }
+
+  /**
+   * Set the layer style.
+   * @param {import('../style/webgl.js').WebGLStyle} style Layer style.
+   */
+  setStyle(style) {
+    this.style = style;
+    this.clearRenderer();
+    this.changed();
+  }
+}
+
+export default WebGLVectorLayer;

--- a/src/ol/layer/WebGLVector.js
+++ b/src/ol/layer/WebGLVector.js
@@ -78,12 +78,12 @@ class WebGLVectorLayer extends Layer {
     /**
      * @private
      */
-    this.style = options.style;
+    this.style_ = options.style;
 
     /**
      * @private
      */
-    this.hitDetectionDisabled = !!options.disableHitDetection;
+    this.hitDetectionDisabled_ = !!options.disableHitDetection;
   }
 
   /**
@@ -91,9 +91,9 @@ class WebGLVectorLayer extends Layer {
    */
   createRenderer() {
     return new WebGLVectorLayerRenderer(this, {
-      style: this.style,
+      style: this.style_,
       variables: this.styleVariables_,
-      disableHitDetection: this.hitDetectionDisabled,
+      disableHitDetection: this.hitDetectionDisabled_,
     });
   }
 

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -104,10 +104,11 @@ export const Attributes = {
 class VectorStyleRenderer {
   /**
    * @param {VectorStyle} styleOrShaders Literal style or custom shaders
+   * @param {import('../../style/flat.js').StyleVariables} variables Style variables
    * @param {import('../../webgl/Helper.js').default} helper Helper
    * @param {boolean} enableHitDetection Whether to enable the hit detection (needs compatible shader)
    */
-  constructor(styleOrShaders, helper, enableHitDetection) {
+  constructor(styleOrShaders, variables, helper, enableHitDetection) {
     /**
      * @private
      * @type {import('../../webgl/Helper.js').default}
@@ -125,6 +126,7 @@ class VectorStyleRenderer {
         /** @type {import('../../style/webgl.js').WebGLStyle} */ (
           styleOrShaders
         ),
+        variables,
       );
       shaders = {
         builder: parseResult.builder,

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -227,7 +227,7 @@ class VectorStyleRenderer {
 
     const customAttributesDesc = Object.entries(this.customAttributes_).map(
       ([name, value]) => ({
-        name: `a_prop_${name}`,
+        name: `a_${name}`,
         size: value.size || 1,
         type: AttributeType.FLOAT,
       }),

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -178,7 +178,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     const customAttributes = options.attributes
       ? options.attributes.map(function (attribute) {
           return {
-            name: 'a_prop_' + attribute.name,
+            name: 'a_' + attribute.name,
             size: 1,
             type: AttributeType.FLOAT,
           };
@@ -205,7 +205,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     if (this.hitDetectionEnabled_) {
       this.attributes.push({
-        name: 'a_prop_hitColor',
+        name: 'a_hitColor',
         size: 4,
         type: AttributeType.FLOAT,
       });

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -48,6 +48,7 @@ export const Uniforms = {
  * @typedef {Object} Options
  * @property {string} [className='ol-layer'] A CSS class name to set to the canvas element.
  * @property {VectorStyle|Array<VectorStyle>} style Vector style as literal style or shaders; can also accept an array of styles
+ * @property {Object<string, number|Array<number>|string|boolean>} variables Style variables
  * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
  * prevent all hit detection on the layer.
  * @property {Array<import("./Layer").PostProcessesOptions>} [postProcesses] Post-processes definitions
@@ -139,6 +140,12 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
     this.currentFrameStateTransform_ = createTransform();
 
     /**
+     * @type {import('../../style/flat.js').StyleVariables}
+     * @private
+     */
+    this.styleVariables_ = {};
+
+    /**
      * @type {Array<VectorStyle>}
      * @private
      */
@@ -223,6 +230,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    * @private
    */
   applyOptions_(options) {
+    this.styleVariables_ = options.variables;
     this.styles_ = Array.isArray(options.style)
       ? options.style
       : [options.style];
@@ -235,7 +243,12 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
     this.buffers_ = [];
     this.styleRenderers_ = this.styles_.map(
       (style) =>
-        new VectorStyleRenderer(style, this.helper, this.hitDetectionEnabled_),
+        new VectorStyleRenderer(
+          style,
+          this.styleVariables_,
+          this.helper,
+          this.hitDetectionEnabled_,
+        ),
     );
   }
 

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -362,7 +362,11 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
     // draw the normal canvas
     this.helper.prepareDraw(frameState);
     this.renderWorlds(frameState, false, startWorld, endWorld, worldWidth);
-    this.helper.finalizeDraw(frameState);
+    this.helper.finalizeDraw(
+      frameState,
+      this.dispatchPreComposeEvent,
+      this.dispatchPostComposeEvent,
+    );
 
     const canvas = this.helper.getCanvas();
     const layerState = frameState.layerStatesArray[frameState.layerIndex];

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -42,6 +42,9 @@ export const Attributes = {
 /**
  * @typedef {Object} Options
  * @property {VectorStyle|Array<VectorStyle>} style Vector style as literal style or shaders; can also accept an array of styles
+ * @property {import('../../style/flat.js').StyleVariables} [variables] Style variables. Each variable must hold a literal value (not
+ * an expression). These variables can be used as {@link import("../../expr/expression.js").ExpressionValue expressions} in the styles properties
+ * using the `['var', 'varName']` operator.
  * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
  * prevent all hit detection on the layer.
  * @property {number} [cacheSize=512] The vector tile cache size.
@@ -81,6 +84,12 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
      * @private
      */
     this.styles_ = [];
+
+    /**
+     * @type {import('../../style/flat.js').StyleVariables}
+     * @private
+     */
+    this.styleVariables_ = options.variables || {};
 
     /**
      * @type {Array<VectorStyleRenderer>}
@@ -188,6 +197,7 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       if (!isShaders) {
         const parseResult = parseLiteralStyle(
           /** @type {import('../../style/webgl.js').WebGLStyle} */ (style),
+          this.styleVariables_,
         );
         addBuilderParams(parseResult.builder);
         shaders = {
@@ -205,6 +215,7 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       }
       return new VectorStyleRenderer(
         shaders,
+        this.styleVariables_,
         this.helper,
         this.hitDetectionEnabled_,
       );

--- a/src/ol/style/flat.js
+++ b/src/ol/style/flat.js
@@ -300,3 +300,10 @@ export function createDefaultStyle() {
  * @property {boolean} [else] If true, the rule applies only if no other previous rule applies.
  * If the else rule also has a filter, the rule will not apply if the filter does not match.
  */
+
+/**
+ * Style variables are provided as an object. The variables can be read in a {@link import("../expr/expression.js").ExpressionValue style expression}
+ * using the `['var', 'varName']` operator.
+ * Each variable must hold a literal value (not an expression).
+ * @typedef {Object<string, number|Array<number>|string|boolean>} StyleVariables
+ */

--- a/src/ol/style/webgl.js
+++ b/src/ol/style/webgl.js
@@ -14,8 +14,6 @@
  * @typedef {Object} BaseProps
  * @property {ExpressionValue} [filter] Filter expression. If it resolves to a number strictly greater than 0, the
  * point will be displayed. If undefined, all points will show.
- * @property {Object<string, number | Array<number> | string | boolean>} [variables] Style variables; each variable must hold a number.
- * Note: **this object is meant to be mutated**: changes to the values will immediately be visible on the rendered features
  */
 
 /**

--- a/src/ol/webgl/ShaderBuilder.js
+++ b/src/ol/webgl/ShaderBuilder.js
@@ -479,7 +479,7 @@ ${this.uniforms_
   .join('\n')}
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
@@ -487,7 +487,7 @@ ${this.attributes_
   .join('\n')}
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -531,7 +531,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -561,7 +561,7 @@ ${this.uniforms_
   })
   .join('\n')}
 varying vec2 v_texCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -582,7 +582,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`;
   }
@@ -609,7 +609,7 @@ attribute float a_measureEnd;
 attribute float a_parameters;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
@@ -620,7 +620,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_measureStart;
 varying float v_measureEnd;
@@ -699,7 +699,7 @@ void main(void) {
   v_segmentStart = segmentStartPx;
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
   v_measureStart = a_measureStart;
   v_measureEnd = a_measureEnd;
@@ -732,7 +732,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_measureStart;
 varying float v_measureEnd;
@@ -870,7 +870,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`;
   }
@@ -892,13 +892,13 @@ ${this.uniforms_
   })
   .join('\n')}
 attribute vec2 a_position;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 ${this.attributes_
   .map(function (attribute) {
     return 'attribute ' + attribute + ';';
   })
   .join('\n')}
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return 'varying ' + varying.type + ' ' + varying.name + ';';
@@ -907,7 +907,7 @@ ${this.varyings_
 ${this.vertexShaderFunctions_.join('\n')}
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, u_depth, 1.0);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return '  ' + varying.name + ' = ' + varying.expression + ';';
@@ -931,7 +931,7 @@ ${this.uniforms_
     return 'uniform ' + uniform + ';';
   })
   .join('\n')}
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 ${this.varyings_
   .map(function (varying) {
     return 'varying ' + varying.type + ' ' + varying.name + ';';
@@ -970,7 +970,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`;
   }

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -861,9 +861,10 @@ function parseFillProperties(
  * {@link module:ol/renderer/webgl/PointsLayer~WebGLPointsLayerRenderer}.
  *
  * @param {import("../style/webgl.js").WebGLStyle} style Literal style.
+ * @param {import('../style/flat.js').StyleVariables} variables Style variables.
  * @return {StyleParseResult} Result containing shader params, attributes and uniforms.
  */
-export function parseLiteralStyle(style) {
+export function parseLiteralStyle(style, variables) {
   /**
    * @type {import("../expr/gpu.js").CompilationContext}
    */
@@ -922,7 +923,7 @@ export function parseLiteralStyle(style) {
     builder.addUniform(`${glslType} ${uniformName}`);
 
     uniforms[uniformName] = () => {
-      const value = style.variables[variable.name];
+      const value = variables[variable.name];
       if (typeof value === 'number') {
         return value;
       }

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -988,7 +988,7 @@ export function parseLiteralStyle(style, variables) {
       return value;
     };
 
-    attributes[property.name] = {
+    attributes[`prop_${property.name}`] = {
       size: getGlslSizeFromType(property.type),
       callback,
     };

--- a/src/ol/webgl/styleparser.js
+++ b/src/ol/webgl/styleparser.js
@@ -914,7 +914,12 @@ export function parseLiteralStyle(style) {
   for (const varName in fragContext.variables) {
     const variable = fragContext.variables[varName];
     const uniformName = uniformNameForVariable(variable.name);
-    builder.addUniform(`${getGlslTypeFromType(variable.type)} ${uniformName}`);
+    let glslType = getGlslTypeFromType(variable.type);
+    if (variable.type === ColorType) {
+      // we're not packing colors when they're passed as uniforms
+      glslType = 'vec4';
+    }
+    builder.addUniform(`${glslType} ${uniformName}`);
 
     uniforms[uniformName] = () => {
       const value = style.variables[variable.name];
@@ -925,7 +930,7 @@ export function parseLiteralStyle(style) {
         return value ? 1 : 0;
       }
       if (variable.type === ColorType) {
-        return packColor([...asArray(value || '#eee')]);
+        return asArray(value || '#eee');
       }
       if (typeof value === 'string') {
         return getStringNumberEquivalent(value);

--- a/test/browser/spec/ol/layer/WebGLVector.test.js
+++ b/test/browser/spec/ol/layer/WebGLVector.test.js
@@ -1,0 +1,189 @@
+import Map from '../../../../../src/ol/Map.js';
+import VectorSource from '../../../../../src/ol/source/Vector.js';
+import View from '../../../../../src/ol/View.js';
+import WebGLVectorLayer from '../../../../../src/ol/layer/WebGLVector.js';
+import WebGLVectorLayerRenderer from '../../../../../src/ol/renderer/webgl/VectorLayer.js';
+import {getRenderPixel} from '../../../../../src/ol/render.js';
+
+describe('ol/layer/WebGLVector', function () {
+  /** @type {WebGLVectorLayer} */
+  let layer;
+  /** @type {Map} */
+  let map, target;
+
+  beforeEach(function (done) {
+    layer = new WebGLVectorLayer({
+      className: 'testlayer',
+      source: new VectorSource(),
+      style: [
+        {
+          'circle-radius': 4,
+          'circle-fill-color': ['var', 'fillColor'],
+        },
+        {
+          'fill-color': ['var', 'fillColor'],
+        },
+      ],
+      variables: {
+        fillColor: 'rgba(255, 0, 0, 0.5)',
+      },
+      disableHitDetection: false,
+    });
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    document.body.appendChild(target);
+    map = new Map({
+      target: target,
+      layers: [layer],
+      view: new View({
+        center: [0, 0],
+        zoom: 2,
+      }),
+    });
+    map.once('rendercomplete', () => done());
+  });
+
+  afterEach(function () {
+    disposeMap(map);
+    map.getLayers().forEach((layer) => layer.dispose());
+  });
+
+  describe('dispose()', () => {
+    it('calls dispose on the renderer', () => {
+      const renderer = layer.getRenderer();
+      const spy = sinon.spy(renderer, 'dispose');
+      layer.dispose();
+      expect(spy.called).to.be(true);
+    });
+  });
+
+  it('creates a renderer with the given parameters', function () {
+    const renderer = layer.getRenderer();
+    expect(renderer).to.be.a(WebGLVectorLayerRenderer);
+    expect(renderer.styles_).to.eql([
+      {
+        'circle-radius': 4,
+        'circle-fill-color': ['var', 'fillColor'],
+      },
+      {
+        'fill-color': ['var', 'fillColor'],
+      },
+    ]);
+    expect(renderer.styleVariables_).to.eql({
+      fillColor: 'rgba(255, 0, 0, 0.5)',
+    });
+    expect(renderer.hitDetectionEnabled_).to.be(true);
+  });
+
+  describe('updateStyleVariables()', function () {
+    it('updates style variables', function () {
+      layer.updateStyleVariables({
+        fillColor: 'yellow',
+      });
+      expect(layer.styleVariables_['fillColor']).to.be('yellow');
+      const renderer = layer.getRenderer();
+      const uniforms = renderer.styleRenderers_[0].uniforms_;
+      expect(uniforms.u_var_fillColor()).to.eql([255, 255, 0, 1]);
+    });
+
+    it('can be called before the layer is rendered', function () {
+      layer = new WebGLVectorLayer({
+        style: {
+          'fill-color': ['var', 'fillColor'],
+        },
+        source: new VectorSource(),
+      });
+
+      layer.updateStyleVariables({foo: 'bam'});
+      expect(layer.styleVariables_.foo).to.be('bam');
+    });
+
+    it('can be called even if no initial variables are provided', function () {
+      const layer = new WebGLVectorLayer({
+        source: new VectorSource(),
+      });
+
+      layer.updateStyleVariables({foo: 'bam'});
+      expect(layer.styleVariables_.foo).to.be('bam');
+    });
+  });
+
+  it('dispatches a precompose event with WebGL context', (done) => {
+    let called = false;
+    layer.on('precompose', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('dispatches a prerender event with WebGL context and inverse pixel transform', (done) => {
+    let called = false;
+    layer.on('prerender', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      const mapSize = event.frameState.size;
+      const bottomLeft = getRenderPixel(event, [0, mapSize[1]]);
+      expect(bottomLeft).to.eql([0, 0]);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('dispatches a postrender event with WebGL context and inverse pixel transform', (done) => {
+    let called = false;
+    layer.on('postrender', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      const mapSize = event.frameState.size;
+      const topRight = getRenderPixel(event, [mapSize[1], 0]);
+      const pixelRatio = event.frameState.pixelRatio;
+      expect(topRight).to.eql([
+        mapSize[0] * pixelRatio,
+        mapSize[1] * pixelRatio,
+      ]);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('works if the layer is constructed without a source', (done) => {
+    const sourceless = new WebGLVectorLayer({
+      className: 'testlayer',
+      style: {
+        'fill-color': 'red',
+      },
+    });
+
+    map.addLayer(sourceless);
+
+    sourceless.setSource(new VectorSource());
+
+    let called = false;
+    layer.on('postrender', (event) => {
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+  });
+});

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -110,7 +110,7 @@ describe('VectorStyleRenderer', () => {
 
   describe('constructor using style', () => {
     beforeEach(() => {
-      vectorStyleRenderer = new VectorStyleRenderer(SAMPLE_STYLE, helper);
+      vectorStyleRenderer = new VectorStyleRenderer(SAMPLE_STYLE, {}, helper);
     });
     it('creates a VectorStyleRenderer', () => {
       expect(vectorStyleRenderer.customAttributes_).to.eql({
@@ -153,7 +153,11 @@ describe('VectorStyleRenderer', () => {
   });
   describe('constructor using shaders', () => {
     beforeEach(() => {
-      vectorStyleRenderer = new VectorStyleRenderer(SAMPLE_SHADERS(), helper);
+      vectorStyleRenderer = new VectorStyleRenderer(
+        SAMPLE_SHADERS(),
+        {},
+        helper,
+      );
     });
     it('creates a VectorStyleRenderer', () => {
       expect(vectorStyleRenderer.customAttributes_).to.eql({
@@ -197,7 +201,11 @@ describe('VectorStyleRenderer', () => {
   });
   describe('methods', () => {
     beforeEach(() => {
-      vectorStyleRenderer = new VectorStyleRenderer(SAMPLE_SHADERS(), helper);
+      vectorStyleRenderer = new VectorStyleRenderer(
+        SAMPLE_SHADERS(),
+        {},
+        helper,
+      );
     });
     describe('generateBuffers', () => {
       let buffers;
@@ -335,7 +343,11 @@ describe('VectorStyleRenderer', () => {
       sinon.spy(helper, 'enableAttributes');
       sinon.spy(helper, 'useProgram');
       sinon.spy(helper, 'drawElements');
-      vectorStyleRenderer = new VectorStyleRenderer(fillOnlyShaders, helper);
+      vectorStyleRenderer = new VectorStyleRenderer(
+        fillOnlyShaders,
+        {},
+        helper,
+      );
       buffers = await vectorStyleRenderer.generateBuffers(
         geometryBatch,
         SAMPLE_TRANSFORM,
@@ -376,7 +388,11 @@ describe('VectorStyleRenderer', () => {
       sinon.spy(helper, 'enableAttributes');
       sinon.spy(helper, 'useProgram');
       sinon.spy(helper, 'drawElements');
-      vectorStyleRenderer = new VectorStyleRenderer(strokeOnlyShaders, helper);
+      vectorStyleRenderer = new VectorStyleRenderer(
+        strokeOnlyShaders,
+        {},
+        helper,
+      );
       buffers = await vectorStyleRenderer.generateBuffers(
         geometryBatch,
         SAMPLE_TRANSFORM,
@@ -417,7 +433,11 @@ describe('VectorStyleRenderer', () => {
       sinon.spy(helper, 'enableAttributes');
       sinon.spy(helper, 'useProgram');
       sinon.spy(helper, 'drawElements');
-      vectorStyleRenderer = new VectorStyleRenderer(symbolOnlyShaders, helper);
+      vectorStyleRenderer = new VectorStyleRenderer(
+        symbolOnlyShaders,
+        {},
+        helper,
+      );
       buffers = await vectorStyleRenderer.generateBuffers(
         geometryBatch,
         SAMPLE_TRANSFORM,

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -28,10 +28,10 @@ const SAMPLE_SHADERS = () => ({
     .setStrokeColorExpression('vec4(1.0)')
     .setSymbolColorExpression('vec4(1.0)'),
   attributes: {
-    attr1: {
+    prop_attr1: {
       callback: (feature) => feature.get('test'),
     },
-    attr2: {callback: () => [10, 20, 30], size: 3},
+    prop_attr2: {callback: () => [10, 20, 30], size: 3},
   },
   uniforms: {
     custom: () => 1234,
@@ -114,11 +114,11 @@ describe('VectorStyleRenderer', () => {
     });
     it('creates a VectorStyleRenderer', () => {
       expect(vectorStyleRenderer.customAttributes_).to.eql({
-        color: {
+        prop_color: {
           callback: {},
           size: 2,
         },
-        size: {
+        prop_size: {
           callback: {},
           size: 1,
         },
@@ -161,10 +161,10 @@ describe('VectorStyleRenderer', () => {
     });
     it('creates a VectorStyleRenderer', () => {
       expect(vectorStyleRenderer.customAttributes_).to.eql({
-        attr1: {
+        prop_attr1: {
           callback: {},
         },
-        attr2: {
+        prop_attr2: {
           callback: {},
           size: 3,
         },

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -778,12 +778,12 @@ describe('ol/renderer/webgl/PointsLayer', function () {
         source: new VectorSource({
           features: [new Feature(new Point([0, 0]))],
         }),
+        variables: {
+          r: 0,
+          g: 255,
+          b: 0,
+        },
         style: {
-          variables: {
-            r: 0,
-            g: 255,
-            b: 0,
-          },
           'circle-radius': 14,
           'circle-fill-color': [
             'color',

--- a/test/browser/spec/ol/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/webgl/shaderbuilder.test.js
@@ -24,11 +24,11 @@ describe('ol.webgl.ShaderBuilder', () => {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -69,7 +69,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -92,11 +92,11 @@ void main(void) {
 uniform float u_myUniform;
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -136,7 +136,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -157,11 +157,11 @@ void main(void) {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -201,7 +201,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -221,11 +221,11 @@ void main(void) {
 
 attribute vec2 a_position;
 attribute float a_index;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
 varying vec2 v_quadCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -265,7 +265,7 @@ void main(void) {
   float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
   float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
   v_texCoord = vec2(u, v);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_angle = angle;
   c = cos(-v_angle);
   s = sin(-v_angle);
@@ -296,7 +296,7 @@ void main(void) {
       expect(builder.getSymbolFragmentShader()).to.eql(`${COMMON_HEADER}
 
 varying vec2 v_texCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -314,7 +314,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`);
     });
@@ -332,7 +332,7 @@ void main(void) {
 uniform float u_myUniform;
 uniform vec2 u_myUniform2;
 varying vec2 v_texCoord;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying vec2 v_centerPx;
 varying float v_angle;
 varying vec2 v_quadSizePx;
@@ -349,7 +349,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.05) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`);
     });
@@ -390,14 +390,14 @@ attribute float a_measureEnd;
 attribute float a_parameters;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
 varying vec2 v_segmentStart;
 varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_measureStart;
 varying float v_measureEnd;
@@ -473,7 +473,7 @@ void main(void) {
   v_segmentStart = segmentStartPx;
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
   v_measureStart = a_measureStart;
   v_measureEnd = a_measureEnd;
@@ -496,7 +496,7 @@ varying vec2 v_segmentEnd;
 varying float v_angleStart;
 varying float v_angleEnd;
 varying float v_width;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_distanceOffsetPx;
 varying float v_measureStart;
 varying float v_measureEnd;
@@ -631,7 +631,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`);
       });
@@ -656,15 +656,15 @@ void main(void) {
       expect(builder.getFillVertexShader()).to.eql(`${COMMON_HEADER}
 uniform float u_myUniform;
 attribute vec2 a_position;
-attribute vec4 a_prop_hitColor;
+attribute vec4 a_hitColor;
 attribute vec2 a_myAttr;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
 void main(void) {
   gl_Position = u_projectionMatrix * vec4(a_position, u_depth, 1.0);
-  v_prop_hitColor = a_prop_hitColor;
+  v_hitColor = a_hitColor;
   v_opacity = 0.4;
   v_test = vec3(1.0, 2.0, 3.0);
 }`);
@@ -687,7 +687,7 @@ void main(void) {
 
       expect(builder.getFillFragmentShader()).to.eql(`${COMMON_HEADER}
 uniform float u_myUniform;
-varying vec4 v_prop_hitColor;
+varying vec4 v_hitColor;
 varying float v_opacity;
 varying vec3 v_test;
 
@@ -723,7 +723,7 @@ void main(void) {
   gl_FragColor.rgb *= gl_FragColor.a;
   if (u_hitDetection > 0) {
     if (gl_FragColor.a < 0.1) { discard; };
-    gl_FragColor = v_prop_hitColor;
+    gl_FragColor = v_hitColor;
   }
 }`);
     });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -55,7 +55,7 @@ describe('ol/webgl/styleparser', () => {
         `vec2(mix(4.0, 8.0, clamp((a_prop_population - u_var_lower) / (u_var_higher - u_var_lower), 0.0, 1.0)) * 2. + 0.5)`,
       );
       expect(Object.keys(result.attributes).length).to.eql(1);
-      expect(result.attributes).to.have.property('population');
+      expect(result.attributes).to.have.property('prop_population');
       expect(result.uniforms).to.have.property(lowerUniformName);
       expect(result.uniforms).to.have.property(higherUniformName);
     });
@@ -85,7 +85,7 @@ describe('ol/webgl/styleparser', () => {
         '!(v_prop_attr0 >= 0.0 && v_prop_attr0 <= 10.0)',
       );
       expect(Object.keys(result.attributes).length).to.eql(1);
-      expect(result.attributes).to.have.property('attr0');
+      expect(result.attributes).to.have.property('prop_attr0');
     });
 
     it('correctly adds string variables to the string literals mapping', () => {
@@ -165,10 +165,10 @@ describe('ol/webgl/styleparser', () => {
           );
           expect(result.builder.symbolRotateWithView_).to.eql(true);
           expect(Object.keys(result.attributes).length).to.eql(4);
-          expect(result.attributes).to.have.property('attr1');
-          expect(result.attributes).to.have.property('heading');
-          expect(result.attributes).to.have.property('color1');
-          expect(result.attributes).to.have.property('color2');
+          expect(result.attributes).to.have.property('prop_attr1');
+          expect(result.attributes).to.have.property('prop_heading');
+          expect(result.attributes).to.have.property('prop_color1');
+          expect(result.attributes).to.have.property('prop_color2');
           expect(result.uniforms).to.eql({});
         });
       });
@@ -269,10 +269,10 @@ describe('ol/webgl/styleparser', () => {
           );
           expect(result.builder.symbolRotateWithView_).to.eql(true);
           expect(Object.keys(result.attributes).length).to.eql(4);
-          expect(result.attributes).to.have.property('attr1');
-          expect(result.attributes).to.have.property('heading');
-          expect(result.attributes).to.have.property('color1');
-          expect(result.attributes).to.have.property('color2');
+          expect(result.attributes).to.have.property('prop_attr1');
+          expect(result.attributes).to.have.property('prop_heading');
+          expect(result.attributes).to.have.property('prop_color1');
+          expect(result.attributes).to.have.property('prop_color2');
           expect(result.uniforms).to.eql({});
         });
       });
@@ -370,9 +370,9 @@ describe('ol/webgl/styleparser', () => {
           );
           expect(result.builder.symbolRotateWithView_).to.eql(true);
           expect(Object.keys(result.attributes).length).to.eql(3);
-          expect(result.attributes).to.have.property('attr1');
-          expect(result.attributes).to.have.property('heading');
-          expect(result.attributes).to.have.property('color1');
+          expect(result.attributes).to.have.property('prop_attr1');
+          expect(result.attributes).to.have.property('prop_heading');
+          expect(result.attributes).to.have.property('prop_color1');
           expect(Object.keys(result.uniforms).length).to.eql(2);
           expect(result.uniforms).to.have.property(`u_texture${uid}_size`);
           expect(result.uniforms).to.have.property(`u_texture${uid}`);
@@ -708,9 +708,9 @@ describe('ol/webgl/styleparser', () => {
             'dashDistanceField_450289113(currentLengthPx + (u_time * 5.0), currentRadiusPx, capType)',
           );
           expect(Object.keys(result.attributes).length).to.eql(3);
-          expect(result.attributes).to.have.property('intensity');
-          expect(result.attributes).to.have.property('offset');
-          expect(result.attributes).to.have.property('size');
+          expect(result.attributes).to.have.property('prop_intensity');
+          expect(result.attributes).to.have.property('prop_offset');
+          expect(result.attributes).to.have.property('prop_size');
           expect(result.uniforms).to.have.property('u_var_width');
           expect(result.uniforms).to.have.property('u_var_capType');
           expect(result.uniforms).to.have.property('u_var_joinType');
@@ -836,7 +836,7 @@ describe('ol/webgl/styleparser', () => {
             'mix(vec4(0.0, 0.0, 1.0, 1.0), vec4(1.0, 0.0, 0.0, 1.0), clamp(((v_prop_intensity * u_var_scale) - 0.0) / (10.0 - 0.0), 0.0, 1.0))',
           );
           expect(Object.keys(result.attributes).length).to.eql(1);
-          expect(result.attributes).to.have.property('intensity');
+          expect(result.attributes).to.have.property('prop_intensity');
           expect(result.uniforms).to.have.property('u_var_scale');
         });
       });
@@ -914,7 +914,7 @@ describe('ol/webgl/styleparser', () => {
         );
         expect(result.attributes).to.eql({
           geometryType: {size: 1, callback: {}},
-          type: {size: 1, callback: {}},
+          prop_type: {size: 1, callback: {}},
         });
       });
     });
@@ -986,12 +986,12 @@ describe('ol/webgl/styleparser', () => {
       });
       it('returns attributes with their callbacks in the result', () => {
         expect(parseResult.attributes).to.eql({
-          iconSize: {size: 2, callback: {}},
-          color: {size: 2, callback: {}},
-          lineType: {size: 1, callback: {}},
-          lineWidth: {size: 1, callback: {}},
-          transparent: {size: 1, callback: {}},
-          fillColor: {size: 2, callback: {}},
+          prop_iconSize: {size: 2, callback: {}},
+          prop_color: {size: 2, callback: {}},
+          prop_lineType: {size: 1, callback: {}},
+          prop_lineWidth: {size: 1, callback: {}},
+          prop_transparent: {size: 1, callback: {}},
+          prop_fillColor: {size: 2, callback: {}},
         });
       });
       it('processes the feature attributes according to their types', () => {
@@ -1004,24 +1004,24 @@ describe('ol/webgl/styleparser', () => {
           transparent: true,
           geometry: new Point([0, 0]),
         });
-        expect(parseResult.attributes['iconSize'].callback(feature)).to.eql([
-          12, 18,
-        ]);
-        expect(parseResult.attributes['color'].callback(feature)).to.eql(
+        expect(
+          parseResult.attributes['prop_iconSize'].callback(feature),
+        ).to.eql([12, 18]);
+        expect(parseResult.attributes['prop_color'].callback(feature)).to.eql(
           packColor(asArray('pink')),
         );
-        expect(parseResult.attributes['lineType'].callback(feature)).to.be.a(
-          'number',
-        );
-        expect(parseResult.attributes['lineWidth'].callback(feature)).to.eql(
-          0.5,
-        );
-        expect(parseResult.attributes['fillColor'].callback(feature)).to.eql(
-          packColor(asArray('rgba(123, 240, 100, 0.3)')),
-        );
-        expect(parseResult.attributes['transparent'].callback(feature)).to.eql(
-          1,
-        );
+        expect(
+          parseResult.attributes['prop_lineType'].callback(feature),
+        ).to.be.a('number');
+        expect(
+          parseResult.attributes['prop_lineWidth'].callback(feature),
+        ).to.eql(0.5);
+        expect(
+          parseResult.attributes['prop_fillColor'].callback(feature),
+        ).to.eql(packColor(asArray('rgba(123, 240, 100, 0.3)')));
+        expect(
+          parseResult.attributes['prop_transparent'].callback(feature),
+        ).to.eql(1);
       });
     });
 
@@ -1194,7 +1194,7 @@ describe('ol/webgl/styleparser', () => {
         ],
       });
 
-      expect(result.attributes.foo.callback({get: () => 'green'})).to.be.a(
+      expect(result.attributes.prop_foo.callback({get: () => 'green'})).to.be.a(
         'number',
       );
     });

--- a/test/browser/spec/ol/webgl/styleparser.test.js
+++ b/test/browser/spec/ol/webgl/styleparser.test.js
@@ -1062,11 +1062,11 @@ describe('ol/webgl/styleparser', () => {
       it('adds uniforms to the shader builder', () => {
         expect(parseResult.builder.uniforms_).to.eql([
           'vec2 u_var_iconSize',
-          'vec2 u_var_color',
+          'vec4 u_var_color',
           'float u_var_lineType',
           'float u_var_lineWidth',
           'float u_var_transparent',
-          'vec2 u_var_fillColor',
+          'vec4 u_var_fillColor',
         ]);
       });
       it('returns uniforms in the result', () => {
@@ -1081,13 +1081,11 @@ describe('ol/webgl/styleparser', () => {
       });
       it('processes uniforms according to their types', () => {
         expect(parseResult.uniforms['u_var_iconSize']()).to.eql([12, 18]);
-        expect(parseResult.uniforms['u_var_color']()).to.eql(
-          packColor(asArray('pink')),
-        );
+        expect(parseResult.uniforms['u_var_color']()).to.eql(asArray('pink'));
         expect(parseResult.uniforms['u_var_lineType']()).to.be.a('number');
         expect(parseResult.uniforms['u_var_lineWidth']()).to.eql(0.5);
         expect(parseResult.uniforms['u_var_fillColor']()).to.eql(
-          packColor(asArray('rgba(123, 240, 100, 0.3)')),
+          asArray('rgba(123, 240, 100, 0.3)'),
         );
         expect(parseResult.uniforms['u_var_transparent']()).to.eql(1);
       });

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -1,4 +1,3 @@
-import Feature from '../../../../src/ol/Feature.js';
 import expect from '../../expect.js';
 import {
   AnyType,
@@ -11,7 +10,6 @@ import {
   newParsingContext,
 } from '../../../../src/ol/expr/expression.js';
 import {
-  FEATURE_ID_PROPERTY_NAME,
   arrayToGlsl,
   buildExpression,
   colorToGlsl,
@@ -20,7 +18,6 @@ import {
   numberToGlsl,
   stringToGlsl,
 } from '../../../../src/ol/expr/gpu.js';
-import {MultiPolygon} from '../../../../src/ol/geom.js';
 
 describe('ol/expr/gpu.js', () => {
   describe('numberToGlsl()', () => {
@@ -142,23 +139,16 @@ describe('ol/expr/gpu.js', () => {
         name: 'id',
         type: AnyType,
         expression: ['id'],
-        expected: 'a_prop_OL_FEATURE_ID',
+        expected: 'a_featureId',
         contextAssertion: (context) => {
-          const prop = context.properties[FEATURE_ID_PROPERTY_NAME];
-          expect(prop.name).to.equal(FEATURE_ID_PROPERTY_NAME);
-          expect(prop.type).to.equal(StringType | NumberType);
-          expect(prop.evaluator).to.be.an(Function);
-          const feature = new Feature();
-          expect(prop.evaluator(feature)).to.eql(null);
-          feature.setId(1234);
-          expect(prop.evaluator(feature)).to.eql(1234);
+          expect(context.featureId).to.be(true);
         },
       },
       {
         name: 'id (in fragment shader)',
         type: AnyType,
         expression: ['id'],
-        expected: 'v_prop_OL_FEATURE_ID',
+        expected: 'v_featureId',
         context: {
           inFragmentShader: true,
         },
@@ -185,14 +175,9 @@ describe('ol/expr/gpu.js', () => {
         name: 'geometry-type',
         type: AnyType,
         expression: ['geometry-type'],
-        expected: 'a_prop_geometryType',
+        expected: 'a_geometryType',
         contextAssertion: (context) => {
-          const prop = context.properties['geometryType'];
-          expect(prop.name).to.equal('geometryType');
-          expect(prop.type).to.equal(StringType);
-          expect(prop.evaluator).to.be.an(Function);
-          const feature = new Feature(new MultiPolygon([]));
-          expect(prop.evaluator(feature)).to.eql('Polygon');
+          expect(context.geometryType).to.be(true);
         },
       },
       {
@@ -202,7 +187,7 @@ describe('ol/expr/gpu.js', () => {
         context: {
           inFragmentShader: true,
         },
-        expected: 'v_prop_geometryType',
+        expected: 'v_geometryType',
       },
       {
         name: 'line-metric',

--- a/test/rendering/cases/webgl-circles/main.js
+++ b/test/rendering/cases/webgl-circles/main.js
@@ -1,11 +1,10 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 
 const blueCircle = {
@@ -41,15 +40,7 @@ const scaledRotateWithView = {
 };
 const style = [blueCircle, dataDriven, scaledRotated, scaledRotateWithView];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [
       new Feature({
@@ -58,6 +49,7 @@ const vector = new WebGLLayer({
       }),
     ],
   }),
+  style,
 });
 
 const raster = new TileLayer({

--- a/test/rendering/cases/webgl-fill-pattern/main.js
+++ b/test/rendering/cases/webgl-fill-pattern/main.js
@@ -1,10 +1,9 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
-import Polygon from 'ol/geom/Polygon.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 
 const polygon1 = new Feature({
   geometry: new Polygon([
@@ -67,27 +66,19 @@ const subImageTint = {
   'fill-color': 'red',
 };
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style: this.get('style'),
-    });
-  }
-}
-
-const vector1 = new WebGLLayer({
+const vector1 = new WebGLVectorLayer({
   style: srcPattern,
   source: new VectorSource({
     features: [polygon1],
   }),
 });
-const vector2 = new WebGLLayer({
+const vector2 = new WebGLVectorLayer({
   style: imagePattern,
   source: new VectorSource({
     features: [polygon2],
   }),
 });
-const vector3 = new WebGLLayer({
+const vector3 = new WebGLVectorLayer({
   style: subImageTint,
   source: new VectorSource({
     features: [polygon3],

--- a/test/rendering/cases/webgl-holes/main.js
+++ b/test/rendering/cases/webgl-holes/main.js
@@ -1,9 +1,8 @@
 import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 
 /**
  * This is a properly oriented polygon.  The exterior ring is oriented counterclockwise
@@ -38,24 +37,17 @@ const data = {
 
 const format = new GeoJSON({featureProjection: 'EPSG:3857'});
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
+new Map({
+  layers: [
+    new WebGLVectorLayer({
+      source: new VectorSource({
+        features: format.readFeatures(data),
+      }),
       style: {
         'fill-color': '#ddd',
         'stroke-color': 'red',
         'stroke-width': 2,
       },
-    });
-  }
-}
-
-new Map({
-  layers: [
-    new WebGLLayer({
-      source: new VectorSource({
-        features: format.readFeatures(data),
-      }),
     }),
   ],
   target: 'map',

--- a/test/rendering/cases/webgl-icons/main.js
+++ b/test/rendering/cases/webgl-icons/main.js
@@ -1,11 +1,10 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 
 // generate an icon
@@ -64,15 +63,7 @@ const style = [
   withAnchor,
 ];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [
       new Feature({
@@ -81,6 +72,7 @@ const vector = new WebGLLayer({
       }),
     ],
   }),
+  style,
 });
 
 const raster = new TileLayer({

--- a/test/rendering/cases/webgl-line-metric/main.js
+++ b/test/rendering/cases/webgl-line-metric/main.js
@@ -1,12 +1,11 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Map from '../../../../src/ol/Map.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 
 const openLine = new Feature({
   geometry: new LineString(
@@ -77,18 +76,11 @@ const shouldNotShowUp = {
 
 const style = [filterAbove, widthChanges, colorInterpolation, shouldNotShowUp];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [openLine, polygon, point],
   }),
+  style,
 });
 
 new Map({

--- a/test/rendering/cases/webgl-line-pattern/main.js
+++ b/test/rendering/cases/webgl-line-pattern/main.js
@@ -1,10 +1,9 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Map from '../../../../src/ol/Map.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 
 const line = new Feature({
   geometry: new LineString([
@@ -59,18 +58,11 @@ const subImage = {
 };
 const style = [srcPattern, imagePattern, withTint, subImage];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [line],
   }),
+  style,
 });
 
 const map = new Map({

--- a/test/rendering/cases/webgl-line/main.js
+++ b/test/rendering/cases/webgl-line/main.js
@@ -1,10 +1,9 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import LineString from '../../../../src/ol/geom/LineString.js';
 import Map from '../../../../src/ol/Map.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 
 const openLine = new Feature({
   geometry: new LineString([
@@ -61,18 +60,11 @@ const dashed = {
 };
 const style = [bevelJoins, dataDriven, miterJoins, dashed];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [openLine, closedLine],
   }),
+  style,
 });
 
 new Map({

--- a/test/rendering/cases/webgl-shapes/main.js
+++ b/test/rendering/cases/webgl-shapes/main.js
@@ -1,11 +1,10 @@
 import Feature from '../../../../src/ol/Feature.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import Point from '../../../../src/ol/geom/Point.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 
 const blueStar = {
@@ -49,15 +48,7 @@ const scaledRotateWithView = {
 };
 const style = [blueStar, dataDriven, scaledRotated, scaledRotateWithView];
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      style,
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features: [
       new Feature({
@@ -66,6 +57,7 @@ const vector = new WebGLLayer({
       }),
     ],
   }),
+  style,
 });
 
 const raster = new TileLayer({

--- a/test/rendering/cases/webgl-vector-geographic/main.js
+++ b/test/rendering/cases/webgl-vector-geographic/main.js
@@ -1,25 +1,11 @@
 import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 import {useGeographic} from '../../../../src/ol/proj.js';
 
 useGeographic();
-
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      className: this.getClassName(),
-      style: {
-        'fill-color': '#ddd',
-        'stroke-color': '#00AAFF',
-        'stroke-width': 1,
-      },
-    });
-  }
-}
 
 const format = new GeoJSON();
 const features = format.readFeatures({
@@ -43,10 +29,15 @@ const features = format.readFeatures({
   ],
 });
 
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     features,
   }),
+  style: {
+    'fill-color': '#ddd',
+    'stroke-color': '#00AAFF',
+    'stroke-width': 1,
+  },
 });
 
 new Map({

--- a/test/rendering/cases/webgl-vector/main.js
+++ b/test/rendering/cases/webgl-vector/main.js
@@ -1,30 +1,21 @@
 import GeoJSON from '../../../../src/ol/format/GeoJSON.js';
-import Layer from '../../../../src/ol/layer/Layer.js';
 import Map from '../../../../src/ol/Map.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 import View from '../../../../src/ol/View.js';
-import WebGLVectorLayerRenderer from '../../../../src/ol/renderer/webgl/VectorLayer.js';
+import WebGLVectorLayer from '../../../../src/ol/layer/WebGLVector.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 
-class WebGLLayer extends Layer {
-  createRenderer() {
-    return new WebGLVectorLayerRenderer(this, {
-      className: this.getClassName(),
-      style: {
-        'fill-color': '#ddd',
-        'stroke-color': '#eee',
-        'stroke-width': 2,
-      },
-    });
-  }
-}
-
-const vector = new WebGLLayer({
+const vector = new WebGLVectorLayer({
   source: new VectorSource({
     url: '/data/countries.json',
     format: new GeoJSON(),
   }),
+  style: {
+    'fill-color': '#ddd',
+    'stroke-color': '#eee',
+    'stroke-width': 2,
+  },
 });
 
 const raster = new TileLayer({


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This PR introduces the *WebGLVectorLayer* class which makes it much simpler to use the WebGL vector renderer. This simplification can be observed in the way many examples and rendering tests were simplified without any change in functionality.

To use it:

```js
const vector = new WebGLVectorLayer({
  source: new VectorSource(...),
  style: {
    'fill-color': ['var', 'mainColor'],
    'stroke-color': '#eee',
    'stroke-width': 2,
  },
  variables: {
    mainColor: 'rgba(255, 120, 0, 1)',
  },
});

vector.updateStyleVariables({
  mainColor: 'green'
})
```

This PR also improves the way style variables are given to a layer. WebGL layers now have a `variables` option next to the `style` option, and the style expressions can reference variables using the `['var', ...]` operator. This brings the "webgl" style and flat style formats closer, and the webgl style format will be able to be dropped soon once this change is in.

Additional changes:
* fixes a bug where color variables were causing a shader compilation error
* adds support for the `['id']` operator in webgl style expression

Addresses https://github.com/openlayers/openlayers/discussions/16187

Done in cooperation with @romprokop814 