### PR TITLE
Properly encode URI components

### DIFF
--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -325,7 +325,7 @@ class WMTS extends TileImage {
           url = appendParams(url, localContext);
         } else {
           url = url.replace(/\{(\w+?)\}/g, function (m, p) {
-            return localContext[p];
+            return encodeURIComponent(localContext[p]);
           });
         }
         return url;

--- a/test/browser/spec/ol/source/WMTS.test.js
+++ b/test/browser/spec/ol/source/WMTS.test.js
@@ -319,6 +319,33 @@ describe('ol/source/WMTS', function () {
         'http://host/{Layer}/{Style}/{Time}/{tilematrixset}/{TileMatrix}/{TileCol}/{TileRow}.jpg/Time-42',
       );
     });
+
+    it('properly encodes values from dimensions', function () {
+      const source = new WMTS({
+        layer: 'layer',
+        style: 'default',
+        dimensions: {'Time': '2010/2020'},
+        urls: [
+          'http://host/{Layer}/{Style}/{Time}/{tilematrixset}/{TileMatrix}/{TileCol}/{TileRow}.jpg',
+        ],
+        matrixSet: 'EPSG:3857',
+        requestEncoding: 'REST',
+        tileGrid: defaultTileGrid,
+      });
+
+      const projection = getProjection('EPSG:3857');
+      const url = source.tileUrlFunction(
+        source.getTileCoordForTileUrlFunction([1, 1, 1]),
+        1,
+        projection,
+      );
+      expect(url).to.be.eql(
+        'http://host/layer/default/2010%2F2020/EPSG:3857/1/1/1.jpg',
+      );
+      expect(source.getKey()).to.be.eql(
+        'http://host/{Layer}/{Style}/{Time}/{tilematrixset}/{TileMatrix}/{TileCol}/{TileRow}.jpg/Time-2010/2020',
+      );
+    });
   });
 
   describe('when creating options from Esri capabilities', function () {


### PR DESCRIPTION
The WMSTS source currently assembles a URL without encoding path components. This changes that.

Fixes #16408.