### PR TITLE
Fix VectorTile source removeSourceTiles

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -286,14 +286,15 @@ class VectorTile extends UrlTile {
    * @param {VectorRenderTile} tile Vector render tile.
    */
   removeSourceTiles(tile) {
+    const tileKey = tile.getKey();
     const sourceTiles = tile.sourceTiles;
     for (let i = 0, ii = sourceTiles.length; i < ii; ++i) {
       const sourceTileUrl = sourceTiles[i].getTileUrl();
-      const tileKey = this.getKey();
       if (!this.tileKeysBySourceTileUrl_[sourceTileUrl]) {
         return;
       }
-      const index = this.tileKeysBySourceTileUrl_[sourceTileUrl][tileKey];
+      const index =
+        this.tileKeysBySourceTileUrl_[sourceTileUrl].indexOf(tileKey);
       if (index === -1) {
         continue;
       }

--- a/test/browser/spec/ol/source/VectorTile.test.js
+++ b/test/browser/spec/ol/source/VectorTile.test.js
@@ -88,6 +88,51 @@ describe('ol/source/VectorTile', function () {
       expect(source.tileKeysBySourceTileUrl_).to.eql({});
     });
 
+    it('unreferences source tiles with different source and render tile grids', () => {
+      const source = new VectorTileSource({
+        format: new GeoJSON(),
+        url: 'spec/ol/data/point.json?{z}-{x}-{y}',
+      });
+      source.tileGrids_['EPSG:3857'] = new TileGrid({
+        origin: [12345678, 12345678],
+        resolutions: [
+          100000, 50000, 25000, 12500, 6250, 3125, 1562.5, 781.25, 390.625,
+          195.3125, 97.65625, 48.828125, 24.4140625, 12.20703125, 6.103515625,
+          3.0517578125, 1.52587890625, 0.762939453125, 0.3814697265625,
+        ],
+        tileSize: 678,
+      });
+
+      const tiles = [
+        source.getTile(14, 8938, 5680, 1, source.getProjection()),
+        source.getTile(14, 8939, 5680, 1, source.getProjection()),
+      ];
+      tiles.forEach((tile) => tile.load());
+      expect(Object.keys(source.sourceTiles_).length).to.be(3);
+      expect(source.tileKeysBySourceTileUrl_).to.eql({
+        'spec/ol/data/point.json?13-5988-6377': [
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8938,5680',
+        ],
+        'spec/ol/data/point.json?13-5989-6377': [
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8938,5680',
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8939,5680',
+        ],
+        'spec/ol/data/point.json?13-5990-6377': [
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8939,5680',
+        ],
+      });
+      tiles[1].dispose();
+      expect(Object.keys(source.sourceTiles_).length).to.be(2);
+      expect(source.tileKeysBySourceTileUrl_).to.eql({
+        'spec/ol/data/point.json?13-5988-6377': [
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8938,5680',
+        ],
+        'spec/ol/data/point.json?13-5989-6377': [
+          'spec/ol/data/point.json?{z}-{x}-{y}/14,8938,5680',
+        ],
+      });
+    });
+
     it('handles empty tiles', function () {
       const source = new VectorTileSource({
         format: new GeoJSON(),


### PR DESCRIPTION
Fixes #16423 

There is a test where the expected format is also from `tile.getKey()`:
https://github.com/openlayers/openlayers/blob/f9fe6a4e42c8275986f304e3f9a284d258f97c90/test/browser/spec/ol/source/VectorTile.test.js#L83-L85