### PR TITLE
Fix ol/source/Vector forEachFeature with null geometries

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -602,7 +602,16 @@ class VectorSource extends Source {
    */
   forEachFeature(callback) {
     if (this.featuresRtree_) {
-      return this.featuresRtree_.forEach(callback);
+      let result = this.featuresRtree_.forEach(callback);
+      if (!result) {
+        for (const key in this.nullGeometryFeatures_) {
+          result = callback(this.nullGeometryFeatures_[key]);
+          if (result) {
+            break;
+          }
+        }
+      }
+      return result;
     }
     if (this.featuresCollection_) {
       this.featuresCollection_.forEach(callback);

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -320,6 +320,26 @@ describe('ol/source/Vector', function () {
       });
     });
 
+    describe('#forEachFeature', function () {
+      it('iterates over all features of the rtree', function () {
+        let i = 0;
+        vectorSource.forEachFeature((f) => {
+          ++i;
+        });
+        expect(i).to.be(features.length);
+      });
+      it('iterates over all features of the collection', function () {
+        const source = new VectorSource({
+          features: features,
+          useSpatialIndex: false,
+        });
+        let i = 0;
+        source.forEachFeature((f) => {
+          ++i;
+        });
+        expect(i).to.be(features.length);
+      });
+    });
     describe('#forEachFeatureInExtent', function () {
       it('is called the expected number of times', function () {
         const f = sinon.spy();


### PR DESCRIPTION
`forEachFeature` did not iterator over the null geometries when using the spatial index.