### PR TITLE
Skip tiles not in rotated viewport

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -19,6 +19,7 @@ import {
   createEmpty,
   equals,
   getIntersection,
+  getRotatedViewport,
   getTopLeft,
   intersects,
 } from '../../extent.js';
@@ -416,6 +417,15 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         tileSource.zDirection,
       ),
     );
+    const rotation = viewState.rotation;
+    const viewport = rotation
+      ? getRotatedViewport(
+          viewState.center,
+          viewState.resolution,
+          rotation,
+          frameState.size,
+        )
+      : undefined;
     for (let z = initialZ; z >= minZ; --z) {
       const tileRange = tileGrid.getTileRangeForExtentAndZ(
         extent,
@@ -427,6 +437,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
       for (let x = tileRange.minX; x <= tileRange.maxX; ++x) {
         for (let y = tileRange.minY; y <= tileRange.maxY; ++y) {
+          if (
+            rotation &&
+            !tileGrid.tileCoordIntersectsViewport([z, x, y], viewport)
+          ) {
+            continue;
+          }
           const tile = this.getTile(z, x, y, frameState);
           if (!tile) {
             continue;

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -232,6 +232,42 @@ describe('ol/renderer/webgl/TileLayer', function () {
       };
       expect(wantedTiles).to.eql(expected);
     });
+
+    it('skips tiles not in the rotated viewport', () => {
+      const z = 10;
+      const resolution = map.getView().getResolutionForZoom(z);
+      frameState.viewState.resolution = resolution;
+      frameState.viewState.rotation = Math.PI / 4;
+      const extent = [
+        -frameState.size[0],
+        -frameState.size[1],
+        frameState.size[0],
+        frameState.size[1],
+      ].map((c) => c * resolution * Math.SQRT2);
+
+      renderer.prepareFrame(frameState);
+      renderer.enqueueTiles(
+        frameState,
+        extent,
+        z,
+        newTileRepresentationLookup(),
+        tileLayer.getPreload(),
+      );
+
+      const source = tileLayer.getSource();
+      const sourceKey = getUid(source);
+      expect(frameState.wantedTiles[sourceKey]).to.be.an(Object);
+
+      const wantedTiles = frameState.wantedTiles[sourceKey];
+
+      const expected = {
+        [sourceKey + '/10,511,511']: true,
+        [sourceKey + '/10,511,512']: true,
+        [sourceKey + '/10,512,511']: true,
+        [sourceKey + '/10,512,512']: true,
+      };
+      expect(wantedTiles).to.eql(expected);
+    });
   });
 
   describe('#createTileRepresentation', () => {


### PR DESCRIPTION
It is no longer used since 01702e09af859904dac845245b5d5c90fff97e7f. 

It was used to not load tiles that do not intersect a rotated viewport. Maybe this was changed unintentionally?