### PR TITLE
Update High DPI WMTS capabilities url

### DIFF
--- a/examples/wmts-hidpi.js
+++ b/examples/wmts-hidpi.js
@@ -5,7 +5,8 @@ import {DEVICE_PIXEL_RATIO} from '../src/ol/has.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import WMTS, {optionsFromCapabilities} from '../src/ol/source/WMTS.js';
 
-const capabilitiesUrl = 'https://basemap.at/wmts/1.0.0/WMTSCapabilities.xml';
+const capabilitiesUrl =
+  'https://mapsneu.wien.gv.at/basemapneu/1.0.0/WMTSCapabilities.xml';
 
 // HiDPI support:
 // * Use 'bmaphidpi' layer (pixel ratio 2) for device pixel ratio > 1


### PR DESCRIPTION
The High DPI WMTS example https://openlayers.org/en/v10.3.1/examples/wmts-hidpi.html is not showing all the tiles as the capabilities document is outdated and refers to subdomains which are no longer in use.  The latest capabilities url is provided via the link in https://basemap.at/highdpi/,

Corrected example https://deploy-preview-16463--ol-site.netlify.app/en/latest/examples/wmts-hidpi.html