### PR TITLE
Consistent use of relative imports

### DIFF
--- a/examples/rectangle.js
+++ b/examples/rectangle.js
@@ -1,11 +1,11 @@
-import Feature from 'ol/Feature.js';
-import {fromExtent} from 'ol/geom/Polygon.js';
-import VectorLayer from 'ol/layer/Vector.js';
-import VectorSource from 'ol/source/Vector.js';
+import Feature from '../src/ol/Feature.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
+import {fromExtent} from '../src/ol/geom/Polygon.js';
 import TileLayer from '../src/ol/layer/Tile.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
 import OSM from '../src/ol/source/OSM.js';
+import VectorSource from '../src/ol/source/Vector.js';
 
 const map = new Map({
   layers: [

--- a/test/rendering/cases/fill-pattern/main.js
+++ b/test/rendering/cases/fill-pattern/main.js
@@ -1,7 +1,7 @@
-import Polygon from 'ol/geom/Polygon.js';
 import Feature from '../../../../src/ol/Feature.js';
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
+import Polygon from '../../../../src/ol/geom/Polygon.js';
 import VectorLayer from '../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../src/ol/source/Vector.js';
 


### PR DESCRIPTION
This updates one example and one rendering test to use relative imports for consistency with the rest.

[Webpack is configured](https://github.com/openlayers/openlayers/blob/debafa92a66a147b53cb14323f4f48371327a647/examples/webpack/config.mjs#L86-L89) to allow imports from `ol`. That allows examples that use `ol-mapbox-style` to work (see #8928), but I think our own imports should be consistent.