### PR TITLE
Fix return type of ImageObjectPromiseLoader

### DIFF
--- a/src/ol/Image.js
+++ b/src/ol/Image.js
@@ -53,7 +53,7 @@ import {CREATE_IMAGE_BITMAP, IMAGE_DECODE} from './has.js';
  * Loader function used for image sources. Receives extent, resolution and pixel ratio as arguments.
  * The function returns a promise for an  {@link import("./Image.js").ImageObject image object}.
  *
- * @typedef {function(import("./extent.js").Extent, number, number, (function(HTMLImageElement, string): void)=): import("./DataTile.js").ImageLike|ImageObject|Promise<import("./DataTile.js").ImageLike|ImageObject>} ImageObjectPromiseLoader
+ * @typedef {function(import("./extent.js").Extent, number, number, (function(HTMLImageElement, string): void)=): Promise<import("./DataTile.js").ImageLike|ImageObject>} ImageObjectPromiseLoader
  */
 
 class ImageWrapper extends EventTarget {
@@ -62,7 +62,7 @@ class ImageWrapper extends EventTarget {
    * @param {number|Array<number>|undefined} resolution Resolution. If provided as array, x and y
    * resolution will be assumed.
    * @param {number} pixelRatio Pixel ratio.
-   * @param {import("./ImageState.js").default|import("./Image.js").Loader} stateOrLoader State.
+   * @param {import("./ImageState.js").default|Loader} stateOrLoader State.
    */
   constructor(extent, resolution, pixelRatio, stateOrLoader) {
     super();
@@ -100,7 +100,7 @@ class ImageWrapper extends EventTarget {
 
     /**
      * @protected
-     * @type {import("./Image.js").Loader}
+     * @type {Loader|null}
      */
     this.loader = typeof stateOrLoader === 'function' ? stateOrLoader : null;
   }

--- a/src/ol/source/arcgisRest.js
+++ b/src/ol/source/arcgisRest.js
@@ -93,7 +93,6 @@ export function createLoader(options) {
   const ratio = options.ratio ?? 1.5;
   const crossOrigin = options.crossOrigin ?? null;
 
-  /** @type {import('../Image.js').ImageObjectPromiseLoader} */
   return function (extent, resolution, pixelRatio) {
     pixelRatio = options.hidpi ? pixelRatio : 1;
 

--- a/src/ol/source/mapguide.js
+++ b/src/ol/source/mapguide.js
@@ -97,7 +97,6 @@ export function createLoader(options) {
   const ratio = options.ratio ?? 1;
   const crossOrigin = options.crossOrigin ?? null;
 
-  /** @type {import('../Image.js').ImageObjectPromiseLoader} */
   return function (extent, resolution, pixelRatio) {
     const image = new Image();
     image.crossOrigin = crossOrigin;

--- a/src/ol/source/wms.js
+++ b/src/ol/source/wms.js
@@ -166,9 +166,6 @@ export function createLoader(options) {
   const load = options.load || decode;
   const crossOrigin = options.crossOrigin ?? null;
 
-  /**
-   * @type {import("../Image.js").Loader}
-   */
   return (extent, resolution, pixelRatio) => {
     extent = getRequestExtent(extent, resolution, pixelRatio, ratio);
     if (pixelRatio != 1 && (!hidpi || options.serverType === undefined)) {


### PR DESCRIPTION
Remove ImageLike and ImageObject from the return type. It always returns a promise.

There's still the `Loader` typedef which includes these in the return type.
https://github.com/openlayers/openlayers/blob/10d4a6febdb8866d2197584344bcec5f6e95a604/src/ol/Image.js#L48