### PR TITLE
Fix function or null/undefined types

### DIFF
--- a/src/ol/format/GPX.js
+++ b/src/ol/format/GPX.js
@@ -184,6 +184,10 @@ const GPX_SERIALIZERS = makeStructureNS(NAMESPACE_URIS, {
  */
 
 /**
+ * @typedef {function(Feature, Node): void} ReadExtensions
+ */
+
+/**
  * @classdesc
  * Feature format for reading and writing data in the GPX format.
  *
@@ -214,7 +218,7 @@ class GPX extends XMLFeature {
     this.dataProjection = getProjection('EPSG:4326');
 
     /**
-     * @type {function(Feature, Node): void|undefined}
+     * @type {ReadExtensions|undefined}
      * @private
      */
     this.readExtensions_ = options.readExtensions;

--- a/src/ol/interaction/Extent.js
+++ b/src/ol/interaction/Extent.js
@@ -73,6 +73,10 @@ export class ExtentEvent extends Event {
   }
 }
 
+/**
+ * @typedef {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent} PointerHandler
+ */
+
 /***
  * @template Return
  * @typedef {import("../Observable").OnSignature<import("../Observable").EventTypes, import("../events/Event.js").default, Return> &
@@ -132,7 +136,7 @@ class Extent extends PointerInteraction {
 
     /**
      * Handler for pointer move events
-     * @type {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null}
+     * @type {PointerHandler|null}
      * @private
      */
     this.pointerHandler_ = null;
@@ -511,7 +515,7 @@ function getPointHandler(fixedPoint) {
 /**
  * @param {import("../coordinate.js").Coordinate} fixedP1 first corner that will be unchanged in the new extent
  * @param {import("../coordinate.js").Coordinate} fixedP2 second corner that will be unchanged in the new extent
- * @return {function (import("../coordinate.js").Coordinate): import("../extent.js").Extent|null} event handler
+ * @return {PointerHandler|null} event handler
  */
 function getEdgeHandler(fixedP1, fixedP2) {
   if (fixedP1[0] == fixedP2[0]) {

--- a/src/ol/layer/BaseVector.js
+++ b/src/ol/layer/BaseVector.js
@@ -187,8 +187,7 @@ class BaseVectorLayer extends Layer {
   }
 
   /**
-   * @return {function(import("../Feature.js").default, import("../Feature.js").default): number|null|undefined} Render
-   *     order.
+   * @return {import("../render.js").OrderFunction|null|undefined} Render order.
    */
   getRenderOrder() {
     return /** @type {import("../render.js").OrderFunction|null|undefined} */ (

--- a/src/ol/proj/Projection.js
+++ b/src/ol/proj/Projection.js
@@ -4,6 +4,14 @@
 import {METERS_PER_UNIT} from './Units.js';
 
 /**
+ * The function is called with a `number` view resolution and a
+ * {@link module:ol/coordinate~Coordinate} as arguments, and returns the `number` resolution
+ * in projection units at the passed coordinate.
+ * @typedef {function(number, import("../coordinate.js").Coordinate):number} GetPointResolution
+ * @api
+ */
+
+/**
  * @typedef {Object} Options
  * @property {string} code The SRS identifier code, e.g. `EPSG:4326`.
  * @property {import("./Units.js").Units} [units] Units. Required unless a
@@ -15,7 +23,7 @@ import {METERS_PER_UNIT} from './Units.js';
  * If not provided, the `units` are used to get the meters per unit from the {@link METERS_PER_UNIT}
  * lookup table.
  * @property {import("../extent.js").Extent} [worldExtent] The world extent for the SRS.
- * @property {function(number, import("../coordinate.js").Coordinate):number} [getPointResolution]
+ * @property {GetPointResolution} [getPointResolution]
  * Function to determine resolution at a point. The function is called with a
  * `number` view resolution and a {@link module:ol/coordinate~Coordinate} as arguments, and returns
  * the `number` resolution in projection units at the passed coordinate. If this is `undefined`,
@@ -111,7 +119,7 @@ class Projection {
 
     /**
      * @private
-     * @type {function(number, import("../coordinate.js").Coordinate):number|undefined}
+     * @type {GetPointResolution|undefined}
      */
     this.getPointResolutionFunc_ = options.getPointResolution;
 
@@ -262,7 +270,7 @@ class Projection {
 
   /**
    * Get the custom point resolution function for this projection (if set).
-   * @return {function(number, import("../coordinate.js").Coordinate):number|undefined} The custom point
+   * @return {GetPointResolution|undefined} The custom point
    * resolution function (if set).
    */
   getPointResolutionFunc() {

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -131,7 +131,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     /**
      * @private
-     * @type {function(import("../../Feature.js").default, import("../../Feature.js").default): number|null}
+     * @type {import("../../render.js").OrderFunction|null}
      */
     this.renderedRenderOrder_ = null;
 


### PR DESCRIPTION
If the function type is not in parentheses the null/undefined will be part of the return type.
