### PR TITLE
Clear renderer on layer source changes

### DIFF
--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -261,6 +261,7 @@ class Layer extends BaseLayer {
           this.dispatchEvent('sourceready');
         }, 0);
       }
+      this.clearRenderer();
     }
     this.changed();
   }

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -80,6 +80,7 @@ describe('ol/renderer/webgl/TileLayer', function () {
     tileLayer.setSource(null);
     expect(renderer.prepareFrame(frameState)).to.be(false);
     tileLayer.setSource(source);
+    renderer = tileLayer.getRenderer();
     expect(renderer.prepareFrame(frameState)).to.be(true);
     const tileGrid = source.getTileGrid();
     tileLayer.setExtent(tileGrid.getTileCoordExtent([2, 0, 0]));


### PR DESCRIPTION
See https://github.com/openlayers/openlayers/issues/16446 for details.

The goal of this change is to ensure the tile cache in tile renderers is gone when the source of the layer the renderer manages is changed to another source using `setSource`.
Currently the tilecache is not cleared if the new source has the same revision as the old source, potentially leading to very corrupt tiles being rendered (for example if a wms tile source has a completely different gutter size)