### PR TITLE
Only peek tiles we're not sure we're going to use

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -488,7 +488,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     for (let i = 0; i < staleKeys.length; ++i) {
       const cacheKey = getCacheKey(staleKeys[i], z, x, y);
       if (tileCache.containsKey(cacheKey)) {
-        const tile = tileCache.get(cacheKey);
+        const tile = tileCache.peek(cacheKey);
         if (tile.getState() === TileState.LOADED) {
           tile.endTransition(getUid(this));
           addTileToLookup(tilesByZ, tile, z);
@@ -529,7 +529,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         const cacheKey = getCacheKey(sourceKey, altZ, x, y);
         let loaded = false;
         if (tileCache.containsKey(cacheKey)) {
-          const tile = tileCache.get(cacheKey);
+          const tile = tileCache.peek(cacheKey);
           if (tile.getState() === TileState.LOADED) {
             addTileToLookup(tilesByZ, tile, altZ);
             loaded = true;


### PR DESCRIPTION
Fixes #16508.

The problem is that `TileCache#get()` marks a tile as used, and when looking for alt or stale tiles we're not sure we're actually going to use them. But marking stale and alt tiles as newer can result in actually needed tiles to get purged from the cache. So I changed those call sites of `TileCache#get()` to `TileCache#peek()`, which does not mark the tiles as used in the cache.