### PR TITLE
An EMPTY tile stays EMPTY

### DIFF
--- a/src/ol/Tile.js
+++ b/src/ol/Tile.js
@@ -172,6 +172,10 @@ class Tile extends EventTarget {
    * @api
    */
   setState(state) {
+    if (this.state === TileState.EMPTY) {
+      // no more state changes
+      return;
+    }
     if (this.state !== TileState.ERROR && this.state > state) {
       throw new Error('Tile load sequence violation');
     }


### PR DESCRIPTION
Since #16455, a tile gets a `TileState.EMPTY` state when it is disposed. Currently we don't abort tile loading upon disposal, so listeners will still try to set a `TileState.LOADED` or `TileState.ERROR` on the tile. This violates the tile loading sequence assertion on the `Tiles`'s `setState()` method.

This pull request changes the `setState()` method so it returns early when the tile's state is `TileState.EMPTY`.

In the future, we could/should abort tile loading upon tile disposal.