### PR TITLE
Ignore site build directory

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
     ignores: [
       'config/jsdoc/api/template/static/scripts/',
       'examples/resources/*',
+      'site/build/*',
     ],
   },
   {


### PR DESCRIPTION
That directory is result of a build process, so it should be ignored.