### PR TITLE
Fix for undefined `renderedProjection` in web worker's offscreen canvas layer example

### DIFF
--- a/examples/offscreen-canvas.worker.js
+++ b/examples/offscreen-canvas.worker.js
@@ -159,10 +159,13 @@ worker.addEventListener('message', (event) => {
   frameState.layerStatesArray = layers.map((l) => l.getLayerState());
   layers.forEach((layer) => {
     if (inView(layer.getLayerState(), frameState.viewState)) {
+      const renderer = layer.getRenderer();
+      if (!renderer.prepareFrame(frameState)) {
+        return;
+      }
       if (layer.getDeclutter() && !frameState.declutterTree) {
         frameState.declutter = {};
       }
-      const renderer = layer.getRenderer();
       renderer.renderFrame(frameState, canvas);
     }
   });


### PR DESCRIPTION
We can either restore this specific line of code - https://github.com/openlayers/openlayers/pull/16313/commits/600d84bdbea192b77821a1194fcbb02e5b2ce527#diff-ea22661e28efe5304b2c3a407112dccd7f89002aa2f784fac4fbae08aa75bffdL842 or fix offscreen layer example to call `prepareFrame` method before `renderFrame` like in this pr.

Fixes https://github.com/openlayers/openlayers/issues/16521