### PR TITLE
Introduce a WebGLVectorTileLayer class

### DIFF
--- a/config/tsconfig-strict.json
+++ b/config/tsconfig-strict.json
@@ -146,6 +146,7 @@
     "../src/ol/layer/WebGLPoints.js",
     "../src/ol/layer/WebGLVector.js",
     "../src/ol/layer/WebGLTile.js",
+    "../src/ol/layer/WebGLVectorTile.js",
     "../src/ol/loadingstrategy.js",
     "../src/ol/Map.js",
     "../src/ol/MapBrowserEvent.js",

--- a/examples/webgl-vector-tiles.js
+++ b/examples/webgl-vector-tiles.js
@@ -1,64 +1,353 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import {asArray} from '../src/ol/color.js';
 import MVT from '../src/ol/format/MVT.js';
 import WebGLVectorTileLayer from '../src/ol/layer/WebGLVectorTile.js';
 import VectorTileSource from '../src/ol/source/VectorTile.js';
-import Fill from '../src/ol/style/Fill.js';
-import Icon from '../src/ol/style/Icon.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
-import Text from '../src/ol/style/Text.js';
-import {packColor, parseLiteralStyle} from '../src/ol/webgl/styleparser.js';
 
 const key =
   'pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ';
 
-const parsedStyleResult = parseLiteralStyle({
-  'fill-color': ['get', 'fillColor'],
-  'stroke-color': ['get', 'strokeColor'],
-  'stroke-width': ['get', 'strokeWidth'],
-  'circle-radius': 4,
-  'circle-fill-color': '#777',
-});
-
-// TODO: convert this style function to a flat style
-const styleFunction = createMapboxStreetsV6Style(
-  Style,
-  Fill,
-  Stroke,
-  Icon,
-  Text,
-);
-
-const style = {
-  builder: parsedStyleResult.builder,
-  attributes: {
-    prop_fillColor: {
-      size: 2,
-      callback: (feature) => {
-        const style = styleFunction(feature, 1)[0];
-        const color = asArray(style?.getFill()?.getColor() || '#eee');
-        return packColor(color);
-      },
-    },
-    prop_strokeColor: {
-      size: 2,
-      callback: (feature) => {
-        const style = styleFunction(feature, 1)[0];
-        const color = asArray(style?.getStroke()?.getColor() || '#eee');
-        return packColor(color);
-      },
-    },
-    prop_strokeWidth: {
-      size: 1,
-      callback: (feature) => {
-        const style = styleFunction(feature, 1)[0];
-        return style?.getStroke()?.getWidth() || 0;
-      },
+const style = [
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'landuse'],
+      ['==', ['get', 'class'], 'park'],
+    ],
+    style: {
+      'fill-color': '#d8e8c8',
     },
   },
-};
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'landuse'],
+      ['==', ['get', 'class'], 'cemetery'],
+    ],
+    style: {
+      'fill-color': '#e0e4dd',
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'landuse'],
+      ['==', ['get', 'class'], 'hospital'],
+    ],
+    style: {
+      'fill-color': '#fde',
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'landuse'],
+      ['==', ['get', 'class'], 'school'],
+    ],
+    style: {
+      'fill-color': '#f0e8f8',
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'landuse'],
+      ['==', ['get', 'class'], 'wood'],
+    ],
+    style: {
+      'fill-color': 'rgb(233,238,223)',
+    },
+  },
+  {
+    filter: ['==', ['get', 'layer'], 'waterway'],
+    style: {
+      'stroke-color': '#a0c8f0',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: ['==', ['get', 'layer'], 'water'],
+    style: {
+      'fill-color': '#a0c8f0',
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'aeroway'],
+      ['==', ['geometry-type'], 'Polygon'],
+    ],
+    style: {
+      'fill-color': 'rgb(242,239,235)',
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'aeroway'],
+      ['==', ['geometry-type'], 'LineString'],
+      ['<=', ['resolution'], 76.43702828517625],
+    ],
+    style: {
+      'fill-color': '#f0ede9',
+    },
+  },
+  {
+    filter: ['==', ['get', 'layer'], 'building'],
+    style: {
+      'fill-color': '#f2eae2',
+      'stroke-color': '#dfdbd7',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'motorway_link'],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'service'],
+    ],
+    style: {
+      'stroke-color': '#cfcdca',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      [
+        'any',
+        ['==', ['get', 'class'], 'street'],
+        ['==', ['get', 'class'], 'street_limited'],
+      ],
+    ],
+    style: {
+      'stroke-color': '#cfcdca',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'main'],
+      ['<=', ['resolution'], 1222.99245256282],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'motorway'],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'path'],
+    ],
+    style: {
+      'stroke-color': '#cba',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'tunnel'],
+      ['==', ['get', 'class'], 'major_rail'],
+    ],
+    style: {
+      'stroke-color': '#bbb',
+      'stroke-width': 2,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      ['==', ['get', 'class'], 'motorway_link'],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      [
+        'any',
+        ['==', ['get', 'class'], 'street'],
+        ['==', ['get', 'class'], 'street_limited'],
+      ],
+      ['==', ['geometry-type'], 'LineString'],
+    ],
+    style: {
+      'stroke-color': '#cfcdca',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      ['==', ['get', 'class'], 'main'],
+      ['<=', ['resolution'], 1222.99245256282],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      ['==', ['get', 'class'], 'motorway'],
+      ['<=', ['resolution'], 4891.96981025128],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      ['==', ['get', 'class'], 'path'],
+    ],
+    style: {
+      'stroke-color': '#cba',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'road'],
+      ['==', ['get', 'class'], 'major_rail'],
+    ],
+    style: {
+      'stroke-color': '#bbb',
+      'stroke-width': 2,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'bridge'],
+      [
+        'any',
+        ['==', ['get', 'class'], 'motorway'],
+        ['==', ['get', 'class'], 'motorway_link'],
+      ],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'bridge'],
+      [
+        'any',
+        ['==', ['get', 'class'], 'street'],
+        ['==', ['get', 'class'], 'street_limited'],
+        ['==', ['get', 'class'], 'service'],
+      ],
+    ],
+    style: {
+      'stroke-color': '#cfcdca',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'bridge'],
+      ['==', ['get', 'class'], 'main'],
+      ['<=', ['resolution'], 1222.99245256282],
+    ],
+    style: {
+      'stroke-color': '#e9ac77',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'bridge'],
+      ['==', ['get', 'class'], 'path'],
+    ],
+    style: {
+      'stroke-color': '#cba',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'bridge'],
+      ['==', ['get', 'class'], 'major_rail'],
+    ],
+    style: {
+      'stroke-color': '#bbb',
+      'stroke-width': 2,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'admin'],
+      ['>=', ['get', 'admin_level'], 2],
+      ['==', ['get', 'maritime'], 0],
+    ],
+    style: {
+      'stroke-color': '#9e9cab',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: [
+      'all',
+      ['==', ['get', 'layer'], 'admin'],
+      ['>=', ['get', 'admin_level'], 2],
+      ['==', ['get', 'maritime'], 1],
+    ],
+    style: {
+      'stroke-color': '#a0c8f0',
+      'stroke-width': 1,
+    },
+  },
+  {
+    style: {'circle-radius': 4, 'circle-fill-color': '#777'},
+  },
+];
 
 const map = new Map({
   layers: [

--- a/src/ol/layer/WebGLVectorTile.js
+++ b/src/ol/layer/WebGLVectorTile.js
@@ -1,0 +1,120 @@
+/**
+ * @module ol/layer/WebGLVectorTile
+ */
+import WebGLVectorTileLayerRenderer from '../renderer/webgl/VectorTileLayer.js';
+import BaseTileLayer from './BaseTile.js';
+
+/***
+ * @template T
+ * @typedef {T extends import("../source/Vector.js").default<infer U extends import("../Feature.js").FeatureLike> ? U : never} ExtractedFeatureType
+ */
+
+/**
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorTileSourceType>]
+ * @typedef {Object} Options
+ * @property {string} [className='ol-layer'] A CSS class name to set to the layer element.
+ * @property {number} [opacity=1] Opacity (0, 1).
+ * @property {boolean} [visible=true] Visibility.
+ * @property {import("../extent.js").Extent} [extent] The bounding extent for layer rendering.  The layer will not be
+ * rendered outside of this extent.
+ * FIXME: not supported yet
+ * @property {number} [zIndex] The z-index for layer rendering.  At rendering time, the layers
+ * will be ordered, first by Z-index and then by position. When `undefined`, a `zIndex` of 0 is assumed
+ * for layers that are added to the map's `layers` collection, or `Infinity` when the layer's `setMap()`
+ * method was used.
+ * @property {number} [minResolution] The minimum resolution (inclusive) at which this layer will be
+ * visible.
+ * @property {number} [maxResolution] The maximum resolution (exclusive) below which this layer will
+ * be visible.
+ * @property {number} [minZoom] The minimum view zoom level (exclusive) above which this layer will be
+ * visible.
+ * @property {number} [maxZoom] The maximum view zoom level (inclusive) at which this layer will
+ * be visible.
+ * @property {VectorTileSourceType} [source] Source.
+ * @property {import('../style/flat.js').FlatStyleLike} style Layer style.
+ * @property {import('../style/flat.js').StyleVariables} [variables] Style variables. Each variable must hold a literal value (not
+ * an expression). These variables can be used as {@link import("../expr/expression.js").ExpressionValue expressions} in the styles properties
+ * using the `['var', 'varName']` operator.
+ * To update style variables, use the {@link import("./WebGLVector.js").default#updateStyleVariables} method.
+ * @property {import("./Base.js").BackgroundColor} [background] Background color for the layer. If not specified, no background
+ * will be rendered.
+ * FIXME: not supported yet
+ * @property {boolean} [disableHitDetection=false] Setting this to true will provide a slight performance boost, but will
+ * prevent all hit detection on the layer.
+ * @property {Object<string, *>} [properties] Arbitrary observable properties. Can be accessed with `#get()` and `#set()`.
+ */
+
+/**
+ * @classdesc
+ * Layer optimized for rendering large vector datasets.
+ *
+ * **Important: a `WebGLVector` layer must be manually disposed when removed, otherwise the underlying WebGL context
+ * will not be garbage collected.**
+ *
+ * Note that any property set in the options is set as a {@link module:ol/Object~BaseObject}
+ * property on the layer object; for example, setting `title: 'My Title'` in the
+ * options means that `title` is observable, and has get/set accessors.
+ *
+ * @template {import("../source/VectorTile.js").default<FeatureType>} [VectorTileSourceType=import("../source/VectorTile.js").default<*>]
+ * @template {import('../Feature.js').FeatureLike} [FeatureType=ExtractedFeatureType<VectorTileSourceType>]
+ * @extends {BaseTileLayer<VectorTileSourceType, WebGLVectorTileLayerRenderer>}
+ */
+class WebGLVectorTileLayer extends BaseTileLayer {
+  /**
+   * @param {Options<VectorTileSourceType, FeatureType>} [options] Options.
+   */
+  constructor(options) {
+    const baseOptions = Object.assign({}, options);
+
+    super(baseOptions);
+
+    /**
+     * @type {import('../style/flat.js').StyleVariables}
+     * @private
+     */
+    this.styleVariables_ = options.variables || {};
+
+    /**
+     * @private
+     */
+    this.style_ = options.style;
+
+    /**
+     * @private
+     */
+    this.hitDetectionDisabled_ = !!options.disableHitDetection;
+  }
+
+  /**
+   * @override
+   */
+  createRenderer() {
+    return new WebGLVectorTileLayerRenderer(this, {
+      style: this.style_,
+      variables: this.styleVariables_,
+      disableHitDetection: this.hitDetectionDisabled_,
+    });
+  }
+
+  /**
+   * Update any variables used by the layer style and trigger a re-render.
+   * @param {import('../style/flat.js').StyleVariables} variables Variables to update.
+   */
+  updateStyleVariables(variables) {
+    Object.assign(this.styleVariables_, variables);
+    this.changed();
+  }
+
+  /**
+   * Set the layer style.
+   * @param {import('../style/flat.js').FlatStyleLike} style Layer style.
+   */
+  setStyle(style) {
+    this.style = style;
+    this.clearRenderer();
+    this.changed();
+  }
+}
+
+export default WebGLVectorTileLayer;

--- a/src/ol/render/webgl/renderinstructions.js
+++ b/src/ol/render/webgl/renderinstructions.js
@@ -21,7 +21,7 @@ function pushCustomAttributesInRenderInstructions(
   for (const key in customAttributes) {
     const attr = customAttributes[key];
     const value = attr.callback.call(batchEntry, batchEntry.feature);
-    renderInstructions[currentIndex + shift++] = value[0] ?? value;
+    renderInstructions[currentIndex + shift++] = value?.[0] ?? value;
     if (!attr.size || attr.size === 1) {
       continue;
     }

--- a/test/browser/spec/ol/layer/WebGLVectorTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLVectorTile.test.js
@@ -1,0 +1,194 @@
+import {spy as sinonSpy} from 'sinon';
+import Map from '../../../../../src/ol/Map.js';
+import View from '../../../../../src/ol/View.js';
+import WebGLVectorTileLayer from '../../../../../src/ol/layer/WebGLVectorTile.js';
+import {getRenderPixel} from '../../../../../src/ol/render.js';
+import WebGLVectorTileLayerRenderer from '../../../../../src/ol/renderer/webgl/VectorTileLayer.js';
+import VectorTileSource from '../../../../../src/ol/source/VectorTile.js';
+
+describe('ol/layer/WebGLVectorTile', function () {
+  /** @type {WebGLVectorTileLayer} */
+  let layer;
+  /** @type {Map} */
+  let map, target;
+
+  beforeEach(function (done) {
+    layer = new WebGLVectorTileLayer({
+      className: 'testlayer',
+      source: new VectorTileSource({}),
+      style: [
+        {
+          'circle-radius': 4,
+          'circle-fill-color': ['var', 'fillColor'],
+        },
+        {
+          'fill-color': ['var', 'fillColor'],
+        },
+      ],
+      variables: {
+        fillColor: 'rgba(255, 0, 0, 0.5)',
+      },
+      disableHitDetection: false,
+    });
+    target = document.createElement('div');
+    target.style.width = '100px';
+    target.style.height = '100px';
+    document.body.appendChild(target);
+    map = new Map({
+      target: target,
+      layers: [layer],
+      view: new View({
+        center: [0, 0],
+        zoom: 2,
+      }),
+    });
+    map.once('rendercomplete', () => done());
+  });
+
+  afterEach(function () {
+    disposeMap(map);
+    map.getLayers().forEach((layer) => layer.dispose());
+  });
+
+  describe('dispose()', () => {
+    it('calls dispose on the renderer', () => {
+      const renderer = layer.getRenderer();
+      const spy = sinonSpy(renderer, 'dispose');
+      layer.dispose();
+      expect(spy.called).to.be(true);
+    });
+  });
+
+  it('creates a renderer with the given parameters', function () {
+    const renderer = layer.getRenderer();
+    expect(renderer).to.be.a(WebGLVectorTileLayerRenderer);
+    expect(renderer.styles_).to.eql([
+      {
+        style: {
+          'circle-radius': 4,
+          'circle-fill-color': ['var', 'fillColor'],
+        },
+      },
+      {
+        style: {
+          'fill-color': ['var', 'fillColor'],
+        },
+      },
+    ]);
+    expect(renderer.styleVariables_).to.eql({
+      fillColor: 'rgba(255, 0, 0, 0.5)',
+    });
+    expect(renderer.hitDetectionEnabled_).to.be(true);
+  });
+
+  describe('updateStyleVariables()', function () {
+    it('updates style variables', function () {
+      layer.updateStyleVariables({
+        fillColor: 'yellow',
+      });
+      expect(layer.styleVariables_['fillColor']).to.be('yellow');
+      const renderer = layer.getRenderer();
+      const uniforms = renderer.styleRenderers_[0].uniforms_;
+      expect(uniforms.u_var_fillColor()).to.eql([255, 255, 0, 1]);
+    });
+
+    it('can be called before the layer is rendered', function () {
+      layer = new WebGLVectorTileLayer({
+        style: {
+          'fill-color': ['var', 'fillColor'],
+        },
+        source: new VectorTileSource({}),
+      });
+
+      layer.updateStyleVariables({foo: 'bam'});
+      expect(layer.styleVariables_.foo).to.be('bam');
+    });
+
+    it('can be called even if no initial variables are provided', function () {
+      const layer = new WebGLVectorTileLayer({
+        source: new VectorTileSource({}),
+      });
+
+      layer.updateStyleVariables({foo: 'bam'});
+      expect(layer.styleVariables_.foo).to.be('bam');
+    });
+  });
+
+  it('dispatches a precompose event with WebGL context', (done) => {
+    let called = false;
+    layer.on('precompose', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('dispatches a prerender event with WebGL context and inverse pixel transform', (done) => {
+    let called = false;
+    layer.on('prerender', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      const mapSize = event.frameState.size;
+      const bottomLeft = getRenderPixel(event, [0, mapSize[1]]);
+      expect(bottomLeft).to.eql([0, 0]);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('dispatches a postrender event with WebGL context and inverse pixel transform', (done) => {
+    let called = false;
+    layer.on('postrender', (event) => {
+      expect(event.context).to.be.a(WebGLRenderingContext);
+      const mapSize = event.frameState.size;
+      const topRight = getRenderPixel(event, [mapSize[1], 0]);
+      const pixelRatio = event.frameState.pixelRatio;
+      expect(topRight).to.eql([
+        mapSize[0] * pixelRatio,
+        mapSize[1] * pixelRatio,
+      ]);
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+
+    map.render();
+  });
+
+  it('works if the layer is constructed without a source', (done) => {
+    const sourceless = new WebGLVectorTileLayer({
+      className: 'testlayer',
+      style: {
+        'fill-color': 'red',
+      },
+    });
+
+    map.addLayer(sourceless);
+
+    sourceless.setSource(new VectorTileSource({}));
+
+    let called = false;
+    layer.on('postrender', (event) => {
+      called = true;
+    });
+
+    map.once('rendercomplete', () => {
+      expect(called).to.be(true);
+      done();
+    });
+  });
+});

--- a/test/rendering/cases/webgl-vectortile-masking/main.js
+++ b/test/rendering/cases/webgl-vectortile-masking/main.js
@@ -2,8 +2,7 @@ import Feature from '../../../../src/ol/Feature.js';
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import Polygon from '../../../../src/ol/geom/Polygon.js';
-import VectorTile from '../../../../src/ol/layer/VectorTile.js';
-import WebGLVectorTileLayerRenderer from '../../../../src/ol/renderer/webgl/VectorTileLayer.js';
+import WebGLVectorTileLayer from '../../../../src/ol/layer/WebGLVectorTile.js';
 import VectorTileSource from '../../../../src/ol/source/VectorTile.js';
 
 const source = new VectorTileSource({
@@ -40,10 +39,11 @@ const source = new VectorTileSource({
   },
 });
 
-class WebGLVectorTileLayer extends VectorTile {
-  createRenderer() {
-    return new WebGLVectorTileLayerRenderer(this, {
-      className: this.getClassName(),
+const map = new Map({
+  pixelRatio: 2,
+  layers: [
+    new WebGLVectorTileLayer({
+      source,
       style: {
         'fill-color': '#eee',
         'stroke-color': 'rgba(136,136,136, 0.5)',
@@ -51,15 +51,6 @@ class WebGLVectorTileLayer extends VectorTile {
         'circle-radius': 2,
         'circle-fill-color': '#707070',
       },
-    });
-  }
-}
-
-const map = new Map({
-  pixelRatio: 2,
-  layers: [
-    new WebGLVectorTileLayer({
-      source,
     }),
   ],
   target: 'map',

--- a/test/rendering/cases/webgl-vectortile-pattern/main.js
+++ b/test/rendering/cases/webgl-vectortile-pattern/main.js
@@ -1,8 +1,7 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import MVT from '../../../../src/ol/format/MVT.js';
-import VectorTile from '../../../../src/ol/layer/VectorTile.js';
-import WebGLVectorTileLayerRenderer from '../../../../src/ol/renderer/webgl/VectorTileLayer.js';
+import WebGLVectorTileLayer from '../../../../src/ol/layer/WebGLVectorTile.js';
 import VectorTileSource from '../../../../src/ol/source/VectorTile.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
 
@@ -28,19 +27,6 @@ context.fillRect(0, 0, 4, 2);
 context.fillStyle = 'rgba(255,0,0,0.7)';
 context.fillRect(4, 0, 4, 2);
 
-class WebGLVectorTileLayer extends VectorTile {
-  createRenderer() {
-    return new WebGLVectorTileLayerRenderer(this, {
-      className: this.getClassName(),
-      style: {
-        'fill-pattern-src': canvasFill.toDataURL('png'),
-        'stroke-pattern-src': canvasStroke.toDataURL('png'),
-        'stroke-width': 1,
-      },
-    });
-  }
-}
-
 const map = new Map({
   layers: [
     new WebGLVectorTileLayer({
@@ -50,6 +36,11 @@ const map = new Map({
         url: '/data/tiles/mapbox-streets-v6/{z}/{x}/{y}.vector.pbf',
         transition: 0,
       }),
+      style: {
+        'fill-pattern-src': canvasFill.toDataURL('png'),
+        'stroke-pattern-src': canvasStroke.toDataURL('png'),
+        'stroke-width': 1,
+      },
     }),
   ],
   target: 'map',

--- a/test/rendering/cases/webgl-vectortile/main.js
+++ b/test/rendering/cases/webgl-vectortile/main.js
@@ -1,25 +1,9 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import MVT from '../../../../src/ol/format/MVT.js';
-import VectorTile from '../../../../src/ol/layer/VectorTile.js';
-import WebGLVectorTileLayerRenderer from '../../../../src/ol/renderer/webgl/VectorTileLayer.js';
+import WebGLVectorTileLayer from '../../../../src/ol/layer/WebGLVectorTile.js';
 import VectorTileSource from '../../../../src/ol/source/VectorTile.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
-
-class WebGLVectorTileLayer extends VectorTile {
-  createRenderer() {
-    return new WebGLVectorTileLayerRenderer(this, {
-      className: this.getClassName(),
-      style: {
-        'fill-color': '#eee',
-        'stroke-color': 'rgba(136,136,136, 0.5)',
-        'stroke-width': 1,
-        'circle-radius': 2,
-        'circle-fill-color': '#707070',
-      },
-    });
-  }
-}
 
 const map = new Map({
   layers: [
@@ -30,6 +14,13 @@ const map = new Map({
         url: '/data/tiles/mapbox-streets-v6/{z}/{x}/{y}.vector.pbf',
         transition: 0,
       }),
+      style: {
+        'fill-color': '#eee',
+        'stroke-color': 'rgba(136,136,136, 0.5)',
+        'stroke-width': 1,
+        'circle-radius': 2,
+        'circle-fill-color': '#707070',
+      },
     }),
   ],
   target: 'map',


### PR DESCRIPTION
This PR introduces a WebGLVectorTileLayer class similarly to #16394.

To use it:

```js
const layer = new WebGLVectorTileLayer({
  source: new VectorTileSource(...),
  style: [
    {
      filter: [
        'all',
        ['==', ['get', 'layer'], 'landuse'],
        ['==', ['get', 'class'], 'park'],
      ],
      style: {
        'fill-color': '#d8e8c8',
      },
    },
    {
      filter: [
        'all',
        ['==', ['get', 'layer'], 'tunnel'],
        ['==', ['get', 'class'], 'service'],
      ],
      style: {
        'stroke-color': '#cfcdca',
        'stroke-width': 1,
      },
    },
    // ...
  ],
  variables: {
    // any user-defined variable here
  },
});
```