### PR TITLE
Add example observing COG load event order

### DIFF
--- a/examples/cog-load-events.css
+++ b/examples/cog-load-events.css
@@ -1,0 +1,30 @@
+.map {
+  background: #85ccf9;
+  position: relative;
+}
+#map {
+  height: 400px;
+  position: relative;
+}
+
+@keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner:after {
+  content: "";
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 40px;
+  height: 40px;
+  margin-top: -20px;
+  margin-left: -20px;
+  border-radius: 50%;
+  border: 5px solid rgba(180, 180, 180, 0.6);
+  border-top-color: rgba(0, 0, 0, 0.6);
+  animation: spinner 0.6s linear infinite;
+}

--- a/examples/cog-load-events.html
+++ b/examples/cog-load-events.html
@@ -1,0 +1,13 @@
+---
+layout: example.html
+title: COG Load Event Order
+shortdesc: Example observing COG load event order.
+docs: >
+  You can check if the map's <code>loadstart</code> event
+  fires before the COG source is ready.  Event order:
+tags: "events, loading, COG"
+cloak:
+  - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ
+    value: Your Mapbox access token from https://mapbox.com/ here
+---
+<div id="map" class="map"></div>

--- a/examples/cog-load-events.js
+++ b/examples/cog-load-events.js
@@ -1,0 +1,37 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import GeoTIFF from '../src/ol/source/GeoTIFF.js';
+
+const source = new GeoTIFF({
+  sources: [
+    {
+      url: 'https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/Q/WD/2020/7/S2A_36QWD_20200701_0_L2A/TCI.tif',
+    },
+  ],
+});
+
+const map = new Map({
+  layers: [new TileLayer({source: source})],
+  target: 'map',
+  view: new View({
+    projection: 'EPSG:3857',
+    center: [3.7e6, 1.9e6],
+    zoom: 8,
+  }),
+});
+
+const docs = document.getElementById('docs');
+
+map.on('loadstart', function () {
+  docs.textContent += ' loadstart';
+  map.getTargetElement().classList.add('spinner');
+});
+map.on('loadend', function () {
+  docs.textContent += ' loadend';
+  map.getTargetElement().classList.remove('spinner');
+});
+
+source.getView().then(() => {
+  docs.textContent += ' cogready';
+});


### PR DESCRIPTION
Reproducer for #16483, allows to check if the map's `loadstart` event fires before the COG source is ready.