### PR TITLE
Make forEachFeatureAtCoordinate work when decluttering without features

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -530,7 +530,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       hitTolerance,
       featureCallback,
       declutter
-        ? frameState.declutter[declutter].all().map((item) => item.value)
+        ? frameState.declutter?.[declutter]?.all().map((item) => item.value)
         : null,
     );
   }

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -380,7 +380,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     const layerUid = getUid(layer);
     const declutter = layer.getDeclutter();
     const declutteredFeatures = declutter
-      ? frameState.declutter[declutter].all().map((item) => item.value)
+      ? frameState.declutter?.[declutter]?.all().map((item) => item.value)
       : null;
     let found;
     foundFeature: for (let i = 0, ii = renderedTiles.length; i < ii; ++i) {
@@ -589,7 +589,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
     ];
     const declutter = this.getLayer().getDeclutter();
     const declutterTree = declutter
-      ? frameState.declutter[declutter]
+      ? frameState.declutter?.[declutter]
       : undefined;
     const layerUid = getUid(this.getLayer());
     const tiles =

--- a/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
@@ -275,6 +275,30 @@ describe('ol/renderer/canvas/VectorLayer', function () {
       expect(spy.getCall(0).args[1]).to.be(layer);
       expect(matches).to.be.empty();
     });
+
+    it('works with declutter: true when source has no features', () => {
+      layer.setDeclutter(true);
+      const spy = sinonSpy();
+      const coordinate = [0, 0];
+      const matches = [];
+      const frameState = {
+        layerStatesArray: [{}],
+        viewState: {
+          center: [0, 0],
+          resolution: 1,
+          rotation: 0,
+        },
+      };
+      expect(() =>
+        renderer.forEachFeatureAtCoordinate(
+          coordinate,
+          frameState,
+          0,
+          spy,
+          matches,
+        ),
+      ).to.not.throwException();
+    });
   });
 
   describe('#prepareFrame and #compose', function () {


### PR DESCRIPTION
Fixes #16536 and adds a regression test to prevent future regressions on it.