### PR TITLE
Do not fail when reprojecting geometries with empty coordinate arrays

### DIFF
--- a/src/ol/format/Feature.js
+++ b/src/ol/format/Feature.js
@@ -445,7 +445,7 @@ export function createGeometry(object, options) {
   }
   const Geometry = GeometryConstructor[object.type];
   return transformGeometryWithOptions(
-    new Geometry(object.flatCoordinates, object.layout, object.ends),
+    new Geometry(object.flatCoordinates, object.layout || 'XY', object.ends),
     false,
     options,
   );

--- a/test/node/ol/format/GeoJSON.test.js
+++ b/test/node/ol/format/GeoJSON.test.js
@@ -591,6 +591,27 @@ describe('ol/format/GeoJSON.js', function () {
         expect(geometry.getCoordinates()).to.eql([]);
       });
     });
+
+    it('works with empty coordinate array and reprojection', () => {
+      const types = [
+        'Point',
+        'LineString',
+        'Polygon',
+        'MultiPoint',
+        'MultiLineString',
+        'MultiPolygon',
+      ];
+      types.forEach((type) => {
+        const geojson = {
+          type,
+          coordinates: [],
+        };
+        const geometry = format.readGeometry(geojson, {
+          featureProjection: 'EPSG:3857',
+        });
+        expect(geometry.getCoordinates()).to.eql([]);
+      });
+    });
   });
 
   describe('#readProjection', function () {


### PR DESCRIPTION
This is a late follow-up on #15388 and fixes #16555