### PR TITLE
Fix text background rendering

### DIFF
--- a/src/ol/render/canvas/Builder.js
+++ b/src/ol/render/canvas/Builder.js
@@ -487,11 +487,13 @@ class CanvasBuilder extends VectorContext {
 
   /**
    * @param {import("../../style/Fill.js").default} fillStyle Fill style.
-   * @param {import("../../style/Stroke.js").default} strokeStyle Stroke style.
-   * @override
+   * @param {import('../canvas.js').FillStrokeState} [state] State.
+   * @return {import('../canvas.js').FillStrokeState} State.
    */
-  setFillStrokeStyle(fillStyle, strokeStyle) {
-    const state = this.state;
+  fillStyleToState(
+    fillStyle,
+    state = /** @type {import('../canvas.js').FillStrokeState} */ ({}),
+  ) {
     if (fillStyle) {
       const fillStyleColor = fillStyle.getColor();
       state.fillPatternScale =
@@ -506,6 +508,18 @@ class CanvasBuilder extends VectorContext {
     } else {
       state.fillStyle = undefined;
     }
+    return state;
+  }
+
+  /**
+   * @param {import("../../style/Stroke.js").default} strokeStyle Stroke style.
+   * @param {import("../canvas.js").FillStrokeState} state State.
+   * @return {import("../canvas.js").FillStrokeState} State.
+   */
+  strokeStyleToState(
+    strokeStyle,
+    state = /** @type {import('../canvas.js').FillStrokeState} */ ({}),
+  ) {
     if (strokeStyle) {
       const strokeStyleColor = strokeStyle.getColor();
       state.strokeStyle = asColorLike(
@@ -550,6 +564,18 @@ class CanvasBuilder extends VectorContext {
       state.lineWidth = undefined;
       state.miterLimit = undefined;
     }
+    return state;
+  }
+
+  /**
+   * @param {import("../../style/Fill.js").default} fillStyle Fill style.
+   * @param {import("../../style/Stroke.js").default} strokeStyle Stroke style.
+   * @override
+   */
+  setFillStrokeStyle(fillStyle, strokeStyle) {
+    const state = this.state;
+    this.fillStyleToState(fillStyle, state);
+    this.strokeStyleToState(strokeStyle, state);
   }
 
   /**
@@ -586,7 +612,7 @@ class CanvasBuilder extends VectorContext {
       state.lineCap,
       state.lineJoin,
       state.miterLimit,
-      this.applyPixelRatio(state.lineDash),
+      state.lineDash ? this.applyPixelRatio(state.lineDash) : null,
       state.lineDashOffset * this.pixelRatio,
     ];
   }

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -377,6 +377,7 @@ class Executor {
     context.lineTo.apply(context, p1);
     if (fillInstruction) {
       this.alignAndScaleFill_ = /** @type {number} */ (fillInstruction[2]);
+      context.fillStyle = /** @type {string} */ (fillInstruction[1]);
       this.fill_(context);
     }
     if (strokeInstruction) {
@@ -703,8 +704,6 @@ class Executor {
       fillKey;
     let pendingFill = 0;
     let pendingStroke = 0;
-    let lastFillInstruction = null;
-    let lastStrokeInstruction = null;
     const coordinateCache = this.coordinateCache_;
     const viewRotation = this.viewRotation_;
     const viewRotationFromTransform =
@@ -867,15 +866,19 @@ class Executor {
             geometryWidths = /** @type {number} */ (instruction[25]);
           }
 
-          let padding, backgroundFill, backgroundStroke;
+          let padding, backgroundFillInstruction, backgroundStrokeInstruction;
           if (instruction.length > 17) {
             padding = /** @type {Array<number>} */ (instruction[16]);
-            backgroundFill = /** @type {boolean} */ (instruction[17]);
-            backgroundStroke = /** @type {boolean} */ (instruction[18]);
+            backgroundFillInstruction = /** @type {Array<*>} */ (
+              instruction[17]
+            );
+            backgroundStrokeInstruction = /** @type {Array<*>} */ (
+              instruction[18]
+            );
           } else {
             padding = defaultPadding;
-            backgroundFill = false;
-            backgroundStroke = false;
+            backgroundFillInstruction = null;
+            backgroundStrokeInstruction = null;
           }
 
           if (rotateWithView && viewRotationFromTransform) {
@@ -908,7 +911,7 @@ class Executor {
               scale,
               snapToPixel,
               padding,
-              backgroundFill || backgroundStroke,
+              !!backgroundFillInstruction || !!backgroundStrokeInstruction,
               feature,
             );
             /** @type {ReplayImageOrLabelArgs} */
@@ -918,12 +921,8 @@ class Executor {
               image,
               dimensions,
               opacity,
-              backgroundFill
-                ? /** @type {Array<*>} */ (lastFillInstruction)
-                : null,
-              backgroundStroke
-                ? /** @type {Array<*>} */ (lastStrokeInstruction)
-                : null,
+              backgroundFillInstruction,
+              backgroundStrokeInstruction,
             ];
             if (declutterTree) {
               let imageArgs, imageDeclutterMode, imageDeclutterBox;
@@ -1192,7 +1191,6 @@ class Executor {
           ++i;
           break;
         case CanvasInstruction.SET_FILL_STYLE:
-          lastFillInstruction = instruction;
           this.alignAndScaleFill_ = instruction[2];
 
           if (pendingFill) {
@@ -1209,7 +1207,6 @@ class Executor {
           ++i;
           break;
         case CanvasInstruction.SET_STROKE_STYLE:
-          lastStrokeInstruction = instruction;
           if (pendingStroke) {
             context.stroke();
             pendingStroke = 0;

--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -345,19 +345,12 @@ class CanvasTextBuilder extends CanvasBuilder {
 
       this.saveTextStates_();
 
-      if (textState.backgroundFill || textState.backgroundStroke) {
-        this.setFillStrokeStyle(
-          textState.backgroundFill,
-          textState.backgroundStroke,
-        );
-        if (textState.backgroundFill) {
-          this.updateFillStyle(this.state, this.createFill);
-        }
-        if (textState.backgroundStroke) {
-          this.updateStrokeStyle(this.state, this.applyStroke);
-          this.hitDetectionInstructions.push(this.createStroke(this.state));
-        }
-      }
+      const backgroundFill = textState.backgroundFill
+        ? this.createFill(this.fillStyleToState(textState.backgroundFill))
+        : null;
+      const backgroundStroke = textState.backgroundStroke
+        ? this.createStroke(this.strokeStyleToState(textState.backgroundStroke))
+        : null;
 
       this.beginGeometry(geometry, feature, index);
 
@@ -408,8 +401,8 @@ class CanvasTextBuilder extends CanvasBuilder {
           : padding.map(function (p) {
               return p * pixelRatio;
             }),
-        !!textState.backgroundFill,
-        !!textState.backgroundStroke,
+        backgroundFill,
+        backgroundStroke,
         this.text_,
         this.textKey_,
         this.strokeKey_,
@@ -420,10 +413,11 @@ class CanvasTextBuilder extends CanvasBuilder {
       ]);
       const scale = 1 / pixelRatio;
       // Set default fill for hit detection background
-      const currentFillStyle = this.state.fillStyle;
-      if (textState.backgroundFill) {
-        this.state.fillStyle = defaultFillStyle;
-        this.hitDetectionInstructions.push(this.createFill(this.state));
+      const hitDetectionBackgroundFill = backgroundFill
+        ? backgroundFill.slice(0)
+        : null;
+      if (hitDetectionBackgroundFill) {
+        hitDetectionBackgroundFill[1] = defaultFillStyle;
       }
       this.hitDetectionInstructions.push([
         CanvasInstruction.DRAW_IMAGE,
@@ -443,8 +437,8 @@ class CanvasTextBuilder extends CanvasBuilder {
         this.declutterMode_,
         this.declutterImageWithText_,
         padding,
-        !!textState.backgroundFill,
-        !!textState.backgroundStroke,
+        hitDetectionBackgroundFill,
+        backgroundStroke,
         this.text_,
         this.textKey_,
         this.strokeKey_,
@@ -453,11 +447,6 @@ class CanvasTextBuilder extends CanvasBuilder {
         this.textOffsetY_,
         geometryWidths,
       ]);
-      // Reset previous fill
-      if (textState.backgroundFill) {
-        this.state.fillStyle = currentFillStyle;
-        this.hitDetectionInstructions.push(this.createFill(this.state));
-      }
 
       this.endGeometry(feature);
     }


### PR DESCRIPTION
Text backgrounds are currently rendered by prepending `SET_FILL_STYLE` and `SET_STROKE_STYLE` instructions. This works as long as we're not decluttering. If we do, these `SET_FILL_STYLE` and `SET_STROKE_STYLE` instructions are no longer guaranteed to be executed immediately before the text background box is drawn.

To fix this, the text builder is modified so the background fill and stroke instructions become part of the text instruction. The code to execute the stroke was already there, only for the fill there was a missing `context.fillStyle = fillInstruction[1]`. So this pull request also removes redundant setting of background stroke properties on the canvas context.

Fixes #16554