### PR TITLE
Set WMS TRANSPARENT parameter default value to the correct value according to the specification

### DIFF
--- a/src/ol/source/wms.js
+++ b/src/ol/source/wms.js
@@ -124,7 +124,7 @@ export function getRequestParams(params, request) {
       'VERSION': DEFAULT_VERSION,
       'FORMAT': 'image/png',
       'STYLES': '',
-      'TRANSPARENT': true,
+      'TRANSPARENT': 'TRUE',
     },
     params,
   );

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -171,7 +171,7 @@ describe('ol/source/ImageWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('200');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -231,14 +231,14 @@ describe('ol/source/ImageWMS', function () {
 
     it('allows various parameters to be overridden', function () {
       options.params.FORMAT = 'image/jpeg';
-      options.params.TRANSPARENT = false;
+      options.params.TRANSPARENT = 'FALSE';
       const source = new ImageWMS(options);
       const image = source.getImage(extent, resolution, pixelRatio, projection);
       image.load();
       const uri = new URL(image.getImage().src);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
-      expect(queryData.get('TRANSPARENT')).to.be('false');
+      expect(queryData.get('TRANSPARENT')).to.be('FALSE');
     });
 
     it('does not add a STYLES= option if one is specified', function () {
@@ -337,7 +337,7 @@ describe('ol/source/ImageWMS', function () {
       expect(imageLoadFunction.getCall(0).args[0]).to.eql(image);
       expect(imageLoadFunction.getCall(0).args[1]).to.be(
         window.location.origin +
-          '/wms?REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=image%2Fpng&STYLES=&TRANSPARENT=true&LAYERS=layer&WIDTH=200&HEIGHT=200&CRS=EPSG%3A4326&BBOX=20%2C10%2C40%2C30',
+          '/wms?REQUEST=GetMap&SERVICE=WMS&VERSION=1.3.0&FORMAT=image%2Fpng&STYLES=&TRANSPARENT=TRUE&LAYERS=layer&WIDTH=200&HEIGHT=200&CRS=EPSG%3A4326&BBOX=20%2C10%2C40%2C30',
       );
     });
 
@@ -418,7 +418,7 @@ describe('ol/source/ImageWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('101');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -448,7 +448,7 @@ describe('ol/source/ImageWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('101');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -477,7 +477,7 @@ describe('ol/source/ImageWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('101');
       expect(uri.hash.replace('#', '')).to.be.empty();

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -231,13 +231,32 @@ describe('ol/source/ImageWMS', function () {
 
     it('allows various parameters to be overridden', function () {
       options.params.FORMAT = 'image/jpeg';
-      options.params.TRANSPARENT = 'FALSE';
+      options.params.TRANSPARENT = false;
       const source = new ImageWMS(options);
       const image = source.getImage(extent, resolution, pixelRatio, projection);
       image.load();
       const uri = new URL(image.getImage().src);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
+      expect(queryData.get('TRANSPARENT')).to.be('false');
+    });
+
+    it('valid TRANSPARENT default value', function () {
+      const source = new ImageWMS(options);
+      const image = source.getImage(extent, resolution, pixelRatio, projection);
+      image.load();
+      const uri = new URL(image.getImage().src);
+      const queryData = uri.searchParams;
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
+    });
+
+    it('valid TRANSPARENT override value', function () {
+      options.params.TRANSPARENT = 'FALSE';
+      const source = new ImageWMS(options);
+      const image = source.getImage(extent, resolution, pixelRatio, projection);
+      image.load();
+      const uri = new URL(image.getImage().src);
+      const queryData = uri.searchParams;
       expect(queryData.get('TRANSPARENT')).to.be('FALSE');
     });
 

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -128,12 +128,29 @@ describe('ol/source/TileWMS', function () {
 
     it('allows various parameters to be overridden', function () {
       options.params.FORMAT = 'image/jpeg';
-      options.params.TRANSPARENT = 'FALSE';
+      options.params.TRANSPARENT = false;
       const source = new TileWMS(options);
       const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
+      expect(queryData.get('TRANSPARENT')).to.be('false');
+    });
+
+    it('valid TRANSPARENT default value', function () {
+      const source = new TileWMS(options);
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
+      const uri = new URL(tile.src_);
+      const queryData = uri.searchParams;
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
+    });
+
+    it('valid TRANSPARENT override value', function () {
+      options.params.TRANSPARENT = 'FALSE';
+      const source = new TileWMS(options);
+      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
+      const uri = new URL(tile.src_);
+      const queryData = uri.searchParams;
       expect(queryData.get('TRANSPARENT')).to.be('FALSE');
     });
 

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -91,7 +91,7 @@ describe('ol/source/TileWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('256');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -128,13 +128,13 @@ describe('ol/source/TileWMS', function () {
 
     it('allows various parameters to be overridden', function () {
       options.params.FORMAT = 'image/jpeg';
-      options.params.TRANSPARENT = false;
+      options.params.TRANSPARENT = 'FALSE';
       const source = new TileWMS(options);
       const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('FORMAT')).to.be('image/jpeg');
-      expect(queryData.get('TRANSPARENT')).to.be('false');
+      expect(queryData.get('TRANSPARENT')).to.be('FALSE');
     });
 
     it('does not add a STYLES= option if one is specified', function () {
@@ -281,7 +281,7 @@ describe('ol/source/TileWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('256');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -313,7 +313,7 @@ describe('ol/source/TileWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('256');
       expect(uri.hash.replace('#', '')).to.be.empty();
@@ -349,7 +349,7 @@ describe('ol/source/TileWMS', function () {
       expect(queryData.get('SERVICE')).to.be('WMS');
       expect(queryData.get('SRS')).to.be(null);
       expect(queryData.get('STYLES')).to.be('');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('TRANSPARENT')).to.be('TRUE');
       expect(queryData.get('VERSION')).to.be('1.3.0');
       expect(queryData.get('WIDTH')).to.be('256');
       expect(uri.hash.replace('#', '')).to.be.empty();


### PR DESCRIPTION
Closes #16559

Accordingly to the WMS specification version 1.3.0 section  7.3.3.9 the valid values for the TRANSPARENT parameter are TRUE and FALSE.

> The optional TRANSPARENT parameter specifies whether the map background is to be made transparent or not.
TRANSPARENT can take on two values, "TRUE" or "FALSE".

Currently OpenLayers sets the TRANSPARENT parameter to the boolean value true by default, which gets serialized as the string "true" when building the URL.

However since section 6.8.1 of the WMS specification specifies that values are case senstitive:

> Parameter names shall not be case sensitive, but parameter values shall be.

This means that 'true' is not a valid value for the TRANSPARENT parameter.


This change thus changes the default value for TRANSPARENT to the string value 'TRUE' which results in the valid value being present in the URL.