### PR TITLE
Make TileImage reprojection independent of tilePixelRatio

### DIFF
--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -296,10 +296,24 @@ class ReprojTile extends Tile {
     if (sources.length === 0) {
       this.state = TileState.ERROR;
     } else {
+      const gutter = this.gutter_;
+      const tileSize = this.sourceTileGrid_.getTileSize(this.sourceZ_);
+      const width = typeof tileSize === 'number' ? tileSize : tileSize[0];
+      const height = typeof tileSize === 'number' ? tileSize : tileSize[1];
+      const pixelRatio = Math.max.apply(
+        null,
+        sources.map((s) =>
+          Math.max(
+            (s.image.width - 2 * gutter) / width,
+            (s.image.height - 2 * gutter) / height,
+          ),
+        ),
+      );
+
       const z = this.wrappedTileCoord_[0];
       const size = this.targetTileGrid_.getTileSize(z);
-      const width = typeof size === 'number' ? size : size[0];
-      const height = typeof size === 'number' ? size : size[1];
+      const targetWidth = typeof size === 'number' ? size : size[0];
+      const targetHeight = typeof size === 'number' ? size : size[1];
       const targetResolution = this.targetTileGrid_.getResolution(z);
       const sourceResolution = this.sourceTileGrid_.getResolution(
         this.sourceZ_,
@@ -310,16 +324,16 @@ class ReprojTile extends Tile {
       );
 
       this.canvas_ = renderReprojected(
-        width,
-        height,
-        this.pixelRatio_,
+        targetWidth,
+        targetHeight,
+        pixelRatio,
         sourceResolution,
         this.sourceTileGrid_.getExtent(),
         targetResolution,
         targetExtent,
         this.triangulation_,
         sources,
-        this.gutter_,
+        gutter,
         this.renderEdges_,
         this.interpolate,
       );

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -194,10 +194,11 @@ class DataTileSource extends TileSource {
 
   /**
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {number} [pixelRatio] Pixel ratio.
    * @return {number} Gutter.
    * @override
    */
-  getGutterForProjection(projection) {
+  getGutterForProjection(projection, pixelRatio) {
     const thisProj = this.getProjection();
     if (
       (!thisProj || equivalent(thisProj, projection)) &&

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -127,9 +127,10 @@ class TileSource extends Source {
 
   /**
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {number} [pixelRatio] Pixel ratio.
    * @return {number} Gutter.
    */
-  getGutterForProjection(projection) {
+  getGutterForProjection(projection, pixelRatio) {
     return 0;
   }
 

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -246,8 +246,8 @@ class TileImage extends UrlTile {
       targetTileGrid,
       tileCoord,
       wrappedTileCoord,
-      this.getTilePixelRatio(pixelRatio),
-      this.getGutter(),
+      pixelRatio,
+      this.getGutterForProjection(sourceProjection, pixelRatio),
       (z, x, y, pixelRatio) =>
         this.getTileInternal(z, x, y, pixelRatio, sourceProjection),
       this.reprojectionErrorThreshold_,

--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -123,10 +123,11 @@ class TileImage extends UrlTile {
 
   /**
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {number} [pixelRatio] Pixel ratio.
    * @return {number} Gutter.
    * @override
    */
-  getGutterForProjection(projection) {
+  getGutterForProjection(projection, pixelRatio) {
     if (
       this.getProjection() &&
       projection &&

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -273,6 +273,20 @@ class TileWMS extends TileImage {
   }
 
   /**
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {number} [pixelRatio] Pixel ratio.
+   * @return {number} Gutter.
+   * @override
+   */
+  getGutterForProjection(projection, pixelRatio) {
+    let ratio = pixelRatio ?? 1;
+    if (ratio !== 1 && (!this.hidpi_ || this.serverType_ === undefined)) {
+      ratio = 1;
+    }
+    return super.getGutterForProjection(projection) * ratio;
+  }
+
+  /**
    * Get the user-provided params, i.e. those passed to the constructor through
    * the "params" option, and possibly updated using the updateParams method.
    * @return {Object} Params.


### PR DESCRIPTION
No tests added as this should not break that added by #16540
Uses cherry picked commit from #16520 to obtain gutter in image pixels if dependent on the map pixel ratio
