### PR TITLE
Avoid seams along tile boundaries for adjacent polygons when renderMode is vector

### DIFF
--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -131,13 +131,12 @@ class ExecutorGroup {
    * @param {import("../../transform.js").Transform} transform Transform.
    */
   clip(context, transform) {
-    const bleed = 0.5; // avoid seams for adjacent polygons along tile boundaries
     const flatClipCoords = this.getClipCoords(transform);
     context.beginPath();
-    context.moveTo(flatClipCoords[0]-bleed, flatClipCoords[1]+bleed);
-    context.lineTo(flatClipCoords[2]-bleed, flatClipCoords[3]-bleed);
-    context.lineTo(flatClipCoords[4]+bleed, flatClipCoords[5]-bleed);
-    context.lineTo(flatClipCoords[6]+bleed, flatClipCoords[7]+bleed);
+    context.moveTo(flatClipCoords[0], flatClipCoords[1]);
+    context.lineTo(flatClipCoords[2], flatClipCoords[3]);
+    context.lineTo(flatClipCoords[4], flatClipCoords[5]);
+    context.lineTo(flatClipCoords[6], flatClipCoords[7]);
     context.clip();
   }
 

--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -131,12 +131,13 @@ class ExecutorGroup {
    * @param {import("../../transform.js").Transform} transform Transform.
    */
   clip(context, transform) {
+    const bleed = 0.5; // avoid seams for adjacent polygons along tile boundaries
     const flatClipCoords = this.getClipCoords(transform);
     context.beginPath();
-    context.moveTo(flatClipCoords[0], flatClipCoords[1]);
-    context.lineTo(flatClipCoords[2], flatClipCoords[3]);
-    context.lineTo(flatClipCoords[4], flatClipCoords[5]);
-    context.lineTo(flatClipCoords[6], flatClipCoords[7]);
+    context.moveTo(flatClipCoords[0]-bleed, flatClipCoords[1]+bleed);
+    context.lineTo(flatClipCoords[2]-bleed, flatClipCoords[3]-bleed);
+    context.lineTo(flatClipCoords[4]+bleed, flatClipCoords[5]-bleed);
+    context.lineTo(flatClipCoords[6]+bleed, flatClipCoords[7]+bleed);
     context.clip();
   }
 

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -461,8 +461,8 @@ class TileGrid {
     const tileSize = toSize(this.getTileSize(tileCoord[0]), this.tmpSize_);
     const minX = origin[0] + tileCoord[1] * tileSize[0] * resolution;
     const minY = origin[1] - (tileCoord[2] + 1) * tileSize[1] * resolution;
-    const maxX = minX + tileSize[0] * resolution;
-    const maxY = minY + tileSize[1] * resolution;
+    const maxX = origin[0] + (tileCoord[1] + 1) * tileSize[0] * resolution;
+    const maxY = origin[1] - tileCoord[2] * tileSize[1] * resolution;
     return createOrUpdate(minX, minY, maxX, maxY, tempExtent);
   }
 


### PR DESCRIPTION
See discussion at https://github.com/openlayers/openlayers/discussions/16541.

I'm not sure if the bleed/margin of the clipping path has any other implications.