### PR TITLE
Support CDATA in writeStringTextNode

### DIFF
--- a/src/ol/format/KML.js
+++ b/src/ol/format/KML.js
@@ -45,7 +45,6 @@ import {
   readDecimal,
   readString,
   writeBooleanTextNode,
-  writeCDATASection,
   writeDecimalTextNode,
   writeStringTextNode,
 } from './xsd.js';
@@ -2508,7 +2507,7 @@ function writeDataNode(node, pair, objectStack) {
  * @param {string} name DisplayName.
  */
 function writeDataNodeName(node, name) {
-  writeCDATASection(node, name);
+  writeStringTextNode(node, name);
 }
 
 /**

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -143,55 +143,16 @@ export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
 }
 
 /**
- * Checks if a given string should be wrapped in a CDATA section
- * @param {string} string String.
- * @return {boolean} true if the string should be wrapped in a CDATA section, else false
- */
-function checkCData(string) {
-  if (string.startsWith(' ')) {
-    return true;
-  }
-
-  if (string.endsWith(' ')) {
-    return true;
-  }
-
-  let space = false;
-  const length = string.length;
-  for (let i = 0; i < length; i++) {
-    const c = string[i];
-    if (
-      c === '\n' ||
-      c === '\t' ||
-      c === '\r' ||
-      c === '>' ||
-      c === '<' ||
-      c === '&' ||
-      c === "'" ||
-      c === '"'
-    ) {
-      return true;
-    }
-
-    if (c === ' ') {
-      if (space) {
-        return true;
-      }
-      space = true;
-    } else {
-      space = false;
-    }
-  }
-
-  return false;
-}
-
-/**
  * @param {Node} node Node to append a TextNode with the string to.
  * @param {string} string String.
  */
 export function writeStringTextNode(node, string) {
-  if (typeof string === 'string' && checkCData(string)) {
+  if (
+    typeof string === 'string' &&
+    (/^\s/.test(string) ||
+      /\s$/.test(string) ||
+      /(\n|\t|\r|<|&| {2})/.test(string))
+  ) {
     string.split(']]>').forEach((part, i, a) => {
       if (i < a.length - 1) {
         part += ']]';

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -143,9 +143,65 @@ export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
 }
 
 /**
+ * Checks if a given string should be wrapped in a CDATA section
+ * @param {string} string String.
+ * @return {boolean} true if the string should be wrapped in a CDATA section, else false
+ */
+function checkCData(string) {
+  if (string.startsWith(' ')) {
+    return true;
+  }
+
+  if (string.endsWith(' ')) {
+    return true;
+  }
+
+  let space = false;
+  const length = string.length;
+  for (let i = 0; i < length; i++) {
+    const c = string[i];
+    if (
+      c === '\n' ||
+      c === '\t' ||
+      c === '\r' ||
+      c === '>' ||
+      c === '<' ||
+      c === '&' ||
+      c === "'" ||
+      c === '"'
+    ) {
+      return true;
+    }
+
+    if (c === ' ') {
+      if (space) {
+        return true;
+      }
+      space = true;
+    } else {
+      space = false;
+    }
+  }
+
+  return false;
+}
+
+/**
  * @param {Node} node Node to append a TextNode with the string to.
  * @param {string} string String.
  */
 export function writeStringTextNode(node, string) {
-  node.appendChild(getDocument().createTextNode(string));
+  if (typeof string === 'string' && checkCData(string)) {
+    string.split(']]>').forEach((part, i, a) => {
+      if (i < a.length - 1) {
+        part += ']]';
+      }
+      if (i > 0) {
+        part = '>' + part;
+      }
+      writeCDATASection(node, part);
+    });
+  } else {
+    node.appendChild(getDocument().createTextNode(string));
+  }
 }

--- a/src/ol/format/xsd.js
+++ b/src/ol/format/xsd.js
@@ -142,6 +142,10 @@ export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
   node.appendChild(getDocument().createTextNode(string));
 }
 
+const whiteSpaceStart = /^\s/;
+const whiteSpaceEnd = /\s$/;
+const cdataCharacters = /(\n|\t|\r|<|&| {2})/;
+
 /**
  * @param {Node} node Node to append a TextNode with the string to.
  * @param {string} string String.
@@ -149,9 +153,9 @@ export function writeNonNegativeIntegerTextNode(node, nonNegativeInteger) {
 export function writeStringTextNode(node, string) {
   if (
     typeof string === 'string' &&
-    (/^\s/.test(string) ||
-      /\s$/.test(string) ||
-      /(\n|\t|\r|<|&| {2})/.test(string))
+    (whiteSpaceStart.test(string) ||
+      whiteSpaceEnd.test(string) ||
+      cdataCharacters.test(string))
   ) {
     string.split(']]>').forEach((part, i, a) => {
       if (i < a.length - 1) {

--- a/test/browser/spec/ol/expect.test.js
+++ b/test/browser/spec/ol/expect.test.js
@@ -72,5 +72,45 @@ describe('expect.js', function () {
         new DOMParser().parseFromString(doc1, 'application/xml'),
       ).to.not.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
     });
+
+    it('Test idential CDATA sections', function () {
+      const doc1 = '<foo><![CDATA[  test  ]]></foo>';
+      const doc2 = '<foo><![CDATA[  test  ]]></foo>';
+      expect(
+        new DOMParser().parseFromString(doc1, 'application/xml'),
+      ).to.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
+    });
+
+    it('Test different CDATA sections', function () {
+      const doc1 = '<foo><![CDATA[test  ]]></foo>';
+      const doc2 = '<foo><![CDATA[  test]]></foo>';
+      expect(
+        new DOMParser().parseFromString(doc1, 'application/xml'),
+      ).to.not.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
+    });
+
+    it('Test CDATA and Textnode', function () {
+      const doc1 = '<foo><![CDATA[test]]></foo>';
+      const doc2 = '<foo>test</foo>';
+      expect(
+        new DOMParser().parseFromString(doc1, 'application/xml'),
+      ).to.not.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
+    });
+
+    it('Test different amount of CDATA sections', function () {
+      const doc1 = '<foo><![CDATA[test1]]><!CDATA[test2]]></foo>';
+      const doc2 = '<foo><![CDATA[test1]]></foo>';
+      expect(
+        new DOMParser().parseFromString(doc1, 'application/xml'),
+      ).to.not.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
+    });
+
+    it('Test missing CDATA section', function () {
+      const doc1 = '<foo></foo>';
+      const doc2 = '<foo><![CDATA[test1]]></foo>';
+      expect(
+        new DOMParser().parseFromString(doc1, 'application/xml'),
+      ).to.not.xmleql(new DOMParser().parseFromString(doc2, 'application/xml'));
+    });
   });
 });

--- a/test/browser/spec/ol/format/kml.test.js
+++ b/test/browser/spec/ol/format/kml.test.js
@@ -2051,7 +2051,7 @@ describe('ol.format.KML', function () {
             '  <Placemark>' +
             '    <ExtendedData>' +
             '      <Data name="foo">' +
-            '        <displayName><![CDATA[display name]]></displayName>' +
+            '        <displayName>display name</displayName>' +
             '        <value>bar</value>' +
             '      </Data>' +
             '    </ExtendedData>' +

--- a/test/browser/spec/ol/format/xsd.test.js
+++ b/test/browser/spec/ol/format/xsd.test.js
@@ -24,6 +24,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'Test');
 
+        expect(node.textContent).to.be('Test');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -33,6 +34,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 123456);
 
+        expect(node.textContent).to.be('123456');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -42,6 +44,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'Basic string with spaces');
 
+        expect(node.textContent).to.be('Basic string with spaces');
         expect(node).to.xmleql(parse(text));
       });
     });
@@ -53,6 +56,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'two  spaces');
 
+        expect(node.textContent).to.be('two  spaces');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -62,6 +66,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, ' test');
 
+        expect(node.textContent).to.be(' test');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -71,6 +76,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test ');
 
+        expect(node.textContent).to.be('test ');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -80,6 +86,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ntest');
 
+        expect(node.textContent).to.be('test\ntest');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -89,6 +96,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ttest');
 
+        expect(node.textContent).to.be('test\ttest');
         expect(node).to.xmleql(parse(text));
       });
     });
@@ -100,6 +108,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test<test');
 
+        expect(node.textContent).to.be('test<test');
         expect(node).to.xmleql(parse(text));
       });
 
@@ -109,6 +118,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test&test');
 
+        expect(node.textContent).to.be('test&test');
         expect(node).to.xmleql(parse(text));
       });
     });
@@ -123,6 +133,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test]]>\ntest');
 
+        expect(node.textContent).to.be('test]]>\ntest');
         expect(node).to.xmleql(check);
       });
 
@@ -135,6 +146,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, ']]>test\ntest');
 
+        expect(node.textContent).to.be(']]>test\ntest');
         expect(node).to.xmleql(check);
       });
 
@@ -147,6 +159,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ntest]]>');
 
+        expect(node.textContent).to.be('test\ntest]]>');
         expect(node).to.xmleql(check);
       });
 
@@ -161,6 +174,7 @@ describe('ol/format/xsd', function () {
         const node = getDocument().createElement('text');
         writeStringTextNode(node, ']]>\ntest]]>\ntest]]>');
 
+        expect(node.textContent).to.be(']]>\ntest]]>\ntest]]>');
         expect(node).to.xmleql(check);
       });
     });

--- a/test/browser/spec/ol/format/xsd.test.js
+++ b/test/browser/spec/ol/format/xsd.test.js
@@ -1,4 +1,9 @@
-import {readDateTime} from '../../../../../src/ol/format/xsd.js';
+import {
+  readDateTime,
+  writeCDATASection,
+  writeStringTextNode,
+} from '../../../../../src/ol/format/xsd.js';
+import {createElementNS, parse} from '../../../../../src/ol/xml.js';
 
 describe('ol/format/xsd', function () {
   describe('readDateTime', function () {
@@ -8,6 +13,203 @@ describe('ol/format/xsd', function () {
       expect(new Date(readDateTime(node) * 1000).toISOString()).to.eql(
         '2016-07-12T12:00:00.000Z',
       );
+    });
+  });
+
+  describe('writeStringTextNode', function () {
+    describe('can handle string data without any special characters', function () {
+      it('can handle basic string data', function () {
+        const text = '<text xmlns="http://www.w3.org/1999/xhtml">Test</text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'Test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('can handle number data', function () {
+        const text = '<text xmlns="http://www.w3.org/1999/xhtml">123456</text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 123456);
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('can handle boolean data', function () {
+        const text = '<text xmlns="http://www.w3.org/1999/xhtml">true</text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, true);
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('can handle string data with spaces', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml">Basic string with spaces</text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'Basic string with spaces');
+
+        expect(node).to.xmleql(parse(text));
+      });
+    });
+
+    describe('can handle string data with whitespaces', function () {
+      it('containing multiple spaces', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[two  spaces]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'two  spaces');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('starting with a space', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[ test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, ' test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('ending with a space', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test ]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test ');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing a linebreak', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ntest]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test\ntest');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing a tab', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ttest]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test\ttest');
+
+        expect(node).to.xmleql(parse(text));
+      });
+    });
+
+    describe('can handle string data with special characters', function () {
+      it('containing "<"', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test<test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test<test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing ">"', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test>test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test>test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing "&"', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test&test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test&test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing "\'"', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\'test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, "test'test");
+
+        expect(node).to.xmleql(parse(text));
+      });
+
+      it('containing """', function () {
+        const text =
+          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test"test]]></text>';
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test"test');
+
+        expect(node).to.xmleql(parse(text));
+      });
+    });
+
+    describe('can handle string data leading to "nested" / multiple CDATA sections', function () {
+      it('containing "]]>" in the middle', function () {
+        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test]]]]><![CDATA[>test]]></text>
+        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeCDATASection(check, 'test]]');
+        writeCDATASection(check, '>test');
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test]]>test');
+
+        expect(node).to.xmleql(check);
+      });
+
+      it('containing "]]>" at the start', function () {
+        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[]]]]><![CDATA[>test\ntest]]></text>
+        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeCDATASection(check, ']]');
+        writeCDATASection(check, '>test\ntest');
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, ']]>test\ntest');
+
+        expect(node).to.xmleql(check);
+      });
+
+      it('containing "]]>" at the end', function () {
+        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ntest]]]]><![CDATA[>]]></text>
+        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeCDATASection(check, 'test\ntest]]');
+        writeCDATASection(check, '>');
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, 'test\ntest]]>');
+
+        expect(node).to.xmleql(check);
+      });
+
+      it('containing "]]>" at the start, middle and the end', function () {
+        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[]]]]><![CDATA[>test]]]]><![CDATA[>test]]]]><!CDATA[>]]></text>';
+        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeCDATASection(check, ']]');
+        writeCDATASection(check, '>test]]');
+        writeCDATASection(check, '>test]]');
+        writeCDATASection(check, '>');
+
+        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        writeStringTextNode(node, ']]>test]]>test]]>');
+
+        expect(node).to.xmleql(check);
+      });
     });
   });
 });

--- a/test/browser/spec/ol/format/xsd.test.js
+++ b/test/browser/spec/ol/format/xsd.test.js
@@ -3,7 +3,7 @@ import {
   writeCDATASection,
   writeStringTextNode,
 } from '../../../../../src/ol/format/xsd.js';
-import {createElementNS, parse} from '../../../../../src/ol/xml.js';
+import {getDocument, parse} from '../../../../../src/ol/xml.js';
 
 describe('ol/format/xsd', function () {
   describe('readDateTime', function () {
@@ -19,37 +19,27 @@ describe('ol/format/xsd', function () {
   describe('writeStringTextNode', function () {
     describe('can handle string data without any special characters', function () {
       it('can handle basic string data', function () {
-        const text = '<text xmlns="http://www.w3.org/1999/xhtml">Test</text>';
+        const text = '<text>Test</text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'Test');
 
         expect(node).to.xmleql(parse(text));
       });
 
       it('can handle number data', function () {
-        const text = '<text xmlns="http://www.w3.org/1999/xhtml">123456</text>';
+        const text = '<text>123456</text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 123456);
 
         expect(node).to.xmleql(parse(text));
       });
 
-      it('can handle boolean data', function () {
-        const text = '<text xmlns="http://www.w3.org/1999/xhtml">true</text>';
-
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, true);
-
-        expect(node).to.xmleql(parse(text));
-      });
-
       it('can handle string data with spaces', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml">Basic string with spaces</text>';
+        const text = '<text>Basic string with spaces</text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'Basic string with spaces');
 
         expect(node).to.xmleql(parse(text));
@@ -58,50 +48,45 @@ describe('ol/format/xsd', function () {
 
     describe('can handle string data with whitespaces', function () {
       it('containing multiple spaces', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[two  spaces]]></text>';
+        const text = '<text><![CDATA[two  spaces]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'two  spaces');
 
         expect(node).to.xmleql(parse(text));
       });
 
       it('starting with a space', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[ test]]></text>';
+        const text = '<text><![CDATA[ test]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, ' test');
 
         expect(node).to.xmleql(parse(text));
       });
 
       it('ending with a space', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test ]]></text>';
+        const text = '<text><![CDATA[test ]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test ');
 
         expect(node).to.xmleql(parse(text));
       });
 
       it('containing a linebreak', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ntest]]></text>';
+        const text = '<text><![CDATA[test\ntest]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ntest');
 
         expect(node).to.xmleql(parse(text));
       });
 
       it('containing a tab', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ttest]]></text>';
+        const text = '<text><![CDATA[test\ttest]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ttest');
 
         expect(node).to.xmleql(parse(text));
@@ -110,51 +95,19 @@ describe('ol/format/xsd', function () {
 
     describe('can handle string data with special characters', function () {
       it('containing "<"', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test<test]]></text>';
+        const text = '<text><![CDATA[test<test]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test<test');
 
         expect(node).to.xmleql(parse(text));
       });
 
-      it('containing ">"', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test>test]]></text>';
-
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, 'test>test');
-
-        expect(node).to.xmleql(parse(text));
-      });
-
       it('containing "&"', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test&test]]></text>';
+        const text = '<text><![CDATA[test&test]]></text>';
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test&test');
-
-        expect(node).to.xmleql(parse(text));
-      });
-
-      it('containing "\'"', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\'test]]></text>';
-
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, "test'test");
-
-        expect(node).to.xmleql(parse(text));
-      });
-
-      it('containing """', function () {
-        const text =
-          '<text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test"test]]></text>';
-
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, 'test"test');
 
         expect(node).to.xmleql(parse(text));
       });
@@ -162,51 +115,51 @@ describe('ol/format/xsd', function () {
 
     describe('can handle string data leading to "nested" / multiple CDATA sections', function () {
       it('containing "]]>" in the middle', function () {
-        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test]]]]><![CDATA[>test]]></text>
-        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        // <text><![CDATA[test]]]]><![CDATA[>\ntest]]></text>
+        const check = getDocument().createElement('text');
         writeCDATASection(check, 'test]]');
-        writeCDATASection(check, '>test');
+        writeCDATASection(check, '>\ntest');
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, 'test]]>test');
+        const node = getDocument().createElement('text');
+        writeStringTextNode(node, 'test]]>\ntest');
 
         expect(node).to.xmleql(check);
       });
 
       it('containing "]]>" at the start', function () {
-        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[]]]]><![CDATA[>test\ntest]]></text>
-        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        // <text><![CDATA[]]]]><![CDATA[>test\ntest]]></text>
+        const check = getDocument().createElement('text');
         writeCDATASection(check, ']]');
         writeCDATASection(check, '>test\ntest');
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, ']]>test\ntest');
 
         expect(node).to.xmleql(check);
       });
 
       it('containing "]]>" at the end', function () {
-        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[test\ntest]]]]><![CDATA[>]]></text>
-        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        // <text><![CDATA[test\ntest]]]]><![CDATA[>]]></text>
+        const check = getDocument().createElement('text');
         writeCDATASection(check, 'test\ntest]]');
         writeCDATASection(check, '>');
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        const node = getDocument().createElement('text');
         writeStringTextNode(node, 'test\ntest]]>');
 
         expect(node).to.xmleql(check);
       });
 
       it('containing "]]>" at the start, middle and the end', function () {
-        // <text xmlns="http://www.w3.org/1999/xhtml"><![CDATA[]]]]><![CDATA[>test]]]]><![CDATA[>test]]]]><!CDATA[>]]></text>';
-        const check = createElementNS('http://www.w3.org/1999/xhtml', 'text');
+        // <text><![CDATA[]]]]><![CDATA[>\ntest]]]]><![CDATA[>\ntest]]]]><!CDATA[>]]></text>';
+        const check = getDocument().createElement('text');
         writeCDATASection(check, ']]');
-        writeCDATASection(check, '>test]]');
-        writeCDATASection(check, '>test]]');
+        writeCDATASection(check, '>\ntest]]');
+        writeCDATASection(check, '>\ntest]]');
         writeCDATASection(check, '>');
 
-        const node = createElementNS('http://www.w3.org/1999/xhtml', 'text');
-        writeStringTextNode(node, ']]>test]]>test]]>');
+        const node = getDocument().createElement('text');
+        writeStringTextNode(node, ']]>\ntest]]>\ntest]]>');
 
         expect(node).to.xmleql(check);
       });

--- a/test/browser/test-extensions.js
+++ b/test/browser/test-extensions.js
@@ -107,6 +107,7 @@ setLogLevel('error');
           nodes.push(child);
         }
       } else if (child.nodeType == 4) {
+        // CDATA section, add it
         nodes.push(child);
       }
     }
@@ -171,6 +172,7 @@ setLogLevel('error');
         );
       }
     } else if (node1.nodeType === 4) {
+      // for CDATA sections compare nodeValue directly
       if (node1.nodeValue !== node2.nodeValue) {
         errors.push(
           'nodeValue cdata test failed | expected ' +

--- a/test/browser/test-extensions.js
+++ b/test/browser/test-extensions.js
@@ -106,6 +106,8 @@ setLogLevel('error');
         ) {
           nodes.push(child);
         }
+      } else if (child.nodeType == 4) {
+        nodes.push(child);
       }
     }
     if (options && options.ignoreElementOrder) {
@@ -166,6 +168,15 @@ setLogLevel('error');
       if (nv1 !== nv2) {
         errors.push(
           'nodeValue test failed | expected ' + nv1 + ' to equal ' + nv2,
+        );
+      }
+    } else if (node1.nodeType === 4) {
+      if (node1.nodeValue !== node2.nodeValue) {
+        errors.push(
+          'nodeValue cdata test failed | expected ' +
+            node1.nodeValue +
+            ' to equal ' +
+            node2.nodeValue,
         );
       }
     } else if (node1.nodeType === 1) {


### PR DESCRIPTION
Closes #10127, Based on code and discussions in #15638 

Summary:
Functionality:
This change affects how the `writeStringTextNode()` function in `ol/format/xsd.js` handles data containing whitespaces (\n\t, multiple spaces, spaces at the start and the end of the text) and special XML characters (<'>&"). Strings containing these will now be wrapped in CDATA section(s). In order to determine if a string is affected by this a new local method `checkCData` was introduced that takes a string and checks if it should be wrapped in CDATA section(s). Checking the string has a worse case performance of O(N), the string will only be iterated once.
The algorithm that breaks a string safely into (potentially) multiple CDATA sections is based on code written in #15638.

As discussed in #15638 `ol/format/KML.js` was also adapted, calls to `writeCDATASection` can now safely be replaced by calls to `writeStringTextNode`.

Testing:
In order to support proper testing changes needed to be done to the `test-extensions`, in particular `getChildNodes` had to be adapted to consider CDATA sections as well as `assertElementNodesEqual` for the actual comparison. Unlike in the text node comparison no whitespaces are removed, the "raw" `nodeValue` is directly compared.

Only one existing test had to be adapted, a KML test contained an unnecessary CDATA section.

New tests were added in `ol/format/xsd.test.js`. These tests cover the expected behavior for "normal" strings and data, strings containing whitespaces, strings containing special characters and strings containing data leading to multiple CDATA sections.

As mentioned in #15638 the chromium implementation of DOMParser has currently a bug and can incorrectly merge two CDATA sections when parsing a XML string. Because of this tests resulting in multiple CDATA sections construct the XMLDocument programmatically, all other tests utilize a XML string containing the expected XML and parsing for comparison.
This bug does only affect testing, the implemented functionality is not affected. If this bug is fixed in future chromium releases we can modify these tests, the expected XML string is provided alongside the test in a comment.


Open Questions:

- [x] In theory it is possible to pass data that is NOT a string to `writeStringTextNode`. Since one KML test did this with a number i supported this with tests for the primitive types boolean and number. In theory one could also pass objects to `writeStringTextNode`, this use case is currently not supported. If this IS a use case we want to support we should probably call `toString` on all input going into `writeStringTextNode`.
- [x] I am unsure if all the special XML characters are really problematic for textnodes. Of course < and & are problematic, but i don't see how '>" are problematic. I added these for now, but if somebody that is more knowledgeable with XML and special cases confirms that these are not problematic in text nodes we can drop them again.