### PR TITLE
Add .gitattributes file to enforce LF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF (Unix) line endings for all text files
+* text=auto eol=lf


### PR DESCRIPTION
This ensures files are checked out with LF line-endings on Windows (it should have no effect on other OSes). 
`npm run test` runs `prettier` which will fail with errors like those below if any CRLF line-endings are found:

```
    1:4    error  Delete `␍`  prettier/prettier
    2:25   error  Delete `␍`  prettier/prettier
    3:4    error  Delete `␍`  prettier/prettier
    4:60   error  Delete `␍`  prettier/prettier
    5:38   error  Delete `␍`  prettier/prettier
```

There is a mention of this in https://github.com/openlayers/eslint-config-openlayers/pull/30 so maybe there is a reason this hasn't been added previously. 