### PR TITLE
Color without dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/rbush": "4.0.0",
-        "color-rgba": "^3.0.0",
-        "color-space": "^2.0.1",
         "earcut": "^3.0.0",
         "geotiff": "^2.1.3",
         "pbf": "4.0.1",
@@ -31,7 +29,6 @@
         "@turf/along": "^7.1.0",
         "@turf/length": "^7.1.0",
         "@types/arcgis-rest-api": "^10.4.4",
-        "@types/color-rgba": "^2.1.3",
         "@types/expect.js": "^0.3.32",
         "@types/geojson": "^7946.0.7",
         "@types/mocha": "^10.0.7",
@@ -1871,12 +1868,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/color-rgba": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@types/color-rgba/-/color-rgba-2.1.3.tgz",
-      "integrity": "sha512-JOqpRixFF2D9Uy9osxJxzUP3lmdQdp7rpj4eMz0mYcZH2yhHwyyY4nMdYumCYWJT0ygLC/kMlkQW5LPZB2cTQw==",
-      "dev": true
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -3568,12 +3559,15 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/color-parse": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
       "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -3582,6 +3576,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
       "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -3591,7 +3587,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.1.0.tgz",
       "integrity": "sha512-zVS/1YXvFB4AoYqpKzcQ694s7dOKXHtSbQfcfuxeuTr4oE1U40zkrqvyEsu8OD9e2pTuGjfRFNUR2Ii4XkoE9w==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/colorette": {
       "version": "2.0.20",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
   },
   "dependencies": {
     "@types/rbush": "4.0.0",
-    "color-rgba": "^3.0.0",
-    "color-space": "^2.0.1",
     "earcut": "^3.0.0",
     "geotiff": "^2.1.3",
     "pbf": "4.0.1",
@@ -68,7 +66,6 @@
     "@turf/along": "^7.1.0",
     "@turf/length": "^7.1.0",
     "@types/arcgis-rest-api": "^10.4.4",
-    "@types/color-rgba": "^2.1.3",
     "@types/expect.js": "^0.3.32",
     "@types/geojson": "^7946.0.7",
     "@types/mocha": "^10.0.7",

--- a/src/ol/color.js
+++ b/src/ol/color.js
@@ -1,11 +1,8 @@
 /**
  * @module ol/color
  */
-import parseRgba from 'color-rgba';
-import lchuv from 'color-space/lchuv.js';
-import rgb from 'color-space/rgb.js';
-import xyz from 'color-space/xyz.js';
-import {clamp} from './math.js';
+import {createCanvasContext2D} from './dom.js';
+import {clamp, toFixed} from './math.js';
 
 /**
  * A color represented as a short array [red, green, blue, alpha].
@@ -22,6 +19,112 @@ import {clamp} from './math.js';
  * @type {Color}
  */
 export const NO_COLOR = [NaN, NaN, NaN, 0];
+
+let colorParseContext;
+/**
+ * @return {CanvasRenderingContext2D} The color parse context
+ */
+function getColorParseContext() {
+  if (!colorParseContext) {
+    colorParseContext = createCanvasContext2D(1, 1, undefined, {
+      willReadFrequently: true,
+      desynchronized: true,
+    });
+  }
+  return colorParseContext;
+}
+
+const rgbModernRegEx =
+  /^rgba?\(\s*(\d+%?)\s+(\d+%?)\s+(\d+%?)(?:\s*\/\s*(\d+%|\d*\.\d+|[01]))?\s*\)$/i;
+const rgbLegacyAbsoluteRegEx =
+  /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*(\d+%|\d*\.\d+|[01]))?\s*\)$/i;
+const rgbLegacyPercentageRegEx =
+  /^rgba?\(\s*(\d+%)\s*,\s*(\d+%)\s*,\s*(\d+%)(?:\s*,\s*(\d+%|\d*\.\d+|[01]))?\s*\)$/i;
+const hexRegEx = /^#([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i;
+
+/**
+ * @param {string} s Color component as number or percentage.
+ * @param {number} divider Divider for percentage.
+ * @return {number} Color component.
+ */
+function toColorComponent(s, divider) {
+  return s.endsWith('%')
+    ? Number(s.substring(0, s.length - 1)) / divider
+    : Number(s);
+}
+
+/**
+ * @param {string} color Color string.
+ */
+function throwInvalidColor(color) {
+  throw new Error('failed to parse "' + color + '" as color');
+}
+
+/**
+ * @param {string} color Color string.
+ * @return {Color} RGBa color array.
+ */
+function parseRgba(color) {
+  // Fast lane for rgb(a) colors
+  if (color.toLowerCase().startsWith('rgb')) {
+    const rgb =
+      color.match(rgbLegacyAbsoluteRegEx) ||
+      color.match(rgbModernRegEx) ||
+      color.match(rgbLegacyPercentageRegEx);
+    if (rgb) {
+      const alpha = rgb[4];
+      const rgbDivider = 100 / 255;
+      return [
+        clamp((toColorComponent(rgb[1], rgbDivider) + 0.5) | 0, 0, 255),
+        clamp((toColorComponent(rgb[2], rgbDivider) + 0.5) | 0, 0, 255),
+        clamp((toColorComponent(rgb[3], rgbDivider) + 0.5) | 0, 0, 255),
+        alpha !== undefined ? clamp(toColorComponent(alpha, 100), 0, 1) : 1,
+      ];
+    }
+    throwInvalidColor(color);
+  }
+  // Fast lane for hex colors (also with alpha)
+  if (color.startsWith('#')) {
+    if (hexRegEx.test(color)) {
+      const hex = color.substring(1);
+      const step = hex.length <= 4 ? 1 : 2;
+      const colorFromHex = [0, 0, 0, 255];
+      for (let i = 0, ii = hex.length; i < ii; i += step) {
+        let colorComponent = parseInt(hex.substring(i, i + step), 16);
+        if (step === 1) {
+          colorComponent += colorComponent << 4;
+        }
+        colorFromHex[i / step] = colorComponent;
+      }
+      colorFromHex[3] = colorFromHex[3] / 255;
+      return colorFromHex;
+    }
+    throwInvalidColor(color);
+  }
+  // Use canvas color serialization to parse the color into hex or rgba
+  // See https://www.w3.org/TR/2021/SPSD-2dcontext-20210128/#serialization-of-a-color
+  const context = getColorParseContext();
+  context.fillStyle = '#abcdef';
+  let invalidCheckFillStyle = context.fillStyle;
+  context.fillStyle = color;
+  if (context.fillStyle === invalidCheckFillStyle) {
+    context.fillStyle = '#fedcba';
+    invalidCheckFillStyle = context.fillStyle;
+    context.fillStyle = color;
+    if (context.fillStyle === invalidCheckFillStyle) {
+      throwInvalidColor(color);
+    }
+  }
+  const colorString = context.fillStyle;
+  if (colorString.startsWith('#') || colorString.startsWith('rgba')) {
+    return parseRgba(colorString);
+  }
+  context.clearRect(0, 0, 1, 1);
+  context.fillRect(0, 0, 1, 1);
+  const colorFromImage = Array.from(context.getImageData(0, 0, 1, 1).data);
+  colorFromImage[3] = toFixed(colorFromImage[3] / 255, 3);
+  return colorFromImage;
+}
 
 /**
  * Return the color as an rgba string.
@@ -69,14 +172,59 @@ export function withAlpha(color) {
   return output;
 }
 
+// The functions b1, b2, a1, a2, rgbaToLcha and lchaToRgba below are adapted from
+// https://stackoverflow.com/a/67219995/2389327
+
+/**
+ * @param {number} v Input value.
+ * @return {number} Output value.
+ */
+function b1(v) {
+  return v > 0.0031308 ? Math.pow(v, 1 / 2.4) * 269.025 - 14.025 : v * 3294.6;
+}
+
+/**
+ * @param {number} v Input value.
+ * @return {number} Output value.
+ */
+function b2(v) {
+  return v > 0.2068965 ? Math.pow(v, 3) : (v - 4 / 29) * (108 / 841);
+}
+
+/**
+ * @param {number} v Input value.
+ * @return {number} Output value.
+ */
+function a1(v) {
+  return v > 10.314724 ? Math.pow((v + 14.025) / 269.025, 2.4) : v / 3294.6;
+}
+
+/**
+ * @param {number} v Input value.
+ * @return {number} Output value.
+ */
+function a2(v) {
+  return v > 0.0088564 ? Math.pow(v, 1 / 3) : v / (108 / 841) + 4 / 29;
+}
+
 /**
  * @param {Color} color RGBA color.
  * @return {Color} LCHuv color with alpha.
  */
 export function rgbaToLcha(color) {
-  const output = xyz.lchuv(rgb.xyz(color));
-  output[3] = color[3];
-  return output;
+  const r = a1(color[0]);
+  const g = a1(color[1]);
+  const b = a1(color[2]);
+  const y = a2(r * 0.222488403 + g * 0.716873169 + b * 0.06060791);
+  const l = 500 * (a2(r * 0.452247074 + g * 0.399439023 + b * 0.148375274) - y);
+  const q = 200 * (y - a2(r * 0.016863605 + g * 0.117638439 + b * 0.865350722));
+  const h = Math.atan2(q, l) * (180 / Math.PI);
+  return [
+    116 * y - 16,
+    Math.sqrt(l * l + q * q),
+    h < 0 ? h + 360 : h,
+    color[3],
+  ];
 }
 
 /**
@@ -84,9 +232,21 @@ export function rgbaToLcha(color) {
  * @return {Color} RGBA color.
  */
 export function lchaToRgba(color) {
-  const output = xyz.rgb(lchuv.xyz(color));
-  output[3] = color[3];
-  return output;
+  const l = (color[0] + 16) / 116;
+  const c = color[1];
+  const h = (color[2] * Math.PI) / 180;
+  const y = b2(l);
+  const x = b2(l + (c / 500) * Math.cos(h));
+  const z = b2(l - (c / 200) * Math.sin(h));
+  const r = b1(x * 3.021973625 - y * 1.617392459 - z * 0.404875592);
+  const g = b1(x * -0.943766287 + y * 1.916279586 + z * 0.027607165);
+  const b = b1(x * 0.069407491 - y * 0.22898585 + z * 1.159737864);
+  return [
+    clamp((r + 0.5) | 0, 0, 255),
+    clamp((g + 0.5) | 0, 0, 255),
+    clamp((b + 0.5) | 0, 0, 255),
+    color[3],
+  ];
 }
 
 /**
@@ -112,14 +272,13 @@ export function fromString(s) {
 
   const color = parseRgba(s);
   if (color.length !== 4) {
-    throw new Error('failed to parse "' + s + '" as color');
+    throwInvalidColor(s);
   }
   for (const c of color) {
     if (isNaN(c)) {
-      throw new Error('failed to parse "' + s + '" as color');
+      throwInvalidColor(s);
     }
   }
-  normalize(color);
   cache[s] = color;
   ++cacheSize;
   return color;
@@ -137,19 +296,6 @@ export function asArray(color) {
     return color;
   }
   return fromString(color);
-}
-
-/**
- * Exported for the tests.
- * @param {Color} color Color.
- * @return {Color} Clamped color.
- */
-export function normalize(color) {
-  color[0] = clamp((color[0] + 0.5) | 0, 0, 255);
-  color[1] = clamp((color[1] + 0.5) | 0, 0, 255);
-  color[2] = clamp((color[2] + 0.5) | 0, 0, 255);
-  color[3] = clamp(color[3], 0, 1);
-  return color;
 }
 
 /**

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -5,7 +5,6 @@
 import {
   fromString,
   lchaToRgba,
-  normalize,
   rgbaToLcha,
   toString,
   withAlpha,
@@ -646,5 +645,5 @@ function interpolateColor(base, value, input1, rgba1, input2, rgba2) {
     lcha1[2] + interpolateNumber(base, value, input1, 0, input2, deltaHue),
     interpolateNumber(base, value, input1, rgba1[3], input2, rgba2[3]),
   ];
-  return normalize(lchaToRgba(lcha));
+  return lchaToRgba(lcha);
 }

--- a/test/browser/spec/ol/color.test.js
+++ b/test/browser/spec/ol/color.test.js
@@ -1,0 +1,118 @@
+import {
+  fromString,
+  isStringColor,
+  lchaToRgba,
+  rgbaToLcha,
+} from '../../../../src/ol/color.js';
+import {toFixed} from '../../../../src/ol/math.js';
+
+describe('ol/color', () => {
+  describe('fromString()', () => {
+    describe('parses a variety of formats', () => {
+      const cases = [
+        // named colors
+        ['red', [255, 0, 0, 1]],
+        ['green', [0, 128, 0, 1]],
+        ['blue', [0, 0, 255, 1]],
+        ['yellow', [255, 255, 0, 1]],
+        ['orange', [255, 165, 0, 1]],
+        ['purple', [128, 0, 128, 1]],
+        ['violet', [238, 130, 238, 1]],
+        ['white', [255, 255, 255, 1]],
+        ['black', [0, 0, 0, 1]],
+        ['wheat', [245, 222, 179, 1]],
+        ['olive', [128, 128, 0, 1]],
+        ['transparent', [0, 0, 0, 0]],
+
+        // hsl(a) varieties
+        ['hsla(84, 51%, 87%, 0.7)', [225, 239, 205, 0.7]],
+        ['hsl(46, 24%, 82%)', [220, 215, 198, 1]],
+        ['hsl(50 80% 40%)', [184, 156, 20, 1]],
+        ['hsl(150deg 30% 60%)', [122, 184, 153, 1]],
+        ['hsl(0 80% 50% / 25%)', [230, 26, 26, 0.25]],
+        ['hsl(210deg 68% 80.39%)', [171, 205, 239, 1]],
+
+        // hwb
+        ['hwb(50deg 30% 40%)', [153, 140, 77, 1]],
+
+        // lch
+        [
+          'lch(from rgba(234 56 78 / 90%) l c h)',
+          [234, 55, 78, toFixed(Math.round(0.9 * 255) / 255, 3)],
+        ],
+      ];
+      for (const c of cases) {
+        it(`works for ${c[0]}`, () => {
+          expect(fromString(c[0])).to.eql(c[1]);
+        });
+      }
+    });
+
+    describe('with invalid colors', () => {
+      const cases = [
+        'tuesday',
+        'oops',
+        'rgb(garbage)',
+        'hsl(oops)',
+        'rgba(42)',
+        'hsla(5)',
+      ];
+
+      for (const c of cases) {
+        it(`throws an error on ${c}`, () => {
+          try {
+            const color = fromString(c);
+            expect().fail(`Expected an error, got ${color}`);
+          } catch (err) {
+            expect(err.message).to.be(`failed to parse "${c}" as color`);
+          }
+        });
+      }
+    });
+  });
+
+  describe('isValid()', () => {
+    it('correctly detects valid colors', () => {
+      expect(isStringColor('lightgreen')).to.be(true);
+      expect(isStringColor('yellow')).to.be(true);
+      expect(isStringColor('GREEN')).to.be(true);
+      expect(isStringColor('notacolor')).to.be(false);
+      expect(isStringColor('red_')).to.be(false);
+    });
+  });
+
+  describe('lch <=> rgb conversions', () => {
+    const cases = [
+      // lch to rgb
+      'lch(54.29% 106.84 40.85)', // red
+      'lch(87.73% 119.78 136.02)', // green
+      'lch(29.57% 131.21 306.29)', // blue
+      'lch(97.61% 94.48 102.85)', // yellow
+      'lch(74.93% 106.84 70.85)', // orange
+      'lch(29.78% 104.55 328.23)', // purple
+      'lch(60.32% 96.98 328.23)', // violet
+      'lch(100% 0 0)', // white
+      'lch(0% 0 0)', // black
+      'lch(90.14% 19.31 86.29)', // wheat
+      'lch(51.87% 44.55 102.85)', // olive
+    ];
+
+    for (const lchString of cases) {
+      it(`works for ${lchString}`, () => {
+        let [l, c, h] = lchString.match(/lch\((.*)\)/)[1].split(' ');
+        l = parseFloat(l.substring(0, l.length - 1));
+        c = parseFloat(c);
+        h = parseFloat(h);
+        const rgba1 = fromString(lchString);
+        const rgba2 = lchaToRgba([l, c, h, 1]);
+        expect(rgba1).to.eql(rgba2);
+
+        const alpha = Math.random();
+        const rgbaIn = [rgba1[0], rgba1[1], rgba1[2], alpha];
+        const lcha = rgbaToLcha(rgbaIn);
+        const rgbaOut = lchaToRgba(lcha);
+        expect(rgbaOut).to.eql(rgbaIn);
+      });
+    }
+  });
+});

--- a/test/browser/spec/ol/expr/cpu.test.js
+++ b/test/browser/spec/ol/expr/cpu.test.js
@@ -1,0 +1,48 @@
+import {
+  buildExpression,
+  newEvaluationContext,
+} from '../../../../../src/ol/expr/cpu.js';
+import {
+  ColorType,
+  newParsingContext,
+} from '../../../../../src/ol/expr/expression.js';
+
+describe('ol/expr/cpu.js', () => {
+  describe('buildExpression()', () => {
+    /**
+     * @typedef {Object} Case
+     * @property {string} name The case name.
+     * @property {import('../../../../src/ol/expr/expression.js').EncodedExpression} expression The encoded expression.
+     * @property {import('../../../../src/ol/expr/cpu.js').EvaluationContext} [context] The evaluation context.
+     * @property {number} type The expression type.
+     * @property {import('../../../../src/ol/expr/expression.js').LiteralValue} expected The expected value.
+     * @property {number} [tolerance] Optional tolerance for numeric comparisons.
+     */
+
+    /**
+     * @type {Array<Case>}
+     */
+    const cases = [
+      {
+        name: 'interpolate (linear color)',
+        type: ColorType,
+        expression: ['interpolate', ['linear'], 0.5, 0, 'red', 1, [0, 255, 0]],
+        expected: [209, 169, 0, 1],
+      },
+    ];
+
+    for (const c of cases) {
+      it(`works for ${c.name}`, () => {
+        const parsingContext = newParsingContext();
+        const evaluator = buildExpression(c.expression, c.type, parsingContext);
+        const evaluationContext = c.context || newEvaluationContext();
+        const value = evaluator(evaluationContext);
+        if (c.tolerance !== undefined) {
+          expect(value).to.roughlyEqual(c.expected, c.tolerance);
+        } else {
+          expect(value).to.eql(c.expected);
+        }
+      });
+    }
+  });
+});

--- a/test/browser/spec/ol/expr/expression.test.js
+++ b/test/browser/spec/ol/expr/expression.test.js
@@ -1,0 +1,157 @@
+import {
+  AnyType,
+  BooleanType,
+  CallExpression,
+  ColorType,
+  LiteralExpression,
+  NumberType,
+  StringType,
+  includesType,
+  isType,
+  newParsingContext,
+  parse,
+  typeName,
+} from '../../../../../src/ol/expr/expression.js';
+
+describe('ol/expr/expression.js', () => {
+  describe('parse()', () => {
+    it('parses a literal color (string)', () => {
+      const expression = parse('fuchsia', ColorType, newParsingContext());
+      expect(expression).to.be.a(LiteralExpression);
+      expect(includesType(expression.type, ColorType));
+      expect(expression.value).to.eql([255, 0, 255, 1]);
+    });
+
+    it('parses a * expression with colors', () => {
+      const context = newParsingContext();
+      const expression = parse(
+        ['*', ['get', 'foo'], 'red', [255, 0, 0, 1]],
+        ColorType,
+        context,
+      );
+      expect(expression).to.be.a(CallExpression);
+      expect(expression.operator).to.be('*');
+      expect(isType(expression.type, ColorType)).to.be(true);
+      expect(expression.args).to.have.length(3);
+      expect(isType(expression.args[0].type, ColorType)).to.be(true);
+      expect(isType(expression.args[1].type, ColorType)).to.be(true);
+      expect(isType(expression.args[2].type, ColorType)).to.be(true);
+    });
+
+    describe('case operation', () => {
+      it('respects the return type (string or array color)', () => {
+        const context = newParsingContext();
+        const expression = parse(
+          [
+            'case',
+            ['>', ['get', 'attr'], 3],
+            'red',
+            ['>', ['get', 'attr'], 1],
+            'yellow',
+            [255, 0, 0],
+          ],
+          ColorType,
+          context,
+        );
+        expect(expression).to.be.a(CallExpression);
+        expect(expression.operator).to.be('case');
+        expect(isType(expression.type, ColorType)).to.be(true);
+        expect(expression.args).to.have.length(5);
+        expect(isType(expression.args[0].type, BooleanType)).to.be(true);
+        expect(isType(expression.args[1].type, ColorType)).to.be(true);
+        expect(isType(expression.args[2].type, BooleanType)).to.be(true);
+        expect(isType(expression.args[3].type, ColorType)).to.be(true);
+        expect(isType(expression.args[4].type, ColorType)).to.be(true);
+      });
+
+      it('respects the return type (string color)', () => {
+        const expression = parse(
+          ['case', true, 'red', false, 'yellow', 'white'],
+          ColorType,
+          newParsingContext(),
+        );
+        expect(isType(expression.type, ColorType)).to.be(true);
+      });
+    });
+
+    describe('match operation', () => {
+      it('respects the return type (color)', () => {
+        const context = newParsingContext();
+        const expression = parse(
+          ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', [255, 0, 0, 1]],
+          ColorType,
+          context,
+        );
+        expect(expression).to.be.a(CallExpression);
+        expect(expression.operator).to.be('match');
+        expect(isType(expression.type, ColorType)).to.be(true);
+        expect(expression.args).to.have.length(6);
+        expect(typeName(expression.args[0].type)).to.be(
+          typeName(BooleanType | StringType | NumberType),
+        );
+        expect(isType(expression.args[1].type, NumberType)).to.be(true);
+        expect(isType(expression.args[2].type, ColorType)).to.be(true);
+        expect(isType(expression.args[3].type, NumberType)).to.be(true);
+        expect(isType(expression.args[4].type, ColorType)).to.be(true);
+        expect(isType(expression.args[5].type, ColorType)).to.be(true);
+      });
+
+      it('respects the return type (color string)', () => {
+        const expression = parse(
+          ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'green'],
+          ColorType,
+          newParsingContext(),
+        );
+        expect(isType(expression.type, ColorType)).to.be(true);
+      });
+    });
+
+    describe('palette operator', () => {
+      it('outputs color type and list of colors as args', () => {
+        const expression = parse(
+          ['palette', 1, ['red', 'rgba(255, 255, 0, 1)', [0, 255, 255]]],
+          ColorType,
+          newParsingContext(),
+        );
+        expect(expression.operator).to.be('palette');
+        expect(isType(expression.type, ColorType)).to.be(true);
+        expect(expression.args).to.have.length(4);
+        expect(isType(expression.args[0].type, NumberType)).to.be(true);
+        expect(isType(expression.args[1].type, ColorType)).to.be(true);
+        expect(isType(expression.args[2].type, ColorType)).to.be(true);
+        expect(isType(expression.args[3].type, ColorType)).to.be(true);
+      });
+    });
+  });
+
+  describe('parse() errors', () => {
+    /**
+     * @typedef {Object} Case
+     * @property {string} name The case name.
+     * @property {Array<*>} expression The expression to parse.
+     * @property {import('../../../../src/ol/expr/expression.js').ParsingContext} [context] The parsing context.
+     * @property {RegExp} error The expected error message.
+     */
+
+    /**
+     * @type {Array<Case>}
+     */
+    const cases = [
+      {
+        name: 'second argument is not an array of colors (palette)',
+        expression: ['palette', ['band', 2], ['red', 'green', 'abcd']],
+        error:
+          'failed to parse color at index 2 in palette expression: failed to parse "abcd" as color',
+      },
+    ];
+
+    for (const {name, expression, error, context} of cases) {
+      it(`throws for ${name}`, () => {
+        const newContext = {...newParsingContext(), ...context};
+        expect(() => parse(expression, AnyType, newContext)).to.throwError(
+          (e) => expect(e.message).to.eql(error),
+        );
+      });
+    }
+  });
+});

--- a/test/browser/spec/ol/expr/gpu.test.js
+++ b/test/browser/spec/ol/expr/gpu.test.js
@@ -1,0 +1,205 @@
+import {
+  AnyType,
+  BooleanType,
+  ColorType,
+  NumberType,
+  StringType,
+  newParsingContext,
+} from '../../../../../src/ol/expr/expression.js';
+import {
+  buildExpression,
+  colorToGlsl,
+  newCompilationContext,
+} from '../../../../../src/ol/expr/gpu.js';
+
+describe('ol/expr/gpu', () => {
+  describe('colorToGlsl()', () => {
+    it('handles colors in string format', () => {
+      expect(colorToGlsl('red')).to.eql('vec4(1.0, 0.0, 0.0, 1.0)');
+      expect(colorToGlsl('#00ff99')).to.eql('vec4(0.0, 1.0, 0.6, 1.0)');
+      expect(colorToGlsl('rgb(100, 0, 255)')).to.eql(
+        'vec4(0.39215686274509803, 0.0, 1.0, 1.0)',
+      );
+      expect(colorToGlsl('rgba(100, 0, 255, 0.3)')).to.eql(
+        'vec4(0.39215686274509803, 0.0, 1.0, 0.3)',
+      );
+    });
+  });
+
+  describe('buildExpression()', () => {
+    /**
+     * @typedef {import('../../../../src/ol/expr/gpu.js').CompilationContext} CompilationContext
+     */
+    /**
+     * @typedef {Object} Case
+     * @property {string} name The case name.
+     * @property {import('../../../../src/ol/expr/expression.js').EncodedExpression} expression The encoded expression.
+     * @property {CompilationContext} [context] The evaluation context.
+     * @property {number} type The expression type.
+     * @property {import('../../../../src/ol/expr/gpu.js').CompiledExpression} [expected] The expected value.
+     * @property {function(CompilationContext):void} [contextAssertion] What the context should look like after compilation.
+     */
+
+    /**
+     * @type {Array<Case>}
+     */
+    const cases = [
+      {
+        name: 'multiplication (infer string as color)',
+        type: ColorType,
+        expression: ['*', [255, 127.5, 0, 0.5], 'red'],
+        expected: '(vec4(1.0, 0.5, 0.0, 0.5) * vec4(1.0, 0.0, 0.0, 1.0))',
+      },
+      {
+        name: 'colors as strings',
+        type: ColorType,
+        expression: [
+          'case',
+          ['>', ['get', 'attr'], 3],
+          'red',
+          ['>', ['get', 'attr'], 1],
+          'yellow',
+          'white',
+        ],
+        expected:
+          '((a_prop_attr > 3.0) ? vec4(1.0, 0.0, 0.0, 1.0) : ((a_prop_attr > 1.0) ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(1.0, 1.0, 1.0, 1.0)))',
+      },
+      {
+        name: 'match (colors)',
+        type: ColorType,
+        expression: ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'white'],
+        expected:
+          '(a_prop_attr == 0.0 ? vec4(1.0, 0.0, 0.0, 1.0) : (a_prop_attr == 1.0 ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(1.0, 1.0, 1.0, 1.0)))',
+      },
+      {
+        name: 'palette',
+        expression: [
+          'palette',
+          ['get', 'color'],
+          ['red', 'rgb(0, 255, 0)', [0, 0, 255, 0.5]],
+        ],
+        type: AnyType,
+        expected:
+          'texture2D(u_paletteTextures[0], vec2((a_prop_color + 0.5) / 3.0, 0.5))',
+        contextAssertion: (context) => {
+          expect(context.paletteTextures[0]).to.eql({
+            name: 'u_paletteTextures[0]',
+            data: Uint8Array.from([
+              // red
+              255, 0, 0, 255,
+              // green
+              0, 255, 0, 255,
+              // blue, 0.5 alpha
+              0, 0, 255, 127,
+            ]),
+            texture_: null,
+          });
+        },
+      },
+      {
+        name: 'combination of interpolate, match, color and number',
+        type: ColorType,
+        expression: [
+          'interpolate',
+          ['linear'],
+          [
+            '^',
+            [
+              '/',
+              [
+                '%',
+                [
+                  '+',
+                  ['time'],
+                  [
+                    'interpolate',
+                    ['linear'],
+                    ['get', 'year'],
+                    1850,
+                    0,
+                    2015,
+                    8,
+                  ],
+                ],
+                8,
+              ],
+              8,
+            ],
+            0.5,
+          ],
+          0,
+          'rgba(255, 255, 0, 0.5)',
+          1,
+          ['match', ['get', 'year'], 2000, 'green', '#ffe52c'],
+        ],
+        expected:
+          'mix(vec4(1.0, 1.0, 0.0, 0.5), (a_prop_year == 2000.0 ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : vec4(1.0, 0.8980392156862745, 0.17254901960784313, 1.0)), clamp((pow((mod((u_time + mix(0.0, 8.0, clamp((a_prop_year - 1850.0) / (2015.0 - 1850.0), 0.0, 1.0))), 8.0) / 8.0), 0.5) - 0.0) / (1.0 - 0.0), 0.0, 1.0))',
+      },
+      {
+        name: 'mix of var and get operators (color)',
+        expression: [
+          'match',
+          ['var', 'selected'],
+          false,
+          'red',
+          ['get', 'validValue'],
+          'green',
+          [
+            'case',
+            ['<', ['time'], 10000],
+            ['var', 'oldColor'],
+            ['var', 'newColor'],
+          ],
+        ],
+        type: ColorType,
+        context: {
+          style: {
+            variables: {
+              selected: true,
+              oldColor: 'grey',
+              newColor: 'white',
+            },
+          },
+        },
+        expected:
+          '(u_var_selected == false ? vec4(1.0, 0.0, 0.0, 1.0) : (u_var_selected == a_prop_validValue ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : ((u_time < 10000.0) ? u_var_oldColor : u_var_newColor)))',
+        contextAssertion: (context) => {
+          expect(context.properties).to.eql({
+            validValue: {
+              name: 'validValue',
+              type: StringType | NumberType | BooleanType,
+            },
+          });
+          expect(context.variables).to.eql({
+            selected: {
+              name: 'selected',
+              type: StringType | NumberType | BooleanType,
+            },
+            newColor: {name: 'newColor', type: ColorType},
+            oldColor: {name: 'oldColor', type: ColorType},
+          });
+        },
+      },
+    ];
+
+    for (const c of cases) {
+      it(`works for ${c.name}`, () => {
+        const parsingContext = newParsingContext();
+        const compilationContext = c.context
+          ? {...newCompilationContext(), ...c.context}
+          : newCompilationContext();
+        parsingContext.style = compilationContext.style;
+        const result = buildExpression(
+          c.expression,
+          c.type,
+          parsingContext,
+          compilationContext,
+        );
+        expect(result).to.eql(c.expected);
+        if (c.contextAssertion) {
+          c.contextAssertion(compilationContext);
+        }
+      });
+    }
+  });
+});

--- a/test/browser/spec/ol/layer/Vector.test.js
+++ b/test/browser/spec/ol/layer/Vector.test.js
@@ -16,6 +16,7 @@ import Icon from '../../../../../src/ol/style/Icon.js';
 import ImageStyle from '../../../../../src/ol/style/Image.js';
 import Stroke from '../../../../../src/ol/style/Stroke.js';
 import Style, {createDefaultStyle} from '../../../../../src/ol/style/Style.js';
+import {Fill} from '../../../../../src/ol/style.js';
 
 describe('ol.layer.Vector', function () {
   describe('constructor', function () {
@@ -125,6 +126,80 @@ describe('ol.layer.Vector', function () {
       };
       layer.setStyle(styleFunction);
       expect(layer.getStyle()).to.be(styleFunction);
+    });
+
+    it('returns a flat style if a flat style was set', () => {
+      const layer = new VectorLayer();
+      const style = [
+        {
+          'stroke-color': 'red',
+          'stroke-width': 10,
+        },
+        {
+          'stroke-color': 'yellow',
+          'stroke-width': 5,
+        },
+      ];
+      layer.setStyle(style);
+      expect(layer.getStyle()).to.be(style);
+    });
+  });
+
+  describe('#setStyle()', () => {
+    it('accepts a flat style', () => {
+      const layer = new VectorLayer();
+      layer.setStyle({
+        'fill-color': 'red',
+      });
+
+      const styleFunction = layer.getStyleFunction();
+      expect(styleFunction).to.be.a(Function);
+
+      const styles = styleFunction(new Feature(), 1);
+      expect(styles).to.be.an(Array);
+      expect(styles).to.have.length(1);
+
+      const style = styles[0];
+      const fill = style.getFill();
+      expect(fill).to.be.a(Fill);
+      expect(fill.getColor()).to.eql([255, 0, 0, 1]);
+    });
+
+    it('accepts an array of flat styles', () => {
+      const layer = new VectorLayer();
+      layer.setStyle([
+        {
+          'stroke-color': 'red',
+          'stroke-width': 10,
+        },
+        {
+          'stroke-color': 'yellow',
+          'stroke-width': 5,
+        },
+      ]);
+
+      const styleFunction = layer.getStyleFunction();
+      expect(styleFunction).to.be.a(Function);
+
+      const styles = styleFunction(new Feature(), 1);
+      expect(styles).to.be.an(Array);
+      expect(styles).to.have.length(2);
+
+      const first = styles[0];
+      expect(first).to.be.a(Style);
+
+      const firstStroke = first.getStroke();
+      expect(firstStroke).to.be.a(Stroke);
+      expect(firstStroke.getColor()).to.eql([255, 0, 0, 1]);
+      expect(firstStroke.getWidth()).to.be(10);
+
+      const second = styles[1];
+      expect(second).to.be.a(Style);
+
+      const secondStroke = second.getStroke();
+      expect(secondStroke).to.be.a(Stroke);
+      expect(secondStroke.getColor()).to.eql([255, 255, 0, 1]);
+      expect(secondStroke.getWidth()).to.be(5);
     });
   });
 

--- a/test/node/ol/color.test.js
+++ b/test/node/ol/color.test.js
@@ -3,7 +3,8 @@ import {
   asString,
   fromString,
   isStringColor,
-  normalize,
+  lchaToRgba,
+  rgbaToLcha,
   toString,
 } from '../../../src/ol/color.js';
 import expect from '../expect.js';
@@ -58,36 +59,14 @@ describe('ol/color', () => {
   describe('fromString()', () => {
     describe('parses a variety of formats', () => {
       const cases = [
-        // named colors
-        ['red', [255, 0, 0, 1]],
-        ['green', [0, 128, 0, 1]],
-        ['blue', [0, 0, 255, 1]],
-        ['yellow', [255, 255, 0, 1]],
-        ['orange', [255, 165, 0, 1]],
-        ['purple', [128, 0, 128, 1]],
-        ['violet', [238, 130, 238, 1]],
-        ['white', [255, 255, 255, 1]],
-        ['black', [0, 0, 0, 1]],
-        ['wheat', [245, 222, 179, 1]],
-        ['olive', [128, 128, 0, 1]],
-        ['transparent', [0, 0, 0, 0]],
-        ['oops', 'failed to parse "oops" as color'],
-
         // rgb(a) varieties
-        ['rgba(255,122,127,0.8)', [255, 122, 127, 0.8]],
-        ['rgb(255 122 127 / 80%)', [255, 122, 127, 0.8]],
-        ['rgb(255 122 127 / .2)', [255, 122, 127, 0.2]],
         ['rgb(30% 20% 50%)', [77, 51, 128, 1]],
-
-        // hsl(a) varieties
-        ['hsla(84, 51%, 87%, 0.7)', [225, 239, 205, 0.7]],
-        ['hsl(46, 24%, 82%)', [220, 215, 198, 1]],
-        ['hsl(50 80% 40%)', [184, 156, 20, 1]],
-        ['hsl(150deg 30% 60%)', [122, 184, 153, 1]],
-        ['hsl(0 80% 50% / 25%)', [230, 25, 25, 0.25]],
-
-        // hwb
-        ['hwb(50deg 30% 40%)', [133, 122, 71, 1]],
+        ['rgba(30%, 20%, 50%, 80%)', [77, 51, 128, 0.8]],
+        ['rgba(255,122,127,0.8)', [255, 122, 127, 0.8]],
+        ['rgb(255, 122, 127)', [255, 122, 127, 1]],
+        ['rgb(255 122 127 / .2)', [255, 122, 127, 0.2]],
+        ['rgb(255 122 127 / 80%)', [255, 122, 127, 0.8]],
+        // other color spaces and formats require the DOM, see test/browser/spec/ol/color.test.js
       ];
       for (const c of cases) {
         it(`works for ${c[0]}`, () => {
@@ -163,37 +142,6 @@ describe('ol/color', () => {
         [0, 0, 255, 0.4711],
       );
     });
-
-    describe('with invalid colors', () => {
-      const cases = [
-        'tuesday',
-        'rgb(garbage)',
-        'hsl(oops)',
-        'rgba(42)',
-        'hsla(5)',
-      ];
-
-      for (const c of cases) {
-        it(`throws an error on ${c}`, () => {
-          try {
-            const color = fromString(c);
-            expect().fail(`Expected an error, got ${color}`);
-          } catch (err) {
-            expect(err.message).to.be(`failed to parse "${c}" as color`);
-          }
-        });
-      }
-    });
-  });
-
-  describe('normalize()', () => {
-    it('clamps out-of-range channels', () => {
-      expect(normalize([-1, 256, 0, 2])).to.eql([0, 255, 0, 1]);
-    });
-
-    it('rounds color channels to integers', () => {
-      expect(normalize([1.2, 2.5, 3.7, 1])).to.eql([1, 3, 4, 1]);
-    });
   });
 
   describe('toString()', () => {
@@ -210,15 +158,97 @@ describe('ol/color', () => {
     });
   });
 
+  describe('with invalid colors', () => {
+    const cases = [
+      '#ab',
+      '#xyz123',
+      'rgb(0%,0,0)',
+      'rgb(0 0,0)',
+      'rgba(0,0,0/0)',
+    ];
+
+    for (const c of cases) {
+      it(`throws an error on ${c}`, () => {
+        try {
+          const color = fromString(c);
+          expect().fail(`Expected an error, got ${color}`);
+        } catch (err) {
+          expect(err.message).to.be(`failed to parse "${c}" as color`);
+        }
+      });
+    }
+  });
+
   describe('isValid()', () => {
     it('correctly detects valid colors', () => {
       expect(isStringColor('rgba(1,3,4,0.4)')).to.be(true);
       expect(isStringColor('rgb(1,3,4)')).to.be(true);
-      expect(isStringColor('lightgreen')).to.be(true);
-      expect(isStringColor('yellow')).to.be(true);
-      expect(isStringColor('GREEN')).to.be(true);
-      expect(isStringColor('notacolor')).to.be(false);
-      expect(isStringColor('red_')).to.be(false);
+    });
+  });
+
+  describe('lch <-> rgb conversion yields same results as the reference implementation', () => {
+    // Reference implementation from
+    // https://stackoverflow.com/questions/7530627/hcl-color-to-rgb-and-backward/67219995#67219995
+    const rgb255 = (v) => (v < 255 ? (v > 0 ? v : 0) : 255);
+    const b1 = (v) =>
+      v > 0.0031308 ? v ** (1 / 2.4) * 269.025 - 14.025 : v * 3294.6;
+    const b2 = (v) => (v > 0.2068965 ? v ** 3 : (v - 4 / 29) * (108 / 841));
+    const a1 = (v) =>
+      v > 10.314724 ? ((v + 14.025) / 269.025) ** 2.4 : v / 3294.6;
+    const a2 = (v) => (v > 0.0088564 ? v ** (1 / 3) : v / (108 / 841) + 4 / 29);
+
+    function fromHCL(h, c, l) {
+      const y = b2((l = (l + 16) / 116));
+      const x = b2(l + (c / 500) * Math.cos((h *= Math.PI / 180)));
+      const z = b2(l - (c / 200) * Math.sin(h));
+      return [
+        rgb255(b1(x * 3.021973625 - y * 1.617392459 - z * 0.404875592)),
+        rgb255(b1(x * -0.943766287 + y * 1.916279586 + z * 0.027607165)),
+        rgb255(b1(x * 0.069407491 - y * 0.22898585 + z * 1.159737864)),
+      ];
+    }
+
+    function toHCL(r, g, b) {
+      const y = a2(
+        (r = a1(r)) * 0.222488403 +
+          (g = a1(g)) * 0.716873169 +
+          (b = a1(b)) * 0.06060791,
+      );
+      const l =
+        500 * (a2(r * 0.452247074 + g * 0.399439023 + b * 0.148375274) - y);
+      const q =
+        200 * (y - a2(r * 0.016863605 + g * 0.117638439 + b * 0.865350722));
+      const h = Math.atan2(q, l) * (180 / Math.PI);
+      return [h < 0 ? h + 360 : h, Math.sqrt(l * l + q * q), 116 * y - 16];
+    }
+
+    it('returns the same values for rgb -> lch -> rgb', () => {
+      const cases = [
+        [255, 0, 0], // red
+        [0, 255, 0], // green
+        [0, 0, 255], // blue
+        [255, 255, 0], // yellow
+        [0, 255, 255], // cyan
+        [255, 0, 255], // magenta
+        [192, 192, 192], // silver
+        [128, 128, 128], // gray
+        [128, 0, 0], // maroon
+        [128, 128, 0], // olive
+        [0, 128, 0], // dark green
+        [128, 0, 128], // purple
+        [0, 128, 128], // teal
+        [0, 0, 128], // navy
+      ];
+      for (const rgb of cases) {
+        const [h, c, l] = toHCL(...rgb);
+        const lch1 = [l, c, h];
+        const lch2 = rgbaToLcha([...rgb, 1]).slice(0, 3);
+        expect(lch2).to.eql(lch1);
+        const rgb1 = fromHCL(lch1[2], lch1[1], lch1[0]).map(Math.round);
+        const rgb2 = lchaToRgba([...lch1, 1]).slice(0, 3);
+        expect(rgb2).to.eql(rgb1);
+        expect(rgb1).to.eql(rgb);
+      }
     });
   });
 });

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -660,12 +660,6 @@ describe('ol/expr/cpu.js', () => {
         expected: 1,
       },
       {
-        name: 'interpolate (linear color)',
-        type: ColorType,
-        expression: ['interpolate', ['linear'], 0.5, 0, 'red', 1, [0, 255, 0]],
-        expected: [219, 170, 0, 1],
-      },
-      {
         name: 'to-string (string)',
         type: StringType,
         expression: ['to-string', 'foo'],

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -112,13 +112,6 @@ describe('ol/expr/expression.js', () => {
       expect(expression.value).to.eql([0, 0, 0, 1]);
     });
 
-    it('parses a literal color (string)', () => {
-      const expression = parse('fuchsia', ColorType, newParsingContext());
-      expect(expression).to.be.a(LiteralExpression);
-      expect(includesType(expression.type, ColorType));
-      expect(expression.value).to.eql([255, 0, 255, 1]);
-    });
-
     it('parses a literal number array', () => {
       const expression = parse([10, 20], NumberArrayType, newParsingContext());
       expect(expression).to.be.a(LiteralExpression);
@@ -227,57 +220,7 @@ describe('ol/expr/expression.js', () => {
       expect(context.properties.has('foo')).to.be(true);
     });
 
-    it('parses a * expression with colors', () => {
-      const context = newParsingContext();
-      const expression = parse(
-        ['*', ['get', 'foo'], 'red', [255, 0, 0, 1]],
-        ColorType,
-        context,
-      );
-      expect(expression).to.be.a(CallExpression);
-      expect(expression.operator).to.be('*');
-      expect(isType(expression.type, ColorType)).to.be(true);
-      expect(expression.args).to.have.length(3);
-      expect(isType(expression.args[0].type, ColorType)).to.be(true);
-      expect(isType(expression.args[1].type, ColorType)).to.be(true);
-      expect(isType(expression.args[2].type, ColorType)).to.be(true);
-    });
-
     describe('case operation', () => {
-      it('respects the return type (string or array color)', () => {
-        const context = newParsingContext();
-        const expression = parse(
-          [
-            'case',
-            ['>', ['get', 'attr'], 3],
-            'red',
-            ['>', ['get', 'attr'], 1],
-            'yellow',
-            [255, 0, 0],
-          ],
-          ColorType,
-          context,
-        );
-        expect(expression).to.be.a(CallExpression);
-        expect(expression.operator).to.be('case');
-        expect(isType(expression.type, ColorType)).to.be(true);
-        expect(expression.args).to.have.length(5);
-        expect(isType(expression.args[0].type, BooleanType)).to.be(true);
-        expect(isType(expression.args[1].type, ColorType)).to.be(true);
-        expect(isType(expression.args[2].type, BooleanType)).to.be(true);
-        expect(isType(expression.args[3].type, ColorType)).to.be(true);
-        expect(isType(expression.args[4].type, ColorType)).to.be(true);
-      });
-
-      it('respects the return type (string color)', () => {
-        const expression = parse(
-          ['case', true, 'red', false, 'yellow', 'white'],
-          ColorType,
-          newParsingContext(),
-        );
-        expect(isType(expression.type, ColorType)).to.be(true);
-      });
-
       it('respects the return type (string)', () => {
         const expression = parse(
           ['case', true, 'red', false, 'yellow', '42'],
@@ -330,27 +273,6 @@ describe('ol/expr/expression.js', () => {
     });
 
     describe('match operation', () => {
-      it('respects the return type (color)', () => {
-        const context = newParsingContext();
-        const expression = parse(
-          ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', [255, 0, 0, 1]],
-          ColorType,
-          context,
-        );
-        expect(expression).to.be.a(CallExpression);
-        expect(expression.operator).to.be('match');
-        expect(isType(expression.type, ColorType)).to.be(true);
-        expect(expression.args).to.have.length(6);
-        expect(typeName(expression.args[0].type)).to.be(
-          typeName(BooleanType | StringType | NumberType),
-        );
-        expect(isType(expression.args[1].type, NumberType)).to.be(true);
-        expect(isType(expression.args[2].type, ColorType)).to.be(true);
-        expect(isType(expression.args[3].type, NumberType)).to.be(true);
-        expect(isType(expression.args[4].type, ColorType)).to.be(true);
-        expect(isType(expression.args[5].type, ColorType)).to.be(true);
-      });
-
       it('respects the return type (string)', () => {
         const expression = parse(
           ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'not_a_color'],
@@ -363,15 +285,6 @@ describe('ol/expr/expression.js', () => {
       it('respects the return type (color array)', () => {
         const expression = parse(
           ['match', ['get', 'attr'], 0, [1, 1, 0], 1, [1, 0, 1], [0, 1, 1]],
-          ColorType,
-          newParsingContext(),
-        );
-        expect(isType(expression.type, ColorType)).to.be(true);
-      });
-
-      it('respects the return type (color string)', () => {
-        const expression = parse(
-          ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'green'],
           ColorType,
           newParsingContext(),
         );
@@ -422,23 +335,6 @@ describe('ol/expr/expression.js', () => {
         expect(isType(expression.args[2].type, StringType)).to.be(true);
         expect(isType(expression.args[3].type, StringType)).to.be(true);
         expect(isType(expression.args[4].type, StringType)).to.be(true);
-      });
-    });
-
-    describe('palette operator', () => {
-      it('outputs color type and list of colors as args', () => {
-        const expression = parse(
-          ['palette', 1, ['red', 'rgba(255, 255, 0, 1)', [0, 255, 255]]],
-          ColorType,
-          newParsingContext(),
-        );
-        expect(expression.operator).to.be('palette');
-        expect(isType(expression.type, ColorType)).to.be(true);
-        expect(expression.args).to.have.length(4);
-        expect(isType(expression.args[0].type, NumberType)).to.be(true);
-        expect(isType(expression.args[1].type, ColorType)).to.be(true);
-        expect(isType(expression.args[2].type, ColorType)).to.be(true);
-        expect(isType(expression.args[3].type, ColorType)).to.be(true);
       });
     });
 
@@ -576,12 +472,6 @@ describe('ol/expr/expression.js', () => {
         name: 'second argument is not an array (palette)',
         expression: ['palette', ['band', 2], 'red'],
         error: 'the second argument of palette must be an array',
-      },
-      {
-        name: 'second argument is not an array of colors (palette)',
-        expression: ['palette', ['band', 2], ['red', 'green', 'abcd']],
-        error:
-          'failed to parse color at index 2 in palette expression: failed to parse "abcd" as color',
       },
     ];
 

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -52,16 +52,6 @@ describe('ol/expr/gpu.js', () => {
         'vec4(0.39215686274509803, 0.0, 1.0, 0.7)',
       );
     });
-    it('handles colors in string format', () => {
-      expect(colorToGlsl('red')).to.eql('vec4(1.0, 0.0, 0.0, 1.0)');
-      expect(colorToGlsl('#00ff99')).to.eql('vec4(0.0, 1.0, 0.6, 1.0)');
-      expect(colorToGlsl('rgb(100, 0, 255)')).to.eql(
-        'vec4(0.39215686274509803, 0.0, 1.0, 1.0)',
-      );
-      expect(colorToGlsl('rgba(100, 0, 255, 0.3)')).to.eql(
-        'vec4(0.39215686274509803, 0.0, 1.0, 0.3)',
-      );
-    });
   });
 
   describe('stringToGlsl()', () => {
@@ -242,12 +232,6 @@ describe('ol/expr/gpu.js', () => {
         type: AnyType,
         expression: ['*', 2, 4, 6, 8],
         expected: '(2.0 * 4.0 * 6.0 * 8.0)',
-      },
-      {
-        name: 'multiplication (infer string as color)',
-        type: ColorType,
-        expression: ['*', [255, 127.5, 0, 0.5], 'red'],
-        expected: '(vec4(1.0, 0.5, 0.0, 0.5) * vec4(1.0, 0.0, 0.0, 1.0))',
       },
       {
         name: 'division',
@@ -458,27 +442,6 @@ describe('ol/expr/gpu.js', () => {
         expected: 'getBandValue(1.0, -1.0, 2.0)',
       },
       {
-        name: 'colors as strings',
-        type: ColorType,
-        expression: [
-          'case',
-          ['>', ['get', 'attr'], 3],
-          'red',
-          ['>', ['get', 'attr'], 1],
-          'yellow',
-          'white',
-        ],
-        expected:
-          '((a_prop_attr > 3.0) ? vec4(1.0, 0.0, 0.0, 1.0) : ((a_prop_attr > 1.0) ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(1.0, 1.0, 1.0, 1.0)))',
-      },
-      {
-        name: 'match (colors)',
-        type: ColorType,
-        expression: ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'white'],
-        expected:
-          '(a_prop_attr == 0.0 ? vec4(1.0, 0.0, 0.0, 1.0) : (a_prop_attr == 1.0 ? vec4(1.0, 1.0, 0.0, 1.0) : vec4(1.0, 1.0, 1.0, 1.0)))',
-      },
-      {
         name: 'match (strings)',
         type: StringType,
         expression: ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'white'],
@@ -611,70 +574,6 @@ describe('ol/expr/gpu.js', () => {
         },
       },
       {
-        name: 'palette',
-        expression: [
-          'palette',
-          ['get', 'color'],
-          ['red', 'rgb(0, 255, 0)', [0, 0, 255, 0.5]],
-        ],
-        type: AnyType,
-        expected:
-          'texture2D(u_paletteTextures[0], vec2((a_prop_color + 0.5) / 3.0, 0.5))',
-        contextAssertion: (context) => {
-          expect(context.paletteTextures[0]).to.eql({
-            name: 'u_paletteTextures[0]',
-            data: Uint8Array.from([
-              // red
-              255, 0, 0, 255,
-              // green
-              0, 255, 0, 255,
-              // blue, 0.5 alpha
-              0, 0, 255, 127,
-            ]),
-            texture_: null,
-          });
-        },
-      },
-      {
-        name: 'combination of interpolate, match, color and number',
-        type: ColorType,
-        expression: [
-          'interpolate',
-          ['linear'],
-          [
-            '^',
-            [
-              '/',
-              [
-                '%',
-                [
-                  '+',
-                  ['time'],
-                  [
-                    'interpolate',
-                    ['linear'],
-                    ['get', 'year'],
-                    1850,
-                    0,
-                    2015,
-                    8,
-                  ],
-                ],
-                8,
-              ],
-              8,
-            ],
-            0.5,
-          ],
-          0,
-          'rgba(255, 255, 0, 0.5)',
-          1,
-          ['match', ['get', 'year'], 2000, 'green', '#ffe52c'],
-        ],
-        expected:
-          'mix(vec4(1.0, 1.0, 0.0, 0.5), (a_prop_year == 2000.0 ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : vec4(1.0, 0.8980392156862745, 0.17254901960784313, 1.0)), clamp((pow((mod((u_time + mix(0.0, 8.0, clamp((a_prop_year - 1850.0) / (2015.0 - 1850.0), 0.0, 1.0))), 8.0) / 8.0), 0.5) - 0.0) / (1.0 - 0.0), 0.0, 1.0))',
-      },
-      {
         name: 'array for symbol size',
         type: NumberType | NumberArrayType,
         expression: [
@@ -710,51 +609,6 @@ describe('ol/expr/gpu.js', () => {
         },
         expected:
           'vec2(ceil((a_prop_width == 0.0 ? u_var_defaultWidth : a_prop_width)), ceil((a_prop_height == 0.0 ? u_var_defaultHeight : a_prop_height)))',
-      },
-      {
-        name: 'mix of var and get operators (color)',
-        expression: [
-          'match',
-          ['var', 'selected'],
-          false,
-          'red',
-          ['get', 'validValue'],
-          'green',
-          [
-            'case',
-            ['<', ['time'], 10000],
-            ['var', 'oldColor'],
-            ['var', 'newColor'],
-          ],
-        ],
-        type: ColorType,
-        context: {
-          style: {
-            variables: {
-              selected: true,
-              oldColor: 'grey',
-              newColor: 'white',
-            },
-          },
-        },
-        expected:
-          '(u_var_selected == false ? vec4(1.0, 0.0, 0.0, 1.0) : (u_var_selected == a_prop_validValue ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : ((u_time < 10000.0) ? u_var_oldColor : u_var_newColor)))',
-        contextAssertion: (context) => {
-          expect(context.properties).to.eql({
-            validValue: {
-              name: 'validValue',
-              type: StringType | NumberType | BooleanType,
-            },
-          });
-          expect(context.variables).to.eql({
-            selected: {
-              name: 'selected',
-              type: StringType | NumberType | BooleanType,
-            },
-            newColor: {name: 'newColor', type: ColorType},
-            oldColor: {name: 'oldColor', type: ColorType},
-          });
-        },
       },
       {
         name: 'mix of var and get operators (number array)',

--- a/test/node/ol/layer/Vector.test.js
+++ b/test/node/ol/layer/Vector.test.js
@@ -1,69 +1,9 @@
-import Feature from '../../../../src/ol/Feature.js';
 import Vector from '../../../../src/ol/layer/Vector.js';
 import Fill from '../../../../src/ol/style/Fill.js';
-import Stroke from '../../../../src/ol/style/Stroke.js';
 import Style, {createDefaultStyle} from '../../../../src/ol/style/Style.js';
 import expect from '../../expect.js';
 
 describe('ol/layer/Vector.js', () => {
-  describe('setStyle()', () => {
-    it('accepts a flat style', () => {
-      const layer = new Vector();
-      layer.setStyle({
-        'fill-color': 'red',
-      });
-
-      const styleFunction = layer.getStyleFunction();
-      expect(styleFunction).to.be.a(Function);
-
-      const styles = styleFunction(new Feature(), 1);
-      expect(styles).to.be.an(Array);
-      expect(styles).to.have.length(1);
-
-      const style = styles[0];
-      const fill = style.getFill();
-      expect(fill).to.be.a(Fill);
-      expect(fill.getColor()).to.eql([255, 0, 0, 1]);
-    });
-
-    it('accepts an array of flat styles', () => {
-      const layer = new Vector();
-      layer.setStyle([
-        {
-          'stroke-color': 'red',
-          'stroke-width': 10,
-        },
-        {
-          'stroke-color': 'yellow',
-          'stroke-width': 5,
-        },
-      ]);
-
-      const styleFunction = layer.getStyleFunction();
-      expect(styleFunction).to.be.a(Function);
-
-      const styles = styleFunction(new Feature(), 1);
-      expect(styles).to.be.an(Array);
-      expect(styles).to.have.length(2);
-
-      const first = styles[0];
-      expect(first).to.be.a(Style);
-
-      const firstStroke = first.getStroke();
-      expect(firstStroke).to.be.a(Stroke);
-      expect(firstStroke.getColor()).to.eql([255, 0, 0, 1]);
-      expect(firstStroke.getWidth()).to.be(10);
-
-      const second = styles[1];
-      expect(second).to.be.a(Style);
-
-      const secondStroke = second.getStroke();
-      expect(secondStroke).to.be.a(Stroke);
-      expect(secondStroke.getColor()).to.eql([255, 255, 0, 1]);
-      expect(secondStroke.getWidth()).to.be(5);
-    });
-  });
-
   describe('getStyle()', () => {
     it('returns the default style if no style was set', () => {
       const layer = new Vector();
@@ -81,21 +21,6 @@ describe('ol/layer/Vector.js', () => {
           color: 'red',
         }),
       });
-      layer.setStyle(style);
-      expect(layer.getStyle()).to.be(style);
-    });
-    it('returns a flat style if a flat style was set', () => {
-      const layer = new Vector();
-      const style = [
-        {
-          'stroke-color': 'red',
-          'stroke-width': 10,
-        },
-        {
-          'stroke-color': 'yellow',
-          'stroke-width': 5,
-        },
-      ];
       layer.setStyle(style);
       expect(layer.getStyle()).to.be(style);
     });

--- a/test/rendering/cases/cog-listener/main.js
+++ b/test/rendering/cases/cog-listener/main.js
@@ -16,9 +16,9 @@ const layer = new TileLayer({
     color: [
       'case',
       ['==', ['band', 2], 0],
-      'rgba(0,0,0,0.)',
+      'rgba(0,0,0,0)',
       ['!=', ['band', 2], 1],
-      'rgba(255,0,0,1.)',
+      'rgba(255,0,0,1)',
       ['array', ['band', 1], ['band', 1], ['band', 1], ['band', 2]],
     ],
   },


### PR DESCRIPTION
This pull request suggests we remove the `color-space` and `color-rgba` (depends on `color-space`) dependencies. While trying to contribute type declarations to `color-space`, I found several bugs there that made me doubt the reliability of that library, and the maintainer seemed to be complicated to interact with.

Basic rgb(a) and hex color parsing can be done with simple regular expressions and string operations, and the rgb -> lch color conversion we use for color interpolation is simple enough to not depend on a library for it. For parsing other css colors and translating them to rgba, we can do that directly in the browser by drawing a pixel with an arbitrary `fillStyle` css color to a 1x1 pixel canvas and reading its rgba values from the `ImageData` of that canvas.

Because that requires a browser environment, I had to move some of the tests from node to browser. Also, the linear color interpolation test (moved from node to browser as well) has slightly different rgb values for the interpolated color. I cross-checked the result with two other libraries (`color-convert` and `@texel/color`), and all have slightly different results, so I think that's ok.

Finally, having less dependencies is also good if we want to work towards module loading directly in the browser.



