### PR TITLE
Update filter style in Filter WebGL Line example

### DIFF
--- a/examples/filter-webgl-line.html
+++ b/examples/filter-webgl-line.html
@@ -7,6 +7,7 @@ docs: >
     contain an M ("measure") parameter in their coordinates. For each trajectory the timestamp is stored in the M
     parameter using an `XYM` layout. This let us show the progression on a specific time for each trajectory on the map.
 tags: "draw, vector, webgl, line, line-metric, measure, layout"
+experimental: true
 ---
 <div id="map" class="map"></div>
 <form>

--- a/examples/filter-webgl-line.js
+++ b/examples/filter-webgl-line.js
@@ -7,16 +7,18 @@ import OSM from '../src/ol/source/OSM.js';
 import VectorSource from '../src/ol/source/Vector.js';
 
 const lineStyle = {
-  'stroke-width': 4,
-  'stroke-color': [
-    'interpolate',
-    ['linear'],
-    ['line-metric'],
-    1303200000,
-    'hsl(312,100%,39%)',
-    1303240000,
-    'hsl(36,100%,45%)',
-  ],
+  style: {
+    'stroke-width': 4,
+    'stroke-color': [
+      'interpolate',
+      ['linear'],
+      ['line-metric'],
+      1303200000,
+      'hsl(312,100%,39%)',
+      1303240000,
+      'hsl(36,100%,45%)',
+    ],
+  },
   filter: ['<=', ['line-metric'], ['var', 'timestamp']],
 };
 


### PR DESCRIPTION
Update the filter style to work with version 10.4.0
Also mark as experimental as with other WebGL vector layer examples
https://deploy-preview-16606--ol-site.netlify.app/en/latest/examples/filter-webgl-line.html
