### PR TITLE
Translate double-quoted type-import paths in examples

### DIFF
--- a/examples/custom-interactions.js
+++ b/examples/custom-interactions.js
@@ -21,7 +21,7 @@ class Drag extends PointerInteraction {
     });
 
     /**
-     * @type {import("../src/ol/coordinate.js").Coordinate}
+     * @type {import('../src/ol/coordinate.js').Coordinate}
      * @private
      */
     this.coordinate_ = null;
@@ -47,7 +47,7 @@ class Drag extends PointerInteraction {
 }
 
 /**
- * @param {import("../src/ol/MapBrowserEvent.js").default} evt Map browser event.
+ * @param {import('../src/ol/MapBrowserEvent.js').default} evt Map browser event.
  * @return {boolean} `true` to start the drag sequence.
  */
 function handleDownEvent(evt) {
@@ -66,7 +66,7 @@ function handleDownEvent(evt) {
 }
 
 /**
- * @param {import("../src/ol/MapBrowserEvent.js").default} evt Map browser event.
+ * @param {import('../src/ol/MapBrowserEvent.js').default} evt Map browser event.
  */
 function handleDragEvent(evt) {
   const deltaX = evt.coordinate[0] - this.coordinate_[0];
@@ -80,7 +80,7 @@ function handleDragEvent(evt) {
 }
 
 /**
- * @param {import("../src/ol/MapBrowserEvent.js").default} evt Event.
+ * @param {import('../src/ol/MapBrowserEvent.js').default} evt Event.
  */
 function handleMoveEvent(evt) {
   if (this.cursor_) {

--- a/examples/igc.js
+++ b/examples/igc.js
@@ -190,7 +190,7 @@ control.addEventListener('input', function () {
   const m = time.start + time.duration * value;
   vectorSource.forEachFeature(function (feature) {
     const geometry =
-      /** @type {import("../src/ol/geom/LineString.js").default} */ (
+      /** @type {import('../src/ol/geom/LineString.js').default} */ (
         feature.getGeometry()
       );
     const coordinate = geometry.getCoordinateAtM(m, true);

--- a/examples/measure.js
+++ b/examples/measure.js
@@ -34,7 +34,7 @@ const vector = new VectorLayer({
 
 /**
  * Currently drawn feature.
- * @type {import("../src/ol/Feature.js").default}
+ * @type {import('../src/ol/Feature.js').default}
  */
 let sketch;
 
@@ -76,7 +76,7 @@ const continueLineMsg = 'Click to continue drawing the line';
 
 /**
  * Handle pointer move.
- * @param {import("../src/ol/MapBrowserEvent").default} evt The event.
+ * @param {import('../src/ol/MapBrowserEvent').default} evt The event.
  */
 const pointerMoveHandler = function (evt) {
   if (evt.dragging) {
@@ -193,7 +193,7 @@ function addInteraction() {
     // set sketch
     sketch = evt.feature;
 
-    /** @type {import("../src/ol/coordinate.js").Coordinate|undefined} */
+    /** @type {import('../src/ol/coordinate.js').Coordinate|undefined} */
     let tooltipCoord = evt.coordinate;
 
     listener = sketch.getGeometry().on('change', function (evt) {

--- a/examples/view-padding.js
+++ b/examples/view-padding.js
@@ -11,7 +11,7 @@ import Fill from '../src/ol/style/Fill.js';
 import Stroke from '../src/ol/style/Stroke.js';
 import Style from '../src/ol/style/Style.js';
 
-/** @type {VectorSource<import("../src/ol/geom/SimpleGeometry.js").default>} */
+/** @type {VectorSource<import('../src/ol/Feature.js').default<import('../src/ol/geom/SimpleGeometry.js').default>>} */
 const source = new VectorSource({
   url: 'data/geojson/switzerland.geojson',
   format: new GeoJSON(),

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -29,8 +29,7 @@ function getPackageInfo() {
 
 handlebars.registerHelper(
   'md',
-  (str) =>
-    new handlebars.SafeString(marked(str, {headerIds: false, mangle: false})),
+  (str) => new handlebars.SafeString(marked(str, {async: false})),
 );
 
 /**

--- a/examples/webpack/example-builder.js
+++ b/examples/webpack/example-builder.js
@@ -282,9 +282,12 @@ export default class ExampleBuilder {
     return (
       source
         // remove "../src/" prefix to have the same import syntax as the documentation
-        .replace(/'\.\.\/src\//g, "'")
+        .replaceAll(
+          /(["'])(\.\.\/src\/ol\/[^"']+\.js)\1/g,
+          (full, quote, path) => "'" + path.slice(7) + "'",
+        )
         // Remove worker loader import and modify `new Worker()` to add source
-        .replace(/import Worker from 'worker-loader![^\n]*\n/g, '')
+        .replaceAll(/import Worker from 'worker-loader![^\n]*\n/g, '')
         .replace('new Worker()', "new Worker('./worker.js', {type: 'module'})")
     );
   }


### PR DESCRIPTION
e. g. https://openlayers.org/en/v10.3.1/examples/custom-interactions.html
```patch
-@type {import("../src/ol/coordinate.js").Coordinate}
+@type {import('ol/coordinate.js').Coordinate}
```