### PR TITLE
Link to GitHub repository instead of npm package

### DIFF
--- a/site/src/3rd-party/index.hbs
+++ b/site/src/3rd-party/index.hbs
@@ -16,7 +16,7 @@ layout: default.hbs
         <td><a href="https://github.com/openlayers">OpenLayers</a></td>
       </tr>
       <tr>
-        <td><a href="https://npmjs.com/package/ol-mapbox-style">ol-mapbox-style</a></td>
+        <td><a href="https://github.com/openlayers/ol-mapbox-style">ol-mapbox-style</a></td>
         <td>Create OpenLayers maps from Mapbox Style objects.</td>
         <td><a href="https://github.com/openlayers">OpenLayers</a></td>
       </tr>


### PR DESCRIPTION
Like other 3rd party libraries, the link for ol-mapbox-style should go to the GitHub repository instead the npm package.