### PR TITLE
Add option to snap to segment intersections

### DIFF
--- a/examples/snap.html
+++ b/examples/snap.html
@@ -6,7 +6,10 @@ docs: >
   Example of using the snap interaction together with
   draw and modify interactions. The snap interaction must be added
   last, as it needs to be the first to handle the
-  <code>pointermove</code> event.</p>
+  <code>pointermove</code> event.</p> By default, the Snap interaction snaps to edges
+  (<code>edge: true</code>) and vertices (<code>vertex: true</code>).
+  It can also be configured to snap to intersections between edges, which is done here with the
+  <code>intersection: true</code> option.
 tags: "draw, edit, modify, vector, snap"
 ---
 <div id="map" class="map"></div>

--- a/examples/snap.js
+++ b/examples/snap.js
@@ -135,6 +135,7 @@ ExampleModify.setActive(false);
 // are responsible of doing the snapping.
 const snap = new Snap({
   source: vector.getSource(),
+  intersection: true,
 });
 
 const snappedElement = document.getElementById('snapped');

--- a/src/ol/geom/flat/segments.js
+++ b/src/ol/geom/flat/segments.js
@@ -29,3 +29,27 @@ export function forEach(flatCoordinates, offset, end, stride, callback) {
   }
   return false;
 }
+
+/**
+ * Calculate the intersection point of two line segments.
+ * Reference: https://stackoverflow.com/a/72474223/2389327
+ * @param {Array<import("../../coordinate.js").Coordinate>} segment1 The first line segment as an array of two points.
+ * @param {Array<import("../../coordinate.js").Coordinate>} segment2 The second line segment as an array of two points.
+ * @return {import("../../coordinate.js").Coordinate|undefined} The intersection point or `undefined` if no intersection.
+ */
+export function getIntersectionPoint(segment1, segment2) {
+  const [a, b] = segment1;
+  const [c, d] = segment2;
+  const t =
+    ((a[0] - c[0]) * (c[1] - d[1]) - (a[1] - c[1]) * (c[0] - d[0])) /
+    ((a[0] - b[0]) * (c[1] - d[1]) - (a[1] - b[1]) * (c[0] - d[0]));
+  const u =
+    ((a[0] - c[0]) * (a[1] - b[1]) - (a[1] - c[1]) * (a[0] - b[0])) /
+    ((a[0] - b[0]) * (c[1] - d[1]) - (a[1] - b[1]) * (c[0] - d[0]));
+
+  // Check if lines actually intersect
+  if (0 <= t && t <= 1 && 0 <= u && u <= 1) {
+    return [a[0] + t * (b[0] - a[0]), a[1] + t * (b[1] - a[1])];
+  }
+  return undefined;
+}

--- a/test/node/ol/geom/flat/segments.test.js
+++ b/test/node/ol/geom/flat/segments.test.js
@@ -1,5 +1,8 @@
 import {spy as sinonSpy} from 'sinon';
-import {forEach as forEachSegment} from '../../../../../src/ol/geom/flat/segments.js';
+import {
+  forEach as forEachSegment,
+  getIntersectionPoint,
+} from '../../../../../src/ol/geom/flat/segments.js';
 import expect from '../../../expect.js';
 
 describe('ol/geom/flat/segments.js', function () {
@@ -62,6 +65,45 @@ describe('ol/geom/flat/segments.js', function () {
         [1, 1, 1],
         [2, 2, 2],
       ]);
+    });
+  });
+
+  describe('getIntersectionPoint()', () => {
+    it('returns the intersection point', () => {
+      const segment1 = [
+        [0, 0],
+        [1, 1],
+      ];
+      const segment2 = [
+        [0, 1],
+        [1, 0],
+      ];
+      const intersection = getIntersectionPoint(segment1, segment2);
+      expect(intersection).to.eql([0.5, 0.5]);
+    });
+    it('returns undefined if there is no intersection', () => {
+      const segment1 = [
+        [0, 0],
+        [1, 1],
+      ];
+      const segment2 = [
+        [0, 2],
+        [1, 3],
+      ];
+      const intersection = getIntersectionPoint(segment1, segment2);
+      expect(intersection).to.be(undefined);
+    });
+    it('returns undefined if the segments are collinear', () => {
+      const segment1 = [
+        [0, 0],
+        [2, 2],
+      ];
+      const segment2 = [
+        [1, 1],
+        [3, 3],
+      ];
+      const intersection = getIntersectionPoint(segment1, segment2);
+      expect(intersection).to.be(undefined);
     });
   });
 });


### PR DESCRIPTION
This pull request adds a new option to the `Snap` interaction:
```js
new Snap({
  intersection: true,
  // ...
});
```
With this, snapping to segment intersections can be enabled. The [`snap.html`](https://deploy-preview-16617--ol-site.netlify.app/en/latest/examples/snap.html) example was updated to show this new feature when drawing linestrings or polygons.