### PR TITLE
Do not include typescript tests in root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,6 +59,5 @@
   "include": [
     "types/**/*.ts",
     "src/ol/**/*.js",
-    "test/typescript/cases/**/*.ts"
   ]
 }


### PR DESCRIPTION
Now that `test/typescript/` has its own tsconfig, we should remove that directory from the root tsconfig, to avoid considering .d.ts files in `build/ol/` when working on the library. Also, `npm run typecheck` fails when `build/ol/` has not been built.  This pull request fixes that as well.