### PR TITLE
New option to specify custom segmenters for the Snap interaction

### DIFF
--- a/examples/snap-custom-segmenter.html
+++ b/examples/snap-custom-segmenter.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: Snap Interaction with Custom Segmenter
+shortdesc: Example of using the snap interaction with a custom LineString segmenter.
+docs: >
+  The Snap interaction can be configured with a custom segmenter for each geometry type.
+  In this example, a custom LineString segmenter adds snapping to the midpoint of each segment.
+tags: "draw, modify, vector, snap, midpoint"
+---
+<div id="map" class="map"></div>

--- a/examples/snap-custom-segmenter.js
+++ b/examples/snap-custom-segmenter.js
@@ -1,0 +1,49 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import Draw from '../src/ol/interaction/Draw.js';
+import Modify from '../src/ol/interaction/Modify.js';
+import Snap from '../src/ol/interaction/Snap.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import VectorSource from '../src/ol/source/Vector.js';
+
+const vector = new VectorLayer({
+  background: '#333',
+  source: new VectorSource(),
+  style: {
+    'stroke-color': '#ffcc33',
+  },
+});
+
+const map = new Map({
+  layers: [vector],
+  target: 'map',
+  view: new View({
+    center: [-11000000, 4600000],
+    zoom: 4,
+  }),
+});
+
+const modify = new Modify({
+  source: vector.getSource(),
+});
+map.addInteraction(modify);
+
+const draw = new Draw({
+  source: vector.getSource(),
+  type: 'LineString',
+});
+map.addInteraction(draw);
+
+const snap = new Snap({
+  source: vector.getSource(),
+  segmenters: {
+    LineString: (geometry) => {
+      const segments = [];
+      geometry.forEachSegment((c1, c2) => {
+        segments.push([c1, c2], [[(c1[0] + c2[0]) / 2, (c1[1] + c2[1]) / 2]]);
+      });
+      return segments;
+    },
+  },
+});
+map.addInteraction(snap);

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -705,4 +705,40 @@ describe('ol.interaction.Snap', function () {
       });
     }
   });
+
+  describe('Custom segmenters', () => {
+    it('calls custom segmenters and uses their results', function (done) {
+      const customSegmenters = {
+        Point(geometry) {
+          const coordinates = geometry.getCoordinates();
+          return [
+            [
+              [coordinates[0] - 1, coordinates[1]],
+              [coordinates[0] + 1, coordinates[1]],
+            ],
+          ];
+        },
+      };
+
+      const point = new Feature(new Point([0, 0]));
+      const snapInteraction = new Snap({
+        features: new Collection([point]),
+        segmenters: customSegmenters,
+      });
+      snapInteraction.setMap(new Map({}));
+
+      const rBushItems = snapInteraction.rBush_.getAll();
+      const customSegment = rBushItems.find((item) => {
+        return (
+          item.segment[0][0] === -1 &&
+          item.segment[0][1] === 0 &&
+          item.segment[1][0] === 1 &&
+          item.segment[1][1] === 0
+        );
+      });
+
+      expect(!!customSegment).to.be(true);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds a new option that allows users to customize how the Snap interaction creates snap segments:
```js
new Snap({
  segmenters: {
    LineString: (geometry) => {
      const segments = [];
      geometry.forEachSegment((c1, c2) => {
        segments.push([
          [c1, c2],
          [[(c1[0] + c2[0]) / 2, (c1[1] + c2[1]) / 2]]
        ]);
      });
      return segments;
    },
  },
  // ...
});
```
The above would make the midpoint of each segment of a linestring a snap target, in addition to each edge and vertex of the linestring.

This pull request also makes the default segmenters more efficient, by avoiding unnecessary allocation and not binding to a `Snap` instance.