### PR TITLE
Remove `@type` comments from examples

### DIFF
--- a/examples/icon-color.html
+++ b/examples/icon-color.html
@@ -6,6 +6,5 @@ docs: >
   Example assigning a custom color to an icon. The icon styles in this example use images with a white fill. For some features, custom colors set using the `color` property.
   Note that icon files need to obey the same origin policy or send proper CORS headers for this to work. When relying on CORS headers, the `ol/style/Icon` must be configured with `crossOrigin: 'anonymous'`.
 tags: "vector, style, icon, marker"
-resources:
 ---
 <div id="map" class="map"></div>

--- a/examples/webgl-draw-line.js
+++ b/examples/webgl-draw-line.js
@@ -10,14 +10,7 @@ import {fromLonLat} from '../src/ol/proj.js';
 import OSM from '../src/ol/source/OSM.js';
 import VectorSource from '../src/ol/source/Vector.js';
 
-/**
- * @type {import('../src/ol/style/flat.js').FlatStyle}
- */
-let style;
-
-/**
- * @type {import('../src/ol/style/flat.js').StyleVariables}
- */
+/** @type {import('../src/ol/style/flat.js').StyleVariables} */
 const styleVariables = {
   width: 12,
   offset: 0,
@@ -74,7 +67,8 @@ const getStyle = (dash, pattern) => {
   return newStyle;
 };
 
-style = getStyle(false, false);
+/** @type {import('../src/ol/style/flat.js').FlatStyle} */
+let style = getStyle(false, false);
 
 let vector = new WebGLVectorLayer({
   source,

--- a/examples/webpack/config.mjs
+++ b/examples/webpack/config.mjs
@@ -8,6 +8,7 @@ import ExampleBuilder from './example-builder.js';
 const src = path.join(dirname(fileURLToPath(import.meta.url)), '..');
 const root = path.join(src, '..');
 
+/** @type {import('webpack').Configuration} */
 export default {
   context: src,
   target: ['browserslist'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "es-main": "^1.0.2",
         "eslint": "^9.16.0",
         "eslint-config-openlayers": "^20.0.0",
+        "espree": "^10.3.0",
         "expect.js": "0.3.1",
         "express": "^4.17.1",
         "fflate": "^0.8.2",
@@ -5226,7 +5227,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
       "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.14.0",
         "acorn-jsx": "^5.3.2",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "es-main": "^1.0.2",
     "eslint": "^9.16.0",
     "eslint-config-openlayers": "^20.0.0",
+    "espree": "^10.3.0",
     "expect.js": "0.3.1",
     "express": "^4.17.1",
     "fflate": "^0.8.2",


### PR DESCRIPTION
Will remove the comments only when not in watch mode, as it slows down rebuilding quite a bit.