### PR TITLE
Defer calls to View.fit() when neither options.size or viewportsize is set

### DIFF
--- a/examples/deferred-fit.html
+++ b/examples/deferred-fit.html
@@ -1,0 +1,21 @@
+---
+layout: example.html
+title: Deferred view fitting
+shortdesc: This example demonstrates how deferred fit works.
+docs: >
+  This example demonstrates calling <code>fit()</code> before a map has a physical
+  size on screen. Part of the demonstration is how you can use the <code>Promise</code>
+  returned by <code>fit</code> to know when the view has been adjusted.
+  </p>
+tags: "fit"
+---
+<div class="mapcontainer">
+  <div id="map" class="map"></div>
+  <div class="padding-top"></div>
+  <div class="padding-left"></div>
+  <div class="padding-right"></div>
+  <div class="padding-bottom"></div>
+  <div class="center"></div>
+</div>
+<button id="setmaptarget">Set map target</button> (the map is rendered in the DOM and the view is fit).<br/>
+<div id="fitmessage" style="color: #040"></div>

--- a/examples/deferred-fit.js
+++ b/examples/deferred-fit.js
@@ -1,0 +1,31 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const view = new View();
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+  ],
+  view: view,
+});
+
+const fitmessage = document.getElementById('fitmessage');
+const setmaptarget = document.getElementById('setmaptarget');
+
+view.fit([2766140, 8427067, 2803328, 8462993]).then(() => {
+  const message = `Deferred View.fit() done, resolution = ${view.getResolution()}, center = ${view.getCenter()}`;
+  fitmessage.innerHTML = message;
+});
+
+setmaptarget.addEventListener(
+  'click',
+  function () {
+    map.setTarget('map');
+  },
+  false,
+);

--- a/test/browser/spec/ol/View.test.js
+++ b/test/browser/spec/ol/View.test.js
@@ -1811,6 +1811,7 @@ describe('ol/View', function () {
         resolutions: [200, 100, 50, 20, 10, 5, 2, 1],
         zoom: 5,
       });
+      view.setViewportSize([100, 100]);
     });
     it('fits correctly to the geometry (with unconstrained resolution)', function () {
       view.fit(
@@ -1980,6 +1981,31 @@ describe('ol/View', function () {
           },
         },
       );
+    });
+  });
+
+  describe('fit async', function () {
+    let view;
+    beforeEach(function () {
+      view = new View();
+    });
+
+    it('fits to the extent after viewport has been set', function (done) {
+      let promiseResolved = false;
+
+      view.fit([1000, 1000, 2000, 2000]).then(() => {
+        promiseResolved = true;
+
+        expect(promiseResolved).to.be(true);
+        expect(view.getResolution()).to.be(10 / 3);
+        expect(view.getCenter()[0]).to.be(1500);
+        expect(view.getCenter()[1]).to.be(1500);
+        done();
+      });
+      expect(view.getResolution()).to.be(undefined);
+      expect(promiseResolved).to.be(false);
+
+      view.setViewportSize([300, 300]);
     });
   });
 


### PR DESCRIPTION
Ensure `View.fit()` does the operation only after a viewportsize is set. This allows developers to call fit() before a view is connected to a map.

- If viewportsize has already been set, or `options.size` is given to `fit()`, fitting is done immediately
- Otherwise, the implementation defers calling `View.fitInternal()` until `View.setViewportsize()` is called
- `View.fit()` returns a promise that is resolved when fitting has been done
- Deferred calls to `fit()` will start animating only after the viewportsize is known and this has no effect on animation callbacks

I have included an example that shows how this works. It might or might not be a good enough example to merge, but I will leave that up for disucssion.

Fixes #16572 