### PR TITLE
Fix cloak in example

### DIFF
--- a/examples/load-events.html
+++ b/examples/load-events.html
@@ -7,7 +7,7 @@ docs: >
   to show a loading spinner on top of the map.
 tags: "events, loading, spinner"
 cloak:
-  - key: pk.eyJ1IjoiYWhvY2V2YXIiLCJhIjoiY2t0cGdwMHVnMGdlbzMxbDhwazBic2xrNSJ9.WbcTL9uj8JPAsnT9mgb7oQ
-    value: Your Mapbox access token from https://mapbox.com/ here
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
The Spinner example was cloaking the wrong key
