### PR TITLE
Add Mapserver Examples

### DIFF
--- a/examples/mapserver-cgi.html
+++ b/examples/mapserver-cgi.html
@@ -8,7 +8,7 @@ docs: >
   used in this example can be seen [here](https://demo.mapserver.org/itasca_legend/itasca3.txt).
 
   It is **strongly** recommended to configure MapServer to serve WMS and use the OpenLayers
-  WMS loader, rather than this older CGI approach.
+  [WMS loader](mapserver-wms.html), rather than this older CGI approach.
 tags: "mapserver, cgi"
 ---
 <div id="map" class="map"></div>

--- a/examples/mapserver-ogc-features.css
+++ b/examples/mapserver-ogc-features.css
@@ -1,0 +1,3 @@
+.bw {
+  filter: grayscale(100%);
+}

--- a/examples/mapserver-ogc-features.html
+++ b/examples/mapserver-ogc-features.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: MapServer OGC Features
+shortdesc: Example of displaying features from an MapServer OGC Features API
+docs: >
+  This example loads features from a [MapServer OGC API Server](https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections?f=html)
+  using the [OGC API - Features](https://ogcapi.ogc.org/features/) specification.
+tags: "mapserver, ogc, vector"
+---
+<div id="map" class="map"></div>

--- a/examples/mapserver-ogc-features.js
+++ b/examples/mapserver-ogc-features.js
@@ -11,15 +11,11 @@ import View from '../src/ol/View.js';
 const mapServerUrl = `https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/lakes/items`;
 const params = `f=json&limit=1000`;
 
-const lakeStyle = new Style({
-  fill: new Fill({
-    color: 'rgba(70, 130, 180, 0.6)',
-  }),
-  stroke: new Stroke({
-    color: 'rgba(25, 25, 112, 1)',
-    width: 2,
-  }),
-});
+const lakeStyle = {
+  'fill-color': 'rgba(70, 130, 180, 0.6)',
+  'stroke-color': 'rgba(25, 25, 112, 1)',
+  'stroke-width': 2
+}
 
 const layer = new VectorLayer({
   style: lakeStyle,

--- a/examples/mapserver-ogc-features.js
+++ b/examples/mapserver-ogc-features.js
@@ -4,7 +4,6 @@ import VectorLayer from 'ol/layer/Vector.js';
 import {bbox as bboxStrategy} from 'ol/loadingstrategy.js';
 import OSM from 'ol/source/OSM.js';
 import VectorSource from 'ol/source/Vector.js';
-import {Fill, Stroke, Style} from 'ol/style';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 
@@ -14,8 +13,8 @@ const params = `f=json&limit=1000`;
 const lakeStyle = {
   'fill-color': 'rgba(70, 130, 180, 0.6)',
   'stroke-color': 'rgba(25, 25, 112, 1)',
-  'stroke-width': 2
-}
+  'stroke-width': 2,
+};
 
 const layer = new VectorLayer({
   style: lakeStyle,

--- a/examples/mapserver-ogc-features.js
+++ b/examples/mapserver-ogc-features.js
@@ -1,0 +1,51 @@
+import GeoJSON from 'ol/format/GeoJSON.js';
+import TileLayer from 'ol/layer/Tile.js';
+import VectorLayer from 'ol/layer/Vector.js';
+import {bbox as bboxStrategy} from 'ol/loadingstrategy.js';
+import OSM from 'ol/source/OSM.js';
+import VectorSource from 'ol/source/Vector.js';
+import {Fill, Stroke, Style} from 'ol/style';
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+
+const mapServerUrl = `https://demo.mapserver.org/cgi-bin/mapserv/localdemo/ogcapi/collections/lakes/items`;
+const params = `f=json&limit=1000`;
+
+const lakeStyle = new Style({
+  fill: new Fill({
+    color: 'rgba(70, 130, 180, 0.6)',
+  }),
+  stroke: new Stroke({
+    color: 'rgba(25, 25, 112, 1)',
+    width: 2,
+  }),
+});
+
+const layer = new VectorLayer({
+  style: lakeStyle,
+  source: new VectorSource({
+    url: function (extent) {
+      const extentString = extent.join(',');
+      const url = `${mapServerUrl}?${params}&bbox=${extentString}`;
+      return url;
+    },
+    strategy: bboxStrategy,
+    format: new GeoJSON(),
+  }),
+});
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      className: 'bw',
+      source: new OSM(),
+    }),
+    layer,
+  ],
+  target: 'map',
+  view: new View({
+    projection: 'EPSG:3857',
+    center: [0, 0],
+    zoom: 4,
+  }),
+});

--- a/examples/mapserver-wms.html
+++ b/examples/mapserver-wms.html
@@ -1,0 +1,14 @@
+---
+layout: example.html
+title: MapServer WMS
+shortdesc: Example of a MapServer WMS map.
+docs: >
+  Example of a map generated using a [MapServer WMS](https://mapserver.org/ogc/wms_server.html), with an `ImageSource` and a `createLoader`
+  function. <br /><br />
+  You only need to set `serverType` if `hidpi` is `true`. On high-DPI screens, OpenLayers automatically calculates the 
+  map's `pixelRatio` and sends an additional [MAP_RESOLUTION](https://mapserver.org/ogc/wms_server.html#vendor-specific-wms-parameters) parameter
+  to MapServer to ensure fonts and symbols render correctly.
+
+tags: "mapserver, wms, image"
+---
+<div id="map" class="map"></div>

--- a/examples/mapserver-wms.js
+++ b/examples/mapserver-wms.js
@@ -1,0 +1,32 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import ImageLayer from '../src/ol/layer/Image.js';
+import ImageSource from '../src/ol/source/Image.js';
+import {createLoader} from '../src/ol/source/wms.js';
+
+const layer = new ImageLayer({
+  source: new ImageSource({
+    loader: createLoader({
+      url: 'https://demo.mapserver.org/cgi-bin/wms?',
+      params: {
+        LAYERS: ['bluemarble,country_bounds,cities'],
+        VERSION: '1.3.0',
+        FORMAT: 'image/png',
+      },
+      projection: 'EPSG:4326',
+      // note serverType only needs to be set when hidpi is true
+      hidpi: true,
+      serverType: 'mapserver',
+    }),
+  }),
+});
+
+const map = new Map({
+  layers: [layer],
+  target: 'map',
+  view: new View({
+    projection: 'EPSG:4326',
+    center: [0, 0],
+    zoom: 2,
+  }),
+});

--- a/examples/wms-custom-proj.html
+++ b/examples/wms-custom-proj.html
@@ -4,6 +4,6 @@ title: Custom Tiled WMS
 shortdesc: Example of using custom coordinate transform functions.
 docs: >
   With `addCoordinateTransforms()`, custom coordinate transform functions can be added to configured projections.
-tags: "wms, tile, tilelayer, projection"
+tags: "wms, tile, tilelayer, projection, mapserver"
 ---
 <div id="map" class="map"></div>

--- a/examples/wms-image-custom-proj.html
+++ b/examples/wms-image-custom-proj.html
@@ -4,6 +4,6 @@ title: Single Image WMS with Proj4js
 shortdesc: Example of integrating Proj4js for coordinate transforms.
 docs: >
   With [Proj4js](http://proj4js.org/) integration, OpenLayers can transform coordinates between arbitrary projections.
-tags: "wms, single image, proj4js, projection"
+tags: "wms, single image, proj4js, projection, mapserver"
 ---
 <div id="map" class="map"></div>


### PR DESCRIPTION
A couple of new examples of using OpenLayers with MapServer. 

1. A simple WMS example, using https://demo.mapserver.org/ as the back-end. This is also linked to from the example in https://github.com/openlayers/openlayers/pull/16591 which used the older CGI approach of connecting OpenLayers to MapServer. WMS is the recommended approach.
2. An example of using the OGC Features API, from https://demo.mapserver.org/ with MapServer.

A couple of other examples already used MapServer as a back-end - I added a `mapserver` tag to these. 