### PR TITLE
Source has changed when loading failed

### DIFF
--- a/src/ol/featureloader.js
+++ b/src/ol/featureloader.js
@@ -1,7 +1,6 @@
 /**
  * @module ol/featureloader
  */
-import {VOID} from './functions.js';
 
 /**
  *
@@ -164,7 +163,12 @@ export function xhr(url, format) {
           success(features);
         }
       },
-      /* FIXME handle error */ failure ? failure : VOID,
+      () => {
+        this.changed();
+        if (failure !== undefined) {
+          failure();
+        }
+      },
     );
   };
 }


### PR DESCRIPTION
The reason why the map's `loadend` event does not fire when a vector source failed to load (e.g. due to a 404 response) is because the map does not get to know about a failed load. The `loadend` event is dispatched in a `postrender` function, but for a failed load no layer rendering is requested, so `postrender` is not called.

That said, the fix is to mark the source as changed when loading failed, so the renderer goes through the same sequence as if features were added from a successful load.

Fixes #16640.