### PR TITLE
Simplify MapBrowserEvent types and conditions code

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1099,7 +1099,7 @@ class Map extends BaseObject {
   }
 
   /**
-   * @param {UIEvent} browserEvent Browser event.
+   * @param {PointerEvent|KeyboardEvent|WheelEvent} browserEvent Browser event.
    * @param {string} [type] Type.
    */
   handleBrowserEvent(browserEvent, type) {
@@ -1117,9 +1117,7 @@ class Map extends BaseObject {
       // coordinates so interactions cannot be used.
       return;
     }
-    const originalEvent = /** @type {PointerEvent} */ (
-      mapBrowserEvent.originalEvent
-    );
+    const originalEvent = mapBrowserEvent.originalEvent;
     const eventType = originalEvent.type;
     if (
       eventType === PointerEventType.POINTERDOWN ||

--- a/src/ol/MapBrowserEvent.js
+++ b/src/ol/MapBrowserEvent.js
@@ -7,7 +7,7 @@ import MapEvent from './MapEvent.js';
  * @classdesc
  * Events emitted as map browser events are instances of this type.
  * See {@link module:ol/Map~Map} for which events trigger a map browser event.
- * @template {UIEvent} EVENT
+ * @template {PointerEvent|KeyboardEvent|WheelEvent} [EVENT=PointerEvent|KeyboardEvent|WheelEvent]
  */
 class MapBrowserEvent extends MapEvent {
   /**

--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -2,7 +2,6 @@
  * @module ol/events/condition
  */
 import MapBrowserEventType from '../MapBrowserEventType.js';
-import {assert} from '../asserts.js';
 import {FALSE, TRUE} from '../functions.js';
 import {MAC, WEBKIT} from '../has.js';
 
@@ -45,9 +44,7 @@ export function all(var_args) {
  * @api
  */
 export const altKeyOnly = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   return (
     originalEvent.altKey &&
     !(originalEvent.metaKey || originalEvent.ctrlKey) &&
@@ -64,9 +61,7 @@ export const altKeyOnly = function (mapBrowserEvent) {
  * @api
  */
 export const altShiftKeysOnly = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   return (
     originalEvent.altKey &&
     !(originalEvent.metaKey || originalEvent.ctrlKey) &&
@@ -137,10 +132,12 @@ export const click = function (mapBrowserEvent) {
  * @return {boolean} The result.
  */
 export const mouseActionButton = function (mapBrowserEvent) {
-  const originalEvent = /** @type {MouseEvent} */ (
-    mapBrowserEvent.originalEvent
+  const originalEvent = mapBrowserEvent.originalEvent;
+  return (
+    originalEvent instanceof PointerEvent &&
+    originalEvent.button == 0 &&
+    !(WEBKIT && MAC && originalEvent.ctrlKey)
   );
-  return originalEvent.button == 0 && !(WEBKIT && MAC && originalEvent.ctrlKey);
 };
 
 /**
@@ -215,9 +212,7 @@ export const noModifierKeys = function (mapBrowserEvent) {
  * @api
  */
 export const platformModifierKeyOnly = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   return (
     !originalEvent.altKey &&
     (MAC ? originalEvent.metaKey : originalEvent.ctrlKey) &&
@@ -234,9 +229,7 @@ export const platformModifierKeyOnly = function (mapBrowserEvent) {
  * @api
  */
 export const platformModifierKey = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   return MAC ? originalEvent.metaKey : originalEvent.ctrlKey;
 };
 
@@ -249,9 +242,7 @@ export const platformModifierKey = function (mapBrowserEvent) {
  * @api
  */
 export const shiftKeyOnly = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   return (
     !originalEvent.altKey &&
     !(originalEvent.metaKey || originalEvent.ctrlKey) &&
@@ -269,9 +260,7 @@ export const shiftKeyOnly = function (mapBrowserEvent) {
  * @api
  */
 export const targetNotEditable = function (mapBrowserEvent) {
-  const originalEvent = /** @type {KeyboardEvent|MouseEvent|TouchEvent} */ (
-    mapBrowserEvent.originalEvent
-  );
+  const originalEvent = mapBrowserEvent.originalEvent;
   const tagName = /** @type {Element} */ (originalEvent.target).tagName;
   return (
     tagName !== 'INPUT' &&
@@ -292,15 +281,11 @@ export const targetNotEditable = function (mapBrowserEvent) {
  * @api
  */
 export const mouseOnly = function (mapBrowserEvent) {
-  const pointerEvent = /** @type {import("../MapBrowserEvent").default} */ (
-    mapBrowserEvent
-  ).originalEvent;
-  assert(
-    pointerEvent !== undefined,
-    'mapBrowserEvent must originate from a pointer event',
-  );
+  const pointerEvent = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return pointerEvent.pointerType == 'mouse';
+  return (
+    pointerEvent instanceof PointerEvent && pointerEvent.pointerType == 'mouse'
+  );
 };
 
 /**
@@ -311,15 +296,11 @@ export const mouseOnly = function (mapBrowserEvent) {
  * @api
  */
 export const touchOnly = function (mapBrowserEvent) {
-  const pointerEvt = /** @type {import("../MapBrowserEvent").default} */ (
-    mapBrowserEvent
-  ).originalEvent;
-  assert(
-    pointerEvt !== undefined,
-    'mapBrowserEvent must originate from a pointer event',
-  );
+  const pointerEvt = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return pointerEvt.pointerType === 'touch';
+  return (
+    pointerEvt instanceof PointerEvent && pointerEvt.pointerType === 'touch'
+  );
 };
 
 /**
@@ -330,15 +311,9 @@ export const touchOnly = function (mapBrowserEvent) {
  * @api
  */
 export const penOnly = function (mapBrowserEvent) {
-  const pointerEvt = /** @type {import("../MapBrowserEvent").default} */ (
-    mapBrowserEvent
-  ).originalEvent;
-  assert(
-    pointerEvt !== undefined,
-    'mapBrowserEvent must originate from a pointer event',
-  );
+  const pointerEvt = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return pointerEvt.pointerType === 'pen';
+  return pointerEvt instanceof PointerEvent && pointerEvt.pointerType === 'pen';
 };
 
 /**
@@ -351,12 +326,10 @@ export const penOnly = function (mapBrowserEvent) {
  * @api
  */
 export const primaryAction = function (mapBrowserEvent) {
-  const pointerEvent = /** @type {import("../MapBrowserEvent").default} */ (
-    mapBrowserEvent
-  ).originalEvent;
-  assert(
-    pointerEvent !== undefined,
-    'mapBrowserEvent must originate from a pointer event',
+  const pointerEvent = mapBrowserEvent.originalEvent;
+  return (
+    pointerEvent instanceof PointerEvent &&
+    pointerEvent.isPrimary &&
+    pointerEvent.button === 0
   );
-  return pointerEvent.isPrimary && pointerEvent.button === 0;
 };

--- a/src/ol/interaction/DblClickDragZoom.js
+++ b/src/ol/interaction/DblClickDragZoom.js
@@ -71,6 +71,12 @@ class DblClickDragZoom extends Interaction {
     this.trackedPointers_ = {};
 
     /**
+     * @type {PointerEvent|null}
+     * @private
+     */
+    this.down_ = null;
+
+    /**
      * @type {Array<PointerEvent>}
      * @protected
      */
@@ -81,7 +87,7 @@ class DblClickDragZoom extends Interaction {
    * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent  map browser event} and may call into
    * other functions, if event sequences like e.g. 'drag' or 'down-up' etc. are
    * detected.
-   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} mapBrowserEvent Map browser event.
    * @return {boolean} `false` to stop event propagation.
    * @api
    * @override
@@ -120,13 +126,13 @@ class DblClickDragZoom extends Interaction {
 
   /**
    * Handle pointer drag events.
-   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} mapBrowserEvent Event.
    */
   handleDragEvent(mapBrowserEvent) {
     let scaleDelta = 1.0;
 
     const touch0 = this.targetPointers[0];
-    const touch1 = this.down_.originalEvent;
+    const touch1 = this.down_;
     const distance = touch0.clientY - touch1.clientY;
 
     if (this.lastDistance_ !== undefined) {
@@ -148,7 +154,7 @@ class DblClickDragZoom extends Interaction {
 
   /**
    * Handle pointer down events.
-   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} mapBrowserEvent Event.
    * @return {boolean} If the event was consumed.
    */
   handleDownEvent(mapBrowserEvent) {
@@ -157,7 +163,7 @@ class DblClickDragZoom extends Interaction {
       this.anchor_ = null;
       this.lastDistance_ = undefined;
       this.lastScaleDelta_ = 1;
-      this.down_ = mapBrowserEvent;
+      this.down_ = mapBrowserEvent.originalEvent;
       if (!this.handlingDownUpSequence_) {
         map.getView().beginInteraction();
       }
@@ -195,7 +201,7 @@ class DblClickDragZoom extends Interaction {
   }
 
   /**
-   * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} mapBrowserEvent Event.
    * @private
    */
   updateTrackedPointers_(mapBrowserEvent) {

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -983,7 +983,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may actually draw or finish the drawing.
-   * @param {import("../MapBrowserEvent.js").default} event Map browser event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event Map browser event.
    * @return {boolean} `false` to stop event propagation.
    * @api
    * @override
@@ -1050,7 +1050,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Handle pointer down events.
-   * @param {import("../MapBrowserEvent.js").default} event Event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event Event.
    * @return {boolean} If the event was consumed.
    * @override
    */
@@ -1301,7 +1301,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Handle pointer up events.
-   * @param {import("../MapBrowserEvent.js").default} event Event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event Event.
    * @return {boolean} If the event was consumed.
    * @override
    */
@@ -1351,7 +1351,7 @@ class Draw extends PointerInteraction {
 
   /**
    * Handle move events.
-   * @param {import("../MapBrowserEvent.js").default} event A move event.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event A move event.
    * @private
    */
   handlePointerMove_(event) {

--- a/test/browser/spec/ol/interaction/dragrotateandzoom.test.js
+++ b/test/browser/spec/ol/interaction/dragrotateandzoom.test.js
@@ -1,7 +1,6 @@
 import Map from '../../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../../src/ol/View.js';
-import Event from '../../../../../src/ol/events/Event.js';
 import DragRotateAndZoom from '../../../../../src/ol/interaction/DragRotateAndZoom.js';
 import VectorLayer from '../../../../../src/ol/layer/Vector.js';
 import VectorSource from '../../../../../src/ol/source/Vector.js';
@@ -52,11 +51,11 @@ describe('ol.interaction.DragRotateAndZoom', function () {
     });
 
     it('does not rotate when rotation is disabled on the view', function () {
-      const pointerEvent = new Event();
-      pointerEvent.type = 'pointermove';
-      pointerEvent.clientX = 20;
-      pointerEvent.clientY = 10;
-      pointerEvent.pointerType = 'mouse';
+      let pointerEvent = new PointerEvent('pointermove', {
+        clientX: 20,
+        clientY: 10,
+        pointerType: 'mouse',
+      });
       let event = new MapBrowserEvent('pointermove', map, pointerEvent, true);
       interaction.lastAngle_ = Math.PI;
 
@@ -83,10 +82,11 @@ describe('ol.interaction.DragRotateAndZoom', function () {
         callCount++;
       });
 
-      pointerEvent.type = 'pointermove';
-      pointerEvent.clientX = 24;
-      pointerEvent.clientY = 16;
-      pointerEvent.pointerType = 'mouse';
+      pointerEvent = new PointerEvent('pointermove', {
+        clientX: 24,
+        clientY: 16,
+        pointerType: 'mouse',
+      });
       event = new MapBrowserEvent('pointermove', map, pointerEvent, true);
 
       interaction.handleDragEvent(event);

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -4,7 +4,6 @@ import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../../src/ol/View.js';
-import Event from '../../../../../src/ol/events/Event.js';
 import {
   click,
   doubleClick,
@@ -100,17 +99,19 @@ describe('ol.interaction.Modify', function () {
     const viewport = map.getViewport();
     // calculated in case body has top < 0 (test runner with small window)
     const position = viewport.getBoundingClientRect();
-    const pointerEvent = new Event();
-    pointerEvent.type = type;
-    pointerEvent.target = viewport.firstChild;
-    pointerEvent.clientX = position.left + x + width / 2;
-    pointerEvent.clientY = position.top + y + height / 2;
-    pointerEvent.shiftKey = modifiers.shift || false;
-    pointerEvent.altKey = modifiers.alt || false;
-    pointerEvent.pointerId = 1;
-    pointerEvent.preventDefault = function () {};
-    pointerEvent.button = button;
-    pointerEvent.isPrimary = true;
+    const pointerEvent = new PointerEvent(type, {
+      clientX: position.left + x + width / 2,
+      clientY: position.top + y + height / 2,
+      shiftKey: modifiers.shift || false,
+      altKey: modifiers.alt || false,
+      button: button,
+      pointerId: 1,
+      isPrimary: true,
+    });
+    Object.defineProperty(pointerEvent, 'target', {
+      writable: false,
+      value: viewport.firstChild,
+    });
     const event = new MapBrowserEvent(type, map, pointerEvent);
     map.handleMapBrowserEvent(event);
   }


### PR DESCRIPTION
I started looking into this because I saw that MapBrowserEvent requires a generic argument. And in the end I was able to simplify the conditions, remove unnecessary asserts and typecasts, and make the tests more robust by using real events instead of mocked objects.