### PR TITLE
Fix hit detection when setting a `filter` in a WebGL Vector Layer

### DIFF
--- a/src/ol/render/webgl/MixedGeometryBatch.js
+++ b/src/ol/render/webgl/MixedGeometryBatch.js
@@ -508,7 +508,7 @@ class MixedGeometryBatch {
    * @param {string} featureUid the feature uid
    * @private
    */
-  returnRef_(ref, featureUid) {
+  removeRef_(ref, featureUid) {
     if (!ref) {
       throw new Error('This feature has no ref: ' + featureUid);
     }
@@ -541,7 +541,7 @@ class MixedGeometryBatch {
     entry = this.clearFeatureEntryInPolygonBatch_(feature) || entry;
     entry = this.clearFeatureEntryInLineStringBatch_(feature) || entry;
     if (entry) {
-      this.returnRef_(entry.ref, getUid(entry.feature));
+      this.removeRef_(entry.ref, getUid(entry.feature));
     }
   }
 
@@ -582,10 +582,19 @@ class MixedGeometryBatch {
    */
   filter(featureFilter) {
     const filtered = new MixedGeometryBatch();
+    filtered.globalCounter_ = this.globalCounter_;
+    filtered.uidToRef_ = this.uidToRef_;
+    filtered.refToFeature_ = this.refToFeature_;
+    let empty = true;
     for (const feature of this.refToFeature_.values()) {
       if (featureFilter(feature)) {
         filtered.addFeature(feature);
+        empty = false;
       }
+    }
+    // no feature was added at all; simply return an empty batch for consistency downstream
+    if (empty) {
+      return new MixedGeometryBatch();
     }
     return filtered;
   }

--- a/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
+++ b/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
@@ -175,6 +175,8 @@ describe('MixedGeometryBatch', function () {
       it('clears the entry related to this feature', () => {
         const keys = Object.keys(mixedBatch.pointBatch.entries);
         expect(keys).to.not.contain(getUid(feature1));
+        expect(mixedBatch.getFeatureFromRef(1)).to.be(undefined);
+        expect(mixedBatch.getFeatureFromRef(2)).to.be(feature2);
       });
       it('recompute geometry count', () => {
         expect(mixedBatch.pointBatch.geometriesCount).to.be(1);
@@ -1265,20 +1267,21 @@ describe('MixedGeometryBatch', function () {
   });
 
   describe('#filter', () => {
+    let feature1, feature2, feature3, feature4;
     beforeEach(() => {
-      const feature1 = new Feature({
+      feature1 = new Feature({
         keep: true,
         geometry: new Point([101, 102]),
       });
-      const feature2 = new Feature({
+      feature2 = new Feature({
         keep: false,
         geometry: new Point([201, 202]),
       });
-      const feature3 = new Feature({
+      feature3 = new Feature({
         keep: false,
         geometry: new Point([301, 302]),
       });
-      const feature4 = new Feature({
+      feature4 = new Feature({
         keep: true,
         geometry: new Point([401, 402]),
       });
@@ -1307,6 +1310,11 @@ describe('MixedGeometryBatch', function () {
           0,
         );
         expect(mixedBatch.lineStringBatch.geometriesCount).to.be(0);
+      });
+
+      it('preserves the feature references from the original batch', () => {
+        expect(mixedBatch.getFeatureFromRef(1)).to.be(feature1);
+        expect(mixedBatch.getFeatureFromRef(4)).to.be(feature4);
       });
     });
     describe('filtering out everything', () => {


### PR DESCRIPTION
The references pointing to the rendered features were lost when applying the filter to the MixedGeometryBatch.

Fixes https://github.com/openlayers/openlayers/issues/16621
Fixes https://github.com/openlayers/openlayers/issues/16678