### PR TITLE
Implement `has` operator on GPU

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -96,6 +96,7 @@ import {toSize} from '../size.js';
  *   * `['any', value1, value2, ...]` returns `true` if any of the inputs are `true`, `false` otherwise.
  *   * `['has', attributeName, keyOrArrayIndex, ...]` returns `true` if feature properties include the (nested) key `attributeName`,
  *     `false` otherwise.
+ *     Note that for WebGL layers, the value {@link module:ol/expr/gpu.UNDEFINED_PROP_VALUE} is used to distinguish when a property is not defined.
  *   * `['between', value1, value2, value3]` returns `true` if `value1` is contained between `value2` and `value3`
  *     (inclusively), or `false` otherwise.
  *   * `['in', needle, haystack]` returns `true` if `needle` is found in `haystack`, and

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -167,6 +167,13 @@ export const FEATURE_ID_PROPERTY_NAME = 'featureId';
 export const GEOMETRY_TYPE_PROPERTY_NAME = 'geometryType';
 
 /**
+ * The value `-9999999` will be used to indicate that a property on a feature is not defined, similar to a "no data" value.
+ * @type {number}
+ * @api
+ */
+export const UNDEFINED_PROP_VALUE = -9999999;
+
+/**
  * @typedef {string} CompiledExpression
  */
 
@@ -243,6 +250,18 @@ const compilers = {
       };
     }
     return uniformNameForVariable(varName);
+  },
+  [Ops.Has]: (context, expression) => {
+    const firstArg = /** @type {LiteralExpression} */ (expression.args[0]);
+    const propName = /** @type {string} */ (firstArg.value);
+    const isExisting = propName in context.properties;
+    if (!isExisting) {
+      context.properties[propName] = {
+        name: propName,
+        type: expression.type,
+      };
+    }
+    return `(a_prop_${propName} != ${numberToGlsl(UNDEFINED_PROP_VALUE)})`;
   },
   [Ops.Resolution]: () => 'u_resolution',
   [Ops.Zoom]: () => 'u_zoom',

--- a/src/ol/render/webgl/renderinstructions.js
+++ b/src/ol/render/webgl/renderinstructions.js
@@ -1,6 +1,7 @@
 /**
  * @module ol/render/webgl/renderinstructions
  */
+import {UNDEFINED_PROP_VALUE} from '../../expr/gpu.js';
 import {transform2D} from '../../geom/flat/transform.js';
 import {apply as applyTransform} from '../../transform.js';
 
@@ -21,7 +22,13 @@ function pushCustomAttributesInRenderInstructions(
   for (const key in customAttributes) {
     const attr = customAttributes[key];
     const value = attr.callback.call(batchEntry, batchEntry.feature);
-    renderInstructions[currentIndex + shift++] = value?.[0] ?? value;
+    let first = value?.[0] ?? value;
+    if (first === undefined) {
+      first = UNDEFINED_PROP_VALUE;
+    } else if (first === null) {
+      first = 0;
+    }
+    renderInstructions[currentIndex + shift++] = first;
     if (!attr.size || attr.size === 1) {
       continue;
     }

--- a/test/browser/spec/ol/render/webgl/renderinstructions.test.js
+++ b/test/browser/spec/ol/render/webgl/renderinstructions.test.js
@@ -58,11 +58,13 @@ describe('Render instructions utilities', function () {
       new Feature({
         test: 1000,
         test2: [22, 33, 44],
+        test3: null,
         geometry: new Point([10, 20]),
       }),
       new Feature({
         test: 2000,
         test2: [44, 55, 66],
+        test3: 3,
         geometry: new Point([30, 40]),
       }),
       new Feature({
@@ -165,6 +167,47 @@ describe('Render instructions utilities', function () {
       expect(Array.from(renderInstructions)).to.eql([
         2, 2, 0, 1, 2, 3, 6, 6, 0, 1, 2, 3,
       ]);
+    });
+  });
+
+  describe('undefined property', () => {
+    it('uses the value UNDEFINED_PROP_VALUE if the feature does not have this property set', () => {
+      renderInstructions = generatePointRenderInstructions(
+        mixedBatch.pointBatch,
+        new Float32Array(0),
+        [
+          {
+            name: 'test',
+            size: 1,
+            callback: function (feature) {
+              return feature.get('anotherProp');
+            },
+          },
+        ],
+        SAMPLE_TRANSFORM,
+      );
+
+      expect(Array.from(renderInstructions)).to.eql([
+        2, 2, -9999999, 6, 6, -9999999,
+      ]);
+    });
+    it('uses zero if the feature have this property set to null', () => {
+      renderInstructions = generatePointRenderInstructions(
+        mixedBatch.pointBatch,
+        new Float32Array(0),
+        [
+          {
+            name: 'test',
+            size: 1,
+            callback: function (feature) {
+              return feature.get('test3');
+            },
+          },
+        ],
+        SAMPLE_TRANSFORM,
+      );
+
+      expect(Array.from(renderInstructions)).to.eql([2, 2, 0, 6, 6, 3]);
     });
   });
 });

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -159,6 +159,12 @@ describe('ol/expr/gpu.js', () => {
         expected: 'currentLineMetric',
       },
       {
+        name: 'has',
+        type: AnyType,
+        expression: ['has', 'myAttr'],
+        expected: '(a_prop_myAttr != -9999999.0)',
+      },
+      {
         name: 'time',
         type: AnyType,
         expression: ['time'],


### PR DESCRIPTION
A fixed value `UNDEFINED_PROP_VALUE = -9999999` is used to determine whether a property is not defined on a feature. This value is accessible in the API.

This should address https://github.com/openlayers/openlayers/issues/16219 by offering a way to check whether a property is defined.