### PR TITLE
Add setParams for setting all URL parameters at once

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -205,6 +205,16 @@ class ImageArcGISRest extends ImageSource {
   }
 
   /**
+   * Set the user-provided params.
+   * @param {Object} params Params.
+   * @api
+   */
+  setParams(params) {
+    this.params_ = Object.assign({}, params);
+    this.changed();
+  }
+
+  /**
    * Update the user-provided params.
    * @param {Object} params Params.
    * @api

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -174,6 +174,16 @@ class ImageMapGuide extends ImageSource {
   }
 
   /**
+   * Set the user-provided params.
+   * @param {Object} params Params.
+   * @api
+   */
+  setParams(params) {
+    this.params_ = Object.assign({}, params);
+    this.changed();
+  }
+
+  /**
    * Update the user-provided params.
    * @param {Object} params Params.
    * @api

--- a/src/ol/source/ImageWMS.js
+++ b/src/ol/source/ImageWMS.js
@@ -266,6 +266,16 @@ class ImageWMS extends ImageSource {
   }
 
   /**
+   * Set the user-provided params.
+   * @param {Object} params Params.
+   * @api
+   */
+  setParams(params) {
+    this.params_ = Object.assign({}, params);
+    this.changed();
+  }
+
+  /**
    * Update the user-provided params.
    * @param {Object} params Params.
    * @api

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -185,6 +185,16 @@ class TileArcGISRest extends TileImage {
   }
 
   /**
+   * Set the user-provided params.
+   * @param {Object} params Params.
+   * @api
+   */
+  setParams(params) {
+    this.params_ = Object.assign({}, params);
+    this.setKey(this.getKeyForParams_());
+  }
+
+  /**
    * Update the user-provided params.
    * @param {Object} params Params.
    * @api

--- a/src/ol/source/TileWMS.js
+++ b/src/ol/source/TileWMS.js
@@ -341,14 +341,32 @@ class TileWMS extends TileImage {
   }
 
   /**
-   * Update the user-provided params.
-   * @param {Object} params Params.
+   * @param {Object} params New URL paremeters.
+   * @private
+   */
+  setParams_(params) {
+    this.params_ = params;
+    this.updateV13_();
+    this.setKey(this.getKeyForParams_());
+  }
+
+  /**
+   * Set the URL parameters passed to the WMS source.
+   * @param {Object} params New URL paremeters.
+   * @api
+   */
+  setParams(params) {
+    this.setParams_(Object.assign({}, params));
+  }
+
+  /**
+   * Update the URL parameters. This method can be used to update a subset of the WMS
+   * parameters. Call `setParams` to set all of the parameters.
+   * @param {Object} params Updated URL parameters.
    * @api
    */
   updateParams(params) {
-    Object.assign(this.params_, params);
-    this.updateV13_();
-    this.setKey(this.getKeyForParams_());
+    this.setParams_(Object.assign(this.params_, params));
   }
 
   /**

--- a/test/browser/spec/ol/source/ImageArcGISRest.test.js
+++ b/test/browser/spec/ol/source/ImageArcGISRest.test.js
@@ -203,6 +203,19 @@ describe('ol/source/ImageArcGISRest', function () {
     });
   });
 
+  describe('#setParams', function () {
+    it('allows params to be set', function () {
+      const before = {test: 'before', foo: 'bar'};
+      const source = new ImageArcGISRest({params: before});
+      source.setParams({test: 'after'});
+
+      const params = source.getParams();
+      expect(params).to.eql({test: 'after'});
+
+      expect(before).to.eql({test: 'before', foo: 'bar'});
+    });
+  });
+
   describe('#getParams', function () {
     it('verify getting a param', function () {
       options.params.TEST = 'value';

--- a/test/browser/spec/ol/source/ImageMapGuide.test.js
+++ b/test/browser/spec/ol/source/ImageMapGuide.test.js
@@ -60,6 +60,19 @@ describe('ol/source/ImageMapGuide', function () {
     });
   });
 
+  describe('#setParams', function () {
+    it('allows params to be set', function () {
+      const before = {test: 'before', foo: 'bar'};
+      const source = new ImageMapGuide({params: before});
+      source.setParams({test: 'after'});
+
+      const params = source.getParams();
+      expect(params).to.eql({test: 'after'});
+
+      expect(before).to.eql({test: 'before', foo: 'bar'});
+    });
+  });
+
   describe('#getParams', function () {
     it('verify getting a param', function () {
       const source = new ImageMapGuide(options);

--- a/test/browser/spec/ol/source/ImageWMS.test.js
+++ b/test/browser/spec/ol/source/ImageWMS.test.js
@@ -59,6 +59,19 @@ describe('ol/source/ImageWMS', function () {
     });
   });
 
+  describe('#setParams', function () {
+    it('sets new parameters', function () {
+      const before = {test: 'before', foo: 'bar'};
+      const source = new ImageWMS({params: before});
+      source.setParams({test: 'after'});
+
+      const params = source.getParams();
+      expect(params).to.eql({test: 'after'});
+
+      expect(before).to.eql({test: 'before', foo: 'bar'});
+    });
+  });
+
   describe('#getImage', function () {
     it('creates an image with the expected URL', function () {
       [1, 1.5].forEach(function (ratio) {

--- a/test/browser/spec/ol/source/TileArcGISRest.test.js
+++ b/test/browser/spec/ol/source/TileArcGISRest.test.js
@@ -2,7 +2,7 @@ import ImageTile from '../../../../../src/ol/ImageTile.js';
 import {get as getProjection} from '../../../../../src/ol/proj.js';
 import TileArcGISRest from '../../../../../src/ol/source/TileArcGISRest.js';
 
-describe('ol.source.TileArcGISRest', function () {
+describe('ol/source/TileArcGISRest', function () {
   let options;
   beforeEach(function () {
     options = {
@@ -117,6 +117,19 @@ describe('ol.source.TileArcGISRest', function () {
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('LAYERS')).to.be('show:1,3,4');
+    });
+  });
+
+  describe('#setParams', function () {
+    it('allows params to be set', function () {
+      const before = {test: 'before', foo: 'bar'};
+      const source = new TileArcGISRest({params: before});
+      source.setParams({test: 'after'});
+
+      const params = source.getParams();
+      expect(params).to.eql({test: 'after'});
+
+      expect(before).to.eql({test: 'before', foo: 'bar'});
     });
   });
 

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -56,6 +56,93 @@ describe('ol/source/TileWMS', function () {
     });
   });
 
+  describe('updateParams()', function () {
+    it('updates a subset of the params', function () {
+      const source = new TileWMS({
+        url: 'http://example.com/wms',
+        params: {
+          LAYERS: 'layer',
+          test: 'before',
+        },
+      });
+
+      const tileCoord = [1, 2, 3];
+      const projection = getProjection('EPSG:4326');
+
+      const urlBefore = new URL(
+        source.tileUrlFunction(tileCoord, 1, projection),
+      );
+      const paramsBefore = urlBefore.searchParams;
+      expect(paramsBefore.get('test')).to.be('before');
+      expect(paramsBefore.get('LAYERS')).to.be('layer');
+      expect(paramsBefore.get('foo')).to.be(null);
+
+      source.updateParams({test: 'after', foo: 'bar'});
+
+      const urlAfter = new URL(
+        source.tileUrlFunction(tileCoord, 1, projection),
+      );
+      const paramsAfter = urlAfter.searchParams;
+      expect(paramsAfter.get('test')).to.be('after');
+      expect(paramsAfter.get('foo')).to.be('bar');
+      expect(paramsAfter.get('LAYERS')).to.be('layer');
+    });
+
+    it('does not modify the object passed to the constructor', function () {
+      const params = {LAYERS: 'layer'};
+      const source = new TileWMS({
+        url: 'http://example.com/wms',
+        params,
+      });
+
+      source.updateParams({LAYERS: 'after'});
+      expect(params.LAYERS).to.be('layer');
+    });
+
+    it('does not modify the object passed to setParams', function () {
+      const params = {LAYERS: 'layer'};
+      const source = new TileWMS({
+        url: 'http://example.com/wms',
+      });
+
+      source.setParams({LAYERS: 'after'});
+      expect(params.LAYERS).to.be('layer');
+    });
+  });
+
+  describe('setParams()', function () {
+    it('sets all of the params', function () {
+      const source = new TileWMS({
+        url: 'http://example.com/wms',
+        params: {
+          LAYERS: 'layer',
+          test: 'before',
+        },
+      });
+
+      const tileCoord = [1, 2, 3];
+      const projection = getProjection('EPSG:4326');
+
+      const urlBefore = new URL(
+        source.tileUrlFunction(tileCoord, 1, projection),
+      );
+      const paramsBefore = urlBefore.searchParams;
+      expect(paramsBefore.get('test')).to.be('before');
+      expect(paramsBefore.get('LAYERS')).to.be('layer');
+      expect(paramsBefore.get('foo')).to.be(null);
+
+      source.setParams({test: 'after', foo: 'bar'});
+
+      const urlAfter = new URL(
+        source.tileUrlFunction(tileCoord, 1, projection),
+      );
+      const paramsAfter = urlAfter.searchParams;
+      expect(paramsAfter.get('test')).to.be('after');
+      expect(paramsAfter.get('foo')).to.be('bar');
+      expect(paramsAfter.get('LAYERS')).to.be(null);
+    });
+  });
+
   describe('#getInterpolate()', function () {
     it('is true by default', function () {
       const source = new TileWMS();


### PR DESCRIPTION
This adds a `source.setParams()` method for setting the URL parameters on the TileWMS, ImageWMS, TileArcGISRest, ImageArcGISRest, and ImageMapGuide sources.

The existing `source.updateParams()` method allows new parameters to be merged with existing ones. This makes it awkward to unset or delete an existing parameter.

The new `source.setParams()` method sets all parameters at once. This makes these sources consistent with other things in the library that have `set*` methods.