### PR TITLE
Avoid comparing `match` operator input value with fallback value

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -502,7 +502,7 @@ function compileMatchExpression(expression, context) {
   }
   return (context) => {
     const value = args[0](context);
-    for (let i = 1; i < length; i += 2) {
+    for (let i = 1; i < length - 1; i += 2) {
       if (value === args[i](context)) {
         return args[i + 1](context);
       }

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -630,6 +630,15 @@ describe('ol/expr/cpu.js', () => {
         expected: 'got other',
       },
       {
+        name: 'match (input equals fallback value)',
+        type: NumberType,
+        expression: ['match', ['get', 'number'], 0, 1, 42],
+        context: {
+          properties: {number: 42},
+        },
+        expected: 42,
+      },
+      {
         name: 'interpolate (linear number)',
         type: NumberType,
         expression: [


### PR DESCRIPTION
This fixes an error that would happen if the input value of `match` ended up being strictly equal to the fallback value.

Reported in https://github.com/openlayers/openlayers/issues/16621#issuecomment-2639192282

Fixes #16621