### PR TITLE
A bug fix in unsnap test

### DIFF
--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -533,16 +533,23 @@ describe('ol.interaction.Snap', function () {
       };
 
       const event = {
-        pixel: [30, 30],
+        pixel: [30 + width / 2, height / 2 - 30],
         coordinate: [30, 30],
         map: map,
       };
 
-      snapInteraction.on('unsnap', function (snapEvent) {
-        expect(snapEvent.feature).to.be(point1);
-        expect(snapEvent.segment).to.be(null);
+      const snapEvents = [];
+      const snapEventHandler = (e) => {
+        snapEvents.push(e);
+        if (snapEvents.length !== 2) {
+          return;
+        }
+        expect(snapEvents.map((e) => e.type)).to.eql(['unsnap', 'snap']);
+        expect(snapEvents.map((e) => e.feature)).to.eql([point1, point2]);
         done();
-      });
+      };
+      snapInteraction.on('unsnap', snapEventHandler);
+      snapInteraction.on('snap', snapEventHandler);
 
       snapInteraction.handleEvent(event);
     });


### PR DESCRIPTION
'unsnaps if snapped to other feature' test is supposedly testing unsnap signal when it snaps to another feature. 

However, the event was not made correctly so it didn't snap to any other feature.  It was simply testing the same thing as 'unsnaps not snapped to anything' test.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
