### PR TITLE
Restore vector tile projection assertion

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -5,6 +5,7 @@
 import TileState from '../TileState.js';
 import VectorRenderTile from '../VectorRenderTile.js';
 import Tile from '../VectorTile.js';
+import {assert} from '../asserts.js';
 import EventType from '../events/EventType.js';
 import {
   buffer as bufferExtent,
@@ -13,6 +14,7 @@ import {
 } from '../extent.js';
 import {loadFeaturesXhr} from '../featureloader.js';
 import {isEmpty} from '../obj.js';
+import {equivalent} from '../proj.js';
 import {toSize} from '../size.js';
 import TileGrid from '../tilegrid/TileGrid.js';
 import {DEFAULT_MAX_ZOOM} from '../tilegrid/common.js';
@@ -365,6 +367,12 @@ class VectorTile extends UrlTile {
     const code = projection.getCode();
     let tileGrid = this.tileGrids_[code];
     if (!tileGrid) {
+      const sourceProjection = this.getProjection();
+      assert(
+        sourceProjection === null || equivalent(sourceProjection, projection),
+        'A VectorTile source can only be rendered if it has a projection compatible with the view projection.',
+      );
+
       // A tile grid that matches the tile size of the source tile grid is more
       // likely to have 1:1 relationships between source tiles and rendered tiles.
       const sourceTileGrid = this.tileGrid;

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -74,8 +74,14 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
   let map;
 
   beforeEach(function () {
+    const proj = new Projection({
+      code: 'custom',
+      units: 'pixels',
+      extent: [-128, -128, 128, 128],
+    });
     vectorTileLayer = new VectorTileLayer({
       source: new VectorTileSource({
+        projection: proj,
         tileGrid: createXYZ({
           tileSize: [256, 256],
           maxZoom: 5,
@@ -120,11 +126,6 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
       style: SAMPLE_RULES,
     });
 
-    const proj = new Projection({
-      code: 'custom',
-      units: 'pixels',
-      extent: [-128, -128, 128, 128],
-    });
     frameState = {
       layerStatesArray: [vectorTileLayer.getLayerState()],
       layerIndex: 0,

--- a/test/browser/spec/ol/source/VectorTile.test.js
+++ b/test/browser/spec/ol/source/VectorTile.test.js
@@ -7,7 +7,7 @@ import {listen, unlistenByKey} from '../../../../../src/ol/events.js';
 import GeoJSON from '../../../../../src/ol/format/GeoJSON.js';
 import MVT from '../../../../../src/ol/format/MVT.js';
 import VectorTileLayer from '../../../../../src/ol/layer/VectorTile.js';
-import {get, get as getProjection} from '../../../../../src/ol/proj.js';
+import {get as getProjection, toLonLat} from '../../../../../src/ol/proj.js';
 import VectorTileSource from '../../../../../src/ol/source/VectorTile.js';
 import TileGrid from '../../../../../src/ol/tilegrid/TileGrid.js';
 import {createXYZ} from '../../../../../src/ol/tilegrid.js';
@@ -180,7 +180,7 @@ describe('ol/source/VectorTile', function () {
     });
 
     it('creates empty tiles outside the source extent', function () {
-      const fullExtent = get('EPSG:3857').getExtent();
+      const fullExtent = getProjection('EPSG:3857').getExtent();
       const source = new VectorTileSource({
         extent: [fullExtent[0], fullExtent[1], 0, 0],
       });
@@ -378,6 +378,18 @@ describe('ol/source/VectorTile', function () {
         expect(loaded).to.eql(['5/13/-28']);
         done();
       }, 0);
+    });
+
+    it('throws if projections are not equivalent', function () {
+      const view = new View({
+        zoom: 11,
+        center: toLonLat([666373.1624999996, 7034265.3572]),
+        projection: 'EPSG:4326',
+      });
+      expect(function () {
+        map.setView(view);
+        map.renderSync();
+      }).to.throwException();
     });
   });
 


### PR DESCRIPTION
Fixes #16738

The underlying problem in #16738 is the previous assertion was lost when source tile caches were removed.  As the source must create a tile grid for the view projection it can be efficiently asserted when that is created.
