### PR TITLE
Adding numbers to font family regex

### DIFF
--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -74,7 +74,7 @@ const fontRegEx = new RegExp(
     '(?:(?:normal|\\1|\\2|\\3)\\s*){0,3}((?:xx?-)?',
     '(?:small|large)|medium|smaller|larger|[\\.\\d]+(?:\\%|in|[cem]m|ex|p[ctx]))',
     '(?:\\s*\\/\\s*(normal|[\\.\\d]+(?:\\%|in|[cem]m|ex|p[ctx])?))',
-    '?\\s*([-,\\"\\\'\\sa-z]+?)\\s*$',
+    '?\\s*([-,\\"\\\'\\sa-z0-9]+?)\\s*$',
   ].join(''),
   'i',
 );


### PR DESCRIPTION
Issue: the regex in css.js designed to check the font families could not parse font names with numbers in them.

Fix: We add `0-9` in the part of the regex that checks for characters inside a font name.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
