### PR TITLE
Fix for a regression issue in snap multipoint

### DIFF
--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -187,7 +187,7 @@ const GEOMETRY_SEGMENTERS = {
     const segments = [];
     const coordinates = geometry.getFlatCoordinates();
     const stride = geometry.getStride();
-    for (let i = 0, ii = coordinates.length - stride; i < ii; i += stride) {
+    for (let i = 0, ii = coordinates.length; i < ii; i += stride) {
       segments.push([coordinates.slice(i, i + 2)]);
     }
     return segments;

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -4,6 +4,7 @@ import Map from '../../../../../src/ol/Map.js';
 import View from '../../../../../src/ol/View.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
+import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import Snap from '../../../../../src/ol/interaction/Snap.js';
 import {
@@ -245,6 +246,45 @@ describe('ol.interaction.Snap', function () {
         done();
       });
       snapInteraction.handleEvent(event);
+    });
+
+    it('snaps to multi point', function (done) {
+      const multiPoint = new Feature(
+        new MultiPoint([
+          [0, 0],
+          [50, 0],
+        ]),
+      );
+      const snapInteraction = new Snap({
+        features: new Collection([multiPoint]),
+        pixelTolerance: 5,
+      });
+      snapInteraction.setMap(map);
+
+      const event1 = {
+        pixel: [3 + width / 2, height / 2],
+        coordinate: [3, 0],
+        map: map,
+      };
+      const event2 = {
+        pixel: [53 + width / 2, height / 2],
+        coordinate: [53, 0],
+        map: map,
+      };
+      const snapEvents = [];
+      snapInteraction.on('snap', function (snapEvent) {
+        snapEvents.push(snapEvent);
+        if (snapEvents.length != 2) {
+          return;
+        }
+        expect(snapEvent.feature).to.be(multiPoint);
+        expect(snapEvent.segment).to.be(null);
+        expect(event1.coordinate).to.eql([0, 0]);
+        expect(event2.coordinate).to.eql([50, 0]);
+        done();
+      });
+      snapInteraction.handleEvent(event1);
+      snapInteraction.handleEvent(event2);
     });
 
     it('snaps to intersection only', function (done) {


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

In the current snap interaction, the last point in multi-point feature will be missed by the default segmenter. I've added a test case addressing this issue, which works with v10.4 and added another commit fixing this.
