### PR TITLE
Extend doc: Add a warning for attributions constructor argument of At…

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -34,7 +34,11 @@ import Control from './Control.js';
  * the control should be re-rendered. This is called in a `requestAnimationFrame`
  * callback.
  * @property {string|Array<string>|undefined} [attributions] Optional attribution(s) that will always be
- * displayed regardless of the layers rendered
+ * displayed regardless of the layers rendered.
+ * **Caution:** Attributions are rendered dynamically using `innerHTML`, which can lead to potential
+ * [**XSS (Cross-Site Scripting)**](https://en.wikipedia.org/wiki/Cross-site_scripting) vulnerabilities.
+ * Use this feature only for trusted content
+ * or ensure that the content is properly sanitized before inserting it.
  */
 
 /**


### PR DESCRIPTION
As discussed in issue #16720, this commit extends the documentation for `attributions` .

Fixes #16720.