### PR TITLE
Avoid instanceof PointerEvent to support cross-document maps

### DIFF
--- a/src/ol/events/condition.js
+++ b/src/ol/events/condition.js
@@ -134,7 +134,7 @@ export const click = function (mapBrowserEvent) {
 export const mouseActionButton = function (mapBrowserEvent) {
   const originalEvent = mapBrowserEvent.originalEvent;
   return (
-    originalEvent instanceof PointerEvent &&
+    'pointerId' in originalEvent &&
     originalEvent.button == 0 &&
     !(WEBKIT && MAC && originalEvent.ctrlKey)
   );
@@ -283,9 +283,7 @@ export const targetNotEditable = function (mapBrowserEvent) {
 export const mouseOnly = function (mapBrowserEvent) {
   const pointerEvent = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return (
-    pointerEvent instanceof PointerEvent && pointerEvent.pointerType == 'mouse'
-  );
+  return 'pointerId' in pointerEvent && pointerEvent.pointerType == 'mouse';
 };
 
 /**
@@ -298,9 +296,7 @@ export const mouseOnly = function (mapBrowserEvent) {
 export const touchOnly = function (mapBrowserEvent) {
   const pointerEvt = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return (
-    pointerEvt instanceof PointerEvent && pointerEvt.pointerType === 'touch'
-  );
+  return 'pointerId' in pointerEvt && pointerEvt.pointerType === 'touch';
 };
 
 /**
@@ -313,7 +309,7 @@ export const touchOnly = function (mapBrowserEvent) {
 export const penOnly = function (mapBrowserEvent) {
   const pointerEvt = mapBrowserEvent.originalEvent;
   // see https://www.w3.org/TR/pointerevents/#widl-PointerEvent-pointerType
-  return pointerEvt instanceof PointerEvent && pointerEvt.pointerType === 'pen';
+  return 'pointerId' in pointerEvt && pointerEvt.pointerType === 'pen';
 };
 
 /**
@@ -328,7 +324,7 @@ export const penOnly = function (mapBrowserEvent) {
 export const primaryAction = function (mapBrowserEvent) {
   const pointerEvent = mapBrowserEvent.originalEvent;
   return (
-    pointerEvent instanceof PointerEvent &&
+    'pointerId' in pointerEvent &&
     pointerEvent.isPrimary &&
     pointerEvent.button === 0
   );

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1736,5 +1736,37 @@ describe('ol/Map', function () {
       spy.restore();
       selectStub.restore();
     });
+
+    describe('external map', () => {
+      let iframe, spy;
+
+      beforeEach(() => {
+        iframe = document.createElement('iframe');
+        iframe.width = '100';
+        iframe.height = '100';
+        iframe.src = 'spec/ol/data/external-map.html';
+        document.body.appendChild(iframe);
+        spy = sinonSpy(dragpan, 'handleDownEvent');
+      });
+      afterEach(() => {
+        map.setTarget(null);
+        document.body.removeChild(iframe);
+        spy.restore();
+      });
+      it('handles events from a map in a separate window', (done) => {
+        document.body.removeChild(map.getTargetElement());
+        map.setTarget(null);
+        const win = iframe.contentWindow;
+        win.addEventListener('DOMContentLoaded', () => {
+          map.setTarget(iframe.contentDocument.getElementById('map'));
+          win.postMessage('test');
+          setTimeout(() => {
+            expect(spy.callCount).to.be(1);
+            expect(spy.firstCall.returnValue).to.be(true);
+            done();
+          }, 100);
+        });
+      });
+    });
   });
 });

--- a/test/browser/spec/ol/data/external-map.html
+++ b/test/browser/spec/ol/data/external-map.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>OpenLayers External Map Test</title>
+  <style>
+    html, body, #map {
+      height: 100%;
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>
+    function makePrimary(event) {
+      Object.defineProperty(event, 'isPrimary', {
+        writable: false,
+        value: true,
+      });
+      return event;
+    }
+    window.addEventListener('message', (e) => {
+      const viewport = document.querySelector('div.ol-viewport');
+      viewport.dispatchEvent(makePrimary(new PointerEvent('pointerdown', {
+        clientX: 10,
+        clientY: 10,
+      })));
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #16776.

The problem is that a `PointerEvent` from a separate window is not an `instanceof PointerEvent`.

Unfortunately testing issues with maps in separate documents is very hard. The issue was fixed very quickly thanks to `git bisect`, but I spent more than half a day figuring out how to automatically test that. And I'm sure there are other unreported issues with maps in separate documents.

Moving forward, I think we should change the `external-map.html` example to use the [Broadcast Channel API](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API)  instead of just setting the map target to an external window, and officially deprecate cross-document support of OpenLayers.