### PR TITLE
Add source uid to tile cache key

### DIFF
--- a/src/ol/layer/Layer.js
+++ b/src/ol/layer/Layer.js
@@ -261,7 +261,6 @@ class Layer extends BaseLayer {
           this.dispatchEvent('sourceready');
         }, 0);
       }
-      this.clearRenderer();
     }
     this.changed();
   }

--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -124,7 +124,7 @@ function getRenderExtent(frameState, extent) {
  * @return {string} The cache key.
  */
 export function getCacheKey(source, tileCoord) {
-  return `${source.getKey()},${source.getRevision()},${getTileCoordKey(tileCoord)}`;
+  return `${getUid(source)},${source.getKey()},${source.getRevision()},${getTileCoordKey(tileCoord)}`;
 }
 
 /**

--- a/test/browser/spec/ol/layer/vectortile.test.js
+++ b/test/browser/spec/ol/layer/vectortile.test.js
@@ -160,11 +160,15 @@ describe('ol.layer.VectorTile', function () {
           .then(function (result) {
             const tile = layer
               .getRenderer()
-              .tileCache_.get(objectURL + ',0/0/0');
+              .tileCache_.get(
+                `${getUid(layer.getSource())},${objectURL},0/0/0`,
+              );
             expect(Object.keys(tile.hitDetectionImageData).length).to.be(1);
             const tile2 = layer2
               .getRenderer()
-              .tileCache_.get(objectURL + ',0/0/0');
+              .tileCache_.get(
+                `${getUid(layer.getSource())},${objectURL},0/0/0`,
+              );
             expect(Object.keys(tile2.hitDetectionImageData).length).to.be(1);
             done();
           })

--- a/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
@@ -106,6 +106,28 @@ describe('ol/renderer/canvas/TileLayer', function () {
         expect(tiles.length).to.be(4);
       });
 
+      it('clears the cache when the layer has a new source with the same key', async () => {
+        const tiles = [];
+        let source = new TileDebug();
+        source.on('tileloadend', (event) => {
+          tiles.push(event.tile);
+        });
+        source.setKey('foo');
+        const layer = new TileLayer({source: source});
+        map.addLayer(layer);
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(tiles.length).to.be(2);
+        source.dispose();
+        source = new TileDebug();
+        source.on('tileloadend', (event) => {
+          tiles.push(event.tile);
+        });
+        source.setKey('foo');
+        layer.setSource(source);
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(tiles.length).to.be(4);
+      });
+
       it('does not mark alt/stale error tiles as newer', async () => {
         const source = new ImageTile({
           url: '#/{z}/{x}/{y}.png',


### PR DESCRIPTION
Reverts the changes made in #16488 and instead fixes #16446 with a simplified version of @MelkorCC's [solution](https://github.com/openlayers/openlayers/commit/6fd52cd2aabe6ffa2f038ce0c27716d1759acadb) initially proposed in #16484 - by adding the source uid to the tile cache key.

Fixes #16653.