### PR TITLE
Add wheel scroll by page.

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -30,6 +30,18 @@ import Interaction, {zoomByDelta} from './Interaction.js';
  */
 
 /**
+ * Mutliplier for the DOM_DELTA_LINE delta value.
+ * @type {number}
+ */
+const DELTA_LINE_MULTIPLIER = 40;
+
+/**
+ * Mutliplier for the DOM_DELTA_PAGE delta value.
+ * @type {number}
+ */
+const DELTA_PAGE_MULTIPLIER = 300;
+
+/**
  * @classdesc
  * Allows the user to zoom the map by scrolling the mouse wheel.
  * @api
@@ -192,12 +204,17 @@ class MouseWheelZoom extends Interaction {
 
     // Delta normalisation inspired by
     // https://github.com/mapbox/mapbox-gl-js/blob/001c7b9/js/ui/handler/scroll_zoom.js
-    let delta;
-    if (mapBrowserEvent.type == EventType.WHEEL) {
-      delta = wheelEvent.deltaY;
-      if (wheelEvent.deltaMode === WheelEvent.DOM_DELTA_LINE) {
-        delta *= 40;
-      }
+    let delta = wheelEvent.deltaY;
+
+    switch (wheelEvent.deltaMode) {
+      case WheelEvent.DOM_DELTA_LINE:
+        delta *= DELTA_LINE_MULTIPLIER;
+        break;
+      case WheelEvent.DOM_DELTA_PAGE:
+        delta *= DELTA_PAGE_MULTIPLIER;
+        break;
+      default:
+      // pass
     }
 
     if (delta === 0) {

--- a/test/browser/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/browser/spec/ol/interaction/mousewheelzoom.test.js
@@ -112,6 +112,27 @@ describe('ol.interaction.MouseWheelZoom', function () {
         map.handleMapBrowserEvent(event);
       });
 
+      it('works in DOM_DELTA_PAGE mode (wheel)', function (done) {
+        map.once('postrender', function () {
+          const call = view.animateInternal.getCall(0);
+          expect(call.args[0].resolution).to.be(2);
+          expect(call.args[0].anchor).to.eql(map.getView().getCenter());
+          done();
+        });
+
+        const event = new MapBrowserEvent('wheel', map, {
+          type: 'wheel',
+          deltaMode: WheelEvent.DOM_DELTA_PAGE,
+          deltaY: 1,
+          target: map.getViewport(),
+          preventDefault: Event.prototype.preventDefault,
+        });
+        event.coordinate = map.getView().getCenter();
+        event.pixel = map.getPixelFromCoordinate(event.coordinate);
+
+        map.handleMapBrowserEvent(event);
+      });
+
       it('works on all browsers (wheel)', function (done) {
         map.once('postrender', function () {
           const call = view.animateInternal.getCall(0);


### PR DESCRIPTION
Related issue: https://github.com/openlayers/openlayers/issues/16788

`wheelEvent.deltaMode === WheelEvent.DOM_DELTA_PAGE` is not handled. The `wheelEvent.deltaY` absolute value itself is a very small number:
* 0.8 on Chrome/Edge (Windows)
* 1 on Firefox (Windows)

as a result scrolling is unreasonable.
I haven't found any native setting for this mode on platforms (Win32, MacIntel, Linux) other than Windows so will go off these numbers.

Set a multiplier of the zoom level delta (300), so that the default behaviour is close to a zoom level (240 on Chrome and 300 on Firefox), leaving the page/browser scaling intricacies, rather than forcing always a zoom level.

P.S. I looked into normalizing pixels, but it's very different across platform and input devices, that is disregarding software manipulation before reaching the DOM. So decided against changing the current line normalization.