### PR TITLE
Fix generate-index script for windows

### DIFF
--- a/tasks/generate-info.js
+++ b/tasks/generate-info.js
@@ -131,7 +131,10 @@ function spawnJSDoc(paths) {
     let output = '';
     let errors = '';
     const cwd = path.join(baseDir, '..');
-    const child = spawn(jsdoc, ['-c', jsdocConfig].concat(paths), {cwd: cwd});
+    const child = spawn(jsdoc, ['-c', jsdocConfig].concat(paths), {
+      cwd,
+      shell: isWindows,
+    });
 
     child.stdout.on('data', (data) => {
       output += String(data);


### PR DESCRIPTION
`shell: true` has to be added when starting a .cmd script on Windows.
https://github.com/nodejs/node/issues/52681#issuecomment-2076426887
