### PR TITLE
Replace dead comment url with url from wayback machine

### DIFF
--- a/src/ol/geom/flat/contains.js
+++ b/src/ol/geom/flat/contains.js
@@ -55,7 +55,7 @@ export function linearRingContainsXY(
   x,
   y,
 ) {
-  // https://geomalgorithms.com/a03-_inclusion.html
+  // https://web.archive.org/web/20210504233957/http://geomalgorithms.com/a03-_inclusion.html
   // Copyright 2000 softSurfer, 2012 Dan Sunday
   // This code may be freely used and modified for any purpose
   // providing that this copyright notice is included with it.


### PR DESCRIPTION
The original page at `geomalgorithms.com/a03-_inclusion.html` is no longer available, it only displays some advertisement. (visit at your own risk)

A snapshot is available here:
https://web.archive.org/web/20210504233957/http://geomalgorithms.com/a03-_inclusion.html