### PR TITLE
Prevent Canvas2D warning in hit detection context

### DIFF
--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -219,6 +219,8 @@ class ExecutorGroup {
       this.hitDetectionContext_ = createCanvasContext2D(
         contextSize,
         contextSize,
+        undefined,
+        {willReadFrequently: false},
       );
     }
     const context = this.hitDetectionContext_;


### PR DESCRIPTION
**Description**
We often read from this Canvas2D context to track hit detection within `forEachFeatureAtCoordinate`. Enable the `willReadFrequently` option to hide browser warnings.

![Screenshot 2025-04-23 at 8 42 01 AM](https://github.com/user-attachments/assets/609a3b2f-56de-4bc3-b815-ab62608c6186)

**Related issues**
- https://github.com/openlayers/openlayers/issues/14954#issuecomment-2780675514
- https://github.com/openlayers/openlayers/issues/14322
- https://github.com/openlayers/openlayers/issues/14221
- https://github.com/openlayers/openlayers/issues/14175

