### PR TITLE
Handle change from fill/stroke to no fill/stroke when overlaps: false

### DIFF
--- a/src/ol/render/canvas/Builder.js
+++ b/src/ol/render/canvas/Builder.js
@@ -624,9 +624,7 @@ class CanvasBuilder extends VectorContext {
   updateFillStyle(state, createFill) {
     const fillStyle = state.fillStyle;
     if (typeof fillStyle !== 'string' || state.currentFillStyle != fillStyle) {
-      if (fillStyle !== undefined) {
-        this.instructions.push(createFill.call(this, state));
-      }
+      this.instructions.push(createFill.call(this, state));
       state.currentFillStyle = fillStyle;
     }
   }
@@ -653,9 +651,7 @@ class CanvasBuilder extends VectorContext {
       state.currentLineWidth != lineWidth ||
       state.currentMiterLimit != miterLimit
     ) {
-      if (strokeStyle !== undefined) {
-        applyStroke.call(this, state);
-      }
+      applyStroke.call(this, state);
       state.currentStrokeStyle = strokeStyle;
       state.currentLineCap = lineCap;
       state.currentLineDash = lineDash;

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -611,6 +611,9 @@ class Executor {
   setStrokeStyle_(context, instruction) {
     context.strokeStyle =
       /** @type {import("../../colorlike.js").ColorLike} */ (instruction[1]);
+    if (!instruction[1]) {
+      return;
+    }
     context.lineWidth = /** @type {number} */ (instruction[2]);
     context.lineCap = /** @type {CanvasLineCap} */ (instruction[3]);
     context.lineJoin = /** @type {CanvasLineJoin} */ (instruction[4]);

--- a/src/ol/render/canvas/PolygonBuilder.js
+++ b/src/ol/render/canvas/PolygonBuilder.js
@@ -255,13 +255,8 @@ class CanvasPolygonBuilder extends CanvasBuilder {
    */
   setFillStrokeStyles_() {
     const state = this.state;
-    const fillStyle = state.fillStyle;
-    if (fillStyle !== undefined) {
-      this.updateFillStyle(state, this.createFill);
-    }
-    if (state.strokeStyle !== undefined) {
-      this.updateStrokeStyle(state, this.applyStroke);
-    }
+    this.updateFillStyle(state, this.createFill);
+    this.updateStrokeStyle(state, this.applyStroke);
   }
 }
 


### PR DESCRIPTION
Fixes #16811 

This pull request makes is so a SET_STROKE_STYLE or SET_FILL_STYLE is also created when a stroke or fill changes from stroke to no stroke or fill to no fill. This way, we can ensure that when a source is configured with the `overlaps: false` hint, the last fill or stroke won't be repeated for all subsequent features.