### PR TITLE
Improve type for Extent to indicate it's a tuple with four numbers

### DIFF
--- a/src/ol/View.js
+++ b/src/ol/View.js
@@ -1940,7 +1940,9 @@ export function createCenterConstraint(options) {
 
   const projection = createProjection(options.projection, 'EPSG:3857');
   if (options.multiWorld !== true && projection.isGlobal()) {
-    const extent = projection.getExtent().slice();
+    const extent = /** @type {import('./extent.js').Extent} */ (
+      projection.getExtent().slice()
+    );
     extent[0] = -Infinity;
     extent[2] = Infinity;
     return createExtent(extent, false, false);

--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -83,7 +83,7 @@ export function clone(extent, dest) {
     dest[3] = extent[3];
     return dest;
   }
-  return extent.slice();
+  return /** @type {Extent} */ (extent.slice());
 }
 
 /**

--- a/src/ol/format/MVT.js
+++ b/src/ol/format/MVT.js
@@ -263,7 +263,14 @@ class MVT extends FeatureFormat {
       }
       const pbfLayer = pbfLayers[name];
 
-      const extent = pbfLayer ? [0, 0, pbfLayer.extent, pbfLayer.extent] : null;
+      const extent = pbfLayer
+        ? /** @type {import('../extent.js').Extent} */ ([
+            0,
+            0,
+            pbfLayer.extent,
+            pbfLayer.extent,
+          ])
+        : null;
       dataProjection.setExtent(extent);
 
       for (let i = 0, ii = pbfLayer.length; i < ii; ++i) {

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -57,6 +57,7 @@ const CIRCLE_CENTER_INDEX = 0;
  */
 const CIRCLE_CIRCUMFERENCE_INDEX = 1;
 
+/** @type {import('../extent.js').Extent} */
 const tempExtent = [0, 0, 0, 0];
 const tempSegment = [];
 

--- a/src/ol/layer/Graticule.js
+++ b/src/ol/layer/Graticule.js
@@ -524,7 +524,9 @@ class Graticule extends VectorLayer {
    */
   strategyFunction(extent, resolution) {
     // extents may be passed in different worlds, to avoid endless loop we use only one
-    let realWorldExtent = extent.slice();
+    let realWorldExtent = /** @type {import('../extent.js').Extent} */ (
+      extent.slice()
+    );
     if (this.projection_ && this.getSource().getWrapX()) {
       wrapExtentX(realWorldExtent, this.projection_);
     }
@@ -533,7 +535,9 @@ class Graticule extends VectorLayer {
         approximatelyEquals(this.loadedExtent_, realWorldExtent, resolution)
       ) {
         // make sure result is exactly equal to previous extent
-        realWorldExtent = this.loadedExtent_.slice();
+        realWorldExtent = /** @type {import('../extent.js').Extent} */ (
+          this.loadedExtent_.slice()
+        );
       } else {
         // we should not keep track of loaded extents
         this.getSource().removeLoadedExtent(this.loadedExtent_);

--- a/src/ol/render.js
+++ b/src/ol/render.js
@@ -79,6 +79,7 @@ export function toContext(context, options) {
     canvas.style.width = size[0] + 'px';
     canvas.style.height = size[1] + 'px';
   }
+  /** @type {import('./extent.js').Extent} */
   const extent = [0, 0, canvas.width, canvas.height];
   const transform = scaleTransform(createTransform(), pixelRatio, pixelRatio);
   return new CanvasImmediateRenderer(context, pixelRatio, extent, transform, 0);

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -607,6 +607,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     const dx = (tileResolution * width) / 2 / tilePixelRatio;
     const dy = (tileResolution * height) / 2 / tilePixelRatio;
+    /** @type {import('../../extent.js').Extent} */
     const canvasExtent = [
       viewCenter[0] - dx,
       viewCenter[1] - dy,

--- a/src/ol/renderer/canvas/VectorImageLayer.js
+++ b/src/ol/renderer/canvas/VectorImageLayer.js
@@ -98,7 +98,9 @@ class CanvasVectorImageLayerRenderer extends CanvasImageLayerRenderer {
     const vectorRenderer = this.vectorRenderer_;
     let renderedExtent = frameState.extent;
     if (this.layerImageRatio_ !== 1) {
-      renderedExtent = renderedExtent.slice(0);
+      renderedExtent = /** @type {import('../../extent.js').Extent} */ (
+        renderedExtent.slice()
+      );
       scaleFromCenter(renderedExtent, this.layerImageRatio_);
     }
     const width = getWidth(renderedExtent) / viewResolution;

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -600,8 +600,12 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
       frameStateExtent,
       vectorLayerRenderBuffer * resolution,
     );
-    const renderedExtent = extent.slice();
-    const loadExtents = [extent.slice()];
+    const renderedExtent = /** @type {import('../../extent.js').Extent} */ (
+      extent.slice()
+    );
+    const loadExtents = [
+      /** @type {import('../../extent.js').Extent} */ (extent.slice()),
+    ];
     const projectionExtent = projection.getExtent();
 
     if (

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -517,7 +517,9 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       vectorSource.loadFeatures(extent, resolution, projection);
 
       this.rebuildBuffers_(frameState);
-      this.previousExtent_ = frameState.extent.slice();
+      this.previousExtent_ = /** @type {import('../../extent.js').Extent} */ (
+        frameState.extent.slice()
+      );
     }
 
     this.helper.useProgram(this.program_, frameState);

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -447,7 +447,9 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
         this.getLayer().changed();
       });
 
-      this.previousExtent_ = frameState.extent.slice();
+      this.previousExtent_ = /** @type {import('../../extent.js').Extent} */ (
+        frameState.extent.slice()
+      );
     }
 
     return true;

--- a/src/ol/reproj/DataTile.js
+++ b/src/ol/reproj/DataTile.js
@@ -256,7 +256,7 @@ class ReprojDataTile extends DataTile {
       }
 
       const sourceExtents = wrapAndSliceX(
-        sourceExtent.slice(),
+        /** @type {import('../extent.js').Extent} */ (sourceExtent.slice()),
         sourceProj,
         true,
       );

--- a/src/ol/reproj/Image.js
+++ b/src/ol/reproj/Image.js
@@ -52,13 +52,17 @@ class ReprojImage extends ImageWrapper {
   ) {
     let maxSourceExtent = sourceProj.getExtent();
     if (maxSourceExtent && sourceProj.canWrapX()) {
-      maxSourceExtent = maxSourceExtent.slice();
+      maxSourceExtent = /** @type {import('../extent.js').Extent} */ (
+        maxSourceExtent.slice()
+      );
       maxSourceExtent[0] = -Infinity;
       maxSourceExtent[2] = Infinity;
     }
     let maxTargetExtent = targetProj.getExtent();
     if (maxTargetExtent && targetProj.canWrapX()) {
-      maxTargetExtent = maxTargetExtent.slice();
+      maxTargetExtent = /** @type {import('../extent.js').Extent} */ (
+        maxTargetExtent.slice()
+      );
       maxTargetExtent[0] = -Infinity;
       maxTargetExtent[2] = Infinity;
     }

--- a/src/ol/reproj/Tile.js
+++ b/src/ol/reproj/Tile.js
@@ -232,7 +232,7 @@ class ReprojTile extends Tile {
       }
 
       const sourceExtents = wrapAndSliceX(
-        sourceExtent.slice(),
+        /** @type {import('../extent.js').Extent} */ (sourceExtent.slice()),
         sourceProj,
         true,
       );

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -311,7 +311,13 @@ class BingMaps extends TileImage {
             const coverageArea = coverageAreas[i];
             if (zoom >= coverageArea.zoomMin && zoom <= coverageArea.zoomMax) {
               const bbox = coverageArea.bbox;
-              const epsg4326Extent = [bbox[1], bbox[0], bbox[3], bbox[2]];
+              const epsg4326Extent =
+                /** @type {import('../extent.js').Extent} */ ([
+                  bbox[1],
+                  bbox[0],
+                  bbox[3],
+                  bbox[2],
+                ]);
               const extent = applyTransform(epsg4326Extent, transform);
               if (intersects(extent, frameState.extent)) {
                 intersecting = true;

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -600,6 +600,7 @@ class GeoTIFFSource extends DataTile {
         );
       }
 
+      /** @type {import('../extent.js').Extent} */
       let sourceExtent;
       let sourceOrigin;
       const sourceTileSizes = new Array(imageCount);
@@ -622,7 +623,9 @@ class GeoTIFFSource extends DataTile {
         const level = imageCount - (imageIndex + 1);
 
         if (!sourceExtent) {
-          sourceExtent = getBoundingBox(image);
+          sourceExtent = /** @type {import('../extent.js').Extent} */ (
+            getBoundingBox(image)
+          );
         }
 
         if (!sourceOrigin) {

--- a/src/ol/source/ImageCanvas.js
+++ b/src/ol/source/ImageCanvas.js
@@ -113,7 +113,7 @@ class ImageCanvasSource extends ImageSource {
       return canvas;
     }
 
-    extent = extent.slice();
+    extent = /** @type {import('../extent.js').Extent} */ (extent.slice());
     scaleFromCenter(extent, this.ratio_);
     const width = getWidth(extent) / resolution;
     const height = getHeight(extent) / resolution;

--- a/src/ol/source/TileJSON.js
+++ b/src/ol/source/TileJSON.js
@@ -27,7 +27,7 @@ import TileImage from './TileImage.js';
  * @property {Array<string>} [grids] Optional grids.
  * @property {number} [minzoom] Minimum zoom level.
  * @property {number} [maxzoom] Maximum zoom level.
- * @property {Array<number>} [bounds] Optional bounds.
+ * @property {import("../extent.js").Extent} [bounds] Optional bounds.
  * @property {Array<number>} [center] Optional center.
  */
 

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -622,7 +622,12 @@ class VectorSource extends Source {
    * @template T
    */
   forEachFeatureAtCoordinateDirect(coordinate, callback) {
-    const extent = [coordinate[0], coordinate[1], coordinate[0], coordinate[1]];
+    const extent = /** @type {import('../extent.js').Extent} */ ([
+      coordinate[0],
+      coordinate[1],
+      coordinate[0],
+      coordinate[1],
+    ]);
     return this.forEachFeatureInExtent(extent, function (feature) {
       const geometry = feature.getGeometry();
       if (
@@ -805,7 +810,12 @@ class VectorSource extends Source {
     let closestFeature = null;
     const closestPoint = [NaN, NaN];
     let minSquaredDistance = Infinity;
-    const extent = [-Infinity, -Infinity, Infinity, Infinity];
+    const extent = /** @type {import('../extent.js').Extent} */ ([
+      -Infinity,
+      -Infinity,
+      Infinity,
+      Infinity,
+    ]);
     filter = filter ? filter : TRUE;
     this.featuresRtree_.forEachInExtent(
       extent,
@@ -1035,7 +1045,11 @@ class VectorSource extends Source {
             );
           },
         );
-        loadedExtentsRtree.insert(extentToLoad, {extent: extentToLoad.slice()});
+        loadedExtentsRtree.insert(extentToLoad, {
+          extent: /** @type {import('../extent.js').Extent} */ (
+            extentToLoad.slice()
+          ),
+        });
       }
     }
     this.loading =

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -492,13 +492,13 @@ export function optionsFromCapabilities(wmtsCap, config) {
       matrixSetExtent[2],
     ];
   }
-  let extent = [
+  let extent = /** @type {import('../extent.js').Extent} */ ([
     origin[0] + tileSpanX * selectedMatrixLimit.MinTileCol,
     // add one to get proper bottom/right coordinate
     origin[1] - tileSpanY * (1 + selectedMatrixLimit.MaxTileRow),
     origin[0] + tileSpanX * (1 + selectedMatrixLimit.MaxTileCol),
     origin[1] - tileSpanY * selectedMatrixLimit.MinTileRow,
-  ];
+  ]);
 
   if (
     matrixSetExtent !== undefined &&

--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -323,7 +323,12 @@ function parseTileMatrixSet(
   const resolutions = new Array(length);
   const sizes = new Array(length);
   const tileSizes = new Array(length);
-  const extent = [-Infinity, -Infinity, Infinity, Infinity];
+  const extent = /** @type {import('../extent.js').Extent} */ ([
+    -Infinity,
+    -Infinity,
+    Infinity,
+    Infinity,
+  ]);
 
   for (let i = 0; i < length; ++i) {
     const id = matrixIds[i];

--- a/src/ol/structs/RBush.js
+++ b/src/ol/structs/RBush.js
@@ -104,7 +104,12 @@ class RBush {
    */
   update(extent, value) {
     const item = this.items_[getUid(value)];
-    const bbox = [item.minX, item.minY, item.maxX, item.maxY];
+    const bbox = /** @type {import('../extent.js').Extent} */ ([
+      item.minX,
+      item.minY,
+      item.maxX,
+      item.maxY,
+    ]);
     if (!equals(bbox, extent)) {
       this.remove(value);
       this.insert(extent, value);


### PR DESCRIPTION
Partially implementing #15769 by adding a tuple type for `Extent`. The other cases should probably be handled as separate PRs.

By making this change, it's easier to use the `Extent` type in projects with a strict TypeScript config.

Looking at how `Extent`s are implemented, they seem to always have four numbers, which makes this a good fit for a tuple type.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
