### PR TITLE
fix(webgl): refactor dashDistanceField function to propery compile with dynamic expressions

### DIFF
--- a/src/ol/render/webgl/style.js
+++ b/src/ol/render/webgl/style.js
@@ -648,9 +648,9 @@ function parseStrokeProperties(style, builder, uniforms, context) {
     const uniqueDashKey = computeHash(style['stroke-line-dash']);
     const dashFunctionName = `dashDistanceField_${uniqueDashKey}`;
 
-    const dashLengthsDef = dashPattern.map(
-      (v, i) => `float dashLength${i} = ${v};`,
-    );
+    const dashLengthsParamsDef = dashPattern
+      .map((v, i) => `float dashLength${i}`)
+      .join(', ');
     const totalLengthDef = dashPattern
       .map((v, i) => `dashLength${i}`)
       .join(' + ');
@@ -664,13 +664,13 @@ function parseStrokeProperties(style, builder, uniforms, context) {
     }
 
     context.functions[dashFunctionName] =
-      `float ${dashFunctionName}(float distance, float radius, float capType, float lineWidth) {
-  ${dashLengthsDef.join('\n  ')}
+      `float ${dashFunctionName}(float distance, float radius, float capType, float lineWidth, ${dashLengthsParamsDef}) {
   float totalDashLength = ${totalLengthDef};
   return ${distanceExpression};
 }`;
+    const dashLengthsCalls = dashPattern.map((v, i) => `${v}`).join(', ');
     builder.setStrokeDistanceFieldExpression(
-      `${dashFunctionName}(currentLengthPx + ${offsetExpression}, currentRadiusPx, capType, v_width)`,
+      `${dashFunctionName}(currentLengthPx + ${offsetExpression}, currentRadiusPx, capType, v_width, ${dashLengthsCalls})`,
     );
   }
 }


### PR DESCRIPTION

This PR fixes an issue with expressions such as: `'stroke-line-dash:' [['get', 'dashLength0'], ['get', 'dashLength1']]`

Previously, the generated shader would look like this:

```glsl
...
varying float v_prop_dashPattern0;
varying float v_prop_dashPattern1;
....
float dashDistanceField_1994565867(float distance, float radius, float capType, float lineWidth) {
  float dashLength0 = a_prop_dashPattern0;
  float dashLength1 = a_prop_dashPattern1;
  float totalDashLength = dashLength0 + dashLength1;
  return getSingleDashDistance(distance, radius, 0., dashLength0, totalDashLength, capType, lineWidth);
}
...
void main(void) {
  float a_prop_dashPattern0 = v_prop_dashPattern0; // assign to original attribute name
  float a_prop_dashPattern1 = v_prop_dashPattern1; // assign to original attribute name
...
  distanceField = max(distanceField, dashDistanceField_1994565867(currentLengthPx + 0., currentRadiusPx, capType, v_width));

....
}

```

Which basicly would not compile, as the `dashDistanceField` function references a prop that is scoped to inside the main function. The fix was to instead pass the dash lengths as parameters to the function.

- Added tests
- Tested fix locally with real world application