### PR TITLE
WebGL / Avoid "Vertex buffer is not big enough for the draw call" error when mixing styles and geometry types

### DIFF
--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -446,6 +446,14 @@ class WebGLHelper extends Disposable {
      * @private
      */
     this.startTime_ = Date.now();
+
+    /**
+     * @type {number}
+     * @private
+     */
+    this.maxAttributeCount_ = this.gl_.getParameter(
+      this.gl_.MAX_VERTEX_ATTRIBS,
+    );
   }
 
   /**
@@ -894,6 +902,7 @@ class WebGLHelper extends Disposable {
    * @param {import("../Map.js").FrameState} [frameState] Frame state.
    */
   useProgram(program, frameState) {
+    this.disableAllAttributes_();
     const gl = this.gl_;
     gl.useProgram(program);
     this.currentProgram_ = program;
@@ -1063,6 +1072,16 @@ class WebGLHelper extends Disposable {
    */
   setUniformMatrixValue(uniform, value) {
     this.gl_.uniformMatrix4fv(this.getUniformLocation(uniform), false, value);
+  }
+
+  /**
+   * Disable all vertex attributes.
+   * @private
+   */
+  disableAllAttributes_() {
+    for (let i = 0; i < this.maxAttributeCount_; i++) {
+      this.gl_.disableVertexAttribArray(i);
+    }
   }
 
   /**

--- a/test/browser/spec/ol/webgl/helper.test.js
+++ b/test/browser/spec/ol/webgl/helper.test.js
@@ -479,4 +479,22 @@ describe('ol/webgl/WebGLHelper', function () {
       ]);
     });
   });
+
+  describe('attributes disabling', () => {
+    let disableAttribSpy;
+    beforeEach(() => {
+      h = new WebGLHelper();
+      disableAttribSpy = sinonSpy(h.getGL(), 'disableVertexAttribArray');
+      const program = h.getProgram(FRAGMENT_SHADER, VERTEX_SHADER);
+      h.useProgram(program, SAMPLE_FRAMESTATE);
+    });
+    it('all active attributes are disabled when enabling programs, disregarding of previous state', () => {
+      const gl = h.getGL();
+      const max = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+      expect(disableAttribSpy.getCalls().length).to.eql(max); // each possible attribute is disabled
+      for (let i = 0; i < max; i++) {
+        expect(disableAttribSpy.getCall(i).args[0]).to.eql(i);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/openlayers/openlayers/issues/16405, #15459 and #14664

This was partly inspired by https://github.com/openlayers/openlayers/pull/16055 and intends to disable all vertex attributes when switching to a new shader before rendering.

I have to hand it down to @kikuchan who found the right fix back then; I didn't think it was necessary to disable all attributes before enabling new ones, but it turns out it was still causing some very hard-to-track issues on some hardware and driver combinations. Now we clear all attributes before enabling the ones relevant to the current shader.

This has a negligible impact on performance as we're not even reading the state of the current attributes but just clearing everything, which amounts to ~5ms spent on more than 15 seconds of recording.