### PR TITLE
Use FontFaceSet for modern font load status tracking

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1470,7 +1470,10 @@ class Map extends BaseObject {
    * Redraws all text after new fonts have loaded
    */
   redrawText() {
-    const layerStates = this.getLayerGroup().getLayerStatesArray();
+    if (!this.frameState_) {
+      return;
+    }
+    const layerStates = this.frameState_.layerStatesArray;
     for (let i = 0, ii = layerStates.length; i < ii; ++i) {
       const layer = layerStates[i].layer;
       if (layer.hasRenderer()) {

--- a/src/ol/css.js
+++ b/src/ol/css.js
@@ -88,6 +88,12 @@ const fontRegExMatchIndex = [
   'family',
 ];
 
+/** @type {Object<string|number, number>} */
+export const fontWeights = {
+  normal: 400,
+  bold: 700,
+};
+
 /**
  * Get the list of font families from a font spec.  Note that this doesn't work
  * for font families that have commas in them.
@@ -103,15 +109,21 @@ export const getFontParameters = function (fontSpec) {
     lineHeight: 'normal',
     size: '1.2em',
     style: 'normal',
-    weight: 'normal',
+    weight: '400',
     variant: 'normal',
   });
   for (let i = 0, ii = fontRegExMatchIndex.length; i < ii; ++i) {
     const value = match[i + 1];
     if (value !== undefined) {
-      style[fontRegExMatchIndex[i]] = value;
+      style[fontRegExMatchIndex[i]] =
+        typeof value === 'string' ? value.trim() : value;
     }
   }
-  style.families = style.family.split(/,\s?/);
+  if (isNaN(Number(style.weight)) && style.weight in fontWeights) {
+    style.weight = fontWeights[style.weight];
+  }
+  style.families = style.family
+    .split(/,\s?/)
+    .map((f) => f.trim().replace(/^['"]|['"]$/g, ''));
   return style;
 };

--- a/test/browser/spec/ol/render/canvas/index.test.js
+++ b/test/browser/spec/ol/render/canvas/index.test.js
@@ -9,58 +9,48 @@ describe('ol.render.canvas', function () {
 
   describe('ol.render.canvas.registerFont()', function () {
     beforeEach(function () {
-      render.checkedFonts.values_ = {};
+      render.checkedFonts.setProperties({}, true);
       render.measureTextHeight('12px sans-serif');
     });
 
     const retries = 100;
 
     it('does not trigger redraw and clear measurements for unavailable fonts', function (done) {
-      this.timeout(4000);
       const spy = sinonSpy();
       render.checkedFonts.addEventListener('propertychange', spy);
       const interval = setInterval(function () {
-        if (
-          render.checkedFonts.get('normal\nnormal\nfoo') == retries &&
-          render.checkedFonts.get('normal\nnormal\nsans-serif') == retries
-        ) {
+        if (render.checkedFonts.get('normal 400 16px "foo"') == retries) {
           clearInterval(interval);
           render.checkedFonts.removeEventListener('propertychange', spy);
           expect(spy.callCount).to.be(0);
           expect(render.textHeights).to.not.eql({});
           done();
         }
-      }, 32);
+      }, 100);
       render.registerFont('12px foo,sans-serif');
     });
 
     it('does not trigger redraw and clear measurements for available fonts', function (done) {
       const spy = sinonSpy();
       render.checkedFonts.addEventListener('propertychange', spy);
-      const interval = setInterval(function () {
-        if (render.checkedFonts.get('normal\nnormal\nsans-serif') == retries) {
-          clearInterval(interval);
-          render.checkedFonts.removeEventListener('propertychange', spy);
-          expect(spy.callCount).to.be(0);
-          expect(render.textHeights).to.not.eql({});
-          done();
-        }
-      }, 32);
+      setTimeout(function () {
+        render.checkedFonts.removeEventListener('propertychange', spy);
+        expect(spy.callCount).to.be(0);
+        expect(render.textHeights).to.not.eql({});
+        done();
+      }, 1000);
       render.registerFont('12px sans-serif');
     });
 
     it("does not trigger redraw and clear measurements for the 'monospace' font", function (done) {
       const spy = sinonSpy();
       render.checkedFonts.addEventListener('propertychange', spy);
-      const interval = setInterval(function () {
-        if (render.checkedFonts.get('normal\nnormal\nmonospace') == retries) {
-          clearInterval(interval);
-          render.checkedFonts.removeEventListener('propertychange', spy);
-          expect(spy.callCount).to.be(0);
-          expect(render.textHeights).to.not.eql({});
-          done();
-        }
-      }, 32);
+      setInterval(function () {
+        render.checkedFonts.removeEventListener('propertychange', spy);
+        expect(spy.callCount).to.be(0);
+        expect(render.textHeights).to.not.eql({});
+        done();
+      }, 1000);
       render.registerFont('12px monospace');
     });
 
@@ -73,10 +63,11 @@ describe('ol.render.canvas', function () {
             'propertychange',
             onPropertyChange,
           );
-          expect(e.key).to.be('normal\nnormal\nAbel');
+          expect(e.key).to.be('normal 400 16px "Abel"');
           expect(render.textHeights).to.eql({});
 
           font.remove();
+          render.checkedFonts.setProperties({}, true);
           done();
         },
       );

--- a/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/vectortilelayer.test.js
@@ -188,9 +188,13 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       layer.changed();
       const revision = layer.getRevision();
       setTimeout(function () {
-        expect(layer.getRevision()).to.be(revision);
-        done();
-      }, 800);
+        try {
+          expect(layer.getRevision()).to.be(revision);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, 1000);
     });
 
     it('does not re-render for available fonts', function (done) {
@@ -199,9 +203,13 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       layer.changed();
       const revision = layer.getRevision();
       setTimeout(function () {
-        expect(layer.getRevision()).to.be(revision);
-        done();
-      }, 800);
+        try {
+          expect(layer.getRevision()).to.be(revision);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      }, 1000);
     });
 
     it('re-renders for fonts that become available', function (done) {
@@ -210,15 +218,19 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       layerStyle[0].getText().setFont(`12px "${fontFamily}",sans-serif`);
       layer.changed();
       const revision = layer.getRevision();
-      setTimeout(function () {
-        try {
-          font.remove();
-          expect(layer.getRevision()).to.be(revision + 1);
-          done();
-        } catch (e) {
-          done(e);
-        }
-      }, 1600);
+      checkedFonts.addEventListener(
+        'propertychange',
+        function onPropertyChange(e) {
+          checkedFonts.removeEventListener('propertychange', onPropertyChange);
+          try {
+            font.remove();
+            expect(layer.getRevision()).to.be(revision + 1);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        },
+      );
     });
 
     it('works for multiple layers that use the same source', function () {
@@ -949,7 +961,7 @@ describe('ol/renderer/canvas/VectorTileLayer', function () {
       checkedFonts.getListeners('propertychange').forEach((listener) => {
         checkedFonts.removeEventListener('propertychange', listener);
       });
-      checkedFonts.setProperties({});
+      checkedFonts.setProperties({}, true);
       disposeMap(map);
     });
 

--- a/test/browser/spec/util.js
+++ b/test/browser/spec/util.js
@@ -1,3 +1,5 @@
+import {checkedFonts} from '../../../src/ol/render/canvas.js';
+
 export function overrideRAF() {
   const raf = window.requestAnimationFrame;
   const caf = window.cancelAnimationFrame;
@@ -16,31 +18,28 @@ export function overrideRAF() {
 }
 
 export function createFontStyle(options) {
-  const styleNode = document.createElement('style');
   const src = Array.isArray(options.src) ? options.src : [options.src];
   function toCssSource(src) {
     const url = typeof src === 'string' ? src : src.url;
     const format = typeof src === 'string' ? undefined : src.format;
     return `url('${url}')${format ? ` format('${format}')` : ''}`;
   }
-  const ruleText = `
-    @font-face {
-      font-family: '${options.fontFamily}';
-      font-style: ${options.fontStyle || 'normal'};
-      font-weight: ${
-        options.fontWeight === undefined ? 400 : options.fontWeight
-      };
-      src: ${src.map(toCssSource).join(',\n  ')};
-    }`;
+  const fontFamily = options.fontFamily;
+  const fontStyle = options.fontStyle || 'normal';
+  const fontWeight =
+    options.fontWeight === undefined ? 400 : options.fontWeight;
+  const fontFace = new FontFace(fontFamily, src.map(toCssSource).join(', '), {
+    style: fontStyle,
+    weight: fontWeight,
+  });
+
   return {
     add() {
-      document.head.appendChild(styleNode);
-      if (styleNode.sheet.cssRules.length === 0) {
-        styleNode.sheet.insertRule(ruleText);
-      }
+      document.fonts.add(fontFace);
     },
     remove() {
-      document.head.removeChild(styleNode);
+      document.fonts.delete(fontFace);
+      checkedFonts.setProperties({}, true);
     },
   };
 }

--- a/test/node/ol/css.test.js
+++ b/test/node/ol/css.test.js
@@ -7,25 +7,37 @@ describe('ol.css', function () {
       {
         font: '2em "Open Sans"',
         style: 'normal',
-        weight: 'normal',
-        families: ['"Open Sans"'],
+        weight: '400',
+        families: ['Open Sans'],
       },
       {
         font: "2em 'Open Sans'",
         style: 'normal',
-        weight: 'normal',
-        families: ['"Open Sans"'],
+        weight: '400',
+        families: ['Open Sans'],
+      },
+      {
+        font: 'bold 2em Open Sans',
+        style: 'normal',
+        weight: '700',
+        families: ['Open Sans'],
       },
       {
         font: '2em "Open Sans", sans-serif',
         style: 'normal',
-        weight: 'normal',
-        families: ['"Open Sans"', 'sans-serif'],
+        weight: '400',
+        families: ['Open Sans', 'sans-serif'],
       },
       {
         font: 'italic small-caps bolder 16px/3 cursive',
         style: 'italic',
         weight: 'bolder',
+        families: ['cursive'],
+      },
+      {
+        font: 'italic small-caps 900 16px/3 cursive',
+        style: 'italic',
+        weight: '900',
         families: ['cursive'],
       },
       {
@@ -35,7 +47,7 @@ describe('ol.css', function () {
       {
         font: '100% fantasy',
         style: 'normal',
-        weight: 'normal',
+        weight: '400',
         families: ['fantasy'],
       },
     ];


### PR DESCRIPTION
This pull request simplifies and improves the way we detect available fonts. The problem can be seen in the https://openlayers.org/en/latest/examples/mapbox-style.html example: after several reloads, the continent labels may be rendered in italic instead of regular. https://deploy-preview-16854--ol-site.netlify.app/en/latest/examples/mapbox-style.html does not have this issue. Note: the changing line breaks between reloads are an [unrelated issue](https://github.com/openlayers/ol-mapbox-style/pull/1309) in ol-mapbox-style.

Instead of comparing font metrics, we now use the `FontFaceSet` API on `document.fonts` (`self.font` in a worker).

The key difference is that fonts installed on the system will no longer immediately be detected. They now will be re-checked until the maximum retries are reached. The result is the same - they are always available, so no redraw is necessary. To compensate for the additional retries, we need less retries overall, because we don't have to retry until a font can be used for rendering, but only until the style sheet containing the font definition is loaded.