### PR TITLE
Fix deferred render order

### DIFF
--- a/src/ol/render/canvas/ExecutorGroup.js
+++ b/src/ol/render/canvas/ExecutorGroup.js
@@ -418,7 +418,7 @@ class ExecutorGroup {
           }
           if (zIndexContext) {
             zIndexContext.offset();
-            const index = zs[i] * maxBuilderTypes + j;
+            const index = zs[i] * maxBuilderTypes + ALL.indexOf(builderType);
             if (!this.deferredZIndexContexts_[index]) {
               this.deferredZIndexContexts_[index] = [];
             }

--- a/test/rendering/cases/layer-vector-decluttering/main.js
+++ b/test/rendering/cases/layer-vector-decluttering/main.js
@@ -184,4 +184,4 @@ source4.addFeature(point);
 source4.addFeature(line);
 map.addLayer(layer4);
 
-render({tolerance: 0.007});
+render({tolerance: 0.001});


### PR DESCRIPTION
I noticed a render test that does not show as failed, despite being incorrectly rendered:

test/rendering/cases/layer-vector-decluttering - expected

![expected](https://github.com/user-attachments/assets/507c6a11-5778-4e84-8732-a5127d11d2d8)

test/rendering/cases/layer-vector-decluttering - actual

![actual](https://github.com/user-attachments/assets/298cb936-ce72-47a4-9886-c23a236108e1)

The problem was an incorrect index of the current builder. I fixed the index, and also set a lower pixel tolerance for the rendering test, so future problems don't go unnoticed.