### PR TITLE
Add option to change TileDebug color

### DIFF
--- a/src/ol/source/TileDebug.js
+++ b/src/ol/source/TileDebug.js
@@ -24,6 +24,7 @@ import ImageTile from './ImageTile.js';
  * If both `source` and individual options are specified the individual options will have precedence.
  * @property {string} [template='z:{z} x:{x} y:{y}'] Template for labeling the tiles.
  * Should include `{x}`, `{y}` or `{-y}`, and `{z}` placeholders.
+ * @property {string} [color='grey'] Color to use to fill the text and grid that will be generated for each tile.
  */
 
 /**
@@ -44,6 +45,7 @@ class TileDebug extends ImageTile {
     options = options || {};
     const template = options.template || 'z:{z} x:{x} y:{y}';
     const source = options.source;
+    const color = options.color || 'grey';
 
     super({
       transition: 0,
@@ -97,10 +99,10 @@ class TileDebug extends ImageTile {
         const [width, height] = this.getTileSize(z);
         const context = createCanvasContext2D(width, height);
 
-        context.strokeStyle = 'grey';
+        context.strokeStyle = color;
         context.strokeRect(0.5, 0.5, width + 0.5, height + 0.5);
 
-        context.fillStyle = 'grey';
+        context.fillStyle = color;
         context.strokeStyle = 'white';
         context.textAlign = 'center';
         context.textBaseline = 'middle';


### PR DESCRIPTION
in the case where there are multiple references used at the same time (i.e. with COG), having the same color for the TileDebug is not ideal for readability.

With this new options, each TileDebug instance can now have a different color, giving more flexibility in the case mentioned above.

Use sample
![image](https://github.com/user-attachments/assets/eb6b0fed-24da-4eea-8e59-dbcc00f46e88)


<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
