### PR TITLE
Select methods for adding/removing features 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.js text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.mjs text eol=lf

--- a/examples/box-selection.html
+++ b/examples/box-selection.html
@@ -3,8 +3,9 @@ layout: example.html
 title: Box Selection
 shortdesc: Using a DragBox interaction to select features.
 docs: >
-  <p>This example shows how to use a <code>DragBox</code> interaction to select features. Selected features are added
-  to the feature overlay of a select interaction (<code>ol/interaction/Select</code>) for highlighting.</p>
+  <p>This example shows how to use a <code>DragBox</code> interaction to select features. Features are
+  selected using a select interaction (<code>ol/interaction/Select</code>), to recieve highlighting
+  and apply filters (features with color <span style="background-color: #CC6767;">#CC6767</span> are not selectable)</p>
   <p>Use <code>Ctrl+Drag</code> (<code>Command+Drag</code> on Mac) to draw boxes.</p>
 tags: "DragBox, feature, selection, box"
 ---

--- a/examples/select-features.js
+++ b/examples/select-features.js
@@ -1,6 +1,11 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import {altKeyOnly, click, pointerMove} from '../src/ol/events/condition.js';
+import {
+  altKeyOnly,
+  click,
+  never,
+  pointerMove,
+} from '../src/ol/events/condition.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
 import Select from '../src/ol/interaction/Select.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
@@ -67,6 +72,7 @@ const selectClick = new Select({
 // select interaction working on "pointermove"
 const selectPointerMove = new Select({
   condition: pointerMove,
+  toggleCondition: never, // otherwise the move events cause the features to flicker when holding shift
   style: selectStyle,
 });
 

--- a/examples/select-hover-features.html
+++ b/examples/select-hover-features.html
@@ -3,7 +3,7 @@ layout: example.html
 title: Select Features by Hover
 shortdesc: Example of selecting features by hovering.
 docs: >
-  In this example, a listener is registered on the map's <code>pointermove</code> to highlight the currently hovered feature.
+  In this example, the Select interaction reacts to the pointermove event for selection
 tags: "select, vector"
 ---
 <div id="map" class="map"></div>

--- a/examples/select-hover-features.js
+++ b/examples/select-hover-features.js
@@ -1,6 +1,8 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
+import {pointerMove} from '../src/ol/events/condition.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Select from '../src/ol/interaction/Select.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import VectorSource from '../src/ol/source/Vector.js';
 import Fill from '../src/ol/style/Fill.js';
@@ -13,17 +15,20 @@ const style = new Style({
   }),
 });
 
+function colorStyle(style) {
+  return function (f) {
+    style.getFill().setColor(f.get('COLOR') || '#eeeeee');
+    return style;
+  };
+}
+
 const vector = new VectorLayer({
   source: new VectorSource({
     url: 'https://openlayers.org/data/vector/ecoregions.json',
     format: new GeoJSON(),
   }),
   background: 'white',
-  style: function (feature) {
-    const color = feature.get('COLOR') || '#eeeeee';
-    style.getFill().setColor(color);
-    return style;
-  },
+  style: colorStyle(style),
 });
 
 const map = new Map({
@@ -46,23 +51,15 @@ const selectStyle = new Style({
 });
 
 const status = document.getElementById('status');
+const select = new Select({
+  condition: pointerMove,
+  style: colorStyle(selectStyle),
+});
+map.addInteraction(select);
 
-let selected = null;
-map.on('pointermove', function (e) {
-  if (selected !== null) {
-    selected.setStyle(undefined);
-    selected = null;
-  }
-
-  map.forEachFeatureAtPixel(e.pixel, function (f) {
-    selected = f;
-    selectStyle.getFill().setColor(f.get('COLOR') || '#eeeeee');
-    f.setStyle(selectStyle);
-    return true;
-  });
-
-  if (selected) {
-    status.innerHTML = selected.get('ECO_NAME');
+select.on('select', function (e) {
+  if (e.selected.length > 0) {
+    status.innerHTML = e.selected[0].get('ECO_NAME');
   } else {
     status.innerHTML = '&nbsp;';
   }

--- a/examples/select-multiple-features.js
+++ b/examples/select-multiple-features.js
@@ -1,21 +1,15 @@
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
+import {always} from '../src/ol/events/condition.js';
 import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Select from '../src/ol/interaction/Select.js';
 import VectorLayer from '../src/ol/layer/Vector.js';
 import {fromLonLat} from '../src/ol/proj.js';
 import VectorSource from '../src/ol/source/Vector.js';
-import Fill from '../src/ol/style/Fill.js';
-import Stroke from '../src/ol/style/Stroke.js';
-import Style from '../src/ol/style/Style.js';
 
-const highlightStyle = new Style({
-  fill: new Fill({
-    color: '#EEE',
-  }),
-  stroke: new Stroke({
-    color: '#3399CC',
-    width: 2,
-  }),
+const select = new Select({
+  toggleCondition: always,
+  multi: true,
 });
 
 const vector = new VectorLayer({
@@ -35,22 +29,11 @@ const map = new Map({
     multiWorld: true,
   }),
 });
-
-const selected = [];
+map.addInteraction(select);
 
 const status = document.getElementById('status');
 
-map.on('singleclick', function (e) {
-  map.forEachFeatureAtPixel(e.pixel, function (f) {
-    const selIndex = selected.indexOf(f);
-    if (selIndex < 0) {
-      selected.push(f);
-      f.setStyle(highlightStyle);
-    } else {
-      selected.splice(selIndex, 1);
-      f.setStyle(undefined);
-    }
-  });
-
-  status.innerHTML = '&nbsp;' + selected.length + ' selected features';
+select.on('select', function () {
+  status.innerHTML =
+    '&nbsp;' + select.getFeatures().getLength() + ' selected features';
 });

--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -377,19 +377,7 @@ class Select extends Interaction {
       this.applySelectedStyle_(feature);
     }
     if (!this.getLayer(feature)) {
-      const layer = /** @type {VectorLayer} */ (
-        this.getMap()
-          .getAllLayers()
-          .find(function (layer) {
-            if (
-              layer instanceof VectorLayer &&
-              layer.getSource() &&
-              layer.getSource().hasFeature(feature)
-            ) {
-              return layer;
-            }
-          })
-      );
+      const layer = this.findLayerOfFeature_(feature);
       if (layer) {
         this.addFeatureLayerAssociation_(feature, layer);
       }
@@ -404,6 +392,28 @@ class Select extends Interaction {
     if (this.style_) {
       this.restorePreviousStyle_(evt.element);
     }
+  }
+
+  /**
+   * @param {Feature} feature Feature of which to get the layer
+   * @return {VectorLayer} layer, if one was found.
+   * @private
+   */
+  findLayerOfFeature_(feature) {
+    const layer = /** @type {VectorLayer} */ (
+      this.getMap()
+        .getAllLayers()
+        .find(function (layer) {
+          if (
+            layer instanceof VectorLayer &&
+            layer.getSource() &&
+            layer.getSource().hasFeature(feature)
+          ) {
+            return layer;
+          }
+        })
+    );
+    return layer;
   }
 
   /**
@@ -458,6 +468,112 @@ class Select extends Interaction {
   }
 
   /**
+   * @param {import("../Feature.js").FeatureLike} feature The feature to select
+   * @param {import("../layer/Layer.js").default} layer Optional layer containing this feature
+   * @return {Feature|undefined} The feature, if its (already) selected.
+   * @private
+   */
+  selectFeatureInternal_(feature, layer) {
+    if (!(feature instanceof Feature)) {
+      return;
+    }
+    if (!this.filter_(feature, layer)) {
+      return;
+    }
+    const features = this.getFeatures();
+    if (!features.getArray().includes(feature)) {
+      this.addFeatureLayerAssociation_(feature, layer);
+      features.push(feature);
+    }
+    return feature;
+  }
+
+  /**
+   * Try to select a feature as if it was clicked and `addCondition` evaluated to True.
+   * Unlike modifying `select.getFeatures()` directly, this respects the `filter` and `layers` options.
+   * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
+   * @param {Feature} feature The feature to select
+   * @return {boolean} True if the feature was selected
+   */
+  selectFeature(feature) {
+    const layer = this.findLayerOfFeature_(feature);
+    if (!this.layerFilter_(layer)) {
+      return false;
+    }
+    const selected = this.selectFeatureInternal_(feature, layer);
+    if (selected) {
+      this.dispatchEvent(
+        new SelectEvent(SelectEventType.SELECT, [selected], [], undefined),
+      );
+    }
+    return !!selected;
+  }
+
+  /**
+   * Deselects a feature if it was previously selected. Also removes layer association.
+   * @param {import("../Feature.js").FeatureLike} feature The feature to deselect
+   * @return {Feature|undefined} The feature, if it was previously selected.
+   * @private
+   */
+  removeFeatureInternal_(feature) {
+    const features = this.getFeatures();
+    if (
+      !(feature instanceof Feature) ||
+      !features.getArray().includes(feature)
+    ) {
+      return;
+    }
+    features.remove(feature);
+    this.removeFeatureLayerAssociation_(feature);
+    return feature;
+  }
+
+  /**
+   * Try to deselect a feature as if it was clicked.
+   * Compared to `select.getFeatures().remove(feature)` this causes a SelectEvent.
+   * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
+   * @param {Feature} feature The feature to deselect
+   * @return {boolean} True if the feature was deselected
+   */
+  deselectFeature(feature) {
+    const deselected = this.removeFeatureInternal_(feature);
+    if (deselected) {
+      this.dispatchEvent(
+        new SelectEvent(SelectEventType.SELECT, [], [deselected], undefined),
+      );
+    }
+    return !!deselected;
+  }
+
+  /**
+   * Try to toggle a feature as if it was clicked and `toggleCondition` was True.
+   * Unlike modifying `select.getFeatures()` directly, this respects the `filter` and `layers` options.
+   * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
+   * @param {Feature} feature The feature to deselect
+   */
+  toggleFeature(feature) {
+    if (!this.deselectFeature(feature)) {
+      this.selectFeature(feature);
+    }
+  }
+  /**
+   * Deselect all features as if a user deselected them.
+   * Compared to `select.getFeatures().clear()` this causes a SelectEvent.
+   * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
+   */
+  clearSelection() {
+    clear(this.featureLayerAssociation_);
+    const features = this.getFeatures();
+    const deselected = features.getArray().slice(); // shallow copy
+    features.clear();
+    if (deselected.length !== 0) {
+      this.dispatchEvent(
+        new SelectEvent(SelectEventType.SELECT, [], deselected, undefined),
+      );
+    }
+  }
+
+  /**
    * Handles the {@link module:ol/MapBrowserEvent~MapBrowserEvent map browser event} and may change the
    * selected state of features.
    * @param {import("../MapBrowserEvent.js").default} mapBrowserEvent Map browser event.
@@ -478,13 +594,17 @@ class Select extends Interaction {
     /**
      * @type {Array<Feature>}
      */
-    const deselected = [];
+    let deselected = [];
 
     /**
      * @type {Array<Feature>}
      */
-    const selected = [];
+    let selected = [];
 
+    // TODO: technically the way i've restructured this logic means that
+    //       instead of first emptying the features list of all extra features and then adding the selected ones back,
+    //       the selected features get added and then the old ones get removed.
+    //       a grow then shrink, instead of a shrink then grow. I can't imagine anyone relying on this, but alas, its worth a mention.
     if (set) {
       // Replace the currently selected feature(s) with the feature(s) at the
       // pixel, or clear the selected feature(s) if there is no feature at
@@ -492,17 +612,8 @@ class Select extends Interaction {
       clear(this.featureLayerAssociation_);
       map.forEachFeatureAtPixel(
         mapBrowserEvent.pixel,
-        /**
-         * @param {import("../Feature.js").FeatureLike} feature Feature.
-         * @param {import("../layer/Layer.js").default} layer Layer.
-         * @return {boolean|undefined} Continue to iterate over the features.
-         */
         (feature, layer) => {
-          if (!(feature instanceof Feature) || !this.filter_(feature, layer)) {
-            return;
-          }
-          this.addFeatureLayerAssociation_(feature, layer);
-          selected.push(feature);
+          selected.push(this.selectFeatureInternal_(feature, layer));
           return !this.multi_;
         },
         {
@@ -510,42 +621,31 @@ class Select extends Interaction {
           hitTolerance: this.hitTolerance_,
         },
       );
-      for (let i = features.getLength() - 1; i >= 0; --i) {
-        const feature = features.item(i);
-        const index = selected.indexOf(feature);
-        if (index > -1) {
-          // feature is already selected
-          selected.splice(index, 1);
-        } else {
-          features.remove(feature);
-          deselected.push(feature);
+      // clear if none were selected
+      if (selected.length === 0) {
+        deselected.push(...features.getArray());
+        features.clear();
+      } else {
+        // keep only newly selected features
+        for (let i = features.getLength() - 1; i >= 0; --i) {
+          const feature = features.item(i);
+          if (!selected.includes(feature)) {
+            deselected.push(this.removeFeatureInternal_(feature));
+          }
         }
-      }
-      if (selected.length !== 0) {
-        features.extend(selected);
       }
     } else {
       // Modify the currently selected feature(s).
       map.forEachFeatureAtPixel(
         mapBrowserEvent.pixel,
-        /**
-         * @param {import("../Feature.js").FeatureLike} feature Feature.
-         * @param {import("../layer/Layer.js").default} layer Layer.
-         * @return {boolean|undefined} Continue to iterate over the features.
-         */
         (feature, layer) => {
-          if (!(feature instanceof Feature) || !this.filter_(feature, layer)) {
-            return;
+          let removedFeature;
+          if (remove || toggle) {
+            removedFeature = this.removeFeatureInternal_(feature);
+            deselected.push(removedFeature);
           }
-          if ((add || toggle) && !features.getArray().includes(feature)) {
-            this.addFeatureLayerAssociation_(feature, layer);
-            selected.push(feature);
-          } else if (
-            (remove || toggle) &&
-            features.getArray().includes(feature)
-          ) {
-            deselected.push(feature);
-            this.removeFeatureLayerAssociation_(feature);
+          if ((add || toggle) && !removedFeature) {
+            selected.push(this.selectFeatureInternal_(feature, layer));
           }
           return !this.multi_;
         },
@@ -554,11 +654,9 @@ class Select extends Interaction {
           hitTolerance: this.hitTolerance_,
         },
       );
-      for (let j = deselected.length - 1; j >= 0; --j) {
-        features.remove(deselected[j]);
-      }
-      features.extend(selected);
     }
+    selected = selected.filter(Boolean);
+    deselected = deselected.filter(Boolean);
     if (selected.length > 0 || deselected.length > 0) {
       this.dispatchEvent(
         new SelectEvent(

--- a/test/browser/karma.config.cjs
+++ b/test/browser/karma.config.cjs
@@ -10,6 +10,7 @@ if (process.env.CI) {
 
 module.exports = function (karma) {
   karma.set({
+    hostname: '127.0.0.1',
     browsers: ['ChromeHeadless'],
     customLaunchers: {
       ChromeHeadless: {


### PR DESCRIPTION
This PR fixes #16918 and fixes #16597

by adding the following (public) methods to the Select interaction:
- `selectFeature(feature)` - selects a feature as if the user clicked it, only if it passes the filters (layer and filter function). sends a SelectEvent if its selected
- `deselectFeature(feature)` - deselects a feature if its currently selected, sending a SelectEvent if it got deselected
- `toggleFeature(feature)` - toggles a feature on and off, sends a SelectEvent depending on what happened
- `clearSelection()` - remove all features from selection, sends a SelectEvent with all of them in .deselected

To accomplish this, i've added some private methods and migrated the mapBrowserEvent handling code to using them.

Examples are updated, i've utilized more features of Select for some of them.

Tests aren't run yet, due to issues (see below)