### PR TITLE
Properly handle boolean attributes in WebGL expressions

### DIFF
--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -14,6 +14,7 @@ import {
   Ops,
   SizeType,
   StringType,
+  isType,
   parse,
   typeName,
 } from './expression.js';
@@ -226,7 +227,11 @@ const compilers = {
         type: expression.type,
       };
     }
-    return 'a_prop_' + propName;
+    let result = 'a_prop_' + propName;
+    if (isType(expression.type, BooleanType)) {
+      result = `(${result} > 0.0)`;
+    }
+    return result;
   },
   [Ops.Id]: (context) => {
     context.featureId = true;
@@ -247,7 +252,11 @@ const compilers = {
         type: expression.type,
       };
     }
-    return uniformNameForVariable(varName);
+    let result = uniformNameForVariable(varName);
+    if (isType(expression.type, BooleanType)) {
+      result = `(${result} > 0.0)`;
+    }
+    return result;
   },
   [Ops.Has]: (context, expression) => {
     const firstArg = /** @type {LiteralExpression} */ (expression.args[0]);

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -332,13 +332,14 @@ describe('ol/expr/gpu.js', () => {
         name: 'all',
         type: AnyType,
         expression: ['all', true, ['get', 'attr6']],
-        expected: '(true && a_prop_attr6)',
+        expected: '(true && (a_prop_attr6 > 0.0))',
       },
       {
         name: 'any',
         type: AnyType,
-        expression: ['any', true, ['get', 'attr6'], true],
-        expected: '(true || a_prop_attr6 || true)',
+        expression: ['any', true, ['get', 'attr6'], true, ['has', 'attr7']],
+        expected:
+          '(true || (a_prop_attr6 > 0.0) || true || (a_prop_attr7 != -9999999.0))',
       },
       {
         name: 'between',
@@ -350,7 +351,7 @@ describe('ol/expr/gpu.js', () => {
         name: 'not',
         type: AnyType,
         expression: ['!', ['get', 'attr6']],
-        expected: '(!a_prop_attr6)',
+        expected: '(!(a_prop_attr6 > 0.0))',
       },
       {
         name: 'array constructor',
@@ -464,6 +465,12 @@ describe('ol/expr/gpu.js', () => {
         ],
         expected:
           '(a_prop_attr2 == 0.0 ? vec4(0.0, 0.0, 1.0, 1.0) : (a_prop_attr2 == 1.0 ? vec4(1.0, 1.0, 2.0, 2.0) : (a_prop_attr2 == 2.0 ? vec4(2.0, 2.0, 3.0, 3.0) : vec4(3.0, 3.0, 4.0, 4.0))))',
+      },
+      {
+        name: 'case (boolean attribute)',
+        type: NumberType,
+        expression: ['case', ['get', 'attr'], 10, ['>', ['zoom'], 10], 5, 3],
+        expected: `((a_prop_attr > 0.0) ? 10.0 : ((u_zoom > 10.0) ? 5.0 : 3.0))`,
       },
       {
         name: 'interpolate (colors, linear)',


### PR DESCRIPTION
This PR makes sure that the generated GLSL for boolean attributes is valid.

For instance, for this expression: `['case', ['get', 'isWider'], 10, 5]`

* before this PR, the GLSL generated is:
  `(a_prop_isWider ? 10.0 : 5.0)` (which gives an error because attributes are always numerical in GLSL)
* after:
  `((a_prop_isWider > 0.0) ? 10.0 : 5.0)`

Note: when an attribute is given a boolean value, it converts `true` to `1.0` and `false` to `0.0` in GLSL.
