### PR TITLE
Expose anchorOrigin and anchor[XY]Units from ol/style/Icon

### DIFF
--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -398,6 +398,23 @@ class Icon extends ImageStyle {
   }
 
   /**
+   * Get the anchor origin
+   * @return {IconOrigin} Origin
+   * @api
+   */
+  getAnchorOrigin() {
+    return this.anchorOrigin_;
+  }
+
+  /**
+   * Get the units used to express the anchor
+   * @return {[IconAnchorUnits, IconAnchorUnits]} units as [x, y]
+   */
+  getAnchorUnits() {
+    return [this.anchorXUnits_, this.anchorYUnits_];
+  }
+
+  /**
    * Get the icon color.
    * @return {import("../color.js").Color} Color.
    * @api

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -192,6 +192,8 @@ describe('ol.style.Icon', function () {
         anchor: fractionAnchor,
       });
       expect(iconStyle.getAnchor()).to.eql([9, 12]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['fraction', 'fraction']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('top-left');
     });
 
     it('uses pixels units', function () {
@@ -203,6 +205,8 @@ describe('ol.style.Icon', function () {
         anchorYUnits: 'pixels',
       });
       expect(iconStyle.getAnchor()).to.eql([2, 18]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['pixels', 'pixels']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('top-left');
     });
 
     it('uses a bottom left anchor origin', function () {
@@ -213,6 +217,8 @@ describe('ol.style.Icon', function () {
         anchorOrigin: 'bottom-left',
       });
       expect(iconStyle.getAnchor()).to.eql([9, 36]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['fraction', 'fraction']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('bottom-left');
     });
 
     it('uses a bottom right anchor origin', function () {
@@ -223,6 +229,8 @@ describe('ol.style.Icon', function () {
         anchorOrigin: 'bottom-right',
       });
       expect(iconStyle.getAnchor()).to.eql([27, 36]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['fraction', 'fraction']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('bottom-right');
     });
 
     it('uses a top right anchor origin', function () {
@@ -233,6 +241,8 @@ describe('ol.style.Icon', function () {
         anchorOrigin: 'top-right',
       });
       expect(iconStyle.getAnchor()).to.eql([27, 12]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['fraction', 'fraction']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('top-right');
     });
 
     it('uses a top right anchor origin + displacement', function () {
@@ -247,6 +257,8 @@ describe('ol.style.Icon', function () {
         size[0] * (1 - fractionAnchor[0]) - 20,
         size[1] * fractionAnchor[1] + 10,
       ]);
+      expect(iconStyle.getAnchorUnits()).to.eql(['fraction', 'fraction']);
+      expect(iconStyle.getAnchorOrigin()).to.eql('top-right');
     });
 
     it('uses displacement', function () {


### PR DESCRIPTION
While migrating my code to TypeScript, I encountered a problem because I was using `anchorOrigin`, `anchorXUnits` and `anchorYUnits` to better decide what to do with my application icons.

As they are labeled as `@private` in the JSDoc, they are automatically made private members of the Icon type definition in TypeScript and can't be accessed.

So I propose we expose them, through a function, so that they may also be used/read in a TypeScript context.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
