### PR TITLE
Handle a KML icon scale of zero correctly

### DIFF
--- a/src/ol/style/Icon.js
+++ b/src/ol/style/Icon.js
@@ -378,10 +378,10 @@ class Icon extends ImageStyle {
     const displacement = this.getDisplacement();
     const scale = this.getScaleArray();
     // anchor is scaled by renderer but displacement should not be scaled
-    // so divide by scale here
+    // so divide by scale here (as long as the scale is not zero)
     return [
-      anchor[0] - displacement[0] / scale[0],
-      anchor[1] + displacement[1] / scale[1],
+      scale[0] == 0 ? 0 : anchor[0] - displacement[0] / scale[0],
+      scale[1] == 0 ? 0 : anchor[1] + displacement[1] / scale[1],
     ];
   }
 

--- a/test/browser/spec/ol/style/icon.test.js
+++ b/test/browser/spec/ol/style/icon.test.js
@@ -318,6 +318,18 @@ describe('ol.style.Icon', function () {
       anchorBig = iconStyleBig.getAnchor();
       expect(anchorScaled).to.eql([anchorBig[0] / scale, anchorBig[1] / scale]);
     });
+
+    it('handles a scale of zero correctly', function () {
+      const scale = 0;
+      const zeroScaleIcon = new Icon({
+        src: 'test.png',
+        size: size,
+        displacement: [20, 10],
+        scale: scale,
+      });
+      // making sure there's no divide by zero leading to [NaN, NaN] or [Infinity, Infinity] result
+      expect(zeroScaleIcon.getAnchor()).to.eql([0, 0]);
+    });
   });
 
   describe('#setAnchor', function () {


### PR DESCRIPTION
making sure there's no divide by zero leading to [NaN, NaN] or [Infinity, Infinity] result in the icon anchor calculation

subsequent work/replaces #15964 

I think I found what was causing the issue this time, the scale was used to calculate the anchor as divisor, without checking if it wasn't possibly zero.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
