### PR TITLE
Use WebGL instanced rendering to improve performance and memory usage

### DIFF
--- a/src/ol/render/webgl/ShaderBuilder.js
+++ b/src/ol/render/webgl/ShaderBuilder.js
@@ -475,7 +475,7 @@ export class ShaderBuilder {
     return `${COMMON_HEADER}
 ${this.uniforms_.map((uniform) => `uniform ${uniform.type} ${uniform.name};`).join('\n')}
 attribute vec2 a_position;
-attribute float a_index;
+attribute vec2 a_localPosition;
 attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
@@ -505,16 +505,7 @@ void main(void) {
   v_quadSizePx = ${this.symbolSizeExpression_};
   vec2 halfSizePx = v_quadSizePx * 0.5;
   vec2 centerOffsetPx = ${this.symbolOffsetExpression_};
-  vec2 offsetPx = centerOffsetPx;
-  if (a_index == 0.0) {
-    offsetPx -= halfSizePx;
-  } else if (a_index == 1.0) {
-    offsetPx += halfSizePx * vec2(1., -1.);
-  } else if (a_index == 2.0) {
-    offsetPx += halfSizePx;
-  } else {
-    offsetPx += halfSizePx * vec2(-1., 1.);
-  }
+  vec2 offsetPx = centerOffsetPx + a_localPosition * halfSizePx * vec2(1., -1.);
   float angle = ${this.symbolRotationExpression_}${this.symbolRotateWithView_ ? ' + u_rotation' : ''};
   float c = cos(-angle);
   float s = sin(-angle);
@@ -522,8 +513,8 @@ void main(void) {
   vec4 center = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
   gl_Position = center + vec4(pxToScreen(offsetPx), u_depth, 0.);
   vec4 texCoord = ${this.texCoordExpression_};
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  float u = mix(texCoord.s, texCoord.p, a_localPosition.x * 0.5 + 0.5);
+  float v = mix(texCoord.t, texCoord.q, a_localPosition.y * 0.5 + 0.5);
   v_texCoord = vec2(u, v);
   v_hitColor = a_hitColor;
   v_angle = angle;
@@ -597,9 +588,10 @@ ${this.attributes_
 ${this.uniforms_.map((uniform) => `uniform ${uniform.type} ${uniform.name};`).join('\n')}
 attribute vec2 a_segmentStart;
 attribute vec2 a_segmentEnd;
+attribute vec2 a_localPosition;
 attribute float a_measureStart;
 attribute float a_measureEnd;
-attribute float a_parameters;
+attribute float a_angleTangentSum;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
 attribute vec4 a_hitColor;
@@ -656,10 +648,9 @@ vec2 getOffsetPoint(vec2 point, vec2 normal, float joinAngle, float offsetPx) {
 void main(void) {
   v_angleStart = a_joinAngles.x;
   v_angleEnd = a_joinAngles.y;
-  float vertexNumber = floor(abs(a_parameters) / 10000. + 0.5);
-  currentLineMetric = vertexNumber < 1.5 ? a_measureStart : a_measureEnd;
+  float startEndRatio = a_localPosition.x * 0.5 + 0.5;
+  currentLineMetric = mix(a_measureStart, a_measureEnd, startEndRatio);
   // we're reading the fractional part while keeping the sign (so -4.12 gives -0.12, 3.45 gives 0.45)
-  float angleTangentSum = fract(abs(a_parameters) / 10000.) * 10000. * sign(a_parameters);
 
   float lineWidth = ${this.strokeWidthExpression_};
   float lineOffsetPx = ${this.strokeOffsetExpression_};
@@ -673,11 +664,11 @@ void main(void) {
   segmentEndPx = getOffsetPoint(segmentEndPx, normalPx, v_angleEnd, lineOffsetPx);
 
   // compute current vertex position
-  float normalDir = vertexNumber < 0.5 || (vertexNumber > 1.5 && vertexNumber < 2.5) ? 1.0 : -1.0;
-  float tangentDir = vertexNumber < 1.5 ? 1.0 : -1.0;
-  float angle = vertexNumber < 1.5 ? v_angleStart : v_angleEnd;
+  float normalDir = -1. * a_localPosition.y;
+  float tangentDir = -1. * a_localPosition.x;
+  float angle = mix(v_angleStart, v_angleEnd, startEndRatio);
   vec2 joinDirection;
-  vec2 positionPx = vertexNumber < 1.5 ? segmentStartPx : segmentEndPx;
+  vec2 positionPx = mix(segmentStartPx, segmentEndPx, startEndRatio);
   // if angle is too high, do not make a proper join
   if (cos(angle) > ${LINESTRING_ANGLE_COSINE_CUTOFF} || isCap(angle)) {
     joinDirection = normalPx * normalDir - tangentPx * tangentDir;
@@ -691,7 +682,7 @@ void main(void) {
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
   v_hitColor = a_hitColor;
-  v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
+  v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * a_angleTangentSum);
   v_measureStart = a_measureStart;
   v_measureEnd = a_measureEnd;
 ${this.attributes_

--- a/src/ol/render/webgl/constants.js
+++ b/src/ol/render/webgl/constants.js
@@ -21,7 +21,8 @@ export const WebGLWorkerMessageType = {
  * @property {WebGLWorkerMessageType} type Message type
  * @property {ArrayBuffer} renderInstructions render instructions raw binary buffer.
  * @property {number} [customAttributesSize] Amount of hit detection + custom attributes count in the render instructions.
- * @property {ArrayBuffer} [vertexBuffer] Vertices array raw binary buffer (sent by the worker).
- * @property {ArrayBuffer} [indexBuffer] Indices array raw binary buffer (sent by the worker).
+ * @property {ArrayBuffer} [indicesBuffer] Indices array raw binary buffer (sent by the worker).
+ * @property {ArrayBuffer} [vertexAttributesBuffer] Vertex attributes array raw binary buffer (sent by the worker).
+ * @property {ArrayBuffer} [instanceAttributesBuffer] Instance attributes array raw binary buffer (sent by the worker).
  * @property {import("../../transform").Transform} [renderInstructionsTransform] Transformation matrix used to project the instructions coordinates
  */

--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -151,6 +151,13 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     /**
      * @private
      */
+    this.instanceAttributesBuffer_ = new WebGLArrayBuffer(
+      ARRAY_BUFFER,
+      DYNAMIC_DRAW,
+    );
+    /**
+     * @private
+     */
     this.indicesBuffer_ = new WebGLArrayBuffer(
       ELEMENT_ARRAY_BUFFER,
       DYNAMIC_DRAW,
@@ -189,36 +196,41 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       : [];
 
     /**
-     * A list of attributes used by the renderer. By default only the position and
-     * index of the vertex (0 to 3) are required.
+     * A list of attributes used by the renderer.
      * @type {Array<import('../../webgl/Helper.js').AttributeDescription>}
      */
     this.attributes = [
+      {
+        name: 'a_localPosition',
+        size: 2,
+        type: AttributeType.FLOAT,
+      },
+    ];
+
+    /**
+     * @type {Array<import('../../webgl/Helper.js').AttributeDescription>}
+     */
+    this.instanceAttributes = [
       {
         name: 'a_position',
         size: 2,
         type: AttributeType.FLOAT,
       },
-      {
-        name: 'a_index',
-        size: 1,
-        type: AttributeType.FLOAT,
-      },
     ];
 
     if (this.hitDetectionEnabled_) {
-      this.attributes.push({
+      this.instanceAttributes.push({
         name: 'a_hitColor',
         size: 4,
         type: AttributeType.FLOAT,
       });
-      this.attributes.push({
+      this.instanceAttributes.push({
         name: 'a_featureUid',
         size: 1,
         type: AttributeType.FLOAT,
       });
     }
-    this.attributes.push(...customAttributes);
+    this.instanceAttributes.push(...customAttributes);
 
     this.customAttributes = options.attributes ? options.attributes : [];
 
@@ -282,9 +294,13 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
         const received = event.data;
         if (received.type === WebGLWorkerMessageType.GENERATE_POINT_BUFFERS) {
           const projectionTransform = received.projectionTransform;
-          this.verticesBuffer_.fromArrayBuffer(received.vertexBuffer);
+          this.verticesBuffer_.fromArrayBuffer(received.vertexAttributesBuffer);
+          this.instanceAttributesBuffer_.fromArrayBuffer(
+            received.instanceAttributesBuffer,
+          );
           this.helper.flushBufferData(this.verticesBuffer_);
-          this.indicesBuffer_.fromArrayBuffer(received.indexBuffer);
+          this.helper.flushBufferData(this.instanceAttributesBuffer_);
+          this.indicesBuffer_.fromArrayBuffer(received.indicesBuffer);
           this.helper.flushBufferData(this.indicesBuffer_);
 
           this.renderTransform_ = projectionTransform;
@@ -523,11 +539,6 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     this.helper.useProgram(this.program_, frameState);
     this.helper.prepareDraw(frameState);
 
-    // write new data
-    this.helper.bindBuffer(this.verticesBuffer_);
-    this.helper.bindBuffer(this.indicesBuffer_);
-    this.helper.enableAttributes(this.attributes);
-
     return true;
   }
 
@@ -679,18 +690,27 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       );
     }
 
-    this.helper.bindBuffer(this.verticesBuffer_);
-    this.helper.bindBuffer(this.indicesBuffer_);
-    this.helper.enableAttributes(this.attributes);
+    const instanceAttributesStride = this.instanceAttributes.reduce(
+      (prev, curr) => prev + (curr.size || 1),
+      0,
+    );
+    const instanceCount =
+      this.instanceAttributesBuffer_.getSize() / instanceAttributesStride;
 
     do {
+      this.helper.bindBuffer(this.indicesBuffer_);
+      this.helper.bindBuffer(this.verticesBuffer_);
+      this.helper.enableAttributes(this.attributes);
+      this.helper.bindBuffer(this.instanceAttributesBuffer_);
+      this.helper.enableAttributesInstanced(this.instanceAttributes);
+
       this.helper.makeProjectionTransform(frameState, this.currentTransform_);
       translateTransform(this.currentTransform_, world * worldWidth, 0);
       multiplyTransform(this.currentTransform_, this.invertRenderTransform_);
       this.helper.applyUniforms(frameState);
       this.helper.applyHitDetectionUniform(forHitDetection);
       const renderCount = this.indicesBuffer_.getSize();
-      this.helper.drawElements(0, renderCount);
+      this.helper.drawElementsInstanced(0, renderCount, instanceCount);
     } while (++world < endWorld);
   }
 

--- a/src/ol/worker/webgl.js
+++ b/src/ol/worker/webgl.js
@@ -20,8 +20,7 @@ worker.onmessage = (event) => {
   const received = event.data;
   switch (received.type) {
     case WebGLWorkerMessageType.GENERATE_POINT_BUFFERS: {
-      // This is specific to point features (x, y, index)
-      const baseVertexAttrsCount = 3;
+      const baseIndicesAttrsCount = 2; // x, y
       const baseInstructionsCount = 2;
 
       const customAttrsCount = received.customAttributesSize;
@@ -29,19 +28,22 @@ worker.onmessage = (event) => {
       const renderInstructions = new Float32Array(received.renderInstructions);
 
       const elementsCount = renderInstructions.length / instructionsCount;
-      const indicesCount = elementsCount * 6;
-      const verticesCount =
-        elementsCount * 4 * (customAttrsCount + baseVertexAttrsCount);
-      const indexBuffer = new Uint32Array(indicesCount);
-      const vertexBuffer = new Float32Array(verticesCount);
+      const instanceAttributesCount =
+        elementsCount * (baseIndicesAttrsCount + customAttrsCount);
+      const indicesBuffer = Uint32Array.from([0, 1, 3, 1, 2, 3]);
+      const vertexAttributesBuffer = Float32Array.from([
+        -1, -1, 1, -1, 1, 1, -1, 1,
+      ]); // local position
+      const instanceAttributesBuffer = new Float32Array(
+        instanceAttributesCount,
+      );
 
       let bufferPositions;
       for (let i = 0; i < renderInstructions.length; i += instructionsCount) {
         bufferPositions = writePointFeatureToBuffers(
           renderInstructions,
           i,
-          vertexBuffer,
-          indexBuffer,
+          instanceAttributesBuffer,
           customAttrsCount,
           bufferPositions,
         );
@@ -50,25 +52,25 @@ worker.onmessage = (event) => {
       /** @type {import('../render/webgl/constants.js').WebGLWorkerGenerateBuffersMessage} */
       const message = Object.assign(
         {
-          vertexBuffer: vertexBuffer.buffer,
-          indexBuffer: indexBuffer.buffer,
+          indicesBuffer: indicesBuffer.buffer,
+          vertexAttributesBuffer: vertexAttributesBuffer.buffer,
+          instanceAttributesBuffer: instanceAttributesBuffer.buffer,
           renderInstructions: renderInstructions.buffer,
         },
         received,
       );
 
       worker.postMessage(message, [
-        vertexBuffer.buffer,
-        indexBuffer.buffer,
+        vertexAttributesBuffer.buffer,
+        instanceAttributesBuffer.buffer,
+        indicesBuffer.buffer,
         renderInstructions.buffer,
       ]);
       break;
     }
     case WebGLWorkerMessageType.GENERATE_LINE_STRING_BUFFERS: {
       /** @type {Array<number>} */
-      const vertices = [];
-      /** @type {Array<number>} */
-      const indices = [];
+      const instanceAttributes = [];
 
       const customAttrsCount = received.customAttributesSize;
       const instructionsPerVertex = 3;
@@ -126,8 +128,7 @@ worker.onmessage = (event) => {
             currentInstructionsIndex + (i + 1) * instructionsPerVertex,
             beforeIndex,
             afterIndex,
-            vertices,
-            indices,
+            instanceAttributes,
             customAttributes,
             invertTransform,
             currentLength,
@@ -139,22 +140,27 @@ worker.onmessage = (event) => {
         currentInstructionsIndex += verticesCount * instructionsPerVertex;
       }
 
-      const indexBuffer = Uint32Array.from(indices);
-      const vertexBuffer = Float32Array.from(vertices);
+      const indicesBuffer = Uint32Array.from([0, 1, 3, 1, 2, 3]);
+      const vertexAttributesBuffer = Float32Array.from([
+        -1, -1, 1, -1, 1, 1, -1, 1,
+      ]); // local position
+      const instanceAttributesBuffer = Float32Array.from(instanceAttributes);
 
       /** @type {import('../render/webgl/constants.js').WebGLWorkerGenerateBuffersMessage} */
       const message = Object.assign(
         {
-          vertexBuffer: vertexBuffer.buffer,
-          indexBuffer: indexBuffer.buffer,
+          indicesBuffer: indicesBuffer.buffer,
+          vertexAttributesBuffer: vertexAttributesBuffer.buffer,
+          instanceAttributesBuffer: instanceAttributesBuffer.buffer,
           renderInstructions: renderInstructions.buffer,
         },
         received,
       );
 
       worker.postMessage(message, [
-        vertexBuffer.buffer,
-        indexBuffer.buffer,
+        vertexAttributesBuffer.buffer,
+        instanceAttributesBuffer.buffer,
+        indicesBuffer.buffer,
         renderInstructions.buffer,
       ]);
       break;
@@ -179,22 +185,25 @@ worker.onmessage = (event) => {
         );
       }
 
-      const indexBuffer = Uint32Array.from(indices);
-      const vertexBuffer = Float32Array.from(vertices);
+      const indicesBuffer = Uint32Array.from(indices);
+      const vertexAttributesBuffer = Float32Array.from(vertices);
+      const instanceAttributesBuffer = Float32Array.from([]); // TODO
 
       /** @type {import('../render/webgl/constants.js').WebGLWorkerGenerateBuffersMessage} */
       const message = Object.assign(
         {
-          vertexBuffer: vertexBuffer.buffer,
-          indexBuffer: indexBuffer.buffer,
+          indicesBuffer: indicesBuffer.buffer,
+          vertexAttributesBuffer: vertexAttributesBuffer.buffer,
+          instanceAttributesBuffer: instanceAttributesBuffer.buffer,
           renderInstructions: renderInstructions.buffer,
         },
         received,
       );
 
       worker.postMessage(message, [
-        vertexBuffer.buffer,
-        indexBuffer.buffer,
+        vertexAttributesBuffer.buffer,
+        instanceAttributesBuffer.buffer,
+        indicesBuffer.buffer,
         renderInstructions.buffer,
       ]);
       break;

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -168,21 +168,26 @@ describe('VectorStyleRenderer', () => {
       ]);
       expect(firstPass.strokeRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.strokeRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: 5126},
+      ]);
+      expect(firstPass.strokeRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_segmentStart', size: 2, type: FLOAT},
         {name: 'a_measureStart', size: 1, type: FLOAT},
         {name: 'a_segmentEnd', size: 2, type: FLOAT},
         {name: 'a_measureEnd', size: 1, type: FLOAT},
         {name: 'a_joinAngles', size: 2, type: FLOAT},
         {name: 'a_distance', size: 1, type: FLOAT},
-        {name: 'a_parameters', size: 1, type: FLOAT},
+        {name: 'a_angleTangentSum', size: 1, type: FLOAT},
         {name: 'a_prop_size', size: 1, type: FLOAT},
         {name: 'a_prop_color', size: 2, type: FLOAT},
         {name: null, size: 1, type: FLOAT},
       ]);
       expect(firstPass.symbolRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.symbolRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: FLOAT},
+      ]);
+      expect(firstPass.symbolRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_position', size: 2, type: FLOAT},
-        {name: 'a_index', size: 1, type: FLOAT},
         {name: 'a_prop_size', size: 1, type: FLOAT},
         {name: 'a_prop_color', size: 2, type: FLOAT},
         {name: null, size: 1, type: FLOAT},
@@ -243,13 +248,16 @@ describe('VectorStyleRenderer', () => {
       ]);
       expect(firstPass.strokeRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.strokeRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: FLOAT},
+      ]);
+      expect(firstPass.strokeRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_segmentStart', size: 2, type: FLOAT},
         {name: 'a_measureStart', size: 1, type: FLOAT},
         {name: 'a_segmentEnd', size: 2, type: FLOAT},
         {name: 'a_measureEnd', size: 1, type: FLOAT},
         {name: 'a_joinAngles', size: 2, type: FLOAT},
         {name: 'a_distance', size: 1, type: FLOAT},
-        {name: 'a_parameters', size: 1, type: FLOAT},
+        {name: 'a_angleTangentSum', size: 1, type: FLOAT},
         {name: 'a_hitColor', size: 4, type: FLOAT},
         {name: 'a_prop_size', size: 1, type: FLOAT},
         {name: 'a_prop_color', size: 2, type: FLOAT},
@@ -257,8 +265,10 @@ describe('VectorStyleRenderer', () => {
       ]);
       expect(firstPass.symbolRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.symbolRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: FLOAT},
+      ]);
+      expect(firstPass.symbolRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_position', size: 2, type: FLOAT},
-        {name: 'a_index', size: 1, type: FLOAT},
         {name: 'a_hitColor', size: 4, type: FLOAT},
         {name: 'a_prop_size', size: 1, type: FLOAT},
         {name: 'a_prop_color', size: 2, type: FLOAT},
@@ -310,20 +320,25 @@ describe('VectorStyleRenderer', () => {
       ]);
       expect(firstPass.strokeRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.strokeRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: FLOAT},
+      ]);
+      expect(firstPass.strokeRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_segmentStart', size: 2, type: FLOAT},
         {name: 'a_measureStart', size: 1, type: FLOAT},
         {name: 'a_segmentEnd', size: 2, type: FLOAT},
         {name: 'a_measureEnd', size: 1, type: FLOAT},
         {name: 'a_joinAngles', size: 2, type: FLOAT},
         {name: 'a_distance', size: 1, type: FLOAT},
-        {name: 'a_parameters', size: 1, type: FLOAT},
+        {name: 'a_angleTangentSum', size: 1, type: FLOAT},
         {name: 'a_prop_attr1', size: 1, type: FLOAT},
         {name: 'a_prop_attr2', size: 3, type: FLOAT},
       ]);
       expect(firstPass.symbolRenderPass.program).to.be.an(WebGLProgram);
       expect(firstPass.symbolRenderPass.attributesDesc).to.eql([
+        {name: 'a_localPosition', size: 2, type: FLOAT},
+      ]);
+      expect(firstPass.symbolRenderPass.instancedAttributesDesc).to.eql([
         {name: 'a_position', size: 2, type: FLOAT},
-        {name: 'a_index', size: 1, type: FLOAT},
         {name: 'a_prop_attr1', size: 1, type: FLOAT},
         {name: 'a_prop_attr2', size: 3, type: FLOAT},
       ]);
@@ -367,7 +382,13 @@ describe('VectorStyleRenderer', () => {
         expect(buffers.lineStringBuffers[1]).to.be.an(WebGLArrayBuffer);
         expect(buffers.lineStringBuffers[1].getType()).to.be(ARRAY_BUFFER);
         expect(buffers.lineStringBuffers[1].getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.lineStringBuffers[1].getArray().slice(0, 14)).to.eql([
+        expect(buffers.lineStringBuffers[1].getArray().slice(0, 8)).to.eql([
+          -1, -1, 1, -1, 1, 1, -1, 1,
+        ]);
+        expect(buffers.lineStringBuffers[2]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.lineStringBuffers[2].getType()).to.be(ARRAY_BUFFER);
+        expect(buffers.lineStringBuffers[2].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.lineStringBuffers[2].getArray().slice(0, 14)).to.eql([
           -45, -47.5, 0, -40, -47.5, 0, 1.5707963705062866, 4.71238899230957, 0,
           0, 3000, 128, 255, 3,
         ]);
@@ -378,8 +399,14 @@ describe('VectorStyleRenderer', () => {
         expect(buffers.pointBuffers[1]).to.be.an(WebGLArrayBuffer);
         expect(buffers.pointBuffers[1].getType()).to.be(ARRAY_BUFFER);
         expect(buffers.pointBuffers[1].getUsage()).to.be(DYNAMIC_DRAW);
-        expect(buffers.pointBuffers[1].getArray().slice(0, 7)).to.eql([
-          -45, -45, 0, 1000, 65280, 255, 1,
+        expect(buffers.pointBuffers[1].getArray().slice(0, 8)).to.eql([
+          -1, -1, 1, -1, 1, 1, -1, 1,
+        ]);
+        expect(buffers.pointBuffers[2]).to.be.an(WebGLArrayBuffer);
+        expect(buffers.pointBuffers[2].getType()).to.be(ARRAY_BUFFER);
+        expect(buffers.pointBuffers[2].getUsage()).to.be(DYNAMIC_DRAW);
+        expect(buffers.pointBuffers[2].getArray().slice(0, 6)).to.eql([
+          -45, -45, 1000, 65280, 255, 1,
         ]);
       });
     });
@@ -392,8 +419,10 @@ describe('VectorStyleRenderer', () => {
         );
         sinonSpy(helper, 'bindBuffer');
         sinonSpy(helper, 'enableAttributes');
+        sinonSpy(helper, 'enableAttributesInstanced');
         sinonSpy(helper, 'useProgram');
         sinonSpy(helper, 'drawElements');
+        sinonSpy(helper, 'drawElementsInstanced');
         preRenderCb = sinonSpy();
         vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
       });
@@ -415,19 +444,23 @@ describe('VectorStyleRenderer', () => {
         );
       });
       it('binds buffers for all render passes & geometry types', function () {
-        expect(helper.bindBuffer.callCount).to.be(8);
+        expect(helper.bindBuffer.callCount).to.be(12);
         const args = helper.bindBuffer.getCalls().map((call) => call.firstArg);
 
         // first pass
         expect(args[0]).to.equal(buffers.polygonBuffers[1]);
         expect(args[1]).to.equal(buffers.polygonBuffers[0]);
-        expect(args[2]).to.equal(buffers.lineStringBuffers[1]);
-        expect(args[3]).to.equal(buffers.lineStringBuffers[0]);
+        expect(args[2]).to.equal(buffers.polygonBuffers[2]);
+        expect(args[3]).to.equal(buffers.lineStringBuffers[1]);
+        expect(args[4]).to.equal(buffers.lineStringBuffers[0]);
+        expect(args[5]).to.equal(buffers.lineStringBuffers[2]);
         // second pass
-        expect(args[4]).to.equal(buffers.pointBuffers[1]);
-        expect(args[5]).to.equal(buffers.pointBuffers[0]);
-        expect(args[6]).to.equal(buffers.polygonBuffers[1]);
-        expect(args[7]).to.equal(buffers.polygonBuffers[0]);
+        expect(args[6]).to.equal(buffers.pointBuffers[1]);
+        expect(args[7]).to.equal(buffers.pointBuffers[0]);
+        expect(args[8]).to.equal(buffers.pointBuffers[2]);
+        expect(args[9]).to.equal(buffers.polygonBuffers[1]);
+        expect(args[10]).to.equal(buffers.polygonBuffers[0]);
+        expect(args[11]).to.equal(buffers.polygonBuffers[2]);
       });
       it('enables attributes for all render passes & geometry types', function () {
         expect(helper.enableAttributes.callCount).to.be(4);
@@ -450,22 +483,26 @@ describe('VectorStyleRenderer', () => {
         expect(preRenderCb.callCount).to.be(4);
       });
       it('renders all render passes & geometry types', function () {
-        expect(helper.drawElements.callCount).to.be(4);
+        expect(helper.drawElements.callCount).to.be(2);
+        expect(helper.drawElementsInstanced.callCount).to.be(2);
+
         expect(helper.drawElements.getCall(0).args).to.eql([
           0,
           buffers.polygonBuffers[0].getSize(),
         ]);
         expect(helper.drawElements.getCall(1).args).to.eql([
           0,
-          buffers.lineStringBuffers[0].getSize(),
+          buffers.polygonBuffers[0].getSize(),
         ]);
-        expect(helper.drawElements.getCall(2).args).to.eql([
+        expect(helper.drawElementsInstanced.getCall(0).args).to.eql([
+          0,
+          buffers.lineStringBuffers[0].getSize(),
+          6, // segments count
+        ]);
+        expect(helper.drawElementsInstanced.getCall(1).args).to.eql([
           0,
           buffers.pointBuffers[0].getSize(),
-        ]);
-        expect(helper.drawElements.getCall(3).args).to.eql([
-          0,
-          buffers.polygonBuffers[0].getSize(),
+          2, // symbols count
         ]);
       });
     });
@@ -479,8 +516,10 @@ describe('VectorStyleRenderer', () => {
       );
       sinonSpy(helper, 'flushBufferData');
       sinonSpy(helper, 'enableAttributes');
+      sinonSpy(helper, 'enableAttributesInstanced');
       sinonSpy(helper, 'useProgram');
       sinonSpy(helper, 'drawElements');
+      sinonSpy(helper, 'drawElementsInstanced');
       vectorStyleRenderer = new VectorStyleRenderer(
         fillOnlyShaders,
         {},
@@ -494,7 +533,7 @@ describe('VectorStyleRenderer', () => {
       vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
     });
     it('only loads buffer data for one geometry type', function () {
-      expect(helper.flushBufferData.callCount).to.be(2);
+      expect(helper.flushBufferData.callCount).to.be(3);
     });
     it('only does one render', function () {
       expect(preRenderCb.callCount).to.be(1);
@@ -505,6 +544,10 @@ describe('VectorStyleRenderer', () => {
       expect(helper.enableAttributes.firstCall.firstArg).to.be(
         renderPass.fillRenderPass.attributesDesc,
       );
+      expect(helper.enableAttributesInstanced.callCount).to.be(1);
+      expect(helper.enableAttributesInstanced.firstCall.firstArg).to.be(
+        renderPass.fillRenderPass.instancedAttributesDesc,
+      );
       expect(helper.useProgram.callCount).to.be(1);
       expect(helper.useProgram.firstCall.firstArg).to.be(
         renderPass.fillRenderPass.program,
@@ -514,6 +557,8 @@ describe('VectorStyleRenderer', () => {
         0,
         buffers.polygonBuffers[0].getSize(),
       ]);
+
+      expect(helper.drawElementsInstanced.callCount).to.be(0);
     });
   });
   describe('rendering only stroke', () => {
@@ -525,8 +570,10 @@ describe('VectorStyleRenderer', () => {
       );
       sinonSpy(helper, 'flushBufferData');
       sinonSpy(helper, 'enableAttributes');
+      sinonSpy(helper, 'enableAttributesInstanced');
       sinonSpy(helper, 'useProgram');
       sinonSpy(helper, 'drawElements');
+      sinonSpy(helper, 'drawElementsInstanced');
       vectorStyleRenderer = new VectorStyleRenderer(
         strokeOnlyShaders,
         {},
@@ -540,7 +587,7 @@ describe('VectorStyleRenderer', () => {
       vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
     });
     it('only loads buffer data for one geometry type', function () {
-      expect(helper.flushBufferData.callCount).to.be(2);
+      expect(helper.flushBufferData.callCount).to.be(3);
     });
     it('only does one render', function () {
       expect(preRenderCb.callCount).to.be(1);
@@ -551,15 +598,22 @@ describe('VectorStyleRenderer', () => {
       expect(helper.enableAttributes.firstCall.firstArg).to.be(
         renderPass.strokeRenderPass.attributesDesc,
       );
+      expect(helper.enableAttributesInstanced.callCount).to.be(1);
+      expect(helper.enableAttributesInstanced.firstCall.firstArg).to.be(
+        renderPass.strokeRenderPass.instancedAttributesDesc,
+      );
       expect(helper.useProgram.callCount).to.be(1);
       expect(helper.useProgram.firstCall.firstArg).to.be(
         renderPass.strokeRenderPass.program,
       );
-      expect(helper.drawElements.callCount).to.be(1);
-      expect(helper.drawElements.firstCall.args).to.eql([
+      expect(helper.drawElementsInstanced.callCount).to.be(1);
+      expect(helper.drawElementsInstanced.firstCall.args).to.eql([
         0,
         buffers.lineStringBuffers[0].getSize(),
+        6, // segments count
       ]);
+
+      expect(helper.drawElements.callCount).to.be(0);
     });
   });
   describe('rendering only symbol', () => {
@@ -571,8 +625,10 @@ describe('VectorStyleRenderer', () => {
       );
       sinonSpy(helper, 'flushBufferData');
       sinonSpy(helper, 'enableAttributes');
+      sinonSpy(helper, 'enableAttributesInstanced');
       sinonSpy(helper, 'useProgram');
       sinonSpy(helper, 'drawElements');
+      sinonSpy(helper, 'drawElementsInstanced');
       vectorStyleRenderer = new VectorStyleRenderer(
         symbolOnlyShaders,
         {},
@@ -586,7 +642,7 @@ describe('VectorStyleRenderer', () => {
       vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
     });
     it('only loads buffer data for one geometry type', function () {
-      expect(helper.flushBufferData.callCount).to.be(2);
+      expect(helper.flushBufferData.callCount).to.be(3);
     });
     it('only does one render', function () {
       expect(preRenderCb.callCount).to.be(1);
@@ -597,15 +653,22 @@ describe('VectorStyleRenderer', () => {
       expect(helper.enableAttributes.firstCall.firstArg).to.be(
         renderPass.symbolRenderPass.attributesDesc,
       );
+      expect(helper.enableAttributesInstanced.callCount).to.be(1);
+      expect(helper.enableAttributesInstanced.firstCall.firstArg).to.be(
+        renderPass.symbolRenderPass.instancedAttributesDesc,
+      );
       expect(helper.useProgram.callCount).to.be(1);
       expect(helper.useProgram.firstCall.firstArg).to.be(
         renderPass.symbolRenderPass.program,
       );
-      expect(helper.drawElements.callCount).to.be(1);
-      expect(helper.drawElements.firstCall.args).to.eql([
+      expect(helper.drawElementsInstanced.callCount).to.be(1);
+      expect(helper.drawElementsInstanced.firstCall.args).to.eql([
         0,
         buffers.pointBuffers[0].getSize(),
+        buffers.pointBuffers[2].getSize() / 6,
       ]);
+
+      expect(helper.drawElements.callCount).to.be(0);
     });
   });
 

--- a/test/browser/spec/ol/render/webgl/bufferUtil.test.js
+++ b/test/browser/spec/ol/render/webgl/bufferUtil.test.js
@@ -9,168 +9,94 @@ import {
   makeInverse as makeInverseTransform,
 } from '../../../../../../src/ol/transform.js';
 
-describe('webgl render utils', function () {
+describe('webgl buffer generation utils', function () {
   describe('writePointFeatureToBuffers', function () {
-    let vertexBuffer, indexBuffer, instructions;
+    let instanceAttributesBuffer, instructions;
 
     beforeEach(function () {
-      vertexBuffer = new Float32Array(100);
-      indexBuffer = new Uint32Array(100);
+      instanceAttributesBuffer = new Float32Array(100);
       instructions = new Float32Array(100);
 
       instructions.set([0, 0, 0, 0, 10, 11]);
     });
 
     it('writes correctly to the buffers (without custom attributes)', function () {
-      const stride = 3;
+      const stride = 2;
       const positions = writePointFeatureToBuffers(
         instructions,
         4,
-        vertexBuffer,
-        indexBuffer,
+        instanceAttributesBuffer,
         0,
       );
 
-      expect(vertexBuffer[0]).to.eql(10);
-      expect(vertexBuffer[1]).to.eql(11);
-      expect(vertexBuffer[2]).to.eql(0);
+      expect(instanceAttributesBuffer[0]).to.eql(10);
+      expect(instanceAttributesBuffer[1]).to.eql(11);
 
-      expect(vertexBuffer[stride + 0]).to.eql(10);
-      expect(vertexBuffer[stride + 1]).to.eql(11);
-      expect(vertexBuffer[stride + 2]).to.eql(1);
-
-      expect(vertexBuffer[stride * 2 + 0]).to.eql(10);
-      expect(vertexBuffer[stride * 2 + 1]).to.eql(11);
-      expect(vertexBuffer[stride * 2 + 2]).to.eql(2);
-
-      expect(vertexBuffer[stride * 3 + 0]).to.eql(10);
-      expect(vertexBuffer[stride * 3 + 1]).to.eql(11);
-      expect(vertexBuffer[stride * 3 + 2]).to.eql(3);
-
-      expect(indexBuffer[0]).to.eql(0);
-      expect(indexBuffer[1]).to.eql(1);
-      expect(indexBuffer[2]).to.eql(3);
-      expect(indexBuffer[3]).to.eql(1);
-      expect(indexBuffer[4]).to.eql(2);
-      expect(indexBuffer[5]).to.eql(3);
-
-      expect(positions.indexPosition).to.eql(6);
-      expect(positions.vertexPosition).to.eql(stride * 4);
+      expect(positions.instanceAttributesPosition).to.eql(stride);
     });
 
     it('writes correctly to the buffers (with 2 custom attributes)', function () {
       instructions.set([0, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13]);
-      const stride = 5;
+      const stride = 4;
       const positions = writePointFeatureToBuffers(
         instructions,
         8,
-        vertexBuffer,
-        indexBuffer,
+        instanceAttributesBuffer,
         2,
       );
 
-      expect(vertexBuffer[0]).to.eql(10);
-      expect(vertexBuffer[1]).to.eql(11);
-      expect(vertexBuffer[2]).to.eql(0);
-      expect(vertexBuffer[3]).to.eql(12);
-      expect(vertexBuffer[4]).to.eql(13);
+      expect(instanceAttributesBuffer[0]).to.eql(10);
+      expect(instanceAttributesBuffer[1]).to.eql(11);
+      expect(instanceAttributesBuffer[2]).to.eql(12);
+      expect(instanceAttributesBuffer[3]).to.eql(13);
 
-      expect(vertexBuffer[stride + 0]).to.eql(10);
-      expect(vertexBuffer[stride + 1]).to.eql(11);
-      expect(vertexBuffer[stride + 2]).to.eql(1);
-      expect(vertexBuffer[stride + 3]).to.eql(12);
-      expect(vertexBuffer[stride + 4]).to.eql(13);
-
-      expect(vertexBuffer[stride * 2 + 0]).to.eql(10);
-      expect(vertexBuffer[stride * 2 + 1]).to.eql(11);
-      expect(vertexBuffer[stride * 2 + 2]).to.eql(2);
-      expect(vertexBuffer[stride * 2 + 3]).to.eql(12);
-      expect(vertexBuffer[stride * 2 + 4]).to.eql(13);
-
-      expect(vertexBuffer[stride * 3 + 0]).to.eql(10);
-      expect(vertexBuffer[stride * 3 + 1]).to.eql(11);
-      expect(vertexBuffer[stride * 3 + 2]).to.eql(3);
-      expect(vertexBuffer[stride * 3 + 3]).to.eql(12);
-      expect(vertexBuffer[stride * 3 + 4]).to.eql(13);
-
-      expect(indexBuffer[0]).to.eql(0);
-      expect(indexBuffer[1]).to.eql(1);
-      expect(indexBuffer[2]).to.eql(3);
-      expect(indexBuffer[3]).to.eql(1);
-      expect(indexBuffer[4]).to.eql(2);
-      expect(indexBuffer[5]).to.eql(3);
-
-      expect(positions.indexPosition).to.eql(6);
-      expect(positions.vertexPosition).to.eql(stride * 4);
+      expect(positions.instanceAttributesPosition).to.eql(stride);
     });
 
     it('correctly chains buffer writes', function () {
       instructions.set([10, 11, 20, 21, 30, 31]);
-      const stride = 3;
+      const stride = 2;
       let positions = writePointFeatureToBuffers(
         instructions,
         0,
-        vertexBuffer,
-        indexBuffer,
+        instanceAttributesBuffer,
         0,
       );
       positions = writePointFeatureToBuffers(
         instructions,
         2,
-        vertexBuffer,
-        indexBuffer,
+        instanceAttributesBuffer,
         0,
         positions,
       );
       positions = writePointFeatureToBuffers(
         instructions,
         4,
-        vertexBuffer,
-        indexBuffer,
+        instanceAttributesBuffer,
         0,
         positions,
       );
 
-      expect(vertexBuffer[0]).to.eql(10);
-      expect(vertexBuffer[1]).to.eql(11);
-      expect(vertexBuffer[2]).to.eql(0);
+      expect(instanceAttributesBuffer[0]).to.eql(10);
+      expect(instanceAttributesBuffer[1]).to.eql(11);
 
-      expect(vertexBuffer[stride * 4 + 0]).to.eql(20);
-      expect(vertexBuffer[stride * 4 + 1]).to.eql(21);
-      expect(vertexBuffer[stride * 4 + 2]).to.eql(0);
+      expect(instanceAttributesBuffer[stride + 0]).to.eql(20);
+      expect(instanceAttributesBuffer[stride + 1]).to.eql(21);
 
-      expect(vertexBuffer[stride * 8 + 0]).to.eql(30);
-      expect(vertexBuffer[stride * 8 + 1]).to.eql(31);
-      expect(vertexBuffer[stride * 8 + 2]).to.eql(0);
+      expect(instanceAttributesBuffer[stride * 2 + 0]).to.eql(30);
+      expect(instanceAttributesBuffer[stride * 2 + 1]).to.eql(31);
 
-      expect(indexBuffer[6 + 0]).to.eql(4);
-      expect(indexBuffer[6 + 1]).to.eql(5);
-      expect(indexBuffer[6 + 2]).to.eql(7);
-      expect(indexBuffer[6 + 3]).to.eql(5);
-      expect(indexBuffer[6 + 4]).to.eql(6);
-      expect(indexBuffer[6 + 5]).to.eql(7);
-
-      expect(indexBuffer[6 * 2 + 0]).to.eql(8);
-      expect(indexBuffer[6 * 2 + 1]).to.eql(9);
-      expect(indexBuffer[6 * 2 + 2]).to.eql(11);
-      expect(indexBuffer[6 * 2 + 3]).to.eql(9);
-      expect(indexBuffer[6 * 2 + 4]).to.eql(10);
-      expect(indexBuffer[6 * 2 + 5]).to.eql(11);
-
-      expect(positions.indexPosition).to.eql(6 * 3);
-      expect(positions.vertexPosition).to.eql(stride * 4 * 3);
+      expect(positions.instanceAttributesPosition).to.eql(stride * 3);
     });
   });
 
   describe('writeLineSegmentToBuffers', function () {
-    let vertexArray, indexArray, instructions;
+    let instanceAttributesArray, instructions;
     let instructionsTransform, invertInstructionsTransform;
     let currentLength, currentAngleTangentSum;
 
     beforeEach(function () {
-      vertexArray = [];
-      indexArray = [];
-
+      instanceAttributesArray = [];
       instructions = new Float32Array(100);
 
       instructionsTransform = createTransform();
@@ -188,8 +114,7 @@ describe('webgl render utils', function () {
           9,
           null,
           null,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [],
           invertInstructionsTransform,
           100,
@@ -198,24 +123,12 @@ describe('webgl render utils', function () {
         currentLength = result.length;
         currentAngleTangentSum = result.angle;
       });
-      // we expect 4 vertices (one quad) with 10 attributes each:
-      // Xstart, Ystart, Mstart, Xend, Yend, Mend, joinAngleStart, joinAngleEnd, base distance, vertex number (0..3)
+      // we expect one quad with 10 attributes each:
+      // Xstart, Ystart, Mstart, Xend, Yend, Mend, joinAngleStart, joinAngleEnd, base distance, angle tangent sum
       it('generates a quad for the segment', function () {
-        expect(vertexArray).to.have.length(40);
-        expect(vertexArray.slice(0, 10)).to.eql([
+        expect(instanceAttributesArray).to.eql([
           5, 5, 30, 25, 5, 40, -1, -1, 100, 100,
         ]);
-        expect(vertexArray.slice(10, 20)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 10100,
-        ]);
-        expect(vertexArray.slice(20, 30)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 20100,
-        ]);
-        expect(vertexArray.slice(30, 40)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 30100,
-        ]);
-        expect(indexArray).to.have.length(6);
-        expect(indexArray).to.eql([0, 1, 2, 1, 3, 2]);
       });
       it('computes the new current length', () => {
         expect(currentLength).to.eql(102);
@@ -234,8 +147,7 @@ describe('webgl render utils', function () {
           6,
           null,
           null,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [888, 999],
           invertInstructionsTransform,
           100,
@@ -247,22 +159,9 @@ describe('webgl render utils', function () {
       // we expect 4 vertices (one quad) with 10 attributes each:
       // Xstart, Ystart, Xend, Yend, joinAngleStart, joinAngleEnd, base distance, vertex number (0..3), + 2 custom attributes
       it('adds custom attributes in the vertices buffer', function () {
-        expect(vertexArray).to.have.length(48);
-        expect(vertexArray.slice(0, 12)).to.eql([
+        expect(instanceAttributesArray).to.eql([
           5, 5, 30, 25, 5, 40, -1, -1, 100, 100, 888, 999,
         ]);
-        expect(vertexArray.slice(12, 24)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 10100, 888, 999,
-        ]);
-        expect(vertexArray.slice(24, 36)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 20100, 888, 999,
-        ]);
-        expect(vertexArray.slice(36, 48)).to.eql([
-          5, 5, 30, 25, 5, 40, -1, -1, 100, 30100, 888, 999,
-        ]);
-      });
-      it('does not impact indices array', function () {
-        expect(indexArray).to.have.length(6);
       });
       it('computes the new current length', () => {
         expect(currentLength).to.eql(102);
@@ -281,8 +180,7 @@ describe('webgl render utils', function () {
           4,
           7,
           null,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [],
           invertInstructionsTransform,
           0,
@@ -291,16 +189,10 @@ describe('webgl render utils', function () {
         currentAngleTangentSum = result.angle;
       });
       it('generate the correct amount of vertices', () => {
-        expect(vertexArray).to.have.length(40);
+        expect(instanceAttributesArray).to.have.length(10);
       });
       it('correctly encodes the join angles', () => {
-        expect(vertexArray.slice(6, 8)).to.eql([Math.PI / 2, -1]);
-        expect(vertexArray.slice(16, 18)).to.eql([Math.PI / 2, -1]);
-        expect(vertexArray.slice(26, 28)).to.eql([Math.PI / 2, -1]);
-        expect(vertexArray.slice(36, 38)).to.eql([Math.PI / 2, -1]);
-      });
-      it('does not impact indices array', function () {
-        expect(indexArray).to.have.length(6);
+        expect(instanceAttributesArray.slice(6, 8)).to.eql([Math.PI / 2, -1]);
       });
       it('angle tangent sum decreases by one', () => {
         expect(currentAngleTangentSum).roughlyEqual(9, 1e-9);
@@ -316,8 +208,7 @@ describe('webgl render utils', function () {
           3,
           5,
           null,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [],
           invertInstructionsTransform,
           0,
@@ -326,16 +217,13 @@ describe('webgl render utils', function () {
         currentAngleTangentSum = result.angle;
       });
       it('generate the correct amount of vertices', () => {
-        expect(vertexArray).to.have.length(40);
+        expect(instanceAttributesArray).to.have.length(10);
       });
       it('correctly encodes the join angle', () => {
-        expect(vertexArray.slice(6, 8)).to.eql([(Math.PI * 3) / 2, -1]);
-        expect(vertexArray.slice(16, 18)).to.eql([(Math.PI * 3) / 2, -1]);
-        expect(vertexArray.slice(26, 28)).to.eql([(Math.PI * 3) / 2, -1]);
-        expect(vertexArray.slice(36, 38)).to.eql([(Math.PI * 3) / 2, -1]);
-      });
-      it('does not impact indices array', function () {
-        expect(indexArray).to.have.length(6);
+        expect(instanceAttributesArray.slice(6, 8)).to.eql([
+          (Math.PI * 3) / 2,
+          -1,
+        ]);
       });
       it('angle tangent sum increases by one', () => {
         expect(currentAngleTangentSum).roughlyEqual(11, 1e-9);
@@ -351,8 +239,7 @@ describe('webgl render utils', function () {
           3,
           null,
           5,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [],
           invertInstructionsTransform,
           0,
@@ -361,16 +248,13 @@ describe('webgl render utils', function () {
         currentAngleTangentSum = result.angle;
       });
       it('generate the correct amount of vertices', () => {
-        expect(vertexArray).to.have.length(40);
+        expect(instanceAttributesArray).to.have.length(10);
       });
       it('correctly encodes the join angle', () => {
-        expect(vertexArray.slice(6, 8)).to.eql([-1, (Math.PI * 7) / 4]);
-        expect(vertexArray.slice(16, 18)).to.eql([-1, (Math.PI * 7) / 4]);
-        expect(vertexArray.slice(26, 28)).to.eql([-1, (Math.PI * 7) / 4]);
-        expect(vertexArray.slice(36, 38)).to.eql([-1, (Math.PI * 7) / 4]);
-      });
-      it('does not impact indices array', function () {
-        expect(indexArray).to.have.length(6);
+        expect(instanceAttributesArray.slice(6, 8)).to.eql([
+          -1,
+          (Math.PI * 7) / 4,
+        ]);
       });
       it('angle tangent sum decreases', () => {
         expect(currentAngleTangentSum).roughlyEqual(
@@ -389,8 +273,7 @@ describe('webgl render utils', function () {
           3,
           null,
           5,
-          vertexArray,
-          indexArray,
+          instanceAttributesArray,
           [],
           invertInstructionsTransform,
           0,
@@ -399,16 +282,10 @@ describe('webgl render utils', function () {
         currentAngleTangentSum = result.angle;
       });
       it('generate the correct amount of vertices', () => {
-        expect(vertexArray).to.have.length(40);
+        expect(instanceAttributesArray).to.have.length(10);
       });
       it('correctly encodes join angles', () => {
-        expect(vertexArray.slice(6, 8)).to.eql([-1, Math.PI / 2]);
-        expect(vertexArray.slice(16, 18)).to.eql([-1, Math.PI / 2]);
-        expect(vertexArray.slice(26, 28)).to.eql([-1, Math.PI / 2]);
-        expect(vertexArray.slice(36, 38)).to.eql([-1, Math.PI / 2]);
-      });
-      it('does not impact indices array', function () {
-        expect(indexArray).to.have.length(6);
+        expect(instanceAttributesArray.slice(6, 8)).to.eql([-1, Math.PI / 2]);
       });
       it('angle tangent sum increases', () => {
         expect(currentAngleTangentSum).roughlyEqual(11, 1e-9);

--- a/test/browser/spec/ol/render/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/render/webgl/shaderbuilder.test.js
@@ -23,7 +23,7 @@ describe('ol.webgl.ShaderBuilder', () => {
       expect(builder.getSymbolVertexShader()).to.eql(`${COMMON_HEADER}
 
 attribute vec2 a_position;
-attribute float a_index;
+attribute vec2 a_localPosition;
 attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
@@ -51,16 +51,7 @@ void main(void) {
   v_quadSizePx = vec2(6.0);
   vec2 halfSizePx = v_quadSizePx * 0.5;
   vec2 centerOffsetPx = vec2(5.0, -7.0);
-  vec2 offsetPx = centerOffsetPx;
-  if (a_index == 0.0) {
-    offsetPx -= halfSizePx;
-  } else if (a_index == 1.0) {
-    offsetPx += halfSizePx * vec2(1., -1.);
-  } else if (a_index == 2.0) {
-    offsetPx += halfSizePx;
-  } else {
-    offsetPx += halfSizePx * vec2(-1., 1.);
-  }
+  vec2 offsetPx = centerOffsetPx + a_localPosition * halfSizePx * vec2(1., -1.);
   float angle = 0.0;
   float c = cos(-angle);
   float s = sin(-angle);
@@ -68,8 +59,8 @@ void main(void) {
   vec4 center = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
   gl_Position = center + vec4(pxToScreen(offsetPx), u_depth, 0.);
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  float u = mix(texCoord.s, texCoord.p, a_localPosition.x * 0.5 + 0.5);
+  float v = mix(texCoord.t, texCoord.q, a_localPosition.y * 0.5 + 0.5);
   v_texCoord = vec2(u, v);
   v_hitColor = a_hitColor;
   v_angle = angle;
@@ -93,7 +84,7 @@ void main(void) {
       expect(builder.getSymbolVertexShader()).to.eql(`${COMMON_HEADER}
 uniform float u_myUniform;
 attribute vec2 a_position;
-attribute float a_index;
+attribute vec2 a_localPosition;
 attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
@@ -119,16 +110,7 @@ void main(void) {
   v_quadSizePx = vec2(6.0);
   vec2 halfSizePx = v_quadSizePx * 0.5;
   vec2 centerOffsetPx = vec2(5.0, -7.0);
-  vec2 offsetPx = centerOffsetPx;
-  if (a_index == 0.0) {
-    offsetPx -= halfSizePx;
-  } else if (a_index == 1.0) {
-    offsetPx += halfSizePx * vec2(1., -1.);
-  } else if (a_index == 2.0) {
-    offsetPx += halfSizePx;
-  } else {
-    offsetPx += halfSizePx * vec2(-1., 1.);
-  }
+  vec2 offsetPx = centerOffsetPx + a_localPosition * halfSizePx * vec2(1., -1.);
   float angle = 0.0;
   float c = cos(-angle);
   float s = sin(-angle);
@@ -136,8 +118,8 @@ void main(void) {
   vec4 center = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
   gl_Position = center + vec4(pxToScreen(offsetPx), u_depth, 0.);
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  float u = mix(texCoord.s, texCoord.p, a_localPosition.x * 0.5 + 0.5);
+  float v = mix(texCoord.t, texCoord.q, a_localPosition.y * 0.5 + 0.5);
   v_texCoord = vec2(u, v);
   v_hitColor = a_hitColor;
   v_angle = angle;
@@ -159,7 +141,7 @@ void main(void) {
       expect(builder.getSymbolVertexShader()).to.eql(`${COMMON_HEADER}
 
 attribute vec2 a_position;
-attribute float a_index;
+attribute vec2 a_localPosition;
 attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
@@ -184,16 +166,7 @@ void main(void) {
   v_quadSizePx = vec2(6.0);
   vec2 halfSizePx = v_quadSizePx * 0.5;
   vec2 centerOffsetPx = vec2(5.0, -7.0);
-  vec2 offsetPx = centerOffsetPx;
-  if (a_index == 0.0) {
-    offsetPx -= halfSizePx;
-  } else if (a_index == 1.0) {
-    offsetPx += halfSizePx * vec2(1., -1.);
-  } else if (a_index == 2.0) {
-    offsetPx += halfSizePx;
-  } else {
-    offsetPx += halfSizePx * vec2(-1., 1.);
-  }
+  vec2 offsetPx = centerOffsetPx + a_localPosition * halfSizePx * vec2(1., -1.);
   float angle = 0.0 + u_rotation;
   float c = cos(-angle);
   float s = sin(-angle);
@@ -201,8 +174,8 @@ void main(void) {
   vec4 center = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
   gl_Position = center + vec4(pxToScreen(offsetPx), u_depth, 0.);
   vec4 texCoord = vec4(0.0, 0.5, 0.5, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  float u = mix(texCoord.s, texCoord.p, a_localPosition.x * 0.5 + 0.5);
+  float v = mix(texCoord.t, texCoord.q, a_localPosition.y * 0.5 + 0.5);
   v_texCoord = vec2(u, v);
   v_hitColor = a_hitColor;
   v_angle = angle;
@@ -223,7 +196,7 @@ void main(void) {
       expect(builder.getSymbolVertexShader()).to.eql(`${COMMON_HEADER}
 
 attribute vec2 a_position;
-attribute float a_index;
+attribute vec2 a_localPosition;
 attribute vec4 a_hitColor;
 
 varying vec2 v_texCoord;
@@ -248,16 +221,7 @@ void main(void) {
   v_quadSizePx = vec2(6.0);
   vec2 halfSizePx = v_quadSizePx * 0.5;
   vec2 centerOffsetPx = vec2(5.0, -7.0);
-  vec2 offsetPx = centerOffsetPx;
-  if (a_index == 0.0) {
-    offsetPx -= halfSizePx;
-  } else if (a_index == 1.0) {
-    offsetPx += halfSizePx * vec2(1., -1.);
-  } else if (a_index == 2.0) {
-    offsetPx += halfSizePx;
-  } else {
-    offsetPx += halfSizePx * vec2(-1., 1.);
-  }
+  vec2 offsetPx = centerOffsetPx + a_localPosition * halfSizePx * vec2(1., -1.);
   float angle = u_time * 0.2;
   float c = cos(-angle);
   float s = sin(-angle);
@@ -265,8 +229,8 @@ void main(void) {
   vec4 center = u_projectionMatrix * vec4(a_position, 0.0, 1.0);
   gl_Position = center + vec4(pxToScreen(offsetPx), u_depth, 0.);
   vec4 texCoord = vec4(0.0, 0.0, 1.0, 1.0);
-  float u = a_index == 0.0 || a_index == 3.0 ? texCoord.s : texCoord.p;
-  float v = a_index == 2.0 || a_index == 3.0 ? texCoord.t : texCoord.q;
+  float u = mix(texCoord.s, texCoord.p, a_localPosition.x * 0.5 + 0.5);
+  float v = mix(texCoord.t, texCoord.q, a_localPosition.y * 0.5 + 0.5);
   v_texCoord = vec2(u, v);
   v_hitColor = a_hitColor;
   v_angle = angle;
@@ -391,9 +355,10 @@ void main(void) {
 uniform float u_myUniform;
 attribute vec2 a_segmentStart;
 attribute vec2 a_segmentEnd;
+attribute vec2 a_localPosition;
 attribute float a_measureStart;
 attribute float a_measureEnd;
-attribute float a_parameters;
+attribute float a_angleTangentSum;
 attribute float a_distance;
 attribute vec2 a_joinAngles;
 attribute vec4 a_hitColor;
@@ -450,10 +415,9 @@ vec2 getOffsetPoint(vec2 point, vec2 normal, float joinAngle, float offsetPx) {
 void main(void) {
   v_angleStart = a_joinAngles.x;
   v_angleEnd = a_joinAngles.y;
-  float vertexNumber = floor(abs(a_parameters) / 10000. + 0.5);
-  currentLineMetric = vertexNumber < 1.5 ? a_measureStart : a_measureEnd;
+  float startEndRatio = a_localPosition.x * 0.5 + 0.5;
+  currentLineMetric = mix(a_measureStart, a_measureEnd, startEndRatio);
   // we're reading the fractional part while keeping the sign (so -4.12 gives -0.12, 3.45 gives 0.45)
-  float angleTangentSum = fract(abs(a_parameters) / 10000.) * 10000. * sign(a_parameters);
 
   float lineWidth = 4.0;
   float lineOffsetPx = 0.;
@@ -467,11 +431,11 @@ void main(void) {
   segmentEndPx = getOffsetPoint(segmentEndPx, normalPx, v_angleEnd, lineOffsetPx);
 
   // compute current vertex position
-  float normalDir = vertexNumber < 0.5 || (vertexNumber > 1.5 && vertexNumber < 2.5) ? 1.0 : -1.0;
-  float tangentDir = vertexNumber < 1.5 ? 1.0 : -1.0;
-  float angle = vertexNumber < 1.5 ? v_angleStart : v_angleEnd;
+  float normalDir = -1. * a_localPosition.y;
+  float tangentDir = -1. * a_localPosition.x;
+  float angle = mix(v_angleStart, v_angleEnd, startEndRatio);
   vec2 joinDirection;
-  vec2 positionPx = vertexNumber < 1.5 ? segmentStartPx : segmentEndPx;
+  vec2 positionPx = mix(segmentStartPx, segmentEndPx, startEndRatio);
   // if angle is too high, do not make a proper join
   if (cos(angle) > 0.985 || isCap(angle)) {
     joinDirection = normalPx * normalDir - tangentPx * tangentDir;
@@ -485,7 +449,7 @@ void main(void) {
   v_segmentEnd = segmentEndPx;
   v_width = lineWidth;
   v_hitColor = a_hitColor;
-  v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * angleTangentSum);
+  v_distanceOffsetPx = a_distance / u_resolution - (lineOffsetPx * a_angleTangentSum);
   v_measureStart = a_measureStart;
   v_measureEnd = a_measureEnd;
   v_opacity = 0.4;

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -113,25 +113,21 @@ describe('ol/renderer/webgl/PointsLayer', function () {
       );
       renderer.prepareFrame(frameState);
 
-      const attributePerVertex = 3;
+      const attributePerVertex = 2;
 
       renderer.worker_.addEventListener('message', function (event) {
         if (event.data.type !== WebGLWorkerMessageType.GENERATE_POINT_BUFFERS) {
           return;
         }
-        expect(renderer.verticesBuffer_.getArray().length).to.eql(
-          2 * 4 * attributePerVertex,
+        expect(renderer.verticesBuffer_.getArray().length).to.eql(8);
+        expect(renderer.instanceAttributesBuffer_.getArray().length).to.eql(
+          2 * attributePerVertex,
         );
-        expect(renderer.indicesBuffer_.getArray().length).to.eql(2 * 6);
+        expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
 
-        expect(renderer.verticesBuffer_.getArray()[0]).to.eql(10);
-        expect(renderer.verticesBuffer_.getArray()[1]).to.eql(20);
-        expect(
-          renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 0],
-        ).to.eql(30);
-        expect(
-          renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 1],
-        ).to.eql(40);
+        expect(renderer.instanceAttributesBuffer_.getArray()).to.eql([
+          10, 20, 30, 40,
+        ]);
         done();
       });
     });
@@ -155,7 +151,7 @@ describe('ol/renderer/webgl/PointsLayer', function () {
       );
       renderer.prepareFrame(frameState);
 
-      const attributePerVertex = 8;
+      const attributePerVertex = 7;
 
       renderer.worker_.addEventListener('message', function (event) {
         if (event.data.type !== WebGLWorkerMessageType.GENERATE_POINT_BUFFERS) {
@@ -164,19 +160,21 @@ describe('ol/renderer/webgl/PointsLayer', function () {
         if (!renderer.verticesBuffer_.getArray()) {
           return;
         }
-        expect(renderer.verticesBuffer_.getArray().length).to.eql(
-          2 * 4 * attributePerVertex,
+        expect(renderer.verticesBuffer_.getArray().length).to.eql(8);
+        expect(renderer.instanceAttributesBuffer_.getArray().length).to.eql(
+          2 * attributePerVertex,
         );
-        expect(renderer.indicesBuffer_.getArray().length).to.eql(2 * 6);
+        expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
 
-        expect(renderer.verticesBuffer_.getArray()[0]).to.eql(10);
-        expect(renderer.verticesBuffer_.getArray()[1]).to.eql(20);
+        expect(renderer.instanceAttributesBuffer_.getArray().length).to.eql(14);
         expect(
-          renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 0],
-        ).to.eql(30);
+          renderer.instanceAttributesBuffer_.getArray().slice(0, 2),
+        ).to.eql([10, 20]);
         expect(
-          renderer.verticesBuffer_.getArray()[4 * attributePerVertex + 1],
-        ).to.eql(40);
+          renderer.instanceAttributesBuffer_
+            .getArray()
+            .slice(attributePerVertex, 2 + attributePerVertex),
+        ).to.eql([30, 40]);
         done();
       });
     });
@@ -200,11 +198,13 @@ describe('ol/renderer/webgl/PointsLayer', function () {
         if (event.data.type !== WebGLWorkerMessageType.GENERATE_POINT_BUFFERS) {
           return;
         }
-        const attributePerVertex = 3;
-        expect(renderer.verticesBuffer_.getArray().length).to.eql(
-          4 * attributePerVertex,
+        const attributePerVertex = 1;
+        expect(renderer.verticesBuffer_.getArray().length).to.eql(8);
+        expect(renderer.instanceAttributesBuffer_.getArray().length).to.eql(
+          2 * attributePerVertex,
         );
         expect(renderer.indicesBuffer_.getArray().length).to.eql(6);
+
         done();
       });
     });

--- a/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorLayer.test.js
@@ -482,7 +482,7 @@ describe('ol/renderer/webgl/VectorLayer', () => {
         await new Promise((resolve) => setTimeout(resolve, 150));
       });
       it('deletes previous buffers', () => {
-        expect(renderer.helper.deleteBuffer.callCount).to.be(6); // 1 * buffer * 3 types of geometry * 2 different styles
+        expect(renderer.helper.deleteBuffer.callCount).to.be(9); // 3 buffers (index, vertex, instance) * 3 types of geometry
       });
     });
   });
@@ -643,7 +643,7 @@ describe('ol/renderer/webgl/VectorLayer', () => {
       ).to.be(true);
     });
     it('deletes webgl buffers', () => {
-      expect(deleteBufferSpy.callCount).to.be(6); // 1 buffer * 3 types of geometry * 2 different styles
+      expect(deleteBufferSpy.callCount).to.be(9); // 3 buffers (index, vertex, instance) * 3 types of geometry
     });
   });
 });

--- a/test/browser/spec/ol/worker/webgl.test.js
+++ b/test/browser/spec/ol/worker/webgl.test.js
@@ -51,15 +51,16 @@ describe('ol/worker/webgl', () => {
         expect(responseData.testString).to.be('abcd');
       });
       it('responds with buffer data', () => {
-        const indices = Array.from(new Uint32Array(responseData.indexBuffer));
+        const indices = Array.from(new Uint32Array(responseData.indicesBuffer));
         const vertices = Array.from(
-          new Float32Array(responseData.vertexBuffer),
+          new Float32Array(responseData.vertexAttributesBuffer),
         );
-        expect(indices).to.eql([0, 1, 3, 1, 2, 3, 4, 5, 7, 5, 6, 7]);
-        expect(vertices).to.eql([
-          0, 10, 0, 111, 0, 10, 1, 111, 0, 10, 2, 111, 0, 10, 3, 111, 20, 30, 0,
-          222, 20, 30, 1, 222, 20, 30, 2, 222, 20, 30, 3, 222,
-        ]);
+        const instanceAttrs = Array.from(
+          new Float32Array(responseData.instanceAttributesBuffer),
+        );
+        expect(indices).to.eql([0, 1, 3, 1, 2, 3]);
+        expect(vertices).to.eql([-1, -1, 1, -1, 1, 1, -1, 1]);
+        expect(instanceAttrs).to.eql([0, 10, 111, 20, 30, 222]);
       });
     });
 
@@ -67,6 +68,7 @@ describe('ol/worker/webgl', () => {
       let responseData;
       let indices;
       let vertices;
+      let instanceAttrs;
       beforeEach((done) => {
         const renderInstructions = Float32Array.from([
           111, 4, 20, 30, -1, 40, 50, -2, 6, 7, -3, 80, 90, -4,
@@ -88,8 +90,13 @@ describe('ol/worker/webgl', () => {
         worker.addEventListener('message', (event) => {
           if (event.data.id === id) {
             responseData = event.data;
-            indices = Array.from(new Uint32Array(responseData.indexBuffer));
-            vertices = Array.from(new Float32Array(responseData.vertexBuffer));
+            indices = Array.from(new Uint32Array(responseData.indicesBuffer));
+            vertices = Array.from(
+              new Float32Array(responseData.vertexAttributesBuffer),
+            );
+            instanceAttrs = Array.from(
+              new Float32Array(responseData.instanceAttributesBuffer),
+            );
             done();
           }
         });
@@ -103,22 +110,21 @@ describe('ol/worker/webgl', () => {
         expect(responseData.testString).to.be('abcd');
       });
       it('responds with buffer data', () => {
-        expect(indices).to.eql([
-          0, 1, 2, 1, 3, 2, 4, 5, 6, 5, 7, 6, 8, 9, 10, 9, 11, 10,
-        ]);
-        expect(vertices.length).to.eql(132); // 3 segments, 4 vertices each, 10 attributes each + 1 custom attr
+        expect(indices).to.eql([0, 1, 3, 1, 2, 3]);
+        expect(vertices).to.eql([-1, -1, 1, -1, 1, 1, -1, 1]);
+        expect(instanceAttrs.length).to.eql(33); // 3 segments, 10 attributes each + 1 custom attr
       });
       it('computes join angles for an open line', () => {
         // join angles for first and last segments; the line is not a loop so it starts and ends with -1 angles
-        expect(vertices.slice(6, 8)).to.eql([-1, 0.11635516583919525]);
-        expect(vertices.slice(6 + 88, 8 + 88)).to.eql([
+        expect(instanceAttrs.slice(6, 8)).to.eql([-1, 0.11635516583919525]);
+        expect(instanceAttrs.slice(6 + 22, 8 + 22)).to.eql([
           0.05909299477934837, -1,
         ]);
       });
       it('computes the base length for each segment', () => {
-        expect(vertices[8]).to.eql(0);
-        expect(vertices[8 + 44]).to.eql(28.284271240234375);
-        expect(vertices[8 + 88]).to.eql(83.1021499633789);
+        expect(instanceAttrs[8]).to.eql(0);
+        expect(instanceAttrs[8 + 11]).to.eql(28.284271240234375);
+        expect(instanceAttrs[8 + 22]).to.eql(83.1021499633789);
       });
 
       describe('closed line', () => {
@@ -144,7 +150,10 @@ describe('ol/worker/webgl', () => {
             if (event.data.id === id) {
               responseData = event.data;
               vertices = Array.from(
-                new Float32Array(responseData.vertexBuffer),
+                new Float32Array(responseData.vertexAttributesBuffer),
+              );
+              instanceAttrs = Array.from(
+                new Float32Array(responseData.instanceAttributesBuffer),
               );
               done();
             }
@@ -152,10 +161,10 @@ describe('ol/worker/webgl', () => {
         });
         it('computes join angles for a closed loop', () => {
           // the sum of the first and last join angle should be 2PI
-          expect(vertices.slice(6, 8)).to.eql([
+          expect(instanceAttrs.slice(6, 8)).to.eql([
             3.380202054977417, 0.11635516583919525,
           ]);
-          expect(vertices.slice(6 + 88, 8 + 88)).to.eql([
+          expect(instanceAttrs.slice(6 + 22, 8 + 22)).to.eql([
             6.16093111038208, 2.9029834270477295,
           ]);
         });
@@ -197,12 +206,16 @@ describe('ol/worker/webgl', () => {
         expect(responseData.testString).to.be('abcd');
       });
       it('responds with buffer data', () => {
-        const indices = Array.from(new Uint32Array(responseData.indexBuffer));
+        const indices = Array.from(new Uint32Array(responseData.indicesBuffer));
         const vertices = Array.from(
-          new Float32Array(responseData.vertexBuffer),
+          new Float32Array(responseData.vertexAttributesBuffer),
+        );
+        const instanceAttrs = Array.from(
+          new Float32Array(responseData.instanceAttributesBuffer),
         );
         expect(indices).to.have.length(27);
         expect(vertices).to.have.length(33);
+        expect(instanceAttrs).to.eql([]); // no instance attributes for polygons
       });
     });
   });


### PR DESCRIPTION
This PR reworks various part of the WebGL rendering pipeline to use the `ANGLE_instanced_arrays` extension. This extension brings many benefits, mainly a significant reduction of the WebGL buffers memory usage (up to 75% for lines and symbols), simplified shaders and potentially faster rendering.

The `ANGLE_instanced_arrays` extension is [widely available](https://developer.mozilla.org/en-US/docs/Web/API/ANGLE_instanced_arrays) on most devices and making it a hard requirement should not be a problem in my opinion. If the extension is not supported, WebGL vector layers will simply throw a failed assertion.


Benchmark with this change:
![image](https://github.com/user-attachments/assets/a7d5c8f2-82b8-46f5-981d-dcadef441241)
Memory usage on main thread: ~200MB

Benchmark without this change:
![image](https://github.com/user-attachments/assets/dc26a7e8-37ee-4879-8f52-dffdee5866ff)
Memory usage on main thread: ~250MB


