### PR TITLE
Fix `ol/style/Text` `clone()` to properly handle non-`Fill` instances…

### DIFF
--- a/src/ol/style/Text.js
+++ b/src/ol/style/Text.js
@@ -241,7 +241,10 @@ class Text {
       textAlign: this.getTextAlign(),
       justify: this.getJustify(),
       textBaseline: this.getTextBaseline(),
-      fill: this.getFill() ? this.getFill().clone() : undefined,
+      fill:
+        this.getFill() instanceof Fill
+          ? this.getFill().clone()
+          : this.getFill(),
       stroke: this.getStroke() ? this.getStroke().clone() : undefined,
       offsetX: this.getOffsetX(),
       offsetY: this.getOffsetY(),


### PR DESCRIPTION
Fix `ol/style/Text` `clone()` to properly handle non-`Fill` instances for `fill` property. Prevents unintended default color assignment.

Fixes #16935
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
