### PR TITLE
Do not toggle tracing on pointerup after dragging

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -703,6 +703,15 @@ class Draw extends PointerInteraction {
     this.stopClick_ = !!options.stopClick;
 
     /**
+     * Ignore the next up event. This is set to `true` when a drag event is encountered,
+     * e.g. when the user pans the map while drawing. In this case, we do not want to bail
+     * out of tracing.
+     * @type {boolean}
+     * @private
+     */
+    this.ignoreNextUpEvent_ = false;
+
+    /**
      * The number of points that must be drawn before a polygon ring or line
      * string can be finished.  The default is 3 for polygon rings and 2 for
      * line strings.
@@ -1300,6 +1309,16 @@ class Draw extends PointerInteraction {
   }
 
   /**
+   * Handle drag events.
+   * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event Event.
+   * @override
+   */
+  handleDragEvent(event) {
+    this.ignoreNextUpEvent_ = true;
+    super.handleDragEvent(event);
+  }
+
+  /**
    * Handle pointer up events.
    * @param {import("../MapBrowserEvent.js").default<PointerEvent>} event Event.
    * @return {boolean} If the event was consumed.
@@ -1316,7 +1335,9 @@ class Draw extends PointerInteraction {
 
       this.handlePointerMove_(event);
       const tracing = this.traceState_.active;
-      this.toggleTraceState_(event);
+      if (!this.ignoreNextUpEvent_) {
+        this.toggleTraceState_(event);
+      }
 
       if (this.shouldHandle_) {
         const startingToDraw = !this.finishCoordinate_;
@@ -1342,6 +1363,7 @@ class Draw extends PointerInteraction {
         this.abortDrawing();
       }
     }
+    this.ignoreNextUpEvent_ = false;
 
     if (!pass && this.stopClick_) {
       event.preventDefault();


### PR DESCRIPTION
This pull request fixes #14088, which can be seen in https://openlayers.org/en/latest/examples/tracing.html: when the map is panned during tracing, tracing is toggled off, which is confusing. With the change in this pull request, users can reposition the map without losing the current tracing state.

Before:
![before](https://github.com/user-attachments/assets/172c5e9e-769d-4a84-bfb7-845569f4dcfb)

After:
![after](https://github.com/user-attachments/assets/a57b344c-2f2f-477a-a76b-c2d8f66bc7cd)
