### PR TITLE
Tracing with the Modify intraction

### DIFF
--- a/config/tsconfig-strict.json
+++ b/config/tsconfig-strict.json
@@ -128,6 +128,7 @@
     "../src/ol/interaction/Select.js",
     "../src/ol/interaction/Snap.js",
     "../src/ol/interaction/Translate.js",
+    "../src/ol/interaction/tracing.js",
     "../src/ol/layer.js",
     "../src/ol/layer/Base.js",
     "../src/ol/layer/BaseImage.js",

--- a/examples/draw-modify-trace-snap.html
+++ b/examples/draw-modify-trace-snap.html
@@ -1,7 +1,7 @@
 ---
 layout: example.html
 title: Draw, modify, trace and snap
-shortdesc: Using the draw, modify, trace and snap interactions to edit geometries in the context of existing data.
+shortdesc: Using the draw, modify, and snap interactions to edit existing geometries with tracing enabled.
 docs: >
   The Draw and Modify interactions have a <code>trace</code> option to enable tracing
   around existing features.  This example uses the <code>traceSource</code> option

--- a/examples/draw-modify-trace-snap.html
+++ b/examples/draw-modify-trace-snap.html
@@ -1,0 +1,23 @@
+---
+layout: example.html
+title: Draw, modify, trace and snap
+shortdesc: Using the draw, modify, trace and snap interactions to edit geometries in the context of existing data.
+docs: >
+  The Draw and Modify interactions have a <code>trace</code> option to enable tracing
+  around existing features.  This example uses the <code>traceSource</code> option
+  to trace features from one source and add them to another source.  When drawing, the first click
+  on an edge of the target feature will start tracing. The second click on the edge
+  will stop tracing.  When modifying, dragging a vertex onto an edge of the target feature will activate
+  tracing for the next drag. Now when an adjacent vertex is dragged onto the edge, the segment between the two vertices
+  will be traced along the target feature. If a different vertex is dragged, no tracing will occur.
+tags: "draw, modify, trace, vector, snap, topology"
+---
+<div id="map" class="map"></div>
+<form>
+  <label for="type">Draw geometry mode &nbsp;</label>
+  <select id="type">
+    <option value="Polygon">Polygon</option>
+    <option value="LineString">LineString</option>
+    <option value="None">Modify only</option>
+  </select>
+</form>

--- a/examples/draw-modify-trace-snap.html
+++ b/examples/draw-modify-trace-snap.html
@@ -11,6 +11,9 @@ docs: >
   tracing for the next drag. Now when an adjacent vertex is dragged onto the edge, the segment between the two vertices
   will be traced along the target feature. If a different vertex is dragged, no tracing will occur.
 tags: "draw, modify, trace, vector, snap, topology"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>
 <form>

--- a/examples/draw-modify-trace-snap.js
+++ b/examples/draw-modify-trace-snap.js
@@ -1,0 +1,102 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import Draw from '../src/ol/interaction/Draw.js';
+import Modify from '../src/ol/interaction/Modify.js';
+import Snap from '../src/ol/interaction/Snap.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import ImageTile from '../src/ol/source/ImageTile.js';
+import VectorSource from '../src/ol/source/Vector.js';
+
+const raster = new TileLayer({
+  source: new ImageTile({
+    url: 'https://api.maptiler.com/maps/satellite/{z}/{x}/{y}.jpg?key=get_your_own_D6rA4zTHduk6KOKTXzGB',
+    maxZoom: 20,
+  }),
+});
+
+// features in this layer will be snapped to
+const baseVector = new VectorLayer({
+  source: new VectorSource({
+    format: new GeoJSON(),
+    url: 'data/geojson/fire.json',
+  }),
+  style: {
+    'fill-color': 'rgba(255, 0, 0, 0.3)',
+    'stroke-color': 'rgba(255, 0, 0, 0.9)',
+    'stroke-width': 0.5,
+  },
+});
+
+// this is where the drawn features go
+const drawVector = new VectorLayer({
+  source: new VectorSource(),
+  style: {
+    'stroke-color': 'rgba(100, 255, 0, 1)',
+    'stroke-width': 2,
+    'fill-color': 'rgba(100, 255, 0, 0.3)',
+  },
+});
+
+const map = new Map({
+  layers: [raster, baseVector, drawVector],
+  target: 'map',
+  view: new View({
+    center: [-13378949, 5943751],
+    zoom: 11,
+    maxZoom: 23,
+  }),
+});
+
+let drawInteraction;
+
+const snapInteraction = new Snap({
+  source: baseVector.getSource(),
+});
+
+const modifyInteraction = new Modify({
+  source: drawVector.getSource(),
+  trace: true,
+  traceSource: baseVector.getSource(),
+});
+
+const typeSelect = document.getElementById('type');
+
+function addInteraction() {
+  const value = typeSelect.value;
+  map.addInteraction(modifyInteraction);
+  if (value !== 'None') {
+    drawInteraction = new Draw({
+      type: value,
+      source: drawVector.getSource(),
+      trace: true,
+      traceSource: baseVector.getSource(),
+      style: {
+        'stroke-color': 'rgba(255, 255, 100, 0.5)',
+        'stroke-width': 1.5,
+        'fill-color': 'rgba(255, 255, 100, 0.25)',
+        'circle-radius': 6,
+        'circle-fill-color': 'rgba(255, 255, 100, 0.5)',
+      },
+    });
+    drawInteraction.once('drawend', () => {
+      typeSelect.value = 'None';
+      setTimeout(changeDrawMode, 0);
+    });
+    map.addInteraction(drawInteraction);
+  }
+  map.addInteraction(snapInteraction);
+}
+
+function changeDrawMode() {
+  if (drawInteraction) {
+    map.removeInteraction(drawInteraction);
+    drawInteraction = null;
+  }
+  map.removeInteraction(modifyInteraction);
+  map.removeInteraction(snapInteraction);
+  addInteraction();
+}
+typeSelect.onchange = changeDrawMode;
+addInteraction();

--- a/examples/tracing.html
+++ b/examples/tracing.html
@@ -9,6 +9,9 @@ docs: >
   on an edge of the target feature will start tracing.  The second click on the edge
   will stop tracing.
 tags: "draw, trace, vector, snap, topology"
+cloak:
+  - key: get_your_own_D6rA4zTHduk6KOKTXzGB
+    value: Get your own API key at https://www.maptiler.com/cloud/
 ---
 <div id="map" class="map"></div>
 <form>

--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -25,7 +25,6 @@ import {
 } from '../extent.js';
 import {FALSE, TRUE} from '../functions.js';
 import Circle from '../geom/Circle.js';
-import GeometryCollection from '../geom/GeometryCollection.js';
 import LineString from '../geom/LineString.js';
 import MultiLineString from '../geom/MultiLineString.js';
 import MultiPoint from '../geom/MultiPoint.js';
@@ -34,12 +33,17 @@ import Point from '../geom/Point.js';
 import Polygon, {fromCircle, makeRegular} from '../geom/Polygon.js';
 import {getStrideForLayout} from '../geom/SimpleGeometry.js';
 import VectorLayer from '../layer/Vector.js';
-import {clamp, squaredDistance, toFixed} from '../math.js';
 import {fromUserCoordinate, getUserProjection} from '../proj.js';
 import VectorSource from '../source/Vector.js';
 import {createEditingStyle} from '../style/Style.js';
 import PointerInteraction from './Pointer.js';
 import InteractionProperty from './Property.js';
+import {
+  getCoordinate,
+  getTraceTargetUpdate,
+  getTraceTargets,
+  interpolateCoordinate,
+} from './tracing.js';
 
 /**
  * @typedef {Object} Options
@@ -115,8 +119,7 @@ import InteractionProperty from './Property.js';
  */
 
 /**
- * Coordinate type when drawing lines.
- * @typedef {Array<import("../coordinate.js").Coordinate>} LineCoordType
+ * @typedef {import('./tracing.js').LineCoordType} LineCoordType
  */
 
 /**
@@ -129,23 +132,9 @@ import InteractionProperty from './Property.js';
  * @typedef {PointCoordType|LineCoordType|PolyCoordType} SketchCoordType
  */
 
-/**
- * @typedef {Object} TraceState
- * @property {boolean} active Tracing active.
- * @property {import("../pixel.js").Pixel} [startPx] The initially clicked pixel location.
- * @property {Array<TraceTarget>} [targets] Targets available for tracing.
- * @property {number} [targetIndex] The index of the currently traced target.  A value of -1 indicates
- * that no trace target is active.
- */
+/** @typedef {import('./tracing.js').TraceState} TraceState */
 
-/**
- * @typedef {Object} TraceTarget
- * @property {Array<import("../coordinate.js").Coordinate>} coordinates Target coordinates.
- * @property {boolean} ring The target coordinates are a linear ring.
- * @property {number} startIndex The index of first traced coordinate.  A fractional index represents an
- * edge intersection.  Index values for rings will wrap (may be negative or larger than coordinates length).
- * @property {number} endIndex The index of last traced coordinate.  Details from startIndex also apply here.
- */
+/** @typedef {import('./tracing.js').TraceTarget} TraceTarget */
 
 /**
  * Function that takes an array of coordinates and an optional existing geometry
@@ -207,371 +196,6 @@ export class DrawEvent extends Event {
      */
     this.feature = feature;
   }
-}
-
-/**
- * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
- * @param {Array<Feature>} features The candidate features.
- * @return {Array<TraceTarget>} The trace targets.
- */
-function getTraceTargets(coordinate, features) {
-  /**
-   * @type {Array<TraceTarget>}
-   */
-  const targets = [];
-
-  for (let i = 0; i < features.length; ++i) {
-    const feature = features[i];
-    const geometry = feature.getGeometry();
-    appendGeometryTraceTargets(coordinate, geometry, targets);
-  }
-
-  return targets;
-}
-
-/**
- * @param {import("../coordinate.js").Coordinate} a One coordinate.
- * @param {import("../coordinate.js").Coordinate} b Another coordinate.
- * @return {number} The squared distance between the two coordinates.
- */
-function getSquaredDistance(a, b) {
-  return squaredDistance(a[0], a[1], b[0], b[1]);
-}
-
-/**
- * @param {LineCoordType} coordinates The ring coordinates.
- * @param {number} index The index.  May be wrapped.
- * @return {import("../coordinate.js").Coordinate} The coordinate.
- */
-function getCoordinate(coordinates, index) {
-  const count = coordinates.length;
-  if (index < 0) {
-    return coordinates[index + count];
-  }
-  if (index >= count) {
-    return coordinates[index - count];
-  }
-  return coordinates[index];
-}
-
-/**
- * Get the cumulative squared distance along a ring path.  The end index index may be "wrapped" and it may
- * be less than the start index to indicate the direction of travel.  The start and end index may have
- * a fractional part to indicate a point between two coordinates.
- * @param {LineCoordType} coordinates Ring coordinates.
- * @param {number} startIndex The start index.
- * @param {number} endIndex The end index.
- * @return {number} The cumulative squared distance along the ring path.
- */
-function getCumulativeSquaredDistance(coordinates, startIndex, endIndex) {
-  let lowIndex, highIndex;
-  if (startIndex < endIndex) {
-    lowIndex = startIndex;
-    highIndex = endIndex;
-  } else {
-    lowIndex = endIndex;
-    highIndex = startIndex;
-  }
-  const lowWholeIndex = Math.ceil(lowIndex);
-  const highWholeIndex = Math.floor(highIndex);
-
-  if (lowWholeIndex > highWholeIndex) {
-    // both start and end are on the same segment
-    const start = interpolateCoordinate(coordinates, lowIndex);
-    const end = interpolateCoordinate(coordinates, highIndex);
-    return getSquaredDistance(start, end);
-  }
-
-  let sd = 0;
-
-  if (lowIndex < lowWholeIndex) {
-    const start = interpolateCoordinate(coordinates, lowIndex);
-    const end = getCoordinate(coordinates, lowWholeIndex);
-    sd += getSquaredDistance(start, end);
-  }
-
-  if (highWholeIndex < highIndex) {
-    const start = getCoordinate(coordinates, highWholeIndex);
-    const end = interpolateCoordinate(coordinates, highIndex);
-    sd += getSquaredDistance(start, end);
-  }
-
-  for (let i = lowWholeIndex; i < highWholeIndex - 1; ++i) {
-    const start = getCoordinate(coordinates, i);
-    const end = getCoordinate(coordinates, i + 1);
-    sd += getSquaredDistance(start, end);
-  }
-
-  return sd;
-}
-
-/**
- * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
- * @param {import("../geom/Geometry.js").default} geometry The candidate geometry.
- * @param {Array<TraceTarget>} targets The trace targets.
- */
-function appendGeometryTraceTargets(coordinate, geometry, targets) {
-  if (geometry instanceof LineString) {
-    appendTraceTarget(coordinate, geometry.getCoordinates(), false, targets);
-    return;
-  }
-  if (geometry instanceof MultiLineString) {
-    const coordinates = geometry.getCoordinates();
-    for (let i = 0, ii = coordinates.length; i < ii; ++i) {
-      appendTraceTarget(coordinate, coordinates[i], false, targets);
-    }
-    return;
-  }
-  if (geometry instanceof Polygon) {
-    const coordinates = geometry.getCoordinates();
-    for (let i = 0, ii = coordinates.length; i < ii; ++i) {
-      appendTraceTarget(coordinate, coordinates[i], true, targets);
-    }
-    return;
-  }
-  if (geometry instanceof MultiPolygon) {
-    const polys = geometry.getCoordinates();
-    for (let i = 0, ii = polys.length; i < ii; ++i) {
-      const coordinates = polys[i];
-      for (let j = 0, jj = coordinates.length; j < jj; ++j) {
-        appendTraceTarget(coordinate, coordinates[j], true, targets);
-      }
-    }
-    return;
-  }
-  if (geometry instanceof GeometryCollection) {
-    const geometries = geometry.getGeometries();
-    for (let i = 0; i < geometries.length; ++i) {
-      appendGeometryTraceTargets(coordinate, geometries[i], targets);
-    }
-    return;
-  }
-  // other types cannot be traced
-}
-
-/**
- * @typedef {Object} TraceTargetUpdateInfo
- * @property {number} index The new target index.
- * @property {number} endIndex The new segment end index.
- */
-
-/**
- * @type {TraceTargetUpdateInfo}
- */
-const sharedUpdateInfo = {index: -1, endIndex: NaN};
-
-/**
- * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
- * @param {TraceState} traceState The trace state.
- * @param {import("../Map.js").default} map The map.
- * @param {number} snapTolerance The snap tolerance.
- * @return {TraceTargetUpdateInfo} Information about the new trace target.  The returned
- * object is reused between calls and must not be modified by the caller.
- */
-function getTraceTargetUpdate(coordinate, traceState, map, snapTolerance) {
-  const x = coordinate[0];
-  const y = coordinate[1];
-
-  let closestTargetDistance = Infinity;
-
-  let newTargetIndex = -1;
-  let newEndIndex = NaN;
-
-  for (
-    let targetIndex = 0;
-    targetIndex < traceState.targets.length;
-    ++targetIndex
-  ) {
-    const target = traceState.targets[targetIndex];
-    const coordinates = target.coordinates;
-
-    let minSegmentDistance = Infinity;
-    let endIndex;
-    for (
-      let coordinateIndex = 0;
-      coordinateIndex < coordinates.length - 1;
-      ++coordinateIndex
-    ) {
-      const start = coordinates[coordinateIndex];
-      const end = coordinates[coordinateIndex + 1];
-      const rel = getPointSegmentRelationship(x, y, start, end);
-      if (rel.squaredDistance < minSegmentDistance) {
-        minSegmentDistance = rel.squaredDistance;
-        endIndex = coordinateIndex + rel.along;
-      }
-    }
-
-    if (minSegmentDistance < closestTargetDistance) {
-      closestTargetDistance = minSegmentDistance;
-      if (target.ring && traceState.targetIndex === targetIndex) {
-        // same target, maintain the same trace direction
-        if (target.endIndex > target.startIndex) {
-          // forward trace
-          if (endIndex < target.startIndex) {
-            endIndex += coordinates.length;
-          }
-        } else if (target.endIndex < target.startIndex) {
-          // reverse trace
-          if (endIndex > target.startIndex) {
-            endIndex -= coordinates.length;
-          }
-        }
-      }
-      newEndIndex = endIndex;
-      newTargetIndex = targetIndex;
-    }
-  }
-
-  const newTarget = traceState.targets[newTargetIndex];
-  let considerBothDirections = newTarget.ring;
-  if (traceState.targetIndex === newTargetIndex && considerBothDirections) {
-    // only consider switching trace direction if close to the start
-    const newCoordinate = interpolateCoordinate(
-      newTarget.coordinates,
-      newEndIndex,
-    );
-    const pixel = map.getPixelFromCoordinate(newCoordinate);
-    if (distance(pixel, traceState.startPx) > snapTolerance) {
-      considerBothDirections = false;
-    }
-  }
-
-  if (considerBothDirections) {
-    const coordinates = newTarget.coordinates;
-    const count = coordinates.length;
-    const startIndex = newTarget.startIndex;
-    const endIndex = newEndIndex;
-    if (startIndex < endIndex) {
-      const forwardDistance = getCumulativeSquaredDistance(
-        coordinates,
-        startIndex,
-        endIndex,
-      );
-      const reverseDistance = getCumulativeSquaredDistance(
-        coordinates,
-        startIndex,
-        endIndex - count,
-      );
-      if (reverseDistance < forwardDistance) {
-        newEndIndex -= count;
-      }
-    } else {
-      const reverseDistance = getCumulativeSquaredDistance(
-        coordinates,
-        startIndex,
-        endIndex,
-      );
-      const forwardDistance = getCumulativeSquaredDistance(
-        coordinates,
-        startIndex,
-        endIndex + count,
-      );
-      if (forwardDistance < reverseDistance) {
-        newEndIndex += count;
-      }
-    }
-  }
-
-  sharedUpdateInfo.index = newTargetIndex;
-  sharedUpdateInfo.endIndex = newEndIndex;
-  return sharedUpdateInfo;
-}
-
-/**
- * @param {import("../coordinate.js").Coordinate} coordinate The clicked coordinate.
- * @param {Array<import("../coordinate.js").Coordinate>} coordinates The geometry component coordinates.
- * @param {boolean} ring The coordinates represent a linear ring.
- * @param {Array<TraceTarget>} targets The trace targets.
- */
-function appendTraceTarget(coordinate, coordinates, ring, targets) {
-  const x = coordinate[0];
-  const y = coordinate[1];
-  for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
-    const start = coordinates[i];
-    const end = coordinates[i + 1];
-    const rel = getPointSegmentRelationship(x, y, start, end);
-    if (rel.squaredDistance === 0) {
-      const index = i + rel.along;
-      targets.push({
-        coordinates: coordinates,
-        ring: ring,
-        startIndex: index,
-        endIndex: index,
-      });
-      return;
-    }
-  }
-}
-
-/**
- * @typedef {Object} PointSegmentRelationship
- * @property {number} along The closest point expressed as a fraction along the segment length.
- * @property {number} squaredDistance The squared distance of the point to the segment.
- */
-
-/**
- * @type {PointSegmentRelationship}
- */
-const sharedRel = {along: 0, squaredDistance: 0};
-
-/**
- * @param {number} x The point x.
- * @param {number} y The point y.
- * @param {import("../coordinate.js").Coordinate} start The segment start.
- * @param {import("../coordinate.js").Coordinate} end The segment end.
- * @return {PointSegmentRelationship} The point segment relationship.  The returned object is
- * shared between calls and must not be modified by the caller.
- */
-function getPointSegmentRelationship(x, y, start, end) {
-  const x1 = start[0];
-  const y1 = start[1];
-  const x2 = end[0];
-  const y2 = end[1];
-  const dx = x2 - x1;
-  const dy = y2 - y1;
-  let along = 0;
-  let px = x1;
-  let py = y1;
-  if (dx !== 0 || dy !== 0) {
-    along = clamp(((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy), 0, 1);
-    px += dx * along;
-    py += dy * along;
-  }
-
-  sharedRel.along = along;
-  sharedRel.squaredDistance = toFixed(squaredDistance(x, y, px, py), 10);
-  return sharedRel;
-}
-
-/**
- * @param {LineCoordType} coordinates The coordinates.
- * @param {number} index The index.  May be fractional and may wrap.
- * @return {import("../coordinate.js").Coordinate} The interpolated coordinate.
- */
-function interpolateCoordinate(coordinates, index) {
-  const count = coordinates.length;
-
-  let startIndex = Math.floor(index);
-  const along = index - startIndex;
-  if (startIndex >= count) {
-    startIndex -= count;
-  } else if (startIndex < 0) {
-    startIndex += count;
-  }
-
-  let endIndex = startIndex + 1;
-  if (endIndex >= count) {
-    endIndex -= count;
-  }
-
-  const start = coordinates[startIndex];
-  const x0 = start[0];
-  const y0 = start[1];
-  const end = coordinates[endIndex];
-  const dx = end[0] - x0;
-  const dy = end[1] - y0;
-
-  return [x0 + dx * along, y0 + dy * along];
 }
 
 /***
@@ -1136,7 +760,7 @@ class Draw extends PointerInteraction {
     if (targets.length) {
       this.traceState_ = {
         active: true,
-        startPx: event.pixel.slice(),
+        startCoord: event.coordinate.slice(),
         targets: targets,
         targetIndex: -1,
       };
@@ -1261,7 +885,8 @@ class Draw extends PointerInteraction {
 
     if (traceState.targetIndex === -1) {
       // check if we are ready to pick a target
-      if (distance(traceState.startPx, event.pixel) < this.snapTolerance_) {
+      const startPx = event.map.getPixelFromCoordinate(traceState.startCoord);
+      if (distance(startPx, event.pixel) < this.snapTolerance_) {
         return;
       }
     }

--- a/src/ol/interaction/tracing.js
+++ b/src/ol/interaction/tracing.js
@@ -1,0 +1,409 @@
+/**
+ * Coordinate type when drawing lines.
+ * @typedef {Array<import("../coordinate.js").Coordinate>} LineCoordType
+ */
+
+import {distance} from '../coordinate.js';
+import {
+  GeometryCollection,
+  LineString,
+  MultiLineString,
+  MultiPolygon,
+  Polygon,
+} from '../geom.js';
+import {clamp, squaredDistance, toFixed} from '../math.js';
+
+/**
+ * @param {LineCoordType} coordinates The ring coordinates.
+ * @param {number} index The index.  May be wrapped.
+ * @return {import("../coordinate.js").Coordinate} The coordinate.
+ */
+export function getCoordinate(coordinates, index) {
+  const count = coordinates.length;
+  if (index < 0) {
+    return coordinates[index + count];
+  }
+  if (index >= count) {
+    return coordinates[index - count];
+  }
+  return coordinates[index];
+}
+
+/**
+ * @param {LineCoordType} coordinates The coordinates.
+ * @param {number} index The index.  May be fractional and may wrap.
+ * @return {import("../coordinate.js").Coordinate} The interpolated coordinate.
+ */
+export function interpolateCoordinate(coordinates, index) {
+  const count = coordinates.length;
+
+  let startIndex = Math.floor(index);
+  const along = index - startIndex;
+  if (startIndex >= count) {
+    startIndex -= count;
+  } else if (startIndex < 0) {
+    startIndex += count;
+  }
+
+  let endIndex = startIndex + 1;
+  if (endIndex >= count) {
+    endIndex -= count;
+  }
+
+  const start = coordinates[startIndex];
+  const x0 = start[0];
+  const y0 = start[1];
+  const end = coordinates[endIndex];
+  const dx = end[0] - x0;
+  const dy = end[1] - y0;
+
+  return [x0 + dx * along, y0 + dy * along];
+}
+
+/**
+ * @typedef {Object} TraceTarget
+ * @property {Array<import("../coordinate.js").Coordinate>} coordinates Target coordinates.
+ * @property {boolean} ring The target coordinates are a linear ring.
+ * @property {number} startIndex The index of first traced coordinate.  A fractional index represents an
+ * edge intersection.  Index values for rings will wrap (may be negative or larger than coordinates length).
+ * @property {number} endIndex The index of last traced coordinate.  Details from startIndex also apply here.
+ */
+
+/**
+ * @typedef {Object} TraceState
+ * @property {boolean} active Tracing active.
+ * @property {import("../coordinate.js").Coordinate} [startCoord] The initially clicked coordinate.
+ * @property {Array<TraceTarget>} [targets] Targets available for tracing.
+ * @property {number} [targetIndex] The index of the currently traced target.  A value of -1 indicates
+ * that no trace target is active.
+ */
+
+/**
+ * @typedef {Object} TraceTargetUpdateInfo
+ * @property {number} index The new target index.
+ * @property {number} endIndex The new segment end index.
+ * @property {number} closestTargetDistance The squared distance to the closest target.
+ */
+
+/**
+ * @type {TraceTargetUpdateInfo}
+ */
+const sharedUpdateInfo = {
+  index: -1,
+  endIndex: NaN,
+  closestTargetDistance: Infinity,
+};
+
+/**
+ * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
+ * @param {TraceState} traceState The trace state.
+ * @param {import("../Map.js").default} map The map.
+ * @param {number} snapTolerance The snap tolerance.
+ * @return {TraceTargetUpdateInfo} Information about the new trace target.  The returned
+ * object is reused between calls and must not be modified by the caller.
+ */
+export function getTraceTargetUpdate(
+  coordinate,
+  traceState,
+  map,
+  snapTolerance,
+) {
+  const x = coordinate[0];
+  const y = coordinate[1];
+
+  let closestTargetDistance = Infinity;
+
+  let newTargetIndex = -1;
+  let newEndIndex = NaN;
+
+  for (
+    let targetIndex = 0;
+    targetIndex < traceState.targets.length;
+    ++targetIndex
+  ) {
+    const target = traceState.targets[targetIndex];
+    const coordinates = target.coordinates;
+
+    let minSegmentDistance = Infinity;
+    let endIndex;
+    for (
+      let coordinateIndex = 0;
+      coordinateIndex < coordinates.length - 1;
+      ++coordinateIndex
+    ) {
+      const start = coordinates[coordinateIndex];
+      const end = coordinates[coordinateIndex + 1];
+      const rel = getPointSegmentRelationship(x, y, start, end);
+      if (rel.squaredDistance < minSegmentDistance) {
+        minSegmentDistance = rel.squaredDistance;
+        endIndex = coordinateIndex + rel.along;
+      }
+    }
+
+    if (minSegmentDistance < closestTargetDistance) {
+      closestTargetDistance = minSegmentDistance;
+      if (target.ring && traceState.targetIndex === targetIndex) {
+        // same target, maintain the same trace direction
+        if (target.endIndex > target.startIndex) {
+          // forward trace
+          if (endIndex < target.startIndex) {
+            endIndex += coordinates.length;
+          }
+        } else if (target.endIndex < target.startIndex) {
+          // reverse trace
+          if (endIndex > target.startIndex) {
+            endIndex -= coordinates.length;
+          }
+        }
+      }
+      newEndIndex = endIndex;
+      newTargetIndex = targetIndex;
+    }
+  }
+
+  const newTarget = traceState.targets[newTargetIndex];
+  let considerBothDirections = newTarget.ring;
+  if (traceState.targetIndex === newTargetIndex && considerBothDirections) {
+    // only consider switching trace direction if close to the start
+    const newCoordinate = interpolateCoordinate(
+      newTarget.coordinates,
+      newEndIndex,
+    );
+    const pixel = map.getPixelFromCoordinate(newCoordinate);
+    const startPx = map.getPixelFromCoordinate(traceState.startCoord);
+    if (distance(pixel, startPx) > snapTolerance) {
+      considerBothDirections = false;
+    }
+  }
+
+  if (considerBothDirections) {
+    const coordinates = newTarget.coordinates;
+    const count = coordinates.length;
+    const startIndex = newTarget.startIndex;
+    const endIndex = newEndIndex;
+    if (startIndex < endIndex) {
+      const forwardDistance = getCumulativeSquaredDistance(
+        coordinates,
+        startIndex,
+        endIndex,
+      );
+      const reverseDistance = getCumulativeSquaredDistance(
+        coordinates,
+        startIndex,
+        endIndex - count,
+      );
+      if (reverseDistance < forwardDistance) {
+        newEndIndex -= count;
+      }
+    } else {
+      const reverseDistance = getCumulativeSquaredDistance(
+        coordinates,
+        startIndex,
+        endIndex,
+      );
+      const forwardDistance = getCumulativeSquaredDistance(
+        coordinates,
+        startIndex,
+        endIndex + count,
+      );
+      if (forwardDistance < reverseDistance) {
+        newEndIndex += count;
+      }
+    }
+  }
+
+  sharedUpdateInfo.index = newTargetIndex;
+  sharedUpdateInfo.endIndex = newEndIndex;
+  sharedUpdateInfo.closestTargetDistance = closestTargetDistance;
+  return sharedUpdateInfo;
+}
+
+/**
+ * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
+ * @param {Array<import("../Feature.js").default>} features The candidate features.
+ * @return {Array<TraceTarget>} The trace targets.
+ */
+export function getTraceTargets(coordinate, features) {
+  /**
+   * @type {Array<TraceTarget>}
+   */
+  const targets = [];
+
+  for (let i = 0; i < features.length; ++i) {
+    const feature = features[i];
+    const geometry = feature.getGeometry();
+    appendGeometryTraceTargets(coordinate, geometry, targets);
+  }
+
+  return targets;
+}
+
+/**
+ * @param {import("../coordinate.js").Coordinate} coordinate The coordinate.
+ * @param {import("../geom/Geometry.js").default} geometry The candidate geometry.
+ * @param {Array<TraceTarget>} targets The trace targets.
+ */
+function appendGeometryTraceTargets(coordinate, geometry, targets) {
+  if (geometry instanceof LineString) {
+    appendTraceTarget(coordinate, geometry.getCoordinates(), false, targets);
+    return;
+  }
+  if (geometry instanceof MultiLineString) {
+    const coordinates = geometry.getCoordinates();
+    for (let i = 0, ii = coordinates.length; i < ii; ++i) {
+      appendTraceTarget(coordinate, coordinates[i], false, targets);
+    }
+    return;
+  }
+  if (geometry instanceof Polygon) {
+    const coordinates = geometry.getCoordinates();
+    for (let i = 0, ii = coordinates.length; i < ii; ++i) {
+      appendTraceTarget(coordinate, coordinates[i], true, targets);
+    }
+    return;
+  }
+  if (geometry instanceof MultiPolygon) {
+    const polys = geometry.getCoordinates();
+    for (let i = 0, ii = polys.length; i < ii; ++i) {
+      const coordinates = polys[i];
+      for (let j = 0, jj = coordinates.length; j < jj; ++j) {
+        appendTraceTarget(coordinate, coordinates[j], true, targets);
+      }
+    }
+    return;
+  }
+  if (geometry instanceof GeometryCollection) {
+    const geometries = geometry.getGeometries();
+    for (let i = 0; i < geometries.length; ++i) {
+      appendGeometryTraceTargets(coordinate, geometries[i], targets);
+    }
+    return;
+  }
+  // other types cannot be traced
+}
+
+/**
+ * @param {import("../coordinate.js").Coordinate} coordinate The clicked coordinate.
+ * @param {Array<import("../coordinate.js").Coordinate>} coordinates The geometry component coordinates.
+ * @param {boolean} ring The coordinates represent a linear ring.
+ * @param {Array<TraceTarget>} targets The trace targets.
+ */
+function appendTraceTarget(coordinate, coordinates, ring, targets) {
+  const x = coordinate[0];
+  const y = coordinate[1];
+  for (let i = 0, ii = coordinates.length - 1; i < ii; ++i) {
+    const start = coordinates[i];
+    const end = coordinates[i + 1];
+    const rel = getPointSegmentRelationship(x, y, start, end);
+    if (rel.squaredDistance === 0) {
+      const index = i + rel.along;
+      targets.push({
+        coordinates: coordinates,
+        ring: ring,
+        startIndex: index,
+        endIndex: index,
+      });
+      return;
+    }
+  }
+}
+
+/**
+ * @param {import("../coordinate.js").Coordinate} a One coordinate.
+ * @param {import("../coordinate.js").Coordinate} b Another coordinate.
+ * @return {number} The squared distance between the two coordinates.
+ */
+function getSquaredDistance(a, b) {
+  return squaredDistance(a[0], a[1], b[0], b[1]);
+}
+
+/**
+ * Get the cumulative squared distance along a ring path.  The end index index may be "wrapped" and it may
+ * be less than the start index to indicate the direction of travel.  The start and end index may have
+ * a fractional part to indicate a point between two coordinates.
+ * @param {LineCoordType} coordinates Ring coordinates.
+ * @param {number} startIndex The start index.
+ * @param {number} endIndex The end index.
+ * @return {number} The cumulative squared distance along the ring path.
+ */
+function getCumulativeSquaredDistance(coordinates, startIndex, endIndex) {
+  let lowIndex, highIndex;
+  if (startIndex < endIndex) {
+    lowIndex = startIndex;
+    highIndex = endIndex;
+  } else {
+    lowIndex = endIndex;
+    highIndex = startIndex;
+  }
+  const lowWholeIndex = Math.ceil(lowIndex);
+  const highWholeIndex = Math.floor(highIndex);
+
+  if (lowWholeIndex > highWholeIndex) {
+    // both start and end are on the same segment
+    const start = interpolateCoordinate(coordinates, lowIndex);
+    const end = interpolateCoordinate(coordinates, highIndex);
+    return getSquaredDistance(start, end);
+  }
+
+  let sd = 0;
+
+  if (lowIndex < lowWholeIndex) {
+    const start = interpolateCoordinate(coordinates, lowIndex);
+    const end = getCoordinate(coordinates, lowWholeIndex);
+    sd += getSquaredDistance(start, end);
+  }
+
+  if (highWholeIndex < highIndex) {
+    const start = getCoordinate(coordinates, highWholeIndex);
+    const end = interpolateCoordinate(coordinates, highIndex);
+    sd += getSquaredDistance(start, end);
+  }
+
+  for (let i = lowWholeIndex; i < highWholeIndex - 1; ++i) {
+    const start = getCoordinate(coordinates, i);
+    const end = getCoordinate(coordinates, i + 1);
+    sd += getSquaredDistance(start, end);
+  }
+
+  return sd;
+}
+
+/**
+ * @typedef {Object} PointSegmentRelationship
+ * @property {number} along The closest point expressed as a fraction along the segment length.
+ * @property {number} squaredDistance The squared distance of the point to the segment.
+ */
+
+/**
+ * @type {PointSegmentRelationship}
+ */
+const sharedRel = {along: 0, squaredDistance: 0};
+
+/**
+ * @param {number} x The point x.
+ * @param {number} y The point y.
+ * @param {import("../coordinate.js").Coordinate} start The segment start.
+ * @param {import("../coordinate.js").Coordinate} end The segment end.
+ * @return {PointSegmentRelationship} The point segment relationship.  The returned object is
+ * shared between calls and must not be modified by the caller.
+ */
+export function getPointSegmentRelationship(x, y, start, end) {
+  const x1 = start[0];
+  const y1 = start[1];
+  const x2 = end[0];
+  const y2 = end[1];
+  const dx = x2 - x1;
+  const dy = y2 - y1;
+  let along = 0;
+  let px = x1;
+  let py = y1;
+  if (dx !== 0 || dy !== 0) {
+    along = clamp(((x - x1) * dx + (y - y1) * dy) / (dx * dx + dy * dy), 0, 1);
+    px += dx * along;
+    py += dy * along;
+  }
+
+  sharedRel.along = along;
+  sharedRel.squaredDistance = toFixed(squaredDistance(x, y, px, py), 10);
+  return sharedRel;
+}


### PR DESCRIPTION
Closes #14499.

This pull request adds `trace` and `traceSource` options to the Modify interaction, equivalent to the Draw interaction. The new [draw-modify-trace-snap.html](https://deploy-preview-16997--ol-site.netlify.app/en/latest/examples/draw-modify-trace-snap.html) example shows how Modify with tracing enabled works, with snapping to the `traceSource`.

With a new `src/ol/interaction/tracing.js` module, duplicated code for tracing in Draw and Modify can be reduced to a minimum.