### PR TITLE
add expressions (regex, concat, at, length)

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -128,11 +128,6 @@ function compileExpression(expression, context) {
     case Ops.GeometryType: {
       return (context) => context.geometryType;
     }
-    case Ops.Concat: {
-      const args = expression.args.map((e) => compileExpression(e, context));
-      return (context) =>
-        ''.concat(...args.map((arg) => arg(context).toString()));
-    }
     case Ops.Resolution: {
       return (context) => context.resolution;
     }
@@ -168,6 +163,10 @@ function compileExpression(expression, context) {
     case Ops.Sqrt: {
       return compileNumericExpression(expression, context);
     }
+    case Ops.Concat:
+    case Ops.Regex: {
+      return compileStringExpression(expression, context);
+    }
     case Ops.Case: {
       return compileCaseExpression(expression, context);
     }
@@ -179,6 +178,10 @@ function compileExpression(expression, context) {
     }
     case Ops.ToString: {
       return compileConvertExpression(expression, context);
+    }
+    case Ops.Length:
+    case Ops.At: {
+      return compileLookupExpression(expression, context);
     }
     default: {
       throw new Error(`Unsupported operator ${operator}`);
@@ -376,6 +379,84 @@ function compileLogicalExpression(expression, context) {
     }
     default: {
       throw new Error(`Unsupported logical operator ${op}`);
+    }
+  }
+}
+
+/**
+ * @param {import('./expression.js').CallExpression} expression The call expression.
+ * @param {import('./expression.js').ParsingContext} context The parsing context.
+ * @return {StringEvaluator | NumberEvaluator} The evaluator function.
+ */
+function compileLookupExpression(expression, context) {
+  const op = expression.operator;
+  const length = expression.args.length;
+
+  const args = new Array(length);
+  for (let i = 0; i < length; ++i) {
+    args[i] = compileExpression(expression.args[i], context);
+  }
+  switch (op) {
+    case Ops.Length: {
+      return (context) => {
+        return args[0](context).length;
+      };
+    }
+    case Ops.At: {
+      return (context) => {
+        const index = args[0](context);
+        const array = args[1](context);
+        if (Array.isArray(array)) {
+          // an array from an expression
+          return array.at(index);
+        }
+        // for negative indexes, calculate from the end
+        const arrayLength = args.length - 1;
+        const actualIndex = index < 0 ? arrayLength + index : index;
+        return args[actualIndex + 1](context);
+      };
+    }
+
+    default: {
+      throw new Error(`Unsupported lookup operator ${op}`);
+    }
+  }
+}
+
+/**
+ * @param {import('./expression.js').CallExpression} expression The call expression.
+ * @param {import('./expression.js').ParsingContext} context The parsing context.
+ * @return {StringEvaluator} The evaluator function.
+ */
+function compileStringExpression(expression, context) {
+  const op = expression.operator;
+  const length = expression.args.length;
+
+  const args = new Array(length);
+  for (let i = 0; i < length; ++i) {
+    args[i] = compileExpression(expression.args[i], context);
+  }
+  switch (op) {
+    case Ops.Concat: {
+      return (context) =>
+        ''.concat(...args.map((arg) => arg(context).toString()));
+    }
+    case Ops.Regex: {
+      return (context) => {
+        const value = args[0](context);
+        const regexLiteral = args[1](context);
+
+        const parsed = regexLiteral.match(/^\/(.*)\/([gimsuy]*)$/);
+        const pattern = parsed[1];
+        const flags = parsed[2];
+        const regex = new RegExp(pattern, flags);
+
+        return value.match(regex) ?? [];
+      };
+    }
+
+    default: {
+      throw new Error(`Unsupported string operator ${op}`);
     }
   }
 }

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -128,11 +128,6 @@ function compileExpression(expression, context) {
     case Ops.GeometryType: {
       return (context) => context.geometryType;
     }
-    case Ops.Concat: {
-      const args = expression.args.map((e) => compileExpression(e, context));
-      return (context) =>
-        ''.concat(...args.map((arg) => (arg(context) ?? '').toString()));
-    }
     case Ops.Resolution: {
       return (context) => context.resolution;
     }
@@ -168,6 +163,10 @@ function compileExpression(expression, context) {
     case Ops.Sqrt: {
       return compileNumericExpression(expression, context);
     }
+    case Ops.Concat:
+    case Ops.Regex: {
+      return compileStringExpression(expression, context);
+    }
     case Ops.Case: {
       return compileCaseExpression(expression, context);
     }
@@ -179,6 +178,10 @@ function compileExpression(expression, context) {
     }
     case Ops.ToString: {
       return compileConvertExpression(expression, context);
+    }
+    case Ops.Length:
+    case Ops.At: {
+      return compileLookupExpression(expression, context);
     }
     default: {
       throw new Error(`Unsupported operator ${operator}`);
@@ -376,6 +379,84 @@ function compileLogicalExpression(expression, context) {
     }
     default: {
       throw new Error(`Unsupported logical operator ${op}`);
+    }
+  }
+}
+
+/**
+ * @param {import('./expression.js').CallExpression} expression The call expression.
+ * @param {import('./expression.js').ParsingContext} context The parsing context.
+ * @return {StringEvaluator | NumberEvaluator} The evaluator function.
+ */
+function compileLookupExpression(expression, context) {
+  const op = expression.operator;
+  const length = expression.args.length;
+
+  const args = new Array(length);
+  for (let i = 0; i < length; ++i) {
+    args[i] = compileExpression(expression.args[i], context);
+  }
+  switch (op) {
+    case Ops.Length: {
+      return (context) => {
+        return args[0](context).length;
+      };
+    }
+    case Ops.At: {
+      return (context) => {
+        const index = args[0](context);
+        const array = args[1](context);
+        if (Array.isArray(array)) {
+          // an array from an expression
+          return array.at(index);
+        }
+        // for negative indexes, calculate from the end
+        const arrayLength = args.length - 1;
+        const actualIndex = index < 0 ? arrayLength + index : index;
+        return args[actualIndex + 1](context);
+      };
+    }
+
+    default: {
+      throw new Error(`Unsupported lookup operator ${op}`);
+    }
+  }
+}
+
+/**
+ * @param {import('./expression.js').CallExpression} expression The call expression.
+ * @param {import('./expression.js').ParsingContext} context The parsing context.
+ * @return {StringEvaluator} The evaluator function.
+ */
+function compileStringExpression(expression, context) {
+  const op = expression.operator;
+  const length = expression.args.length;
+
+  const args = new Array(length);
+  for (let i = 0; i < length; ++i) {
+    args[i] = compileExpression(expression.args[i], context);
+  }
+  switch (op) {
+    case Ops.Concat: {
+      return (context) =>
+        ''.concat(...args.map((arg) => (arg(context) ?? '').toString()));
+    }
+    case Ops.Regex: {
+      return (context) => {
+        const value = args[0](context);
+        const regexLiteral = args[1](context);
+
+        const parsed = regexLiteral.match(/^\/(.*)\/([gimsuy]*)$/);
+        const pattern = parsed[1];
+        const flags = parsed[2];
+        const regex = new RegExp(pattern, flags);
+
+        return value.match(regex) ?? [];
+      };
+    }
+
+    default: {
+      throw new Error(`Unsupported string operator ${op}`);
     }
   }
 }

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -123,6 +123,22 @@ import {toSize} from '../size.js';
  *     If the input is a number, it is converted to a string as specified by the "NumberToString" algorithm of the ECMAScript
  *     Language Specification. If the input is a color, it is converted to a string of the form "rgba(r,g,b,a)". (Canvas only)
  *
+ * * String operators:
+ *   * `['concat', value1, ...valueN]` `concat` any number of strings together into a single string.
+ *   * `['regex', value, regex]` performs a regex match against the `value` and returns the matches as an array.
+ *     The regex must be a regex literal string (/.../) and can accepts flags as well, if no result is found, an empty array is returned.
+ *     `\` characters must be escaped.
+ *     e.g. `['regex', 'bold 12px sans-serif', '/(\\d+)px/']` would return ['12px', '12']
+ *
+ * * Lookup operators:
+ *   * `['length', [...]]` or `['length', 'string']` returns the length of a given array or string
+ *   * `['at', index, arr]` Returns the value at the specified index in an array or undefined.
+ *     This operator can only be used with the below types of arrays:
+ *     * A `literal` string array: `['at', 1, ['literal', ['one', 'two', 'three']]]` would return `'two'`
+ *     * A number array: `['at', 1, [1, 2, 3]]` would return `2`
+ *     * A `regex` array: `['at', 1, ['regex', '123', '/\\d/g']]` would return `'2'`
+ *     * An array from a `get` operator: Assuming `feature.get('array')` returns `[1, 2, 3]`, then `['at', 1, ['get', 'array']` would return `2`
+ *
  * Values can either be literals or another operator, as they will be evaluated recursively.
  * Literal values can be of the following types:
  * * `boolean`
@@ -434,6 +450,9 @@ export const Ops = {
   Palette: 'palette',
   ToString: 'to-string',
   Has: 'has',
+  Regex: 'regex',
+  At: 'at',
+  Length: 'length',
 };
 
 /**
@@ -606,6 +625,12 @@ const parsers = {
   [Ops.ToString]: createCallExpressionParser(
     hasArgsCount(1, 1),
     withArgsOfType(BooleanType | NumberType | StringType | ColorType),
+  ),
+  [Ops.At]: createCallExpressionParser(hasArgsCount(2, 2), withAtArgs),
+  [Ops.Length]: createCallExpressionParser(hasArgsCount(1, 1), withLengthArgs),
+  [Ops.Regex]: createCallExpressionParser(
+    hasArgsCount(2, 2),
+    withArgsOfType(StringType),
   ),
 };
 
@@ -1069,6 +1094,95 @@ function withInArgs(encoded, returnType, context) {
 
   const needle = parse(encoded[1], needleType, context);
   return [needle, ...args];
+}
+
+/**
+ * @type {ArgValidator}
+ */
+function withAtArgs(encoded, returnType, context) {
+  const idx = encoded[1];
+  let arr = encoded[2];
+
+  if (typeof idx !== 'number') {
+    throw new Error(
+      `failed to parse "at" expression: the index argument must be a number`,
+    );
+  }
+  const index = parse(idx, NumberType, context);
+
+  if (!Array.isArray(arr)) {
+    throw new Error(
+      `failed to parse "at" expression: the second argument must be an expression that returns an array`,
+    );
+  }
+
+
+  
+  if (typeof arr[0] === "string") {
+    if (!['literal', 'get', 'regex'].includes(arr[0])) {
+      throw new Error(
+        `failed to parse "at" expression: only "literal", "get" and "regex" expressions are supported`,
+      );
+    } 
+
+    if (arr[0] === 'literal') {
+      arr = arr[1];
+      if (!Array.isArray(arr)) {
+        throw new Error(
+        `failed to parse "at" expression: the literal operator must be followed by an array`,
+        );
+      }
+    } else {
+      return [index, parseCallExpression(arr, returnType, context)];
+    }
+  }
+
+  /** @type {Array<Expression>} */
+  const array = new Array(arr.length);
+  for (let i = 0; i < array.length; i++) {
+    try {
+      const arrayType = typeof arr[i] === 'string' ? StringType : NumberType;
+      const arg = parse(arr[i], arrayType, context);
+      array[i] = arg;
+    } catch (err) {
+      throw new Error(`failed to parse "at" array item ${i}: ${err.message}`);
+    }
+  }
+
+  return [index, ...array];
+}
+
+/**
+ * @type {ArgValidator}
+ */
+function withLengthArgs(encoded, returnType, context) {
+  const arrayOrString = encoded[1];
+
+  if (!Array.isArray(arrayOrString) && typeof arrayOrString !== 'string') {
+    throw new Error(
+      `failed to parse "length" expression: only an array or string is allowed`,
+    );
+  }
+
+  if (Array.isArray(arrayOrString)) {
+    const array = new Array(arrayOrString.length);
+    for (let i = 0; i < array.length; i++) {
+      try {
+        const arrayType =
+          typeof arrayOrString[i] === 'string' ? StringType : NumberType;
+        const arg = parse(arrayOrString[i], arrayType, context);
+        array[i] = arg;
+      } catch (err) {
+        throw new Error(
+          `failed to parse "length" array item ${i}: ${err.message}`,
+        );
+      }
+    }
+
+    return array;
+  }
+
+  return [parse(arrayOrString, StringType, context)];
 }
 
 /**

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -123,6 +123,22 @@ import {toSize} from '../size.js';
  *     If the input is a number, it is converted to a string as specified by the "NumberToString" algorithm of the ECMAScript
  *     Language Specification. If the input is a color, it is converted to a string of the form "rgba(r,g,b,a)". (Canvas only)
  *
+ * * String operators:
+ *   * `['concat', value1, ...valueN]` `concat` any number of strings together into a single string.
+ *   * `['regex', value, regex]` performs a regex match against the `value` and returns the matches as an array.
+ *     The regex must be a regex literal string (/.../) and can accepts flags as well, if no result is found, an empty array is returned.
+ *     `\` characters must be escaped.
+ *     e.g. `['regex', 'bold 12px sans-serif', '/(\\d+)px/']` would return ['12px', '12']
+ *
+ * * Lookup operators:
+ *   * `['length', [...]]` or `['length', 'string']` returns the length of a given array or string
+ *   * `['at', index, arr]` Returns the value at the specified index in an array or undefined.
+ *     This operator can only be used with the below types of arrays:
+ *     * A `literal` string array: `['at', 1, ['literal', ['one', 'two', 'three']]]` would return `'two'`
+ *     * A number array: `['at', 1, [1, 2, 3]]` would return `2`
+ *     * A `regex` array: `['at', 1, ['regex', '123', '/\\d/g']]` would return `'2'`
+ *     * An array from a `get` operator: Assuming `feature.get('array')` returns `[1, 2, 3]`, then `['at', 1, ['get', 'array']` would return `2`
+ *
  * Values can either be literals or another operator, as they will be evaluated recursively.
  * Literal values can be of the following types:
  * * `boolean`
@@ -442,6 +458,9 @@ export const Ops = {
   Palette: 'palette',
   ToString: 'to-string',
   Has: 'has',
+  Regex: 'regex',
+  At: 'at',
+  Length: 'length',
 };
 
 /**
@@ -614,6 +633,12 @@ const parsers = {
   [Ops.ToString]: createCallExpressionParser(
     hasArgsCount(1, 1),
     withArgsOfType(BooleanType | NumberType | StringType | ColorType),
+  ),
+  [Ops.At]: createCallExpressionParser(hasArgsCount(2, 2), withAtArgs),
+  [Ops.Length]: createCallExpressionParser(hasArgsCount(1, 1), withLengthArgs),
+  [Ops.Regex]: createCallExpressionParser(
+    hasArgsCount(2, 2),
+    withArgsOfType(StringType),
   ),
 };
 
@@ -1079,6 +1104,93 @@ function withInArgs(encoded, returnType, context) {
 
   const needle = parse(encoded[1], needleType, context);
   return [needle, ...args];
+}
+
+/**
+ * @type {ArgValidator}
+ */
+function withAtArgs(encoded, returnType, context) {
+  const idx = encoded[1];
+  let arr = encoded[2];
+
+  if (typeof idx !== 'number') {
+    throw new Error(
+      `failed to parse "at" expression: the index argument must be a number`,
+    );
+  }
+  const index = parse(idx, NumberType, context);
+
+  if (!Array.isArray(arr)) {
+    throw new Error(
+      `failed to parse "at" expression: the second argument must be an expression that returns an array`,
+    );
+  }
+
+  if (typeof arr[0] === 'string') {
+    if (!['literal', 'get', 'regex'].includes(arr[0])) {
+      throw new Error(
+        `failed to parse "at" expression: only "literal", "get" and "regex" expressions are supported`,
+      );
+    }
+
+    if (arr[0] === 'literal') {
+      arr = arr[1];
+      if (!Array.isArray(arr)) {
+        throw new Error(
+          `failed to parse "at" expression: the literal operator must be followed by an array`,
+        );
+      }
+    } else {
+      return [index, parseCallExpression(arr, returnType, context)];
+    }
+  }
+
+  /** @type {Array<Expression>} */
+  const array = new Array(arr.length);
+  for (let i = 0; i < array.length; i++) {
+    try {
+      const arrayType = typeof arr[i] === 'string' ? StringType : NumberType;
+      const arg = parse(arr[i], arrayType, context);
+      array[i] = arg;
+    } catch (err) {
+      throw new Error(`failed to parse "at" array item ${i}: ${err.message}`);
+    }
+  }
+
+  return [index, ...array];
+}
+
+/**
+ * @type {ArgValidator}
+ */
+function withLengthArgs(encoded, returnType, context) {
+  const arrayOrString = encoded[1];
+
+  if (!Array.isArray(arrayOrString) && typeof arrayOrString !== 'string') {
+    throw new Error(
+      `failed to parse "length" expression: only an array or string is allowed`,
+    );
+  }
+
+  if (Array.isArray(arrayOrString)) {
+    const array = new Array(arrayOrString.length);
+    for (let i = 0; i < array.length; i++) {
+      try {
+        const arrayType =
+          typeof arrayOrString[i] === 'string' ? StringType : NumberType;
+        const arg = parse(arrayOrString[i], arrayType, context);
+        array[i] = arg;
+      } catch (err) {
+        throw new Error(
+          `failed to parse "length" array item ${i}: ${err.message}`,
+        );
+      }
+    }
+
+    return array;
+  }
+
+  return [parse(arrayOrString, StringType, context)];
 }
 
 /**

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -807,6 +807,71 @@ describe('ol/expr/cpu.js', () => {
         expression: ['has', 'property', 0, 'foo'],
         expected: false,
       },
+      {
+        name: 'at (with literal array)',
+        type: StringType,
+        expression: ['at', 0, ['literal', ['one', 'two', 'three']]],
+        expected: 'one',
+      },
+      {
+        name: 'at (with number array)',
+        type: StringType,
+        expression: ['at', 2, [1, 2, 3, 4]],
+        expected: 3,
+      },
+      {
+        name: 'at (with mixed literal)',
+        type: StringType,
+        expression: ['at', 0, ['literal', ['one', 2, 3, 4]]],
+        expected: 'one',
+      },
+      {
+        name: 'at (negative index, with literal array)',
+        type: StringType,
+        expression: ['at', -2, ['literal', ['one', 'two', 'three']]],
+        expected: 'two',
+      },
+      {
+        name: 'at (with array from property)',
+        context: {
+          properties: {
+            array: ['one', 'two', 'three'],
+          },
+        },
+        type: StringType,
+        expression: ['at', 0, ['get', 'array']],
+        expected: 'one',
+      },
+      {
+        name: 'at (with array from regex)',
+        type: StringType,
+        expression: ['at', 0, ['regex', '123', '/\\d/g']],
+        expected: '1',
+      },
+      {
+        name: 'length (array)',
+        type: NumberType,
+        expression: ['length', ['one', 'two', 'three']],
+        expected: 3,
+      },
+      {
+        name: 'length (string)',
+        type: NumberType,
+        expression: ['length', 'hello'],
+        expected: 5,
+      },
+      {
+        name: 'regex (valid)',
+        type: StringType,
+        expression: ['regex', 'hello world', '/^hello/g'],
+        expected: ['hello'],
+      },
+      {
+        name: 'regex (no match)',
+        type: StringType,
+        expression: ['regex', 'hello world', '/^world/g'],
+        expected: [],
+      },
     ];
 
     for (const c of cases) {

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -568,6 +568,36 @@ describe('ol/expr/expression.js', () => {
         error:
           'the type expected from the var operator (number) did not have any overlap with the type of the corresponding style variables (string), variable name: myVar',
       },
+      {
+        name: 'index must be number (at)',
+        expression: ['at', 'one', ['literal', ['one', 'two', 'three']]],
+        error:
+          'failed to parse "at" expression: the index argument must be a number',
+      },
+      {
+        name: 'second argument must be an array (at)',
+        expression: ['at', 0, 'one'],
+        error:
+          'failed to parse "at" expression: the second argument must be an expression that returns an array',
+      },
+      {
+        name: 'must use an expression for array (at)',
+        expression: ['at', 0, ['one', 'two', 'three']],
+        error:
+          'failed to parse "at" expression: only "literal", "get" and "regex" expressions are supported',
+      },
+      {
+        name: 'literal must be an array (at)',
+        expression: ['at', 0, ['literal', 'two', 'three']],
+        error:
+          'failed to parse "at" expression: the literal operator must be followed by an array',
+      },
+      {
+        name: 'argument must be an array or string (length)',
+        expression: ['length', 3],
+        error:
+          'failed to parse "length" expression: only an array or string is allowed',
+      },
     ];
 
     for (const {name, expression, error, context} of cases) {


### PR DESCRIPTION
Allows the ability to run a regex match against a string, useful for parsing existing properties such as css font strings. Also document the concat expression

Fixes https://github.com/openlayers/openlayers/issues/16998
