### PR TITLE
Prevent duplicate rendering on vector tiles with `renderMode: 'vector'`

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -376,6 +376,15 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
   }
 
   /**
+   * Determine whether tiles for next extent should be enqueued for rendering.
+   * @return {boolean} Rendering tiles for next extent is supported.
+   * @protected
+   */
+  enqueueTilesForNextExtent() {
+    return true;
+  }
+
+  /**
    * @param {import("../../Map.js").FrameState} frameState Frame state.
    * @param {import("../../extent.js").Extent} extent The extent to be rendered.
    * @param {number} initialZ The zoom level.
@@ -626,7 +635,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
      */
 
     const preload = tileLayer.getPreload();
-    if (frameState.nextExtent) {
+    if (frameState.nextExtent && this.enqueueTilesForNextExtent()) {
       const targetZ = tileGrid.getZForResolution(
         viewState.nextResolution,
         tileSource.zDirection,

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -113,6 +113,15 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
   }
 
   /**
+   * Determine whether tiles for next extent should be enqueued for rendering.
+   * @return {boolean} Rendering tiles for next extent is supported.
+   * @override
+   */
+  enqueueTilesForNextExtent() {
+    return this.getLayer().getRenderMode() !== 'vector';
+  }
+
+  /**
    * @param {import("../../VectorRenderTile.js").default} tile Tile.
    * @param {import("../../Map.js").FrameState} frameState Frame state.
    * @param {number} x Left of the tile.


### PR DESCRIPTION
Workaround to prevent overdrawing due to rendering additional tiles for animation series nextExtent with VectorTileLayer and renderMode='vector'.

Fixes #16974

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
