### PR TITLE
Missing ol/layer/Group events in apidoc and signature

### DIFF
--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -14,8 +14,22 @@ import {getUid} from '../util.js';
 import BaseLayer from './Base.js';
 
 /**
- * @typedef {'addlayer'|'removelayer'} GroupEventType
+ * @enum {'addlayer'|'removelayer'}
  */
+const GroupEventType = {
+  /**
+   * Triggered when a layer is added
+   * @event GroupEvent#addlayer
+   * @api
+   */
+  ADDLAYER: /** @type {'addlayer'}*/ ('addlayer'),
+  /**
+   * Triggered when a layer is removed
+   * @event GroupEvent#removelayer
+   * @api
+   */
+  REMOVELAYER: /** @type {'removelayer'} */ ('removelayer'),
+};
 
 /**
  * @classdesc
@@ -45,7 +59,8 @@ export class GroupEvent extends Event {
  * @typedef {import("../Observable").OnSignature<import("../Observable").EventTypes, import("../events/Event.js").default, Return> &
  *   import("../Observable").OnSignature<import("./Base").BaseLayerObjectEventTypes|
  *     'change:layers', import("../Object").ObjectEvent, Return> &
- *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|'change:layers', Return>} GroupOnSignature
+ *   import("../Observable").OnSignature<GroupEventType, GroupEvent, Return> &
+ *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|GroupEventType|'change:layers', Return>} GroupOnSignature
  */
 
 /**
@@ -84,6 +99,7 @@ const Property = {
  *
  * A generic `change` event is triggered when the group/Collection changes.
  *
+ * @fires GroupEvent
  * @api
  */
 class LayerGroup extends BaseLayer {
@@ -178,7 +194,7 @@ class LayerGroup extends BaseLayer {
     for (let i = 0, ii = layersArray.length; i < ii; i++) {
       const layer = layersArray[i];
       this.registerLayerListeners_(layer);
-      this.dispatchEvent(new GroupEvent('addlayer', layer));
+      this.dispatchEvent(new GroupEvent(GroupEventType.ADDLAYER, layer));
     }
     this.changed();
   }
@@ -199,8 +215,13 @@ class LayerGroup extends BaseLayer {
 
     if (layer instanceof LayerGroup) {
       listenerKeys.push(
-        listen(layer, 'addlayer', this.handleLayerGroupAdd_, this),
-        listen(layer, 'removelayer', this.handleLayerGroupRemove_, this),
+        listen(layer, GroupEventType.ADDLAYER, this.handleLayerGroupAdd_, this),
+        listen(
+          layer,
+          GroupEventType.REMOVELAYER,
+          this.handleLayerGroupRemove_,
+          this,
+        ),
       );
     }
 
@@ -211,14 +232,14 @@ class LayerGroup extends BaseLayer {
    * @param {GroupEvent} event The layer group event.
    */
   handleLayerGroupAdd_(event) {
-    this.dispatchEvent(new GroupEvent('addlayer', event.layer));
+    this.dispatchEvent(new GroupEvent(GroupEventType.ADDLAYER, event.layer));
   }
 
   /**
    * @param {GroupEvent} event The layer group event.
    */
   handleLayerGroupRemove_(event) {
-    this.dispatchEvent(new GroupEvent('removelayer', event.layer));
+    this.dispatchEvent(new GroupEvent(GroupEventType.REMOVELAYER, event.layer));
   }
 
   /**
@@ -228,7 +249,7 @@ class LayerGroup extends BaseLayer {
   handleLayersAdd_(collectionEvent) {
     const layer = collectionEvent.element;
     this.registerLayerListeners_(layer);
-    this.dispatchEvent(new GroupEvent('addlayer', layer));
+    this.dispatchEvent(new GroupEvent(GroupEventType.ADDLAYER, layer));
     this.changed();
   }
 
@@ -241,7 +262,7 @@ class LayerGroup extends BaseLayer {
     const key = getUid(layer);
     this.listenerKeys_[key].forEach(unlistenByKey);
     delete this.listenerKeys_[key];
-    this.dispatchEvent(new GroupEvent('removelayer', layer));
+    this.dispatchEvent(new GroupEvent(GroupEventType.REMOVELAYER, layer));
     this.changed();
   }
 
@@ -272,7 +293,9 @@ class LayerGroup extends BaseLayer {
     if (collection) {
       const currentLayers = collection.getArray();
       for (let i = 0, ii = currentLayers.length; i < ii; ++i) {
-        this.dispatchEvent(new GroupEvent('removelayer', currentLayers[i]));
+        this.dispatchEvent(
+          new GroupEvent(GroupEventType.REMOVELAYER, currentLayers[i]),
+        );
       }
     }
 

--- a/src/ol/layer/Group.js
+++ b/src/ol/layer/Group.js
@@ -14,7 +14,7 @@ import {getUid} from '../util.js';
 import BaseLayer from './Base.js';
 
 /**
- * @enum {'addlayer'|'removelayer'}
+ * @enum {string}
  */
 const GroupEventType = {
   /**
@@ -22,13 +22,13 @@ const GroupEventType = {
    * @event GroupEvent#addlayer
    * @api
    */
-  ADDLAYER: /** @type {'addlayer'}*/ ('addlayer'),
+  ADDLAYER: 'addlayer',
   /**
    * Triggered when a layer is removed
    * @event GroupEvent#removelayer
    * @api
    */
-  REMOVELAYER: /** @type {'removelayer'} */ ('removelayer'),
+  REMOVELAYER: 'removelayer',
 };
 
 /**
@@ -59,8 +59,8 @@ export class GroupEvent extends Event {
  * @typedef {import("../Observable").OnSignature<import("../Observable").EventTypes, import("../events/Event.js").default, Return> &
  *   import("../Observable").OnSignature<import("./Base").BaseLayerObjectEventTypes|
  *     'change:layers', import("../Object").ObjectEvent, Return> &
- *   import("../Observable").OnSignature<GroupEventType, GroupEvent, Return> &
- *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|GroupEventType|'change:layers', Return>} GroupOnSignature
+ *   import("../Observable").OnSignature<'addlayer'|'removelayer', GroupEvent, Return> &
+ *   import("../Observable").CombinedOnSignature<import("../Observable").EventTypes|import("./Base").BaseLayerObjectEventTypes|'addlayer'|'removelayer'|'change:layers', Return>} GroupOnSignature
  */
 
 /**

--- a/test/typescript/cases/group-layer.ts
+++ b/test/typescript/cases/group-layer.ts
@@ -1,0 +1,7 @@
+import Group from '../../../build/ol/layer/Group.js';
+
+const group = new Group();
+group.on('change', () => {});
+group.on('addlayer', (evt) => evt.layer);
+group.on('removelayer', (evt) => evt.layer);
+group.on(['addlayer', 'removelayer', 'change:layers'], () => {});


### PR DESCRIPTION
https://openlayers.org/en/latest/apidoc/module-ol_layer_Group-LayerGroup.html
https://deploy-preview-17011--ol-site.netlify.app/en/latest/apidoc/module-ol_layer_group-layergroup

Only adding the `@fires GroupEvent` annotation did not show up in the apidoc like:
<img width="201" height="85" alt="image" src="https://github.com/user-attachments/assets/52a15ad9-1ae7-4338-b098-afab42fe3f9b" />
<br>
Strangely ts did not detect invalid event names when using `@enum {string}` for the GroupEventType as it should and does for `ol/Collection`. So I used `@enum {'addlayer'|'removelayer'}`, but no idea why this is the case.
<img width="598" height="327" alt="image" src="https://github.com/user-attachments/assets/ba0508ce-05f6-44a5-9f03-ec580220f5c3" />
<details>
<summary>
Code
</summary>

```js
import Collection from '../../../build/ol/Collection.js';
import Group from '../../../build/ol/layer/Group.js';

const collection = new Collection();
collection.on('as', () => {});
collection.on('add', () => {});
collection.on(['add', 'as'], () => {});

const group = new Group();
group.on('change', () => {});
group.on('addlayer', () => {});
group.on('removelayer', () => {});
group.on('asdf', () => {});
group.on(['addlayer', 'removelayer', 'asdf', 'change:layers'], () => {});
```
</details>

