### PR TITLE
Fix collection unique check with setAt

### DIFF
--- a/src/ol/Collection.js
+++ b/src/ol/Collection.js
@@ -311,12 +311,12 @@ class Collection extends BaseObject {
   /**
    * @private
    * @param {T} elem Element.
-   * @param {number} [ignoreStartingAt] Optional indexes to ignore.
+   * @param {number} [except] Optional index to ignore.
    */
-  assertUnique_(elem, ignoreStartingAt) {
+  assertUnique_(elem, except) {
     const array = this.array_;
-    for (let i = 0, ii = ignoreStartingAt ?? array.length; i < ii; ++i) {
-      if (array[i] === elem) {
+    for (let i = 0, ii = array.length; i < ii; ++i) {
+      if (array[i] === elem && i !== except) {
         throw new Error('Duplicate item added to a unique collection');
       }
     }

--- a/test/node/ol/Collection.test.js
+++ b/test/node/ol/Collection.test.js
@@ -386,6 +386,13 @@ describe('ol/Collection.js', function () {
         unique.setAt(1, item);
       };
       expect(call).to.throwException();
+
+      const item2 = {};
+      unique.setAt(1, item2);
+      const call2 = function () {
+        unique.setAt(0, item2);
+      };
+      expect(call2).to.throwException();
     });
   });
 });


### PR DESCRIPTION
`assertUnique_` is call with the second parameter set in `setAt` which is incompatible with the changes from 60882de1c2b2ba862ea87b96afdf76676a7753ce to `assertUnique_`.