### PR TITLE
Enable trusted publishing

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - run: npm ci
       - run: ./tasks/build-website.sh -v dev -l dev
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - run: npm install --global netlify-cli@6
       - run: npm install unzipper@0.10
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Build Website
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Assert Latest Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,13 +25,13 @@ jobs:
         run: npm ci
       - name: Publish
         run: |
+          npm i -g npm@latest
           VERSION=$(node tasks/next-dev-version.js)
           npm --no-git-tag-version version ${VERSION}
           npm run build-package
           cd build/ol
-          npm publish --provenance --tag dev
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          npm publish --tag dev
+
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
@@ -47,8 +47,7 @@ jobs:
         run: node tasks/newest-tag.js --tag ${GITHUB_REF_NAME}
       - name: Publish
         run: |
+          npm i -g npm@latest
           npm run build-package
           cd build/ol
-          npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,12 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
       - name: Publish
         run: |
-          npm i -g npm@latest
           VERSION=$(node tasks/next-dev-version.js)
           npm --no-git-tag-version version ${VERSION}
           npm run build-package
@@ -39,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
         run: npm ci
@@ -47,7 +46,6 @@ jobs:
         run: node tasks/newest-tag.js --tag ${GITHUB_REF_NAME}
       - name: Publish
         run: |
-          npm i -g npm@latest
           npm run build-package
           cd build/ol
           npm publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm ci
@@ -45,7 +45,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm ci
@@ -64,7 +64,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm ci
@@ -83,7 +83,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm ci
@@ -102,7 +102,7 @@ jobs:
       - name: Set Node.js Version
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
In light of recent malicious attacks,

This PR edits your `publish.yml` to switch to Trusted Publishing. It lets your CI (e.g., GitHub Actions) mint a short‑lived OIDC ID token (`permissions: id-token: write`) that npm exchanges for a publish credential at runtime, so you don't have to store long‑lived npm tokens in CI. npm CLI 11.5.1+ is required, and when you publish public packages from public repos npm will automatically attach provenance attestations. Don't forget to enable a Trusted Publisher for your package in the npmjs.com settings.

See:

https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available

https://docs.npmjs.com/trusted-publishers

https://github.com/e18e/ecosystem-issues/issues/201

Also. If it is already not set, please switch the package's Publishing Access radio button to "Require two-factor authentication and disallow tokens".