### PR TITLE
Fix(WebGLVectorLayer): Pass correct projection LoadFeatures #16872

### DIFF
--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -413,7 +413,7 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
       const userProjection = getUserProjection();
       if (userProjection) {
         vectorSource.loadFeatures(
-          toUserExtent(extent, userProjection),
+          toUserExtent(extent, projection),
           toUserResolution(resolution, projection),
           userProjection,
         );


### PR DESCRIPTION
See issue #16872 


