### PR TITLE
Vector: [Fix] Vector layer wrapping

### DIFF
--- a/examples/polygon-wrapping.html
+++ b/examples/polygon-wrapping.html
@@ -1,0 +1,10 @@
+---
+layout: example.html
+title: Polygon map wrapping
+shortdesc: Renders polygons correctly across the antimeridian
+docs: >
+  A simple map with an OSM basemap and a couple rectangular polygon features (e.g. a bounding box)
+  on either side (and crossing over) the antimeridian.
+tags: "simple, geometry, rectangle, box, bbox, polygon, dateline, wrap, 180"
+---
+<div id="map" class="map"></div>

--- a/examples/polygon-wrapping.js
+++ b/examples/polygon-wrapping.js
@@ -1,0 +1,42 @@
+import Feature from '../src/ol/Feature.js';
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import {fromExtent} from '../src/ol/geom/Polygon.js';
+import TileLayer from '../src/ol/layer/Tile.js';
+import VectorLayer from '../src/ol/layer/Vector.js';
+import {get as getProjection} from '../src/ol/proj.js';
+import OSM from '../src/ol/source/OSM.js';
+import VectorSource from '../src/ol/source/Vector.js';
+
+const proj = getProjection('EPSG:3857');
+const extent = proj.getExtent();
+const leftX = extent[0];
+const rightX = extent[2];
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+    new VectorLayer({
+      updateWhileAnimating: true,
+      updateWhileInteracting: true,
+      source: new VectorSource({
+        features: [
+          new Feature(fromExtent([leftX, -15000000, leftX, 15000000])),
+          new Feature(
+            fromExtent([leftX - 2000000, 4500000, leftX + 4000000, 6500000]),
+          ),
+          new Feature(
+            fromExtent([rightX - 4000000, 7500000, rightX + 2000000, 9500000]),
+          ),
+        ],
+      }),
+    }),
+  ],
+  target: 'map',
+  view: new View({
+    center: [0, 6000000],
+    zoom: 1,
+  }),
+});

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -202,10 +202,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const multiWorld = vectorSource.getWrapX() && projection.canWrapX();
     const worldWidth = multiWorld ? getWidth(projectionExtent) : null;
     const endWorld = multiWorld
-      ? Math.ceil((extent[2] - projectionExtent[2]) / worldWidth) + 1
+      ? Math.ceil((extent[2] - this.sourceExtent_[0]) / worldWidth)
       : 1;
     let world = multiWorld
-      ? Math.floor((extent[0] - projectionExtent[0]) / worldWidth)
+      ? Math.floor((extent[0] - this.sourceExtent_[2]) / worldWidth) + 1
       : 0;
     do {
       let transform = this.getRenderTransform(

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -9,6 +9,7 @@ import {
   buffer,
   containsExtent,
   createEmpty,
+  extend,
   getHeight,
   getWidth,
   intersects as intersectsExtent,
@@ -20,6 +21,7 @@ import {
   getUserProjection,
   toUserExtent,
   toUserResolution,
+  transformExtent,
 } from '../../proj.js';
 import RenderEventType from '../../render/EventType.js';
 import CanvasBuilderGroup from '../../render/canvas/BuilderGroup.js';
@@ -587,6 +589,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const projection = viewState.projection;
     const resolution = viewState.resolution;
     const pixelRatio = frameState.pixelRatio;
+    const multiWorld = vectorSource.getWrapX() && projection.canWrapX();
     const vectorLayerRevision = vectorLayer.getRevision();
     const vectorLayerRenderBuffer = vectorLayer.getRenderBuffer();
     let vectorLayerRenderOrder = vectorLayer.getRenderOrder();
@@ -603,6 +606,26 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     const renderedExtent = extent.slice();
     const loadExtents = [extent.slice()];
     const projectionExtent = projection.getExtent();
+    const rawSourceExtent = vectorSource.getExtent();
+    if (
+      multiWorld &&
+      rawSourceExtent &&
+      (!this.rawSourceExtent_ ||
+        !equals(this.rawSourceExtent_, rawSourceExtent))
+    ) {
+      this.rawSourceExtent_ = rawSourceExtent;
+      // transformExtent will fail if it doesn't find a valid transformFunc for the pair of projections
+      try {
+        this.sourceExtent_ = transformExtent(
+          rawSourceExtent,
+          vectorSource.getProjection() ?? 'EPSG:3857',
+          projection,
+        );
+      } catch {
+        this.sourceExtent_ = rawSourceExtent;
+      }
+      extend(extent, this.sourceExtent_);
+    }
 
     if (
       vectorSource.getWrapX() &&

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -719,7 +719,10 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
 
     const userExtent = toUserExtent(extent, projection);
     /** @type {Array<import("../../Feature.js").default>} */
-    const features = vectorSource.getFeaturesInExtent(userExtent);
+    const features = vectorSource.getFeaturesInExtent(
+      userExtent,
+      userProjection ?? projection,
+    );
     if (vectorLayerRenderOrder) {
       features.sort(vectorLayerRenderOrder);
     }

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -841,15 +841,15 @@ class VectorSource extends Source {
   /**
    * Get the extent of the features currently in the source.
    *
-   * This method is not available when the source is configured with
+   * This will return undefined when the source is configured with
    * `useSpatialIndex` set to `false`.
    * @param {import("../extent.js").Extent} [extent] Destination extent. If provided, no new extent
    *     will be created. Instead, that extent's coordinates will be overwritten.
-   * @return {import("../extent.js").Extent} Extent.
+   * @return {import("../extent.js").Extent | undefined} Extent or undefined.
    * @api
    */
   getExtent(extent) {
-    return this.featuresRtree_.getExtent(extent);
+    return this.featuresRtree_?.getExtent(extent);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

https://github.com/openlayers/openlayers/issues/17085

Vector layers are not wrapping quite right, as described in the above issue (and shown in the example). I did my best to fix this in a way that maintained existing logic and behavior. There were a few issues that needed addressing:
- Features extending beyond the projection extent were not being captured by `getFeaturesInExtent` when the extent didn't cover them in the 'original' copy of the world.
- `getFeaturesInExtent` was not being passed a projection in the `canvas/VectorLayer` call, so even with the above fix, it still wouldn't include the feature.
- Features captured by the above fixes were still not rendered correctly because of the point culling the polygon renderer does. This was fixed by including the whole source extent in maxExtent when in `multiWorld` mode.
- Finally, even with the features included, there were cases where one too few worlds was included in the final render. This just required some changes to the math for start- and endWorld numbers.

I added an example to quickly showcase this working and for my own ease of testing.

I made sure all the tests worked locally (although the rendering test break on my machine even on master).
