### PR TITLE
Snap fixes

### DIFF
--- a/src/ol/events/SnapEvent.js
+++ b/src/ol/events/SnapEvent.js
@@ -13,6 +13,11 @@ export const SnapEventType = {
    * @api
    */
   SNAP: 'snap',
+  /**
+   * Triggered if no longer snapped
+   * @event SnapEvent#unsnap
+   * @api
+   */
   UNSNAP: 'unsnap',
 };
 

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -473,8 +473,6 @@ class Snap extends PointerInteraction {
             segment: segment,
           };
         }
-        tempExtents.length = segmentCount;
-        tempSegmentData.length = segmentCount;
 
         if (this.intersection_) {
           for (let j = 0, jj = segments.length; j < jj; ++j) {
@@ -527,6 +525,8 @@ class Snap extends PointerInteraction {
         if (segmentCount === 1) {
           this.rBush_.insert(tempExtents[0], tempSegmentData[0]);
         } else {
+          tempExtents.length = segmentCount;
+          tempSegmentData.length = segmentCount;
           this.rBush_.load(tempExtents, tempSegmentData);
         }
       }

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -129,7 +129,7 @@ const GEOMETRY_SEGMENTERS = {
     const segments = [];
     const geometries = geometry.getGeometriesArray();
     for (let i = 0; i < geometries.length; ++i) {
-      const segmenter = GEOMETRY_SEGMENTERS[geometries[i].getType()];
+      const segmenter = this[geometries[i].getType()];
       if (segmenter) {
         segments.push(segmenter(geometries[i], projection));
       }
@@ -452,7 +452,8 @@ class Snap extends PointerInteraction {
       if (segmenter) {
         this.indexedFeaturesExtents_[feature_uid] =
           geometry.getExtent(createEmpty());
-        const segments = segmenter(
+        const segments = segmenter.call(
+          this.segmenters_,
           geometry,
           this.getMap().getView().getProjection(),
         );

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -483,12 +483,9 @@ class Snap extends PointerInteraction {
               continue;
             }
             const extent = tempExtents[j];
-            // Calculate intersections with own segments
-            for (let k = 0, kk = segments.length; k < kk; ++k) {
-              if (j === k || j - 1 === k || j + 1 === k) {
-                // Exclude self and neighbours
-                continue;
-              }
+            // Calculate intersections with own segments excluding self and
+            // neighbors
+            for (let k = 0, kk = j - 1; k < kk; ++k) {
               const otherSegment = segments[k];
               if (!intersectsExtent(extent, tempExtents[k])) {
                 continue;

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -324,19 +324,10 @@ class Snap extends PointerInteraction {
   constructor(options) {
     options = options ? options : {};
 
-    const pointerOptions = /** @type {import("./Pointer.js").Options} */ (
-      options
-    );
-
-    if (!pointerOptions.handleDownEvent) {
-      pointerOptions.handleDownEvent = TRUE;
-    }
-
-    if (!pointerOptions.stopDown) {
-      pointerOptions.stopDown = FALSE;
-    }
-
-    super(pointerOptions);
+    super({
+      handleDownEvent: TRUE,
+      stopDown: FALSE,
+    });
 
     /***
      * @type {SnapOnSignature<import("../events").EventsKey>}

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -783,30 +783,23 @@ class Snap extends PointerInteraction {
     let minSquaredDistance = Infinity;
     let closestFeature;
     let closestSegment = null;
-    let isIntersection;
 
     const squaredPixelTolerance = this.pixelTolerance_ * this.pixelTolerance_;
     const getResult = () => {
-      if (closestVertex) {
-        const vertexPixel = map.getPixelFromCoordinate(closestVertex);
-        const squaredPixelDistance = squaredDistance(pixel, vertexPixel);
-        if (
-          squaredPixelDistance <= squaredPixelTolerance &&
-          ((isIntersection && this.intersection_) ||
-            (!isIntersection && (this.vertex_ || this.edge_)))
-        ) {
-          return {
-            vertex: closestVertex,
-            vertexPixel: [
-              Math.round(vertexPixel[0]),
-              Math.round(vertexPixel[1]),
-            ],
-            feature: closestFeature,
-            segment: closestSegment,
-          };
-        }
+      if (!closestVertex) {
+        return null;
       }
-      return null;
+      const vertexPixel = map.getPixelFromCoordinate(closestVertex);
+      const squaredPixelDistance = squaredDistance(pixel, vertexPixel);
+      if (squaredPixelDistance > squaredPixelTolerance) {
+        return null;
+      }
+      return {
+        vertex: closestVertex,
+        vertexPixel: [Math.round(vertexPixel[0]), Math.round(vertexPixel[1])],
+        feature: closestFeature,
+        segment: closestSegment,
+      };
     };
 
     if (this.vertex_ || this.intersection_) {
@@ -816,11 +809,14 @@ class Snap extends PointerInteraction {
           for (const vertex of segmentData.segment) {
             const tempVertexCoord = fromUserCoordinate(vertex, projection);
             const delta = squaredDistance(projectedCoordinate, tempVertexCoord);
-            if (delta < minSquaredDistance) {
+            if (
+              delta < minSquaredDistance &&
+              ((this.intersection_ && segmentData.isIntersection) ||
+                (this.vertex_ && !segmentData.isIntersection))
+            ) {
               closestVertex = vertex;
               minSquaredDistance = delta;
               closestFeature = segmentData.feature;
-              isIntersection = segmentData.isIntersection;
             }
           }
         }

--- a/src/ol/interaction/Snap.js
+++ b/src/ol/interaction/Snap.js
@@ -19,6 +19,7 @@ import {
 import {FALSE, TRUE} from '../functions.js';
 import {fromCircle} from '../geom/Polygon.js';
 import {getIntersectionPoint} from '../geom/flat/segments.js';
+import {clear} from '../obj.js';
 import {
   fromUserCoordinate,
   getUserProjection,
@@ -626,6 +627,7 @@ class Snap extends PointerInteraction {
     const feature = getFeatureFromEvent(evt);
     if (feature) {
       this.removeFeature(feature);
+      delete this.pendingFeatures_[getUid(feature)];
     }
   }
 
@@ -636,10 +638,7 @@ class Snap extends PointerInteraction {
   handleFeatureChange_(evt) {
     const feature = /** @type {import("../Feature.js").default} */ (evt.target);
     if (this.handlingDownUpSequence) {
-      const uid = getUid(feature);
-      if (!(uid in this.pendingFeatures_)) {
-        this.pendingFeatures_[uid] = feature;
-      }
+      this.pendingFeatures_[getUid(feature)] = feature;
     } else {
       this.updateFeature_(feature);
     }
@@ -657,6 +656,7 @@ class Snap extends PointerInteraction {
       for (const feature of featuresToUpdate) {
         this.updateFeature_(feature);
       }
+      clear(this.pendingFeatures_);
     }
     return false;
   }

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -488,6 +488,33 @@ describe('ol.interaction.Snap', function () {
       snapInteraction.handleEvent(event);
     });
 
+    it('snaps to intersection when a vertex is closer, but vertex is false', function () {
+      const line1 = new Feature(
+        new LineString([
+          [-10, 0],
+          [10, 0],
+        ]),
+      );
+      const line2 = new Feature(
+        new LineString([
+          [0, -10],
+          [0, 10],
+        ]),
+      );
+
+      const snapInteraction = new Snap({
+        features: new Collection([line1, line2]),
+        pixelTolerance: 11,
+        intersection: true,
+        vertex: false,
+      });
+      snapInteraction.setMap(map);
+      snapInteraction.on('snap', (evt) => {
+        expect(evt.vertex).to.eql([0, 0]);
+      });
+      snapInteraction.handleEvent(eventFromCoordinate([0, -10]));
+    });
+
     it('unsnaps if snapped to other feature', function () {
       const point1 = new Feature(new Point([10, 10]));
       const point2 = new Feature(new Point([30, 30]));

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -677,7 +677,7 @@ describe('ol.interaction.Snap', function () {
         expect(!!intersectionSegmentData).to.be(intersection);
         if (intersection) {
           expect(intersectionSegmentData.segment[0]).to.eql(intersectionPoint);
-          expect(intersectionSegmentData.isIntersection).to.be(true);
+          expect(intersectionSegmentData.intersectionFeature).to.be.ok();
         }
       });
     }
@@ -702,7 +702,7 @@ describe('ol.interaction.Snap', function () {
 
       const segments = snapInteraction.rBush_
         .getAll()
-        .filter((item) => item.isIntersection);
+        .filter((item) => item.intersectionFeature);
       expect(segments).to.have.length(1);
       expect(segments[0].segment).to.eql([[0, 0]]);
     });
@@ -734,13 +734,13 @@ describe('ol.interaction.Snap', function () {
 
         const intersections2 = snapInteraction.rBush_
           .getAll()
-          .filter((item) => item.isIntersection);
+          .filter((item) => item.intersectionFeature);
         expect(intersections2).to.have.length(1);
 
         snapInteraction.removeFeature(features[i]);
         const intersections1 = snapInteraction.rBush_
           .getAll()
-          .filter((item) => item.isIntersection);
+          .filter((item) => item.intersectionFeature);
         expect(intersections1).to.have.length(0);
       });
     }

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -1,6 +1,7 @@
 import Collection from '../../../../../src/ol/Collection.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
+import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../../src/ol/View.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
@@ -542,6 +543,27 @@ describe('ol.interaction.Snap', function () {
       });
 
       snapInteraction.handleEvent(eventFromCoordinate([30, 30]));
+    });
+
+    it('clears pending feature changes on pointer up', function () {
+      const point1 = new Feature(new Point([10, 10]));
+      const snapInteraction = new Snap({
+        features: new Collection([point1]),
+      });
+      snapInteraction.setMap(map);
+
+      snapInteraction.handleEvent(
+        new MapBrowserEvent(
+          'pointerdown',
+          map,
+          new PointerEvent('pointerdown'),
+        ),
+      );
+      point1.getGeometry().setCoordinates([0, 0]);
+      snapInteraction.handleEvent(
+        new MapBrowserEvent('pointerup', map, new PointerEvent('pointerup')),
+      );
+      expect(Object.keys(snapInteraction.pendingFeatures_)).to.have.length(0);
     });
   });
 

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -681,6 +681,31 @@ describe('ol.interaction.Snap', function () {
         }
       });
     }
+
+    it('only adds single self intersection point', function () {
+      const line1 = new Feature(
+        new LineString([
+          [-10, 0],
+          [10, 0],
+          [10, 10],
+          [-10, -10],
+        ]),
+      );
+
+      const snapInteraction = new Snap({
+        features: new Collection([line1]),
+        intersection: true,
+        vertex: false,
+        edege: false,
+      });
+      snapInteraction.setMap(new Map({}));
+
+      const segments = snapInteraction.rBush_
+        .getAll()
+        .filter((item) => item.isIntersection);
+      expect(segments).to.have.length(1);
+      expect(segments[0].segment).to.eql([[0, 0]]);
+    });
   });
 
   describe('Custom segmenters', () => {

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -1,9 +1,11 @@
+import {spy as sinonSpy} from 'sinon';
 import Collection from '../../../../../src/ol/Collection.js';
 import Feature from '../../../../../src/ol/Feature.js';
 import Map from '../../../../../src/ol/Map.js';
 import MapBrowserEvent from '../../../../../src/ol/MapBrowserEvent.js';
 import View from '../../../../../src/ol/View.js';
 import Circle from '../../../../../src/ol/geom/Circle.js';
+import GeometryCollection from '../../../../../src/ol/geom/GeometryCollection.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import Point from '../../../../../src/ol/geom/Point.js';
@@ -376,6 +378,23 @@ describe('ol.interaction.Snap', function () {
         expect(event.coordinate[1]).to.roughlyEqual(coordinate[1], 1e-10);
       });
       snapInteraction.handleEvent(event);
+    });
+
+    it('uses custom segmenters for geometries of GeometryCollection', function () {
+      const geometryCollection = new Feature(
+        new GeometryCollection([new Point([0, 0])]),
+      );
+      const segmenter = sinonSpy((geometry) => {
+        return [geometry.getCoordinates()];
+      });
+      const snapInteraction = new Snap({
+        features: new Collection([geometryCollection]),
+        segmenters: {
+          Point: segmenter,
+        },
+      });
+      snapInteraction.setMap(map);
+      expect(segmenter.called).to.be(true);
     });
 
     it('handle feature without geometry', function () {

--- a/test/browser/spec/ol/interaction/snap.test.js
+++ b/test/browser/spec/ol/interaction/snap.test.js
@@ -706,6 +706,44 @@ describe('ol.interaction.Snap', function () {
       expect(segments).to.have.length(1);
       expect(segments[0].segment).to.eql([[0, 0]]);
     });
+
+    for (const i of [0, 1]) {
+      it('removes intersections if either feature is removed', function () {
+        const features = [
+          new Feature(
+            new LineString([
+              [0, 0],
+              [10, 10],
+            ]),
+          ),
+          new Feature(
+            new LineString([
+              [0, 10],
+              [10, 0],
+            ]),
+          ),
+        ];
+
+        const snapInteraction = new Snap({
+          features: new Collection(features),
+          intersection: true,
+          vertex: false,
+          edge: false,
+        });
+        snapInteraction.setMap(new Map({}));
+
+        const intersections2 = snapInteraction.rBush_
+          .getAll()
+          .filter((item) => item.isIntersection);
+        expect(intersections2).to.have.length(1);
+
+        snapInteraction.removeFeature(features[i]);
+        const intersections1 = snapInteraction.rBush_
+          .getAll()
+          .filter((item) => item.isIntersection);
+        expect(intersections1).to.have.length(0);
+      });
+    }
   });
 
   describe('Custom segmenters', () => {

--- a/test/browser/spec/util.js
+++ b/test/browser/spec/util.js
@@ -1,22 +1,5 @@
 import {checkedFonts} from '../../../src/ol/render/canvas.js';
 
-export function overrideRAF() {
-  const raf = window.requestAnimationFrame;
-  const caf = window.cancelAnimationFrame;
-
-  window.requestAnimationFrame = function (callback) {
-    return setTimeout(callback, 1);
-  };
-  window.cancelAnimationFrame = function (key) {
-    return clearTimeout(key);
-  };
-
-  return function () {
-    window.requestAnimationFrame = raf;
-    window.cancelAnimationFrame = caf;
-  };
-}
-
 export function createFontStyle(options) {
   const src = Array.isArray(options.src) ? options.src : [options.src];
   function toCssSource(src) {


### PR DESCRIPTION
This fixes some bugs in `ol/interaction/Snap`:

- it did not snap to intersectionts if a vertex is closer to the event coordinate but vertex snapping is disabled
- each self-intersections was added twice
- intersections between two Features could persist because only one of the Features was stored with the SegmentData
- pending Feature changes during ponter interinteractions were applied but never cleared, which means on each pointerup any Feature changed with this interaction was re-added even when it had been removed
- GeometryCollections ignored custom segmenters, always using the defaults