### PR TITLE
Deprecate stable sort

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -14,6 +14,14 @@ stableSort(arr, compareFnc);
 arr.sort(compareFnc);
 ```
 
+#### Deprecation of functions in ol/format/Polyline
+
+The following functions have been deprecated without replacement:
+- decodeDeltas
+- encodeDeltas
+- decodeFloats
+- encodeFloats
+
 ### 10.4.0
 
 #### Deprecation of ol/layer/WebGLPoints

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,18 @@
 
 ### Next Release
 
+#### Deprecation of ol/array's stableSort
+
+Sorting is guaranteed to be stable since [ECMAScript 2019](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability).
+```js
+// Before
+stableSort(arr, compareFnc);
+```
+```js
+// After
+arr.sort(compareFnc);
+```
+
 ### 10.4.0
 
 #### Deprecation of ol/layer/WebGLPoints

--- a/src/ol/array.js
+++ b/src/ol/array.js
@@ -208,6 +208,7 @@ export function equals(arr1, arr2) {
  * @param {Array<*>} arr The array to sort (modifies original).
  * @param {!function(*, *): number} compareFnc Comparison function.
  * @api
+ * @deprecated
  */
 export function stableSort(arr, compareFnc) {
   const length = arr.length;


### PR DESCRIPTION
The function is not used by OpenLayer.

Sorting is guaranteed to be stable since ECMAScript 2019
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#sort_stability

See #16955 and #16968 for the deprecation of ol/format/Polyline functions.