### PR TITLE
Use the dependabot cooldown config to limit bad package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,13 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 5
   open-pull-requests-limit: 10
   versioning-strategy: increase-if-necessary
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: weekly
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
Dependabot now has a `cooldown` configuration option that specifies the number of days to wait before installing a newly released package. The intent of this feature is to reduce supply chain attacks. See https://www.stepsecurity.io/blog/introducing-the-npm-package-cooldown-check for more detail.