### PR TITLE
Fix z0 resolution for tile grids with different width and height

### DIFF
--- a/examples/vector-tiles-4326.js
+++ b/examples/vector-tiles-4326.js
@@ -1,30 +1,16 @@
-import {applyBackground, applyStyle} from 'ol-mapbox-style';
+import {apply} from 'ol-mapbox-style';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
-import VectorTileLayer from '../src/ol/layer/VectorTile.js';
-import VectorTileSource from '../src/ol/source/VectorTile.js';
-import {createXYZ} from '../src/ol/tilegrid.js';
+import LayerGroup from '../src/ol/layer/Group.js';
 
 const key = 'get_your_own_D6rA4zTHduk6KOKTXzGB';
 const url = 'https://api.maptiler.com/maps/basic-4326/style.json?key=' + key;
 
-// Match the server resolutions
-const tileGrid = createXYZ({
-  extent: [-180, -90, 180, 90],
-  tileSize: 512,
-  maxResolution: 180 / 512,
-  maxZoom: 13,
-});
+// Container for ol-mapbox-style layers
+const layer = new LayerGroup();
 
-const layer = new VectorTileLayer({
-  declutter: true,
-  source: new VectorTileSource({
-    projection: 'EPSG:4326',
-    tileGrid: tileGrid,
-  }),
-});
-applyStyle(layer, url, {resolutions: tileGrid.getResolutions()});
-applyBackground(layer, url);
+// The layer group will be populated with a background layer and a VectorTile layer
+apply(layer, url, {projection: 'EPSG:4326'});
 
 const map = new Map({
   target: 'map',

--- a/src/ol/tilegrid.js
+++ b/src/ol/tilegrid.js
@@ -122,15 +122,13 @@ export function createXYZ(options) {
  */
 function resolutionsFromExtent(extent, maxZoom, tileSize, maxResolution) {
   maxZoom = maxZoom !== undefined ? maxZoom : DEFAULT_MAX_ZOOM;
-  tileSize = toSize(tileSize !== undefined ? tileSize : DEFAULT_TILE_SIZE);
 
-  const height = getHeight(extent);
-  const width = getWidth(extent);
-
-  maxResolution =
-    maxResolution > 0
-      ? maxResolution
-      : Math.max(width / tileSize[0], height / tileSize[1]);
+  if (!(maxResolution > 0)) {
+    tileSize = toSize(tileSize !== undefined ? tileSize : DEFAULT_TILE_SIZE);
+    const height = getHeight(extent);
+    const width = getWidth(extent);
+    maxResolution = Math.min(width / tileSize[0], height / tileSize[1]);
+  }
 
   const length = maxZoom + 1;
   const resolutions = new Array(length);

--- a/test/browser/spec/ol/source/TileWMS.test.js
+++ b/test/browser/spec/ol/source/TileWMS.test.js
@@ -252,7 +252,7 @@ describe('ol/source/TileWMS', function () {
 
     it('changes the BBOX order for EN axis orientations', function () {
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
+      const tile = source.getTile(2, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-45,-90,0,-45');
@@ -261,7 +261,7 @@ describe('ol/source/TileWMS', function () {
     it('uses EN BBOX order if version < 1.3', function () {
       options.params.VERSION = '1.1.0';
       const source = new TileWMS(options);
-      const tile = source.getTile(3, 2, 2, 1, getProjection('CRS:84'));
+      const tile = source.getTile(2, 2, 2, 1, getProjection('CRS:84'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
       expect(queryData.get('BBOX')).to.be('-90,-45,-45,0');
@@ -309,7 +309,7 @@ describe('ol/source/TileWMS', function () {
     it('returns a tile if it is contained within layers extent', function () {
       options.extent = [-80, -40, -50, -10];
       const source = new TileWMS(options);
-      const tileCoord = [3, 2, 2];
+      const tileCoord = [2, 2, 2];
       const url = source.tileUrlFunction(
         tileCoord,
         1,
@@ -323,7 +323,7 @@ describe('ol/source/TileWMS', function () {
     it('returns a tile if it intersects layers extent', function () {
       options.extent = [-80, -40, -40, -10];
       const source = new TileWMS(options);
-      const tileCoord = [3, 3, 2];
+      const tileCoord = [2, 3, 2];
       const url = source.tileUrlFunction(
         tileCoord,
         1,

--- a/test/node/ol/tilegrid/TileGrid.test.js
+++ b/test/node/ol/tilegrid/TileGrid.test.js
@@ -1,5 +1,9 @@
 import TileRange from '../../../../src/ol/TileRange.js';
-import {createOrUpdate} from '../../../../src/ol/extent.js';
+import {
+  createOrUpdate,
+  getHeight,
+  getWidth,
+} from '../../../../src/ol/extent.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
 import {METERS_PER_UNIT} from '../../../../src/ol/proj/Units.js';
 import {HALF_SIZE} from '../../../../src/ol/proj/epsg3857.js';
@@ -419,6 +423,18 @@ describe('ol/tilegrid/TileGrid.js', function () {
 
       const resolutions = grid.getResolutions();
       expect(resolutions.length).to.be(DEFAULT_MAX_ZOOM + 1);
+    });
+
+    it('calculates z0 resolution from the shorter edge of the projection extent for correct tile extents', () => {
+      const projection = getProjection('EPSG:4326');
+      const extent = projection.getExtent();
+      const grid = createForProjection(projection);
+      const resolutions = grid.getResolutions();
+      expect(resolutions[0]).to.be(
+        Math.min(getHeight(extent), getWidth(extent)) / DEFAULT_TILE_SIZE,
+      );
+      expect(grid.getTileCoordExtent([0, 0, 0])).to.eql([-180, -90, 0, 90]);
+      expect(grid.getTileCoordExtent([0, 1, 0])).to.eql([0, -90, 180, 90]);
     });
 
     it('accepts a number of zoom levels', function () {
@@ -1074,14 +1090,14 @@ describe('ol/tilegrid/TileGrid.js', function () {
     it('calls the provided function with each tile coordinate', function () {
       const tileGrid = createXYZ({extent: [-180, -90, 180, 90]});
       const tileCoords = [];
-      tileGrid.forEachTileCoord([15, 47, 16, 48], 8, function (tileCoord) {
+      tileGrid.forEachTileCoord([15, 47, 16, 48], 7, function (tileCoord) {
         tileCoords.push(tileCoord);
       });
       expect(tileCoords).to.eql([
-        [8, 138, 29],
-        [8, 138, 30],
-        [8, 139, 29],
-        [8, 139, 30],
+        [7, 138, 29],
+        [7, 138, 30],
+        [7, 139, 29],
+        [7, 139, 30],
       ]);
     });
   });

--- a/test/rendering/cases/layer-tile-none-square/main.js
+++ b/test/rendering/cases/layer-tile-none-square/main.js
@@ -1,6 +1,7 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
+import {METERS_PER_UNIT} from '../../../../src/ol/proj.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
 
@@ -11,6 +12,7 @@ const layer = new TileLayer({
     url: '/data/tiles/512x256/{z}/{x}/{y}.png',
     tileGrid: createXYZ({
       tileSize: [512, 256],
+      maxResolution: (360 / 256) * METERS_PER_UNIT.degrees,
     }),
     transition: 0,
   }),

--- a/test/rendering/cases/reproj-tile-dateline-merc/main.js
+++ b/test/rendering/cases/reproj-tile-dateline-merc/main.js
@@ -5,6 +5,7 @@ import TileLayer from '../../../../src/ol/layer/Tile.js';
 import {register} from '../../../../src/ol/proj/proj4.js';
 import {get, transform} from '../../../../src/ol/proj.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
+import {TileGrid} from '../../../../src/ol/tilegrid.js';
 
 proj4.defs('merc_180', '+proj=merc +lon_0=180 +units=m +no_defs');
 
@@ -17,8 +18,10 @@ const center = transform(center4326, 'EPSG:4326', 'merc_180');
 
 const source = new XYZ({
   projection: 'EPSG:4326',
-  minZoom: 0,
-  maxZoom: 0,
+  tileGrid: new TileGrid({
+    origin: [-180, 90],
+    resolutions: [360 / 256],
+  }),
   url: '/data/tiles/4326/{z}/{x}/{y}.png',
   transition: 0,
 });

--- a/test/rendering/cases/reproj-tile-none-square/main.js
+++ b/test/rendering/cases/reproj-tile-none-square/main.js
@@ -1,11 +1,16 @@
 import Map from '../../../../src/ol/Map.js';
 import View from '../../../../src/ol/View.js';
 import TileLayer from '../../../../src/ol/layer/Tile.js';
-import {toLonLat} from '../../../../src/ol/proj.js';
+import {METERS_PER_UNIT, toLonLat} from '../../../../src/ol/proj.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
 import {createXYZ} from '../../../../src/ol/tilegrid.js';
 
-const tileGrid = createXYZ({tileSize: [512, 256]});
+const tileGrid = createXYZ({
+  tileSize: [512, 256],
+  minZoom: 5,
+  maxZoom: 5,
+  maxResolution: (360 / 256) * METERS_PER_UNIT.degrees,
+});
 const extent = tileGrid.getTileCoordExtent([5, 3, 12]);
 const center = [(extent[0] + extent[2]) / 2, (extent[1] + extent[3]) / 2];
 
@@ -14,7 +19,7 @@ const source = new XYZ({
   minZoom: 5,
   maxZoom: 5,
   url: '/data/tiles/512x256/{z}/{x}/{y}.png',
-  tileSize: [512, 256],
+  tileGrid,
   transition: 0,
 });
 

--- a/test/rendering/cases/reproj-tile-northpole/main.js
+++ b/test/rendering/cases/reproj-tile-northpole/main.js
@@ -5,6 +5,7 @@ import TileLayer from '../../../../src/ol/layer/Tile.js';
 import {register} from '../../../../src/ol/proj/proj4.js';
 import {get, transform} from '../../../../src/ol/proj.js';
 import XYZ from '../../../../src/ol/source/XYZ.js';
+import {TileGrid} from '../../../../src/ol/tilegrid.js';
 
 proj4.defs(
   'EPSG:3413',
@@ -20,7 +21,10 @@ const center4326 = [0, 90];
 const center = transform(center4326, 'EPSG:4326', 'EPSG:3413');
 
 const source = new XYZ({
-  maxZoom: 0,
+  tileGrid: new TileGrid({
+    origin: [-180, 90],
+    resolutions: [360 / 256],
+  }),
   projection: 'EPSG:4326',
   url: '/data/tiles/4326/{z}/{x}/{y}.png',
   transition: 0,


### PR DESCRIPTION
This pull request fixes an issue with the default tile grid we create for a projection. Currently, we take the maximum of the extent's width and height, which - in the case of EPSG:4326 - results in a single tile at zoom 0 that has the whole world sit at the top half of the tile, with the bottom half being empty (`[-180, -270, 180, 90]`). Instead, what we want is two tiles at zoom 0 (`[-180, -90, 0, 90]` and `[0, -90, 180, 90]`).

A visible consequence of this miscalculation is that maps with EPSG:4326 tiles needed a custom tile grid. The simplification resulting from the changes in this pull request can be seen in the vector-tiles-4326 example.