### PR TITLE
Add extra url options for Bing Maps and Google sources

### DIFF
--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -174,7 +174,8 @@ class BingMaps extends TileImage {
     this.placeholderTiles_ = options.placeholderTiles;
 
     const url =
-      (options.url || 'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/') +
+      (options.url ||
+        'https://dev.virtualearth.net/REST/v1/Imagery/Metadata/') +
       this.imagerySet_ +
       '?uriScheme=https&include=ImageryProviders&key=' +
       this.apiKey_ +

--- a/src/ol/source/Google.js
+++ b/src/ol/source/Google.js
@@ -189,7 +189,6 @@ class Google extends TileImage {
      */
     this.attributionUrl_ = baseUrl + 'tile/v1/viewport';
 
-
     this.createSession_();
   }
 


### PR DESCRIPTION
This allows setting a different URL for the Bing Maps Metadata and Google Maps Tile servers, for example to use a reverse proxy that injects the api keys without exposing them in the browser.