### PR TITLE
Bring back tile cache for raster reprojection source tiles

### DIFF
--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -15,29 +15,20 @@ import {
   getTopLeft,
   intersects,
 } from '../../extent.js';
-import {fromUserExtent} from '../../proj.js';
+import {equivalent, fromUserExtent} from '../../proj.js';
 import ReprojTile from '../../reproj/Tile.js';
 import {toSize} from '../../size.js';
 import LRUCache from '../../structs/LRUCache.js';
-import {createOrUpdate as createTileCoord, getKeyZXY} from '../../tilecoord.js';
+import {
+  createOrUpdate as createTileCoord,
+  getCacheKey,
+} from '../../tilecoord.js';
 import {
   apply as applyTransform,
   compose as composeTransform,
 } from '../../transform.js';
 import {getUid} from '../../util.js';
 import CanvasLayerRenderer from './Layer.js';
-
-/**
- * @param {import("../../source/Tile.js").default} source The tile source.
- * @param {string} sourceKey The source key.
- * @param {number} z The tile z level.
- * @param {number} x The tile x level.
- * @param {number} y The tile y level.
- * @return {string} The cache key.
- */
-function getCacheKey(source, sourceKey, z, x, y) {
-  return `${getUid(source)},${sourceKey},${getKeyZXY(z, x, y)}`;
-}
 
 /**
  * @typedef {Object<number, Set<import("../../Tile.js").default>>} TileLookup
@@ -201,6 +192,12 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
      */
     this.tileCache_ = new LRUCache(cacheSize);
 
+    /**
+     * @type {import("../../structs/LRUCache.js").default<import("../../Tile.js").default|null>}
+     * @private
+     */
+    this.sourceTileCache_ = null;
+
     this.maxStaleKeys = cacheSize * 0.5;
   }
 
@@ -209,6 +206,16 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
    */
   getTileCache() {
     return this.tileCache_;
+  }
+
+  /**
+   * @return {LRUCache} Tile cache.
+   */
+  getSourceTileCache() {
+    if (!this.sourceTileCache_) {
+      this.sourceTileCache_ = new LRUCache(512);
+    }
+    return this.sourceTileCache_;
   }
 
   /**
@@ -233,12 +240,17 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     if (tileCache.containsKey(cacheKey)) {
       tile = tileCache.get(cacheKey);
     } else {
+      const projection = frameState.viewState.projection;
+      const sourceProjection = tileSource.getProjection();
       tile = tileSource.getTile(
         z,
         x,
         y,
         frameState.pixelRatio,
-        frameState.viewState.projection,
+        projection,
+        !sourceProjection || equivalent(sourceProjection, projection)
+          ? undefined
+          : this.getSourceTileCache(),
       );
       if (!tile) {
         return null;
@@ -370,6 +382,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
       this.renderedSourceRevision_ = sourceRevision;
       if (this.renderedSourceKey_ === source.getKey()) {
         this.tileCache_.clear();
+        this.sourceTileCache_?.clear();
       }
     }
     return true;
@@ -874,6 +887,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
         const tilesCount = wantedTiles ? Object.keys(wantedTiles).length : 0;
         this.updateCacheSize(tilesCount);
         this.tileCache_.expireCache();
+        this.sourceTileCache_?.expireCache();
       };
 
       frameState.postRenderFunctions.push(postRenderFunction);

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -8,6 +8,7 @@ import {toPromise} from '../functions.js';
 import {equivalent, get as getProjection} from '../proj.js';
 import ReprojDataTile from '../reproj/DataTile.js';
 import {toSize} from '../size.js';
+import {getCacheKey} from '../tilecoord.js';
 import {
   createXYZ,
   extentFromProjection,
@@ -223,9 +224,10 @@ class DataTileSource extends TileSource {
    * @param {number} y Tile coordinate y.
    * @param {import("../proj/Projection.js").default} targetProj The output projection.
    * @param {import("../proj/Projection.js").default} sourceProj The input projection.
+   * @param {import("../structs/LRUCache.js").default<import("../Tile.js").default>} [tileCache] Tile cache.
    * @return {!TileType} Tile.
    */
-  getReprojTile_(z, x, y, targetProj, sourceProj) {
+  getReprojTile_(z, x, y, targetProj, sourceProj, tileCache) {
     const sourceTileGrid =
       this.tileGrid || this.getTileGridForProjection(sourceProj || targetProj);
     const reprojTilePixelRatio = Math.max.apply(
@@ -258,7 +260,7 @@ class DataTileSource extends TileSource {
         pixelRatio: reprojTilePixelRatio,
         gutter: this.gutter_,
         getTileFunction: (z, x, y, pixelRatio) =>
-          this.getTile(z, x, y, pixelRatio),
+          this.getTile(z, x, y, pixelRatio, undefined, tileCache),
         transformMatrix: this.transformMatrix,
       },
       /** @type {import("../reproj/DataTile.js").Options} */ (this.tileOptions),
@@ -276,17 +278,25 @@ class DataTileSource extends TileSource {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} [projection] Projection.
+   * @param {import("../structs/LRUCache.js").default<import("../Tile.js").default>} [tileCache] Tile cache.
    * @return {TileType|null} Tile (or null if outside source extent).
    * @override
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, pixelRatio, projection, tileCache) {
     const sourceProjection = this.getProjection();
     if (
       projection &&
       ((sourceProjection && !equivalent(sourceProjection, projection)) ||
         this.transformMatrix)
     ) {
-      return this.getReprojTile_(z, x, y, projection, sourceProjection);
+      return this.getReprojTile_(
+        z,
+        x,
+        y,
+        projection,
+        sourceProjection,
+        tileCache,
+      );
     }
 
     const size = this.getTileSize(z);
@@ -306,6 +316,12 @@ class DataTileSource extends TileSource {
     const tileCoord = this.getTileCoordForTileUrlFunction([z, x, y]);
     if (!tileCoord) {
       return null;
+    }
+
+    const key = this.getKey();
+    const cacheKey = getCacheKey(this, key, z, x, y);
+    if (tileCache && tileCache.containsKey(cacheKey)) {
+      return /** @type {TileType} */ (tileCache.get(cacheKey));
     }
 
     const requestZ = tileCoord[0];
@@ -340,6 +356,7 @@ class DataTileSource extends TileSource {
     tile.key = this.getKey();
     tile.addEventListener(EventType.CHANGE, this.handleTileChange_);
 
+    tileCache?.set(cacheKey, tile);
     return tile;
   }
 

--- a/src/ol/source/Tile.js
+++ b/src/ol/source/Tile.js
@@ -175,9 +175,10 @@ class TileSource extends Source {
    * @param {number} y Tile coordinate y.
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {import("../structs/LRUCache.js").default<import("../Tile.js").default>} [tileCache] Tile cache.
    * @return {TileType|null} Tile.
    */
-  getTile(z, x, y, pixelRatio, projection) {
+  getTile(z, x, y, pixelRatio, projection, tileCache) {
     return abstract();
   }
 

--- a/src/ol/tilecoord.js
+++ b/src/ol/tilecoord.js
@@ -2,6 +2,8 @@
  * @module ol/tilecoord
  */
 
+import {getUid} from './util.js';
+
 /**
  * An array of three numbers representing the location of a tile in a tile
  * grid. The order is `z` (zoom level), `x` (column), and `y` (row).
@@ -56,6 +58,18 @@ export function getCacheKeyForTileKey(tileKey) {
     .split(',')
     .map(Number);
   return getKeyZXY(z, x, y);
+}
+
+/**
+ * @param {import("./source/Tile.js").default} source The tile source.
+ * @param {string} sourceKey The source key.
+ * @param {number} z The tile z level.
+ * @param {number} x The tile x level.
+ * @param {number} y The tile y level.
+ * @return {string} The cache key.
+ */
+export function getCacheKey(source, sourceKey, z, x, y) {
+  return `${getUid(source)},${sourceKey},${getKeyZXY(z, x, y)}`;
 }
 
 /**

--- a/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/TileLayer.test.js
@@ -148,6 +148,35 @@ describe('ol/renderer/canvas/TileLayer', function () {
           layer.getRenderer().tileCache_.newest_.value_.tileCoord[0],
         ).to.be(9);
       });
+
+      it('caches source tiles when reprojecting', async () => {
+        const source = new TileDebug();
+        const layer = new TileLayer({
+          source: source,
+        });
+        map.addLayer(layer);
+        map.setView(
+          new View({
+            projection: 'EPSG:4326',
+            center: [-122.416667, 37.783333],
+            zoom: 5,
+          }),
+        );
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(
+          layer.getRenderer().sourceTileCache_.getKeys().length,
+        ).to.be.greaterThan(0);
+      });
+
+      it('does not cache source tiles when not reprojecting', async () => {
+        const source = new TileDebug();
+        const layer = new TileLayer({
+          source: source,
+        });
+        map.addLayer(layer);
+        await new Promise((resolve) => map.once('rendercomplete', resolve));
+        expect(layer.getRenderer().sourceTileCache_).to.be(null);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes #16996

We lost caching of source tiles with the switch from caching on the source to caching on the renderer. This pull request adds caching of source tiles on the renderer.
