### PR TITLE
mock `remove()` method of `HTMLDivElement`

### DIFF
--- a/src/ol/dom.js
+++ b/src/ol/dom.js
@@ -157,7 +157,8 @@ export function replaceChildren(node, children) {
 }
 
 /**
- * Creates a minimal structure that mocks a DIV to be used in a worker environment
+ * Creates a minimal structure that mocks a DIV to be used by the composite and
+ * layer renderer in a worker environment
  * @return {HTMLDivElement} mocked DIV
  */
 export function createMockDiv() {
@@ -175,6 +176,10 @@ export function createMockDiv() {
         this.childNodes.push(node);
         return node;
       },
+      /**
+       * dummy function, as this structure is not supposed to have a parent.
+       */
+      remove: function () {},
       /**
        * @param {HTMLElement} node html node.
        * @return {HTMLElement} html node.

--- a/test/browser/spec/ol/dom/dom.test.js
+++ b/test/browser/spec/ol/dom/dom.test.js
@@ -1,5 +1,6 @@
 import {
   createCanvasContext2D,
+  createMockDiv,
   outerHeight,
   outerWidth,
   replaceChildren,
@@ -317,15 +318,15 @@ describe('ol.dom', function () {
     });
   });
 
-  describe('replaceChildren()', function () {
-    function assertChildrenMatch(parent, children) {
-      const actual = parent.childNodes;
-      expect(actual).to.have.length(children.length);
-      for (let i = 0; i < children.length; i++) {
-        expect(actual[i]).to.be(children[i]);
-      }
+  function assertChildrenMatch(parent, children) {
+    const actual = parent.childNodes;
+    expect(actual).to.have.length(children.length);
+    for (let i = 0; i < children.length; i++) {
+      expect(actual[i]).to.be(children[i]);
     }
+  }
 
+  describe('replaceChildren()', function () {
     it('adds new children to an empty parent', function () {
       const parent = document.createElement('div');
       const children = [
@@ -469,6 +470,44 @@ describe('ol.dom', function () {
 
       // confirm we haven't modified the input
       expect(desiredChildren).to.eql(clone);
+    });
+  });
+
+  describe('mockDiv for use in worker', function () {
+    it('mocks appendChild', function () {
+      const parent = createMockDiv();
+      const child = createMockDiv();
+      parent.appendChild(child);
+      assertChildrenMatch(parent, [child]);
+    });
+    it('mocks removeChild', function () {
+      const parent = createMockDiv();
+      const child = createMockDiv();
+      parent.appendChild(child);
+      parent.removeChild(child);
+      assertChildrenMatch(parent, []);
+    });
+    it('mocks insertBefore', function () {
+      const parent = createMockDiv();
+      const childA = createMockDiv();
+      const childB = createMockDiv();
+      const childC = createMockDiv();
+      parent.appendChild(childA);
+      parent.appendChild(childB);
+      parent.insertBefore(childC, childB);
+      assertChildrenMatch(parent, [childA, childC, childB]);
+    });
+    it('mocks firstElementChild', function () {
+      const parent = createMockDiv();
+      const childA = createMockDiv();
+      const childB = createMockDiv();
+      parent.appendChild(childA);
+      parent.appendChild(childB);
+      expect(parent.firstElementChild).to.be(childA);
+    });
+    it('mocks remove()', function () {
+      const parent = createMockDiv();
+      expect(() => parent.remove()).to.not.throwError();
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue when calling `disposeInternal` of the `CompositeRenderer` if the `element_` is a mocked div, which is the case in a worker environment.

 - [x] mock `remove()` method
 - [x] add tests for `mockDiv`

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
