### PR TITLE
Make the link interaction work with views that are not fully defined

### DIFF
--- a/src/ol/interaction/Link.js
+++ b/src/ol/interaction/Link.js
@@ -301,7 +301,7 @@ class Link extends Interaction {
       return;
     }
     const view = map.getView();
-    if (!view) {
+    if (!view || !view.isDef()) {
       return;
     }
 
@@ -421,7 +421,7 @@ class Link extends Interaction {
       return;
     }
     const view = map.getView();
-    if (!view) {
+    if (!view || !view.isDef()) {
       return;
     }
 

--- a/test/browser/spec/ol/interaction/Link.test.js
+++ b/test/browser/spec/ol/interaction/Link.test.js
@@ -48,6 +48,13 @@ describe('ol/interaction/Link', () => {
       view.setRotation(0.5);
     });
 
+    it('works with a view that is not fully defined', () => {
+      map.setView(new View({}));
+      expect(() => {
+        map.addInteraction(new Link());
+      }).to.not.throwError();
+    });
+
     it('accepts a prefix', (done) => {
       map.addInteraction(new Link({prefix: 'ol:'}));
 


### PR DESCRIPTION
Currently, if you add the link interaction to a map that has a view that is not fully defined, there is an unhandled exception. This change fixes that.

Originally part of #17194.