### PR TITLE
Functions for transforming a promise for a view

### DIFF
--- a/examples/cog.js
+++ b/examples/cog.js
@@ -1,4 +1,9 @@
 import Map from '../src/ol/Map.js';
+import {
+  getView,
+  withExtentCenter,
+  withHigherResolutions,
+} from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 
@@ -17,5 +22,5 @@ const map = new Map({
       source: source,
     }),
   ],
-  view: source.getView(),
+  view: getView(source, withHigherResolutions(1), withExtentCenter()),
 });

--- a/test/node/ol/View.test.js
+++ b/test/node/ol/View.test.js
@@ -1,4 +1,9 @@
-import View from '../../../src/ol/View.js';
+import View, {
+  withExtentCenter,
+  withHigherResolutions,
+  withLowerResolutions,
+  withZoom,
+} from '../../../src/ol/View.js';
 import {
   addCommon,
   clearAllProjections,
@@ -26,6 +31,52 @@ describe('ol/View.js', function () {
       const point = view.getCenter();
       expect(point[0]).to.roughlyEqual(center[0], 1e-9);
       expect(point[1]).to.roughlyEqual(center[1], 1e-9);
+    });
+  });
+
+  describe('withZoom()', () => {
+    it('adds a zoom to view properties', () => {
+      const config = {zoom: 2};
+      const transform = withZoom(42);
+      const transformed = transform(config);
+      expect(transformed.zoom).to.eql(42);
+    });
+  });
+
+  describe('withZoom()', () => {
+    it('adds a zoom to view properties', () => {
+      const config = {zoom: 2};
+      const transform = withZoom(42);
+      const transformed = transform(config);
+      expect(transformed.zoom).to.eql(42);
+    });
+  });
+
+  describe('withExtentCenter()', () => {
+    it('adds a center given an extent', () => {
+      const config = {extent: [-180, 0, 0, 90]};
+      const transform = withExtentCenter();
+      const transformed = transform(config);
+      expect(transformed.center).to.eql([-90, 45]);
+      expect(transformed.extent).to.be(undefined);
+    });
+  });
+
+  describe('withHigherResolutions()', () => {
+    it('adds higher resolutions', () => {
+      const config = {resolutions: [100, 50]};
+      const transform = withHigherResolutions(2);
+      const transformed = transform(config);
+      expect(transformed.resolutions).to.eql([100, 50, 25, 12.5]);
+    });
+  });
+
+  describe('withLowerResolutions()', () => {
+    it('adds lower resolutions', () => {
+      const config = {resolutions: [100, 50]};
+      const transform = withLowerResolutions(3);
+      const transformed = transform(config);
+      expect(transformed.resolutions).to.eql([800, 400, 200, 100, 50]);
     });
   });
 });


### PR DESCRIPTION
This adds a few utility functions for transforming a promise for a view.

~These aren't currently marked as part of the API. But I could change that if we want to.~

Originally part of #17194.