### PR TITLE
Fix failing hitdetection test at edge of polygon

### DIFF
--- a/test/browser/spec/ol/layer/Vector.test.js
+++ b/test/browser/spec/ol/layer/Vector.test.js
@@ -474,7 +474,7 @@ describe('ol.layer.Vector', function () {
       map.renderSync();
 
       const pixel1 = map.getPixelFromCoordinate([16, 48]);
-      const pixel2 = map.getPixelFromCoordinate([16.2, 48.2]);
+      const pixel2 = map.getPixelFromCoordinate([16.15, 48.15]);
 
       return Promise.all([
         layer.getFeatures(pixel1).then(function (features) {


### PR DESCRIPTION
Hit detection was done at the top right corner of the polygon. Seems some hardware messes with the color values at the edge instead of just reducing the alpha.

Got these values:
> {r: 255, g: 255, b: 252, i: 16777212, indexFactor: 8388607, hit: false}

instead of these:
> {r: 255, g: 255, b: 254, i: 16777214, indexFactor: 8388607, hit: true}

here (notice the difference in the blue channel):
https://github.com/openlayers/openlayers/blob/fc0efd92d79c65f5af2b4e5db47500dd7ad15c2d/src/ol/render/canvas/hitdetect.js#L195-L207

Checking the center point of the polygon fixes the test.