### PR TITLE
Load unknown projections for GeoTIFF source #17153

### DIFF
--- a/examples/cog-projection.html
+++ b/examples/cog-projection.html
@@ -1,9 +1,9 @@
 ---
 layout: example.html
-title: COG with Projection Lookup
+title: COG with automatic Projection Lookup
 shortdesc: Rendering a COG over another layer in a different projection.
 docs: >
-  Example of using `fromProjectionCode()` to enable a COG to be rendered over another layer in a different projection.
+  Example of automatically using `fromProjectionCode()` to enable a COG to be rendered over another layer in a different projection.
 tags: "cog, projection, proj4js, maptiler"
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB

--- a/examples/cog-projection.js
+++ b/examples/cog-projection.js
@@ -1,7 +1,7 @@
 import proj4 from 'proj4';
 import Map from '../src/ol/Map.js';
 import TileLayer from '../src/ol/layer/WebGLTile.js';
-import {fromProjectionCode, register} from '../src/ol/proj/proj4.js';
+import {register} from '../src/ol/proj/proj4.js';
 import GeoTIFF from '../src/ol/source/GeoTIFF.js';
 import XYZ from '../src/ol/source/XYZ.js';
 
@@ -19,6 +19,7 @@ const cogSource = new GeoTIFF({
       nodata: 0,
     },
   ],
+  loadMissingProjection: true,
 });
 
 cogSource.setAttributions(
@@ -46,11 +47,5 @@ const map = new Map({
       style: {gamma: 0.7},
     }),
   ],
-  view: cogSource
-    .getView()
-    .then((viewConfig) =>
-      fromProjectionCode(viewConfig.projection.getCode()).then(
-        () => viewConfig,
-      ),
-    ),
+  view: cogSource.getView(),
 });

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -13,6 +13,7 @@ import {error as logError} from '../console.js';
 import {applyTransform, getCenter, getIntersection} from '../extent.js';
 import {clamp} from '../math.js';
 import {fromCode as unitsFromCode} from '../proj/Units.js';
+import {fromProjectionCode} from '../proj/proj4.js';
 import {
   Projection,
   createTransformFromCoordinateTransform,
@@ -181,49 +182,63 @@ function getResolutions(image, referenceImage) {
 }
 
 /**
- * @param {GeoTIFFImage} image A GeoTIFF.
- * @return {import("../proj/Projection.js").default} The image projection.
+ * @param {Object<string, any>} geoKeys Geo keys object.
+ * @param {string} geoKey The geo key to lookup.
+ * @param {string} unitKey The unit key to lookup.
+ * @param {boolean} loadMissingProjection Whether to load missing projections.
+ * @return {Promise<Projection|null>} The projection.
  */
-function getProjection(image) {
+async function getProjectionFromKeys(
+  geoKeys,
+  geoKey,
+  unitKey,
+  loadMissingProjection,
+) {
+  const value = geoKeys[geoKey];
+  if (value && value !== 32767) {
+    const code = 'EPSG:' + value;
+    let projection = getCachedProjection(code);
+    if (!projection && loadMissingProjection) {
+      projection = await fromProjectionCode(code);
+    }
+    if (!projection) {
+      const units = unitsFromCode(geoKeys[unitKey]);
+      if (units) {
+        projection = new Projection({
+          code: code,
+          units: units,
+        });
+      }
+    }
+    return projection || null;
+  }
+}
+
+/**
+ * @param {GeoTIFFImage} image A GeoTIFF.
+ * @param {boolean} loadMissingProjection Whether to load missing projections.
+ * @return {Promise<Projection|null>} The image projection.
+ */
+async function getProjection(image, loadMissingProjection) {
   const geoKeys = image.getGeoKeys();
   if (!geoKeys) {
     return null;
   }
-
-  if (
-    geoKeys.ProjectedCSTypeGeoKey &&
-    geoKeys.ProjectedCSTypeGeoKey !== 32767
-  ) {
-    const code = 'EPSG:' + geoKeys.ProjectedCSTypeGeoKey;
-    let projection = getCachedProjection(code);
-    if (!projection) {
-      const units = unitsFromCode(geoKeys.ProjLinearUnitsGeoKey);
-      if (units) {
-        projection = new Projection({
-          code: code,
-          units: units,
-        });
-      }
-    }
+  const projection = await getProjectionFromKeys(
+    geoKeys,
+    'ProjectedCSTypeGeoKey',
+    'ProjLinearUnitsGeoKey',
+    loadMissingProjection,
+  );
+  if (projection) {
     return projection;
   }
-
-  if (geoKeys.GeographicTypeGeoKey && geoKeys.GeographicTypeGeoKey !== 32767) {
-    const code = 'EPSG:' + geoKeys.GeographicTypeGeoKey;
-    let projection = getCachedProjection(code);
-    if (!projection) {
-      const units = unitsFromCode(geoKeys.GeogAngularUnitsGeoKey);
-      if (units) {
-        projection = new Projection({
-          code: code,
-          units: units,
-        });
-      }
-    }
-    return projection;
-  }
-
-  return null;
+  return await getProjectionFromKeys(
+    geoKeys,
+    'GeographicTypeGeoKey',
+    'GeogAngularUnitsGeoKey',
+    loadMissingProjection,
+  );
 }
 
 /**
@@ -399,6 +414,8 @@ function getMaxForDataType(array) {
  * to `false` will make it so any `min` and `max` properties on sources are ignored.
  * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoTIFF metadata
  * will be read for projection information.
+ * @property {boolean} [loadMissingProjection=false] Whether to attempt to load missing projection definitions.
+ * Uses the pre-configured projection lookup function, which can be customized with {@link module:ol/proj/proj4.setProjectionCodeLookup}.
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
@@ -503,6 +520,12 @@ class GeoTIFFSource extends DataTile {
      */
     this.convertToRGB_ = options.convertToRGB || false;
 
+    /**
+     * @type {boolean}
+     * @private
+     */
+    this.loadMissingProjection_ = options.loadMissingProjection || false;
+
     this.setKey(this.sourceInfo_.map((source) => source.url).join(','));
 
     const self = this;
@@ -549,11 +572,14 @@ class GeoTIFFSource extends DataTile {
    * @param {Array<Array<GeoTIFFImage>>} sources Each source is a list of images
    * from a single GeoTIFF.
    */
-  determineProjection(sources) {
+  async determineProjection(sources) {
     const firstSource = sources[0];
     for (let i = firstSource.length - 1; i >= 0; --i) {
       const image = firstSource[i];
-      const projection = getProjection(image);
+      const projection = await getProjection(
+        image,
+        this.loadMissingProjection_,
+      );
       if (projection) {
         this.projection = projection;
         break;
@@ -760,7 +786,7 @@ class GeoTIFFSource extends DataTile {
     }
 
     if (!this.getProjection()) {
-      this.determineProjection(sources);
+      await this.determineProjection(sources);
     }
     this.determineTransformMatrix(sources);
 


### PR DESCRIPTION
Closing #17153

Loads missing projection information using the fromProjectionCode function.
The functionality needs to be enabled explicitly via the option `loadMissingProjection`, otherwise it defaults to the existing behaviour.

Feels not super clean to make all those methods async, but none of them seems to be public API. I couldn't find a better way to intercept with the error that's thrown in DataTile. I'm not really sure how to really test this as it would need to verify that the image is properly reporjected and I'm not sure how to do this.

Any thoughts?