### PR TITLE
Use named import from puppeteer

### DIFF
--- a/test/rendering/test.js
+++ b/test/rendering/test.js
@@ -9,7 +9,7 @@ import {globby} from 'globby';
 import {LogLevel} from 'loglevelnext';
 import pixelmatch from 'pixelmatch';
 import png from 'pngjs';
-import puppeteer from 'puppeteer';
+import {launch} from 'puppeteer';
 import serveStatic from 'serve-static';
 import webpack from 'webpack';
 import webpackMiddleware from 'webpack-dev-middleware';
@@ -238,7 +238,7 @@ async function renderEach(page, entries, options) {
 }
 
 async function render(entries, options) {
-  const browser = await puppeteer.launch({
+  const browser = await launch({
     args: options.puppeteerArgs,
     headless: options.headless ? 'new' : false,
   });


### PR DESCRIPTION
This makes use of the named `launch` export instead of using the default export.

Addresses warnings like this one:
<img width="970" height="126" alt="image" src="https://github.com/user-attachments/assets/3411d018-8c97-4869-9596-8e5a57c773ce" />
