### PR TITLE
Group dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,39 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 5
-  open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  cooldown:
-    default-days: 5
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    groups:
+      development-major:
+        dependency-type: development
+        update-types:
+          - "major"
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - "minor"
+          - "patch"
+      production-major:
+        dependency-type: production
+        update-types:
+          - "major"
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 5
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This makes use of [dependabot groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#prioritizing-meaningful-updates) to organize dependency update pull requests:
 * `production-major` - Major production dependency updates
 * `production-minor-patch` - Minor or patch production dependency updates
 * `development-major` - Major development dependency updates
 * `development-minor-patch` - Minor or patch production dependency updates
 * `actions` - Action updates

The goal of grouping is to have fewer dependency update pull requests.