### PR TITLE
Add getter and setter for the map's pixelRatio

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1038,6 +1038,28 @@ class Map extends BaseObject {
   }
 
   /**
+   * Get the pixel ratio of the rendered map.
+   * @return {number} Pixel ratio.
+   * @api
+   */
+  getPixelRatio() {
+    return this.pixelRatio_;
+  }
+
+  /**
+   * Set the pixel ratio of the rendered map.
+   * @param {number} pixelRatio Pixel ratio.
+   * @api
+   */
+  setPixelRatio(pixelRatio) {
+    if (this.pixelRatio_ === pixelRatio) {
+      return;
+    }
+    this.pixelRatio_ = pixelRatio;
+    this.render();
+  }
+
+  /**
    * Get the map renderer.
    * @return {import("./renderer/Map.js").default|null} Renderer
    */

--- a/src/ol/VectorRenderTile.js
+++ b/src/ol/VectorRenderTile.js
@@ -11,6 +11,7 @@ import {getUid} from './util.js';
  * @property {null|import("./render.js").OrderFunction} renderedRenderOrder RenderedRenderOrder.
  * @property {number} renderedTileRevision RenderedTileRevision.
  * @property {number} renderedResolution RenderedResolution.
+ * @property {number} renderedPixelRatio RenderedPixelRatio.
  * @property {number} renderedRevision RenderedRevision.
  * @property {number} renderedTileResolution RenderedTileResolution.
  * @property {number} renderedTileZ RenderedTileZ.
@@ -135,6 +136,7 @@ class VectorRenderTile extends Tile {
         dirty: false,
         renderedRenderOrder: null,
         renderedResolution: NaN,
+        renderedPixelRatio: NaN,
         renderedRevision: -1,
         renderedTileResolution: NaN,
         renderedTileRevision: -1,

--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -674,6 +674,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
     if (
       this.ready &&
       this.renderedResolution_ == resolution &&
+      this.renderedPixelRatio_ === pixelRatio &&
       this.renderedRevision_ == vectorLayerRevision &&
       this.renderedRenderOrder_ == vectorLayerRenderOrder &&
       this.renderedFrameDeclutter_ === !!frameState.declutter &&

--- a/src/ol/renderer/canvas/VectorTileLayer.js
+++ b/src/ol/renderer/canvas/VectorTileLayer.js
@@ -214,6 +214,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       !builderState.dirty &&
       builderState.renderedResolution === resolution &&
       builderState.renderedRevision == revision &&
+      builderState.renderedPixelRatio === pixelRatio &&
       builderState.renderedRenderOrder == renderOrder
     ) {
       return;
@@ -339,6 +340,7 @@ class CanvasVectorTileLayerRenderer extends CanvasTileLayerRenderer {
       tile.executorGroups[layerUid].push(renderingReplayGroup);
     }
     builderState.renderedRevision = revision;
+    builderState.renderedPixelRatio = pixelRatio;
     builderState.renderedRenderOrder = renderOrder;
     builderState.renderedResolution = resolution;
   }

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1280,6 +1280,32 @@ describe('ol/Map', function () {
     });
   });
 
+  describe('#getPixelRatio() and #setPixelRatio()', function () {
+    let map;
+
+    beforeEach(function () {
+      map = new Map({
+        target: document.createElement('div'),
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map);
+    });
+
+    it('gets the pixel ratio', function () {
+      expect(map.getPixelRatio()).to.be(window.devicePixelRatio || 1);
+    });
+
+    it('sets the pixel ratio and re-renders the map', function () {
+      const spy = sinonSpy(map, 'render');
+      map.setPixelRatio(2);
+      expect(map.getPixelRatio()).to.be(2);
+      expect(spy.called).to.be(true);
+      spy.restore();
+    });
+  });
+
   describe('create interactions', function () {
     let options;
 

--- a/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
@@ -457,6 +457,9 @@ describe('ol/renderer/canvas/VectorLayer', function () {
       frameState.declutter = {};
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroupChanged).to.be(true);
+      frameState.pixelRatio = 2;
+      renderer.prepareFrame(frameState);
+      expect(renderer.replayGroupChanged).to.be(true);
     });
 
     it('dispatches a postrender event when rendering', function () {


### PR DESCRIPTION
Being able to change the map's pixelRatio can be useful in several scenarios, e.g.
* exporting the map with a specific resolution, in combination with a canvas target
* updating the pixel ratio dynamically when browser zoom is applied to the page

To make this work properly, vector and vector tile renderers need to recreate their executor groups upon `pixelRatio` change.