### PR TITLE
fix: dispose Attribution control click listener

### DIFF
--- a/src/ol/control/Attribution.js
+++ b/src/ol/control/Attribution.js
@@ -345,6 +345,19 @@ class Attribution extends Control {
   render(mapEvent) {
     this.updateElement_(mapEvent.frameState);
   }
+
+  /**
+   * Clean up.
+   * @override
+   */
+  disposeInternal() {
+    this.toggleButton_.removeEventListener(
+      EventType.CLICK,
+      this.handleClick_,
+      false,
+    );
+    super.disposeInternal();
+  }
 }
 
 export default Attribution;


### PR DESCRIPTION
Ensure Attribution cleans up its toggleButton_ click listener in disposeInternal() so the control can be garbage-collected properly.