### PR TITLE
Fix: Detect ArcGIS error responses in EsriJSON format reader

### DIFF
--- a/src/ol/format/EsriJSON.js
+++ b/src/ol/format/EsriJSON.js
@@ -127,16 +127,16 @@ class EsriJSON extends JSONFeature {
    */
   readFeaturesFromObject(object, options) {
     options = options ? options : {};
-
-    // if (object['error']) {
-    //   const error = object['error'];
-    //   const message = error.message || 'Unknown error';
-    //   const code = error.code !== undefined ? error.code : '';
-    //   const details = error.details ? ' - ' + error.details.join(', ') : '';
-    //   throw new Error(
-    //     `Error reading FeatureCollection: ${message}${details}${code ? ' (code ' + code + ')' : ''}`,
-    //   );
-    // }
+    
+    if (object['error']) {
+      const error = object['error'];
+      const message = error.message || 'Unknown error';
+      const code = error.code !== undefined ? error.code : '';
+      const details = error.details ? ' - ' + error.details.join(', ') : '';
+      throw new Error(
+        `Error reading FeatureCollection: ${message}${details}${code ? ' (code ' + code + ')' : ''}`,
+      );
+    }
     if (object['features']) {
       const esriJSONFeatureSet = /** @type {EsriJSONFeatureSet} */ (object);
       /** @type {Array<import("../Feature.js").default>} */


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
## Description

This PR fixes #17010 an issue where ArcGIS FeatureServer error responses were not being detected by OpenLayers. ArcGIS returns HTTP 200 status codes even when there are errors, placing the error information in the response body as JSON.

## Changes

- Added error detection in `EsriJSON.readFeaturesFromObject()` to check for error objects in the response
- Throws a descriptive error when an ArcGIS error response is detected, including error code, message, and details
- This allows the VectorSource to properly enter an error state when ArcGIS requests fail

## Example Error Response

When ArcGIS returns an error like:
```json
{
  "error": {
    "code": 400,
    "message": "Invalid URL",
    "details": ["Invalid URL"]
  }
}
```