### PR TITLE
Add the newly added methods of Select interaction  to the apidoc.

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -496,6 +496,7 @@ class Select extends Interaction {
    * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
    * @param {Feature} feature The feature to select
    * @return {boolean} True if the feature was selected
+   * @api
    */
   selectFeature(feature) {
     const layer = this.findLayerOfFeature_(feature);
@@ -538,6 +539,7 @@ class Select extends Interaction {
    * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
    * @param {Feature} feature The feature to deselect
    * @return {boolean} True if the feature was deselected
+   * @api
    */
   deselectFeature(feature) {
     const deselected = this.removeFeatureInternal_(feature);
@@ -554,6 +556,7 @@ class Select extends Interaction {
    * Unlike modifying `select.getFeatures()` directly, this respects the `filter` and `layers` options (except `multi`, which is ignored).
    * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
    * @param {Feature} feature The feature to deselect
+   * @api
    */
   toggleFeature(feature) {
     if (!this.deselectFeature(feature)) {
@@ -564,6 +567,7 @@ class Select extends Interaction {
    * Deselect all features as if a user deselected them.
    * Compared to `select.getFeatures().clear()` this causes a SelectEvent.
    * The {@link module:ol/interaction/Select~SelectEvent} fired by this won't have a mapBrowserEvent property
+   * @api
    */
   clearSelection() {
     clear(this.featureLayerAssociation_);


### PR DESCRIPTION
This PR fixes #17244

The `selectFeature`, `deselectFeature`, `toggleFeature` and `clearSelection` methods for “Select Interaction” submitted in the v10.7.0 are not displayed in the apidoc.

Add the `@api` annotation to the corresponding method to fix this issue.