### PR TITLE
Do not release image canvas, because it might be in use

### DIFF
--- a/src/ol/style/RegularShape.js
+++ b/src/ol/style/RegularShape.js
@@ -5,7 +5,7 @@
 import ImageState from '../ImageState.js';
 import {asArray} from '../color.js';
 import {asColorLike} from '../colorlike.js';
-import {createCanvasContext2D, releaseCanvas} from '../dom.js';
+import {createCanvasContext2D} from '../dom.js';
 import {
   defaultFillStyle,
   defaultLineCap,
@@ -263,9 +263,6 @@ class RegularShape extends ImageStyle {
       // Update the image in place to an ImageBitmap for better performance and lower memory usage
       createImageBitmap(image).then((imageBitmap) => {
         iconImage.setImage(imageBitmap);
-        if (this.hitDetectionCanvas_ !== image) {
-          releaseCanvas(context);
-        }
       });
     }
     return image;


### PR DESCRIPTION
This is a follow-up on #17235, which broke regular shape rendering. That can be seen in https://deploy-preview-17235--ol-site.netlify.app/en/latest/examples/regularshape.html: zoom in a bit, and all shapes will disappear for a fraction of a second.

This pull request is just a quick fix for this regression.

A better fix, which would allow to simplify Image styles significantly, would be to make the `getImage()` function of `ol/style/Image` asynchronous, but that will be more effort. I don't know when I'll get to that.

@jahow, could you review this please? Thanks in advance.