### PR TITLE
Add attributions option to GeoTIFF source

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -348,6 +348,7 @@ function getMaxForDataType(array) {
 
 /**
  * @typedef {Object} Options
+ * @property {import("./Source.js").AttributionLike} [attributions] Attributions.
  * @property {Array<SourceInfo>} sources List of information about GeoTIFF sources.
  * Multiple sources can be combined when their resolution sets are equal after applying a scale.
  * The list of sources defines a mapping between input bands as they are read from each GeoTIFF and
@@ -388,6 +389,7 @@ class GeoTIFFSource extends DataTile {
    */
   constructor(options) {
     super({
+      attributions: options.attributions,
       state: 'loading',
       tileGrid: null,
       projection: options.projection || null,


### PR DESCRIPTION
This PR fixes #17258

The `GeoTIFF` source has no `attributions` constructor option, only can use the setAttributions() method.

The `GeoTIFF` source has no `attributions` constructor option, attributions information can only be set via the `setAttributions` method.

For ease of use, the `attributions` option has been added as a constructor option for the `GeoTIFF` source.