### PR TITLE
modify shaders to avoid clipping issues in iOS issue #15237

### DIFF
--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -210,11 +210,7 @@ function parseStyle(style, bandCount) {
   );
 
   const fragmentShader = `
-    #ifdef GL_FRAGMENT_PRECISION_HIGH
     precision highp float;
-    #else
-    precision mediump float;
-    #endif
 
     varying vec2 v_textureCoord;
     uniform vec4 ${Uniforms.RENDER_EXTENT};


### PR DESCRIPTION
Modify the shaders to evaluate the mapCoord values inside the fragment shader, this is done to avoid precision issues related to the varyings when passing data from the vertex shader to the fragment shader.

This PR solves the issue reported in here: https://github.com/openlayers/openlayers/issues/15237