### PR TITLE
Fix: pass the strokeOffset to rendering also for MultiLineStrings

### DIFF
--- a/src/ol/render/canvas/LineStringBuilder.js
+++ b/src/ol/render/canvas/LineStringBuilder.js
@@ -105,6 +105,7 @@ class CanvasLineStringBuilder extends CanvasBuilder {
     const state = this.state;
     const strokeStyle = state.strokeStyle;
     const lineWidth = state.lineWidth;
+    const strokeOffset = state.strokeOffset;
     if (strokeStyle === undefined || lineWidth === undefined) {
       return;
     }
@@ -133,6 +134,7 @@ class CanvasLineStringBuilder extends CanvasBuilder {
         offset,
         /** @type {number} */ (ends[i]),
         stride,
+        strokeOffset,
       );
     }
     this.hitDetectionInstructions.push(strokeInstruction);


### PR DESCRIPTION
This is a small follow-up fix for the stroke offset support in canvas rendering #17282. 
It fixes the support of the stroke offsets for the multi line geometries.