### PR TITLE
Fix: Clear cached image when source changes while layer is hidden

### DIFF
--- a/src/ol/renderer/canvas/ImageLayer.js
+++ b/src/ol/renderer/canvas/ImageLayer.js
@@ -36,6 +36,12 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
      * @type {?import("../../Image.js").default}
      */
     this.image = null;
+
+    /**
+     * @private
+     * @type {number}
+     */
+    this.renderedSourceRevision_ = 0;
   }
 
   /**
@@ -75,6 +81,14 @@ class CanvasImageLayerRenderer extends CanvasLayerRenderer {
       !isEmpty(renderedExtent)
     ) {
       if (imageSource) {
+        if (
+          !this.getLayer().rendered &&
+          this.renderedSourceRevision_ !== imageSource.getRevision()
+        ) {
+          this.image = null;
+        }
+        this.renderedSourceRevision_ = imageSource.getRevision();
+
         const projection = viewState.projection;
         const image = imageSource.getImage(
           renderedExtent,

--- a/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
@@ -367,4 +367,133 @@ describe('ol/renderer/canvas/ImageLayer', function () {
       });
     });
   });
+
+  describe('cache invalidation on visibility change', function () {
+    /** @type {Map} */
+    let map;
+
+    /** @type {ImageLayer} */
+    let layer;
+
+    /** @type {Static} */
+    let source;
+
+    /** @type {HTMLDivElement} */
+    let target;
+
+    const projection = new Projection({
+      code: 'custom-image',
+      units: 'pixels',
+      extent: [0, 0, 256, 256],
+    });
+
+    beforeEach(function (done) {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+
+      source = new Static({
+        url: 'spec/ol/data/osm-0-0-0.png',
+        projection: projection,
+        imageExtent: [0, 0, 256, 256],
+      });
+
+      layer = new ImageLayer({
+        source: source,
+      });
+
+      map = new Map({
+        target: target,
+        layers: [layer],
+        view: new View({
+          projection: projection,
+          center: [128, 128],
+          zoom: 0,
+        }),
+      });
+
+      source.on('imageloadend', function () {
+        done();
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map);
+    });
+
+    it('tracks source revision during rendering', function () {
+      const renderer = layer.getRenderer();
+      map.renderSync();
+
+      const revision = source.getRevision();
+      expect(renderer.renderedSourceRevision_).to.be(revision);
+
+      source.changed();
+      const newRevision = source.getRevision();
+      expect(newRevision).to.be.greaterThan(revision);
+
+      map.renderSync();
+      expect(renderer.renderedSourceRevision_).to.be(newRevision);
+    });
+
+    it('clears cached image when source changed while hidden', function () {
+      const renderer = layer.getRenderer();
+      map.renderSync();
+      expect(renderer.image).to.not.be(null);
+
+      layer.setVisible(false);
+      map.renderSync();
+
+      source.changed();
+
+      let imageWasCleared = false;
+      const originalImage = renderer.image;
+      Object.defineProperty(renderer, 'image', {
+        get: function () {
+          return this._image;
+        },
+        set: function (value) {
+          if (value === null && this._image === originalImage) {
+            imageWasCleared = true;
+          }
+          this._image = value;
+        },
+        configurable: true,
+      });
+      renderer._image = originalImage;
+
+      layer.setVisible(true);
+      map.renderSync();
+      expect(imageWasCleared).to.be(true);
+    });
+
+    it('preserves cached image when source unchanged while hidden', function () {
+      const renderer = layer.getRenderer();
+      map.renderSync();
+
+      const cachedImage = renderer.image;
+      expect(cachedImage).to.not.be(null);
+
+      layer.setVisible(false);
+      map.renderSync();
+
+      layer.setVisible(true);
+      map.renderSync();
+      expect(renderer.image).to.be(cachedImage);
+    });
+
+    it('keeps cached image when source changes while visible', function () {
+      const renderer = layer.getRenderer();
+      map.renderSync();
+
+      const cachedImage = renderer.image;
+      expect(cachedImage).to.not.be(null);
+
+      source.changed();
+      map.renderSync();
+
+      expect(renderer.image).to.be(cachedImage);
+    });
+  });
 });


### PR DESCRIPTION
When an ImageWMS layer is hidden and its source parameters are changed, 
the old cached image briefly appears when the layer becomes visible again.

**Tested approaches:**
- `layer.changed()`: Does not work because `prepareFrame()` is not called 
  for invisible layers
- Check revision in every `prepareFrame()`: Causes regression - breaks 
  smooth transitions when layer remains visible (shows blank screen)

**Solution:** Track source revision in `unrender()` (called when layer 
becomes invisible) and invalidate cache in `prepareFrame()` only if 
revision changed while hidden. This preserves smooth transitions when 
the layer stays visible.

Fixes #17181 