### PR TITLE
Fix: Sync first and last vertex of polygon during modify drag

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1481,16 +1481,50 @@ class Modify extends PointerInteraction {
         coordinates[depth[0]][segmentData.index + index] = vertex;
         segment[index] = vertex;
         break;
-      case 'Polygon':
+      case 'Polygon': {
         coordinates = geometry.getCoordinates();
-        coordinates[depth[0]][segmentData.index + index] = vertex;
+        const ring = coordinates[depth[0]];
+        const targetIndex = segmentData.index + index;
+
+        // Prevent duplicate change events when vertex already at position
+        if (
+          ring[targetIndex][0] === vertex[0] &&
+          ring[targetIndex][1] === vertex[1]
+        ) {
+          coordinates = null;
+        } else {
+          ring[targetIndex] = vertex;
+          if (targetIndex === 0) {
+            ring[ring.length - 1] = vertex;
+          } else if (targetIndex === ring.length - 1) {
+            ring[0] = vertex;
+          }
+        }
         segment[index] = vertex;
         break;
-      case 'MultiPolygon':
+      }
+      case 'MultiPolygon': {
         coordinates = geometry.getCoordinates();
-        coordinates[depth[1]][depth[0]][segmentData.index + index] = vertex;
+        const mRing = coordinates[depth[1]][depth[0]];
+        const mTargetIndex = segmentData.index + index;
+
+        // Prevent duplicate change events when vertex already at position
+        if (
+          mRing[mTargetIndex][0] === vertex[0] &&
+          mRing[mTargetIndex][1] === vertex[1]
+        ) {
+          coordinates = null;
+        } else {
+          mRing[mTargetIndex] = vertex;
+          if (mTargetIndex === 0) {
+            mRing[mRing.length - 1] = vertex;
+          } else if (mTargetIndex === mRing.length - 1) {
+            mRing[0] = vertex;
+          }
+        }
         segment[index] = vertex;
         break;
+      }
       case 'Circle':
         const circle = /** @type {import("../geom/Circle.js").default} */ (
           geometry


### PR DESCRIPTION
When dragging the first vertex (index 0) of a polygon, the change event 
fires with an invalid polygon state where `coordinates[0] !== coordinates[length-1]`.

This fix synchronizes first/last vertex in `modifyGeometry_()` for Polygon 
and MultiPolygon cases, ensuring all change events have valid coordinates.

**Alternative considered:** A batching approach could reduce change events 
from 2 to 1 by collecting all coordinate changes in `handleDragEvent()` 
and applying them at once. I chose the simpler synchronization approach 
to minimize changes. Happy to refactor to batching if preferred.

Fixes #16950