### PR TITLE
Use .tif extension for overviews to support range requests

### DIFF
--- a/examples/cog-overviews.js
+++ b/examples/cog-overviews.js
@@ -6,7 +6,7 @@ const source = new GeoTIFF({
   sources: [
     {
       url: 'https://openlayers.org/data/raster/no-overviews.tif',
-      overviews: ['https://openlayers.org/data/raster/no-overviews.tif.ovr'],
+      overviews: ['https://openlayers.org/data/raster/no-overviews.ovr.tif'],
     },
   ],
 });


### PR DESCRIPTION
Together with https://github.com/openlayers/data/commit/8ef2522c0b5a7a69fb59c44399ca7a9fbb7c1e8d and https://github.com/openlayers/openlayers.github.io/commit/a3370fa956fb1391c124fc7f8e46d890b83222e4, this pull request fixes the [cog-overviews.html](https://deploy-preview-17295--ol-site.netlify.app/en/latest/examples/cog-overviews.html) example. Due to changes to github pages, range requests now only work for mime types that are marked as non compressible (see https://github.com/jshttp/mime-db/pull/411).