### PR TITLE
Avoid using revision in cache key and update key in SentinelHub source

### DIFF
--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -124,7 +124,7 @@ function getRenderExtent(frameState, extent) {
  * @return {string} The cache key.
  */
 export function getCacheKey(source, tileCoord) {
-  return `${getUid(source)},${source.getKey()},${source.getRevision()},${getTileCoordKey(tileCoord)}`;
+  return `${getUid(source)},${source.getKey()},${getTileCoordKey(tileCoord)}`;
 }
 
 /**

--- a/src/ol/source/SentinelHub.js
+++ b/src/ol/source/SentinelHub.js
@@ -542,12 +542,17 @@ class SentinelHub extends DataTileSource {
     if (!this.token_ || !this.evalscript_ || !this.inputData_) {
       return;
     }
+    this.setKey(this.getKeyForConfig_());
     const state = this.getState();
     if (state === 'ready') {
       this.changed();
       return;
     }
     this.setState('ready');
+  }
+
+  getKeyForConfig_() {
+    return this.token_ + this.evalscript_ + JSON.stringify(this.inputData_);
   }
 
   /**


### PR DESCRIPTION
The WebGL tile renderer's `getCacheKey` function used the source revision in the cache key. This means that tiles in the cache can never be reused after any sort of change on the source (the `source.changed()` method increments the source revision). Instead, it should be possible to reuse tiles from the cache when the source state changes back to some previous state. This branch removes the revision from the cache key for WebGL tile rendering.

In addition, this branch makes it so the Sentinel Hub source updates the source key when any of the token, input data configuration, or evalscript change.

Together, these changes make it possible to reuse tiles from previous states in the Sentinel Hub source.