### PR TITLE
Example: export map as GeoTIFF or PNG with world file

### DIFF
--- a/examples/export-map.html
+++ b/examples/export-map.html
@@ -1,15 +1,25 @@
 ---
 layout: example.html
 title: Map Export
-shortdesc: Export a map as a PNG image.
+shortdesc: Export a map as a GeoTIFF or PNG image.
 docs: >
-  Example of exporting a map as a PNG image, using a HTMLCanvasElement as temporary map target.
-tags: "export, png, openstreetmap"
+  Example of exporting a map, using a HTMLCanvasElement as temporary map target. PNG is easy to export,
+  without using an external library. The GeoTIFF export is georeferenced with the correct projection.
+  The PNG + <a href="https://web.archive.org/web/20230304183331/https://support.esri.com/en/technical-article/000002860">worldfile</a> ZIP is also georeferenced, but users of the image will have to know (or guess)
+  the projection.
+tags: "export, png, geotiff, worldfile"
 resources:
   - https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css
   - https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/fontawesome.min.css
   - https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.1.2/css/solid.css
 ---
 <div id="map" class="map"></div>
-<a id="export-png" class="btn btn-outline-dark" role="button"><i class="fa fa-download"></i> Download PNG</a>
+<div class="btn-group">
+  <a id="export-map" class="btn btn-outline-dark" role="button"><i class="fa fa-download"></i> Download</a>
+  <select id="export-format" class="form-select" style="max-width: 180px;">
+    <option value="geotiff">GeoTIFF</option>
+    <option value="png">PNG</option>
+    <option value="png-world">PNG + Worldfile (ZIP)</option>
+  </select>
+</div>
 <a id="image-download" download="map.png"></a>

--- a/examples/export-map.js
+++ b/examples/export-map.js
@@ -1,3 +1,5 @@
+import {zip} from 'fflate';
+import {writeArrayBuffer as writeGeotiff} from 'geotiff';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import {asArray} from '../src/ol/color.js';
@@ -49,16 +51,98 @@ const map = new Map({
   }),
 });
 
-document.getElementById('export-png').addEventListener('click', () => {
+document.getElementById('export-map').addEventListener('click', () => {
+  const format = document.getElementById('export-format').value;
   const mapCanvas = document.createElement('canvas');
   const size = map.getSize();
   mapCanvas.width = size[0];
   mapCanvas.height = size[1];
-  map.once('rendercomplete', () => {
-    map.setTarget('map');
-    const link = document.getElementById('image-download');
-    link.href = mapCanvas.toDataURL();
-    link.click();
-  });
+
   map.setTarget(mapCanvas);
+  map.once('rendercomplete', () => {
+    const view = map.getView();
+    const extent = view.calculateExtent(size);
+    const resolution = view.getResolution();
+    const projection = view.getProjection();
+
+    if (format === 'geotiff') {
+      exportGeoTIFF(mapCanvas, size, extent, resolution, projection);
+    } else if (format === 'png') {
+      exportPNG(mapCanvas);
+    } else if (format === 'png-world') {
+      exportPNGWithWorldfile(mapCanvas, extent, resolution);
+    }
+
+    map.setTarget('map');
+  });
 });
+
+function exportGeoTIFF(canvas, size, extent, resolution, projection) {
+  const context = canvas.getContext('2d');
+  const imageData = context.getImageData(0, 0, size[0], size[1]);
+  const epsgCode = projection.getCode().split(':')[1];
+
+  const tiff = writeGeotiff(imageData.data, {
+    width: size[0],
+    height: size[1],
+    ModelPixelScale: [resolution, resolution, 0],
+    ModelTiepoint: [0, 0, 0, extent[0], extent[3], 0],
+    GTRasterTypeGeoKey: 1,
+    ProjectedCSTypeGeoKey: parseInt(epsgCode),
+  });
+
+  const blob = new Blob([tiff], {type: 'image/tiff'});
+  downloadFile(blob, 'map-export.tiff');
+}
+
+function exportPNG(canvas) {
+  const link = document.createElement('a');
+  link.href = canvas.toDataURL('image/png');
+  link.download = 'map-export.png';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+function exportPNGWithWorldfile(canvas, extent, resolution) {
+  // Create worldfile content
+  const worldfileContent = [
+    resolution.toFixed(6), // pixel width
+    '0.000000', // rotation
+    '0.000000', // rotation
+    (-resolution).toFixed(6), // pixel height (negative)
+    extent[0].toFixed(6), // upper-left X
+    extent[3].toFixed(6), // upper-left Y
+  ].join('\n');
+
+  // Convert canvas to blob and create zip
+  canvas.toBlob((pngBlob) => {
+    pngBlob.arrayBuffer().then((pngBuffer) => {
+      const files = {
+        'map-export.png': [new Uint8Array(pngBuffer), {level: 0}], // level 0 = no compression for PNG
+        'map-export.pgw': [
+          new TextEncoder().encode(worldfileContent),
+          {level: 6},
+        ],
+      };
+
+      zip(files, (err, data) => {
+        if (err) {
+          alert('Error creating zip:', err);
+          return;
+        }
+        const zipBlob = new Blob([data], {type: 'application/zip'});
+        downloadFile(zipBlob, 'map-export.zip');
+      });
+    });
+  });
+}
+
+function downloadFile(blob, filename) {
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}


### PR DESCRIPTION
This pull request enhances the [export-map example](https://deploy-preview-17313--ol-site.netlify.app/en/latest/examples/export-map.html) by adding options to export as GeoTIFF or as a zip with a PNG and world file. Both options are useful when georeferenced exports are desired. These can e.g. simply be dragged onto a QGIS map.