### PR TITLE
Fix WebGL fill-pattern rendering corruption at high zoom levels (#16705)

### DIFF
--- a/examples/webgl-vector-layer-pattern.html
+++ b/examples/webgl-vector-layer-pattern.html
@@ -1,0 +1,11 @@
+---
+layout: example.html
+title: WebGL Vector Layer with fill-pattern style
+shortdesc: Example of a vector layer rendered using WebGL and a fill-pattern-src
+docs: >
+  The ecoregions are loaded from a GeoJSON file.
+tags: "vector, geojson, webgl"
+experimental: true
+---
+<div id="map" class="map"></div>
+<div id="info">&nbsp;</div>

--- a/examples/webgl-vector-layer-pattern.js
+++ b/examples/webgl-vector-layer-pattern.js
@@ -1,0 +1,88 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import GeoJSON from '../src/ol/format/GeoJSON.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import WebGLVectorLayer from '../src/ol/layer/WebGLVector.js';
+import OSM from '../src/ol/source/OSM.js';
+import VectorSource from '../src/ol/source/Vector.js';
+
+// create pattern
+const canvasFill = document.createElement('canvas');
+canvasFill.width = 16;
+canvasFill.height = 16;
+const context = canvasFill.getContext('2d');
+context.fillStyle = 'rgba(255, 0, 0, 0.5)';
+context.fillRect(0, 0, 8, 8);
+context.fillStyle = 'rgba(94, 255, 0, 0.5)';
+context.fillRect(8, 0, 8, 8);
+context.fillStyle = 'rgba(255, 213, 0, 0.5)';
+context.fillRect(8, 8, 8, 8);
+context.fillStyle = 'rgba(255,255,255,0.5)';
+context.fillRect(0, 8, 8, 8);
+
+/** @type {import('../src/ol/style/flat.js').FlatStyleLike} */
+const style = [
+  {
+    style: {
+      'stroke-color': ['*', ['get', 'COLOR'], [220, 220, 220]],
+      'stroke-width': 2,
+      'stroke-offset': -1,
+      'fill-pattern-src': canvasFill.toDataURL('png'),
+    },
+  },
+];
+
+const osm = new TileLayer({
+  source: new OSM(),
+});
+
+const vectorLayer = new WebGLVectorLayer({
+  source: new VectorSource({
+    url: 'https://openlayers.org/data/vector/ecoregions.json',
+    format: new GeoJSON(),
+  }),
+  style,
+  variables: {
+    highlightedId: -1,
+  },
+});
+
+const map = new Map({
+  layers: [osm, vectorLayer],
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 1,
+  }),
+});
+
+let highlightedId = -1;
+const displayFeatureInfo = function (pixel) {
+  const feature = map.forEachFeatureAtPixel(pixel, function (feature) {
+    return feature;
+  });
+
+  const info = document.getElementById('info');
+  if (feature) {
+    info.innerHTML = feature.get('ECO_NAME') || '&nbsp;';
+  } else {
+    info.innerHTML = '&nbsp;';
+  }
+
+  const id = feature ? feature.getId() : -1;
+  if (id !== highlightedId) {
+    highlightedId = id;
+    vectorLayer.updateStyleVariables({highlightedId});
+  }
+};
+
+map.on('pointermove', function (evt) {
+  if (evt.dragging) {
+    return;
+  }
+  displayFeatureInfo(evt.pixel);
+});
+
+map.on('click', function (evt) {
+  displayFeatureInfo(evt.pixel);
+});

--- a/examples/webgl-vectortile-layer-pattern.html
+++ b/examples/webgl-vectortile-layer-pattern.html
@@ -1,0 +1,11 @@
+---
+layout: example.html
+title: WebGL Vector Tile Layer with fill and stroke patterns
+shortdesc: Example of a vector tile layer rendered using WebGL with fill-pattern and stroke-pattern styles
+docs: >
+  Vector tiles from Mapbox Streets are rendered with canvas-generated fill and stroke patterns.
+  Zoom in past level 17 to verify the pattern stays correct at high zoom.
+tags: "vector, vectortile, webgl, pattern"
+experimental: true
+---
+<div id="map" class="map"></div>

--- a/examples/webgl-vectortile-layer-pattern.js
+++ b/examples/webgl-vectortile-layer-pattern.js
@@ -1,0 +1,56 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import MVT from '../src/ol/format/MVT.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import WebGLVectorTileLayer from '../src/ol/layer/WebGLVectorTile.js';
+import OSM from '../src/ol/source/OSM.js';
+import VectorTileSource from '../src/ol/source/VectorTile.js';
+
+// create fill pattern (4-color checkerboard)
+const canvasFill = document.createElement('canvas');
+canvasFill.width = 16;
+canvasFill.height = 16;
+let context = canvasFill.getContext('2d');
+context.fillStyle = 'rgba(255, 0, 0, 0.7)';
+context.fillRect(0, 0, 8, 8);
+context.fillStyle = 'rgba(94, 255, 0, 0.7)';
+context.fillRect(8, 0, 8, 8);
+context.fillStyle = 'rgb(255, 213, 0)';
+context.fillRect(8, 8, 8, 8);
+context.fillStyle = 'rgba(255,255,255,0.62)';
+context.fillRect(0, 8, 8, 8);
+
+// create stroke pattern (dashed red/black)
+const canvasStroke = document.createElement('canvas');
+canvasStroke.width = 8;
+canvasStroke.height = 2;
+context = canvasStroke.getContext('2d');
+context.fillStyle = 'rgba(0,0,0,0.7)';
+context.fillRect(0, 0, 4, 2);
+context.fillStyle = 'rgba(255,0,0,0.7)';
+context.fillRect(4, 0, 4, 2);
+
+const osm = new TileLayer({
+  source: new OSM(),
+});
+
+const vectorTileLayer = new WebGLVectorTileLayer({
+  source: new VectorTileSource({
+    format: new MVT(),
+    url: 'https://ahocevar.com/geoserver/gwc/service/tms/1.0.0/ne:ne_10m_admin_0_countries@EPSG%3A900913@pbf/{z}/{x}/{-y}.pbf',
+  }),
+  style: {
+    'fill-pattern-src': canvasFill.toDataURL('png'),
+    'stroke-pattern-src': canvasStroke.toDataURL('png'),
+    'stroke-width': 2,
+  },
+});
+
+const map = new Map({
+  layers: [osm, vectorTileLayer],
+  target: 'map',
+  view: new View({
+    center: [1825927.7316762917, 6143091.089223046],
+    zoom: 1,
+  }),
+});

--- a/src/ol/render/webgl/ShaderBuilder.js
+++ b/src/ol/render/webgl/ShaderBuilder.js
@@ -23,6 +23,7 @@ uniform float u_resolution;
 uniform float u_rotation;
 uniform vec4 u_renderExtent;
 uniform vec2 u_patternOrigin;
+uniform vec2 u_patternOrigin_low;
 uniform float u_depth;
 uniform mediump int u_hitDetection;
 
@@ -984,7 +985,8 @@ ${this.attributes_
   )
   .join('\n')}
   vec2 pxPos = gl_FragCoord.xy / u_pixelRatio;
-  vec2 pxOrigin = worldToPx(u_patternOrigin);
+  vec2 pxOrigin = u_patternOrigin;
+  vec2 pxOriginLow = u_patternOrigin_low;
   #ifdef GL_FRAGMENT_PRECISION_HIGH
   vec2 worldPos = pxToWorld(pxPos);
   if (

--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -29,6 +29,7 @@ export const Uniforms = {
   DEPTH: 'u_depth',
   RENDER_EXTENT: 'u_renderExtent', // intersection of layer, source, and view extent
   PATTERN_ORIGIN: 'u_patternOrigin',
+  PATTERN_ORIGIN_LOW: 'u_patternOrigin_low',
   RESOLUTION: 'u_resolution',
   ZOOM: 'u_zoom',
   GLOBAL_ALPHA: 'u_globalAlpha',

--- a/test/browser/spec/ol/render/webgl/shaderbuilder.test.js
+++ b/test/browser/spec/ol/render/webgl/shaderbuilder.test.js
@@ -720,7 +720,8 @@ void main(void) {
   vec3 a_test = v_test; // assign to original attribute name
   vec2 a_myAttr = v_myAttr; // assign to original attribute name
   vec2 pxPos = gl_FragCoord.xy / u_pixelRatio;
-  vec2 pxOrigin = worldToPx(u_patternOrigin);
+  vec2 pxOrigin = u_patternOrigin;
+  vec2 pxOriginLow = u_patternOrigin_low;
   #ifdef GL_FRAGMENT_PRECISION_HIGH
   vec2 worldPos = pxToWorld(pxPos);
   if (

--- a/test/browser/spec/ol/render/webgl/style.test.js
+++ b/test/browser/spec/ol/render/webgl/style.test.js
@@ -1059,7 +1059,7 @@ describe('ol/render/webgl/style', () => {
             'vec4 sampleFillPattern',
           );
           expect(result.builder.fillColorExpression_).to.eql(
-            `1. * sampleFillPattern(u_texture${uid}, u_texture${uid}_size, vec2(0.), u_texture${uid}_size, pxOrigin, pxPos)`,
+            `1. * sampleFillPattern(u_texture${uid}, u_texture${uid}_size, vec2(0.), u_texture${uid}_size, pxOrigin, pxOriginLow, pxPos)`,
           );
         });
       });
@@ -1081,7 +1081,7 @@ describe('ol/render/webgl/style', () => {
             'vec4 sampleFillPattern',
           );
           expect(result.builder.fillColorExpression_).to.eql(
-            `vec4(1.0, 0.0, 0.0, 1.0) * sampleFillPattern(u_texture${uid}, u_texture${uid}_size, vec2(0., u_texture${uid}_size.y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), pxOrigin, pxPos)`,
+            `vec4(1.0, 0.0, 0.0, 1.0) * sampleFillPattern(u_texture${uid}, u_texture${uid}_size, vec2(0., u_texture${uid}_size.y) + vec2(5.0, 5.0) * vec2(0., -1.) + vec2(5.0, 10.0) * vec2(1., -1.), vec2(5.0, 5.0), pxOrigin, pxOriginLow, pxPos)`,
           );
         });
       });


### PR DESCRIPTION
At zoom levels beyond ~17, fill-pattern rendering becomes corrupted because the shader computes pixel positions that exceed float32's ~7 significant digits. The world-to-pixel conversion of the pattern origin (world [0,0]) can produce values in the tens of millions, causing catastrophic precision loss in the subsequent subtraction with the fragment's pixel position.

This fix uses double-float emulation (Dekker splitting) to carry float64 precision through the entire fill-pattern pipeline in the GLSL shader:

CPU side (VectorLayer.js, VectorTileLayer.js):
- Compute the pixel position of world [0,0] using JavaScript's float64
- Dekker-split the result into two float32 components: hi + lo = value
- Pass both as uniforms (u_patternOrigin, u_patternOrigin_low)

Shader side (style.js sampleFillPattern):
- Full double-float arithmetic library in GLSL:
  - ds_add (Knuth's two-sum): error-free addition
  - ds_mul (Veltkamp splitting): error-free multiplication
  - f_sub_df, df_add, df_sub, df_mul_f, df_div_f, df_mod_f
- All precision-critical operations (subtraction, rotation, division by scaleRatio, mod by sampleSize) use double-float arithmetic
- Results collapse to float32 only after mod reduces values to the small [0, sampleSize) range where float32 has sufficient precision

Also fixes the same issue for WebGLVectorTileLayer, where the pattern origin was never computed, causing patterns to be screen-fixed instead of moving with the geometry.

Includes examples for both WebGLVectorLayer and WebGLVectorTileLayer fill/stroke patterns.

Fixes https://github.com/openlayers/openlayers/issues/16705 & https://github.com/openlayers/openlayers/discussions/16704

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
