### PR TITLE
Flat style / allow literal number arrays as well for the `in` (haystack) operator

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -106,6 +106,7 @@ import {toSize} from '../size.js';
  *     * Only literal arrays are supported as `haystack` for now; this means that `haystack` cannot be the result of an
  *     expression. If `haystack` is an array of strings, use the `literal` operator to disambiguate from an expression:
  *     `['literal', ['abc', 'def', 'ghi']]`
+ *     This works as well for number arrays although it is not required. Mixing types (numbers and strings) will produce undefined results.
  *
  * * Conversion operators:
  *   * `['array', value1, ...valueN]` creates a numerical array from `number` values; please note that the amount of
@@ -912,18 +913,22 @@ function withInArgs(encoded, returnType, context) {
    * @type {number}
    */
   let needleType;
-  if (typeof haystack[0] === 'string') {
-    if (haystack[0] !== 'literal') {
-      throw new Error(
-        `for the "in" operator, a string array should be wrapped in a "literal" operator to disambiguate from expressions`,
-      );
-    }
-    if (!Array.isArray(haystack[1])) {
+
+  // check if we're using the 'literal' operator for the haystack
+  if (haystack[0] === 'literal') {
+    haystack = haystack[1];
+    if (!Array.isArray(haystack)) {
       throw new Error(
         `failed to parse "in" expression: the literal operator must be followed by an array`,
       );
     }
-    haystack = haystack[1];
+  } else if (typeof haystack[0] === 'string') {
+    throw new Error(
+      `for the "in" operator, a string array should be wrapped in a "literal" operator to disambiguate from expressions`,
+    );
+  }
+
+  if (typeof haystack[0] === 'string') {
     needleType = StringType;
   } else {
     needleType = NumberType;

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -317,6 +317,23 @@ describe('ol/expr/expression.js', () => {
         expect(isType(expression.args[3].type, NumberType)).to.be(true);
       });
 
+      it('respects the return type (number haystack using literal operator)', () => {
+        const context = newParsingContext();
+        const expression = parse(
+          ['in', ['get', 'attr'], ['literal', [0, 50, 100]]],
+          BooleanType,
+          context,
+        );
+        expect(expression).to.be.a(CallExpression);
+        expect(expression.operator).to.be('in');
+        expect(isType(expression.type, BooleanType)).to.be(true);
+        expect(expression.args).to.have.length(4);
+        expect(isType(expression.args[0].type, NumberType)).to.be(true);
+        expect(isType(expression.args[1].type, NumberType)).to.be(true);
+        expect(isType(expression.args[2].type, NumberType)).to.be(true);
+        expect(isType(expression.args[3].type, NumberType)).to.be(true);
+      });
+
       it('respects the return types (string haystack)', () => {
         const context = newParsingContext();
         const expression = parse(

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -545,6 +545,21 @@ describe('ol/expr/gpu.js', () => {
         },
       },
       {
+        name: 'in (number haystack using literal operator)',
+        expression: ['in', ['get', 'attr'], ['literal', [0, 20, 50]]],
+        type: AnyType,
+        expected: 'operator_in_0(a_prop_attr)',
+        contextAssertion: (context) => {
+          expect(context.functions['operator_in_0']).to
+            .equal(`bool operator_in_0(float inputValue) {
+  if (inputValue == 0.0) { return true; }
+  if (inputValue == 20.0) { return true; }
+  if (inputValue == 50.0) { return true; }
+  return false;
+}`);
+        },
+      },
+      {
         name: 'in (string haystack)',
         expression: ['in', ['get', 'attr'], ['literal', ['abc', 'def', 'ghi']]],
         type: AnyType,


### PR DESCRIPTION
This PR makes it so that using the `literal` keyword for number arrays as a haystack works as expected in the WebGL renderers:

```js
['in', ['get', 'myAttr'], ['literal', [10, 20, 30, 40]]]
```

The current behavior is very counter-intuitive: doing this does not result in an error but silently fails because the number array is parsed as an array of strings and each value is converted to another number. Confirmed to produce very annoying bugs.