### PR TITLE
Update raster source docs

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -473,7 +473,7 @@ export class RasterSourceEvent extends Event {
 /**
  * @typedef {Object} Options
  * @property {Array<import("./Source.js").default|import("../layer/Layer.js").default>} sources Input
- * sources or layers.  For vector data, use an VectorImage layer.
+ * sources or layers.
  * @property {Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
  * and the output will be assigned to the raster source.


### PR DESCRIPTION
I was not able to find out since when it works, but a Raster source works perfectly fine with a `Vector` layer as input source. So it is no longer true that for vector data, an `VectorImage` layer is needed.