### PR TITLE
Fix updateGeometry_ to preserve per-geometry Z/M values

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -1456,9 +1456,11 @@ class Modify extends PointerInteraction {
     const geometry = segmentData.geometry;
     const index = dragSegment[1];
 
-    for (let i = 2; i < geometry.getStride(); ++i) {
+    const stride = geometry.getStride();
+    for (let i = 2; i < stride; ++i) {
       vertex[i] = segment[index][i];
     }
+    vertex.length = stride;
     switch (geometry.getType()) {
       case 'Point':
         coordinates = vertex;

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -509,49 +509,6 @@ describe('ol.interaction.Modify', function () {
       expect(lineFeature.getGeometry().getCoordinates()[4][2]).to.equal(50);
     });
 
-    it('preserves per-geometry Z when dragging shared vertices', function () {
-      const lineXYZ = new Feature({
-        geometry: new LineString([
-          [0, 0, 100],
-          [10, 20, 200],
-          [0, 40, 300],
-        ]),
-      });
-      const lineXY = new Feature({
-        geometry: new LineString([
-          [0, 0],
-          [10, 20],
-          [0, 40],
-        ]),
-      });
-      features.length = 0;
-      features.push(lineXYZ, lineXY);
-
-      const modify = new Modify({
-        features: new Collection(features),
-      });
-      map.addInteraction(modify);
-
-      // Drag the first shared vertex from [0, 0] to [-10, -10]
-      simulateEvent('pointermove', 0, 0, null, 0);
-      simulateEvent('pointerdown', 0, 0, null, 0);
-      simulateEvent('pointermove', -10, 10, null, 0);
-      simulateEvent('pointerdrag', -10, 10, null, 0);
-      simulateEvent('pointerup', -10, 10, null, 0);
-
-      const coordsXYZ = lineXYZ.getGeometry().getCoordinates();
-      const coordsXY = lineXY.getGeometry().getCoordinates();
-
-      // XYZ line should preserve its Z value
-      expect(coordsXYZ[0][0]).to.equal(-10);
-      expect(coordsXYZ[0][1]).to.equal(-10);
-      expect(coordsXYZ[0][2]).to.equal(100);
-
-      // XY line should have moved to the same 2D position
-      expect(coordsXY[0][0]).to.equal(-10);
-      expect(coordsXY[0][1]).to.equal(-10);
-    });
-
     it('keeps polygon geometries valid', function () {
       const overlappingVertexFeature = new Feature({
         geometry: new Polygon([


### PR DESCRIPTION
When dragging shared vertices, the vertex array was mutated in-place with push(), causing the first geometry's higher dimensions to leak into subsequent geometries. Use assignment instead so each geometry writes its own Z/M values from its segment data.

References #17338 