### PR TITLE
Fix typos in GeoZARR source

### DIFF
--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -25,7 +25,7 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * @property {string} url The Zarr URL.
  * @property {string} group The group with arrays to render.
  * @property {Array<string>} bands The band names to render.
- * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoZARR metadata
+ * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoZarr metadata
  * will be read for projection information.
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.


### PR DESCRIPTION
Just fixing a typo and a copy&paste mistake.