### PR TITLE
Improve GeoZarr nodata handling

### DIFF
--- a/examples/geozarr-sparse.js
+++ b/examples/geozarr-sparse.js
@@ -28,12 +28,6 @@ const map = new Map({
           ['interpolate', ['linear'], ['band', 1], 0, 0, 0.5, 255],
           ['interpolate', ['linear'], ['band', 2], 0, 0, 0.5, 255],
           ['interpolate', ['linear'], ['band', 3], 0, 0, 0.5, 255],
-          [
-            'case',
-            ['==', ['+', ['band', 1], ['band', 2], ['band', 3]], 0],
-            0,
-            1,
-          ],
         ],
       },
       source,

--- a/examples/geozarr-stretch.js
+++ b/examples/geozarr-stretch.js
@@ -45,21 +45,7 @@ const layer = new TileLayer({
       ['/', ['band', ['var', 'red']], ['var', 'redMax']],
       ['/', ['band', ['var', 'green']], ['var', 'greenMax']],
       ['/', ['band', ['var', 'blue']], ['var', 'blueMax']],
-      [
-        'case',
-        [
-          '==',
-          [
-            '+',
-            ['band', ['var', 'red']],
-            ['band', ['var', 'green']],
-            ['band', ['var', 'blue']],
-          ],
-          0,
-        ],
-        0,
-        1,
-      ],
+      1,
     ],
   },
   source,

--- a/examples/geozarr.html
+++ b/examples/geozarr.html
@@ -9,8 +9,7 @@ docs: >
 
 
   In this example, a true-color composite is rendered from Sentinel-2 L2A bands B02 (blue), B03 (green), and B04 (red) reflectance values.
-  Reflectance values from 0 to 0.5 are stretched to values between 0 and 255 for the RGB color channels; and values that are all zero are
-  made transparent (with 0 in the alpha channel). A gamma correction is also made to brighten the image.
+  Reflectance values from 0 to 0.5 are stretched to values between 0 and 255 for the RGB color channels. A gamma correction is also made to brighten the image.
 
 
   To try different scenes, browse to the [Sentinel-2 Level-2A](https://api.explorer.eopf.copernicus.eu/browser/external/api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a) catalog of the EOPF Explorer, find a Zarr store, and paste the url after selecting "Custom..." from the dropdown above.

--- a/examples/geozarr.js
+++ b/examples/geozarr.js
@@ -58,12 +58,6 @@ function render() {
             ['interpolate', ['linear'], ['band', 1], 0, 0, 0.5, 255],
             ['interpolate', ['linear'], ['band', 2], 0, 0, 0.5, 255],
             ['interpolate', ['linear'], ['band', 3], 0, 0, 0.5, 255],
-            [
-              'case',
-              ['==', ['+', ['band', 1], ['band', 2], ['band', 3]], 0],
-              0,
-              1,
-            ],
           ],
         },
         source,

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -90,9 +90,10 @@ import BaseTileLayer from './BaseTile.js';
 /**
  * @param {Style} style The layer style.
  * @param {number} [bandCount] The number of bands.
+ * @param {number} [nodataBandIndex] The 1-based band index for the nodata alpha band.
  * @return {ParsedStyle} Shaders and uniforms generated from the style.
  */
-function parseStyle(style, bandCount) {
+function parseStyle(style, bandCount, nodataBandIndex) {
   const vertexShader = `
     attribute vec2 ${Attributes.TEXTURE_COORD};
     uniform mat4 ${Uniforms.TILE_TRANSFORM};
@@ -213,6 +214,23 @@ function parseStyle(style, bandCount) {
     );
   }
 
+  // Ensure getBandValue function exists when nodata discard is needed
+  if (nodataBandIndex > 0 && !('getBandValue' in context.functions)) {
+    let ifBlocks = '';
+    for (let i = 0; i < bandCount; i++) {
+      const colorIndex = Math.floor(i / 4);
+      let bandIndex = i % 4;
+      if (i === bandCount - 1 && bandIndex === 1) {
+        // LUMINANCE_ALPHA - band 1 assigned to rgb and band 2 assigned to alpha
+        bandIndex = 3;
+      }
+      const textureName = `${Uniforms.TILE_TEXTURE_ARRAY}[${colorIndex}]`;
+      ifBlocks += `  if (band == ${i + 1}.0) {\n    return texture2D(${textureName}, v_textureCoord + vec2(dx, dy))[${bandIndex}];\n  }\n`;
+    }
+    context.functions['getBandValue'] =
+      `float getBandValue(float band, float xOffset, float yOffset) {\n  float dx = xOffset / ${Uniforms.TEXTURE_PIXEL_WIDTH};\n  float dy = yOffset / ${Uniforms.TEXTURE_PIXEL_HEIGHT};\n${ifBlocks}\n}`;
+  }
+
   const functionDefintions = Object.keys(context.functions).map(
     function (name) {
       return context.functions[name];
@@ -252,6 +270,8 @@ function parseStyle(style, bandCount) {
       vec4 color = texture2D(${
         Uniforms.TILE_TEXTURE_ARRAY
       }[0],  v_textureCoord);
+
+      ${nodataBandIndex ? `if (getBandValue(${nodataBandIndex}.0, 0.0, 0.0) == 0.0) { discard; }` : ''}
 
       ${pipeline.join('\n')}
 
@@ -397,10 +417,26 @@ class WebGLTileLayer extends BaseTileLayer {
   }
 
   /**
+   * @private
+   * @return {number|undefined} The 1-based band index for the nodata alpha band.
+   */
+  getSourceNodataBandIndex_() {
+    const max = Number.MAX_SAFE_INTEGER;
+    const sources = this.getSources([-max, -max, max, max], max);
+    return sources && sources.length && 'nodataBandIndex' in sources[0]
+      ? sources[0].nodataBandIndex
+      : undefined;
+  }
+
+  /**
    * @override
    */
   createRenderer() {
-    const parsedStyle = parseStyle(this.style_, this.getSourceBandCount_());
+    const parsedStyle = parseStyle(
+      this.style_,
+      this.getSourceBandCount_(),
+      this.getSourceNodataBandIndex_(),
+    );
 
     return new WebGLTileLayerRenderer(this, {
       vertexShader: parsedStyle.vertexShader,
@@ -485,7 +521,11 @@ class WebGLTileLayer extends BaseTileLayer {
     this.styleVariables_ = style.variables || {};
     this.style_ = style;
     if (this.hasRenderer()) {
-      const parsedStyle = parseStyle(this.style_, this.getSourceBandCount_());
+      const parsedStyle = parseStyle(
+        this.style_,
+        this.getSourceBandCount_(),
+        this.getSourceNodataBandIndex_(),
+      );
       const renderer = this.getRenderer();
       renderer.reset({
         vertexShader: parsedStyle.vertexShader,

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -150,6 +150,11 @@ class DataTileSource extends TileSource {
     this.bandCount = options.bandCount === undefined ? 4 : options.bandCount; // assume RGBA if undefined
 
     /**
+     * @type {number|undefined} The 1-based band index for the nodata alpha band.
+     */
+    this.nodataBandIndex;
+
+    /**
      * @private
      * @type {!Object<string, import("../tilegrid/TileGrid.js").default>}
      */

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -48,11 +48,13 @@ export default class GeoZarr extends DataTileSource {
 
     /**
      * @type {string}
+     * @private
      */
     this.url_ = options.url;
 
     /**
      * @type {string}
+     * @private
      */
     this.group_ = options.group;
 
@@ -63,31 +65,37 @@ export default class GeoZarr extends DataTileSource {
 
     /**
      * @type {import('zarrita').Group<any>}
+     * @private
      */
     this.root_ = null;
 
     /**
      * @type {any|null}
+     * @private
      */
     this.consolidatedMetadata_ = null;
 
     /**
      * @type {Array<string>}
+     * @private
      */
     this.bands_ = options.bands;
 
     /**
      * @type {Object<string, Array<string>> | null}
+     * @private
      */
     this.bandsByLevel_ = null;
 
     /**
      * @type {number|undefined}
+     * @private
      */
     this.fillValue_;
 
     /**
      * @type {ResampleMethod}
+     * @private
      */
     this.resampleMethod_ = options.resample || 'linear';
 
@@ -96,12 +104,13 @@ export default class GeoZarr extends DataTileSource {
      */
     this.bandCount = this.bands_.length;
 
-    this.setLoader(this.loadTile_.bind(this));
-
     /**
      * @type {import("../tilegrid/WMTS.js").default}
+     * @override
      */
     this.tileGrid;
+
+    this.setLoader(this.loadTile_.bind(this));
 
     this.configure_()
       .then(() => {
@@ -152,6 +161,10 @@ export default class GeoZarr extends DataTileSource {
       this.tileGrid = tileGrid;
       this.projection = projection;
       this.fillValue_ = fillValue;
+      if (this.fillValue_ !== null && this.fillValue_ !== undefined) {
+        this.bandCount = this.bands_.length + 1;
+        this.nodataBandIndex = this.bandCount;
+      }
     }
     if ('tile_matrix_set' in attributes.multiscales) {
       // If available, use tile_matrix_set (legacy attributes) to get a tile grid, because it
@@ -254,7 +267,7 @@ export default class GeoZarr extends DataTileSource {
       tileRowCount,
       tileResolution,
       this.resampleMethod_,
-      this.fillValue_ || 0,
+      this.fillValue_,
     );
   }
 }
@@ -328,7 +341,7 @@ function getTileGridInfoFromAttributes(
         if (bandArray) {
           availableBands.push(band);
           if (fillValue === undefined) {
-            fillValue = bandArray['fill_value'];
+            fillValue = Number(bandArray['fill_value']);
           }
         }
       }
@@ -409,18 +422,26 @@ function composeData(
   resampleMethod,
   fillValue,
 ) {
-  const bandCount = chunks.length;
+  const chunkCount = chunks.length;
+  const addAlpha = fillValue !== null && fillValue !== undefined;
+  const isNoDataValue = isNaN(fillValue)
+    ? (v) => isNaN(v)
+    : (v) => v === fillValue;
+  const bandCount = chunkCount + (addAlpha ? 1 : 0);
   const tileData = new Float32Array(tileColCount * tileRowCount * bandCount);
   for (let tileRow = 0; tileRow < tileRowCount; tileRow++) {
     for (let tileCol = 0; tileCol < tileColCount; tileCol++) {
-      for (let band = 0; band < bandCount; ++band) {
-        const chunk = chunks[band];
+      let hasData = false;
+      for (let chunkIndex = 0; chunkIndex < chunkCount; ++chunkIndex) {
+        const chunk = chunks[chunkIndex];
         const chunkRowCount = chunk.shape[0];
         const chunkColCount = chunk.shape[1];
-        const scaleFactor = tileResolution / chunkResolutions[band];
-        let value = fillValue;
+        const scaleFactor = tileResolution / chunkResolutions[chunkIndex];
+        let value = 0;
+        let inBounds = false;
         if (scaleFactor === 1) {
           if (tileRow < chunkRowCount && tileCol < chunkColCount) {
+            inBounds = true;
             value = chunk.data[tileRow * chunkColCount + tileCol];
           }
         } else {
@@ -431,6 +452,7 @@ function composeData(
               const valueRow = Math.round(chunkRow);
               const valueCol = Math.round(chunkCol);
               if (valueRow < chunkRowCount && valueCol < chunkColCount) {
+                inBounds = true;
                 value = chunk.data[valueRow * chunkColCount + valueCol];
               }
               break;
@@ -439,6 +461,7 @@ function composeData(
               const row0 = Math.floor(chunkRow);
               const col0 = Math.floor(chunkCol);
               if (row0 < chunkRowCount && col0 < chunkColCount) {
+                inBounds = true;
                 const row1 = Math.min(row0 + 1, chunkRowCount - 1);
                 const col1 = Math.min(col0 + 1, chunkColCount - 1);
 
@@ -461,10 +484,18 @@ function composeData(
             }
           }
         }
-        if (isNaN(value)) {
-          value = fillValue;
+        if (inBounds && !isNoDataValue(value)) {
+          hasData = true;
         }
-        tileData[bandCount * (tileRow * tileColCount + tileCol) + band] = value;
+        if (isNaN(value)) {
+          value = 0;
+        }
+        tileData[bandCount * (tileRow * tileColCount + tileCol) + chunkIndex] =
+          value;
+      }
+      if (addAlpha) {
+        tileData[bandCount * (tileRow * tileColCount + tileCol) + chunkCount] =
+          hasData ? 1 : 0;
       }
     }
   }

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -562,6 +562,171 @@ describe('ol/layer/WebGLTile', function () {
     });
   });
 
+  describe('nodata band index', () => {
+    it('generates getBandValue and discard for source with nodataBandIndex', function () {
+      const source = new DataTileSource({
+        bandCount: 4,
+        loader(z, x, y) {
+          return new Float32Array(256 * 256 * 4);
+        },
+      });
+      source.nodataBandIndex = 4;
+
+      const nodataLayer = new WebGLTileLayer({
+        source: source,
+        style: {
+          color: ['color', 128, 128, 128],
+        },
+      });
+
+      map.addLayer(nodataLayer);
+
+      const compileShaderSpy = sinonSpy(WebGLHelper.prototype, 'compileShader');
+      const renderer = nodataLayer.getRenderer();
+      const viewState = map.getView().getState();
+      const size = map.getSize();
+      const frameState = {
+        viewState: viewState,
+        extent: getForViewAndSize(
+          viewState.center,
+          viewState.resolution,
+          viewState.rotation,
+          size,
+        ),
+        layerStatesArray: map.getLayerGroup().getLayerStatesArray(),
+        layerIndex: 0,
+      };
+      renderer.prepareFrame(frameState);
+      compileShaderSpy.restore();
+
+      const fragmentShader = compileShaderSpy.getCall(0).args[0];
+      expect(fragmentShader).to.contain('getBandValue');
+      expect(fragmentShader).to.contain(
+        'if (getBandValue(4.0, 0.0, 0.0) == 0.0) { discard; }',
+      );
+
+      nodataLayer.dispose();
+    });
+
+    it('does not add discard when source has no nodataBandIndex', function () {
+      const source = new DataTileSource({
+        bandCount: 3,
+        loader(z, x, y) {
+          return new Float32Array(256 * 256 * 3);
+        },
+      });
+
+      const normalLayer = new WebGLTileLayer({
+        source: source,
+        style: {
+          color: ['color', 128, 128, 128],
+        },
+      });
+
+      map.addLayer(normalLayer);
+
+      const compileShaderSpy = sinonSpy(WebGLHelper.prototype, 'compileShader');
+      const renderer = normalLayer.getRenderer();
+      const viewState = map.getView().getState();
+      const size = map.getSize();
+      const frameState = {
+        viewState: viewState,
+        extent: getForViewAndSize(
+          viewState.center,
+          viewState.resolution,
+          viewState.rotation,
+          size,
+        ),
+        layerStatesArray: map.getLayerGroup().getLayerStatesArray(),
+        layerIndex: 0,
+      };
+      renderer.prepareFrame(frameState);
+      compileShaderSpy.restore();
+
+      const fragmentShader = compileShaderSpy.getCall(0).args[0];
+      expect(fragmentShader).not.to.contain(
+        'getBandValue(4.0, 0.0, 0.0) == 0.0',
+      );
+
+      normalLayer.dispose();
+    });
+
+    it('uses existing getBandValue when style has band expressions', function () {
+      const source = new DataTileSource({
+        bandCount: 4,
+        loader(z, x, y) {
+          return new Float32Array(256 * 256 * 4);
+        },
+      });
+      source.nodataBandIndex = 4;
+
+      const nodataLayer = new WebGLTileLayer({
+        source: source,
+        style: {
+          color: [
+            'array',
+            ['/', ['band', 1], 3000],
+            ['/', ['band', 2], 3000],
+            ['/', ['band', 3], 3000],
+            1,
+          ],
+        },
+      });
+
+      map.addLayer(nodataLayer);
+
+      const compileShaderSpy = sinonSpy(WebGLHelper.prototype, 'compileShader');
+      const renderer = nodataLayer.getRenderer();
+      const viewState = map.getView().getState();
+      const size = map.getSize();
+      const frameState = {
+        viewState: viewState,
+        extent: getForViewAndSize(
+          viewState.center,
+          viewState.resolution,
+          viewState.rotation,
+          size,
+        ),
+        layerStatesArray: map.getLayerGroup().getLayerStatesArray(),
+        layerIndex: 0,
+      };
+      renderer.prepareFrame(frameState);
+      compileShaderSpy.restore();
+
+      const fragmentShader = compileShaderSpy.getCall(0).args[0];
+      // getBandValue should exist (from the band expressions)
+      expect(fragmentShader).to.contain('getBandValue');
+      // discard line should still be present
+      expect(fragmentShader).to.contain(
+        'if (getBandValue(4.0, 0.0, 0.0) == 0.0) { discard; }',
+      );
+      // getBandValue should only be defined once
+      const matches = fragmentShader.match(/float getBandValue\(float band/g);
+      expect(matches.length).to.be(1);
+
+      nodataLayer.dispose();
+    });
+
+    it('returns nodataBandIndex from the source', () => {
+      const source = new DataTileSource({
+        bandCount: 4,
+      });
+      source.nodataBandIndex = 4;
+
+      const testLayer = new WebGLTileLayer({source: source});
+      expect(testLayer.getSourceNodataBandIndex_()).to.be(4);
+      testLayer.dispose();
+    });
+
+    it('returns undefined when source has no nodataBandIndex', () => {
+      const testLayer = new WebGLTileLayer({
+        source: new DataTileSource({bandCount: 3}),
+      });
+      expect(testLayer.getSourceNodataBandIndex_()).to.be(undefined);
+      testLayer.dispose();
+    });
+  });
+
   it('dispatches a precompose event with WebGL context', (done) => {
     let called = false;
     layer.on('precompose', (event) => {

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -1,5 +1,62 @@
+import {stub} from 'sinon';
 import {get} from '../../../../../src/ol/proj.js';
 import GeoZarr from '../../../../../src/ol/source/GeoZarr.js';
+
+const ZARR_URL = 'http://test-zarr/test.zarr';
+const GROUP = 'data';
+
+/**
+ * Stub fetch for a minimal v3 Zarr store with the given consolidated metadata.
+ * @param {Object|null} consolidatedMetadata Consolidated metadata, or null for none.
+ * @return {import('sinon').SinonStub} The fetch stub.
+ */
+function stubFetch(consolidatedMetadata) {
+  const rootZarrJson = {
+    zarr_format: 3,
+    node_type: 'group',
+    attributes: {},
+  };
+  if (consolidatedMetadata) {
+    rootZarrJson.consolidated_metadata = {
+      metadata: consolidatedMetadata,
+    };
+  }
+
+  const groupZarrJson = {
+    zarr_format: 3,
+    node_type: 'group',
+    attributes: {
+      zarr_conventions: [
+        {uuid: 'd35379db-88df-4056-af3a-620245f8e347'},
+        {uuid: 'f17cb550-5864-4468-aeb7-f3180cfb622f'},
+        {uuid: '689b58e2-cf7b-45e0-9fff-9cfc0883d6b4'},
+      ],
+      multiscales: {
+        layout: [
+          {
+            asset: 'level0',
+            'spatial:transform': [1, 0, 0, 0, -1, 256],
+          },
+        ],
+      },
+      'spatial:bbox': [0, 0, 256, 256],
+      'proj:code': 'EPSG:4326',
+    },
+  };
+
+  const responses = {
+    [`${ZARR_URL}/zarr.json`]: JSON.stringify(rootZarrJson),
+    [`${ZARR_URL}/${GROUP}/zarr.json`]: JSON.stringify(groupZarrJson),
+  };
+
+  return stub(window, 'fetch').callsFake(function (url) {
+    const body = responses[url];
+    if (body !== undefined) {
+      return Promise.resolve(new Response(body, {status: 200}));
+    }
+    return Promise.resolve(new Response('', {status: 404}));
+  });
+}
 
 describe('ol/source/GeoZarr', function () {
   describe('constructor', function () {
@@ -77,6 +134,63 @@ describe('ol/source/GeoZarr', function () {
       // The actual band value testing will be done in integration tests
       expect(source).to.be.a(GeoZarr);
       expect(source.bands_).to.not.be.empty();
+    });
+  });
+
+  describe('nodataBandIndex', function () {
+    let fetchStub;
+
+    afterEach(function () {
+      if (fetchStub) {
+        fetchStub.restore();
+        fetchStub = null;
+      }
+    });
+
+    it('is undefined before configure_() runs', function () {
+      fetchStub = stubFetch(null);
+      const source = new GeoZarr({
+        url: ZARR_URL,
+        group: GROUP,
+        bands: ['band1'],
+      });
+      expect(source.nodataBandIndex).to.be(undefined);
+      expect(source.bandCount).to.be(1);
+    });
+
+    it('sets nodataBandIndex and increments bandCount when fillValue is present', function (done) {
+      fetchStub = stubFetch({
+        [`${GROUP}/level0/b04`]: {fill_value: 'NaN'},
+        [`${GROUP}/level0/b03`]: {fill_value: 'NaN'},
+      });
+      const source = new GeoZarr({
+        url: ZARR_URL,
+        group: GROUP,
+        bands: ['b04', 'b03'],
+      });
+      source.on('change', function () {
+        if (source.getState() === 'ready') {
+          expect(source.bandCount).to.be(3);
+          expect(source.nodataBandIndex).to.be(3);
+          done();
+        }
+      });
+    });
+
+    it('does not set nodataBandIndex when there is no consolidated metadata', function (done) {
+      fetchStub = stubFetch(null);
+      const source = new GeoZarr({
+        url: ZARR_URL,
+        group: GROUP,
+        bands: ['b04'],
+      });
+      source.on('change', function () {
+        if (source.getState() === 'ready') {
+          expect(source.bandCount).to.be(1);
+          expect(source.nodataBandIndex).to.be(undefined);
+          done();
+        }
+      });
     });
   });
 


### PR DESCRIPTION
This pull request adds nodata handling capabilities to the WebGL tile layer's style parser, and makes use of them for the GeoZarr source:

* Like for GeoTIFF, a nodata/alpha band is added to the data tiles when a `fill_value` hint is found in the zarr metadata.
* The WebGLTile layer's `parseStyle()` function takes a nodata band index as optional 3rd argument. When provided, pixels with `0` in the nodata band will be discarded at the beginning of the style pipeline, making them transparent.

With these changes, there is no need to add nodata handling in the style any more.