### PR TITLE
Cache opened zarrita arrays across GeoZarr tile loads

### DIFF
--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -76,6 +76,15 @@ export default class GeoZarr extends DataTileSource {
     this.consolidatedMetadata_ = null;
 
     /**
+     * Cache of opened zarrita arrays keyed by path. Caching the Promise
+     * (not the resolved value) deduplicates concurrent opens for the same
+     * array path across tiles at the same zoom level.
+     * @type {Map<string, Promise<import('zarrita').Array<import('zarrita').DataType, any>>>}
+     * @private
+     */
+    this.arrayCache_ = new Map();
+
+    /**
      * @type {Array<string>}
      * @private
      */
@@ -251,7 +260,16 @@ export default class GeoZarr extends DataTileSource {
       const maxRow = Math.round((origin[1] - tileExtent[1]) / bandResolution);
 
       const path = `${this.group_}/${bandMatrixId}/${band}`;
-      const array = await open(this.root_.resolve(path), {kind: 'array'});
+      if (!this.arrayCache_.has(path)) {
+        this.arrayCache_.set(
+          path,
+          open(this.root_.resolve(path), {kind: 'array'}).catch((err) => {
+            this.arrayCache_.delete(path);
+            throw err;
+          }),
+        );
+      }
+      const array = await this.arrayCache_.get(path);
       bandPromises.push(
         get(array, [slice(minRow, maxRow), slice(minCol, maxCol)]),
       );


### PR DESCRIPTION
Part of #17368.

zarrita's `open()` fetches `zarr.json` on every call, even for the same array. In a 9-tile viewport with 3 RGB bands, that's 27 identical metadata fetches instead of 3.

Adds a `Map<string, Promise>` on the source keyed by array path. Caching the Promise (not the resolved value) deduplicates concurrent opens - the first tile stores the Promise synchronously, subsequent tiles await the same in-flight fetch. Zoom-safe because paths include the tile matrix ID (`group/0/b04` vs `group/1/b04`). Rejected Promises are evicted so transient errors don't stick.

<details><summary>Metadata fetch reduction</summary>

```
Without cache: 9 tiles x 3 bands = 27 zarr.json fetches
With cache:    3 zarr.json fetches (89% reduction)
```

</details>

Independent of #17370 and #17371, composes with both.

*AI (Claude) supported my development of this PR.*