### PR TITLE
feat(GeoZarr): coalesce concurrent byte-range requests via zarrita

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "geotiff": "^3.0.5",
         "pbf": "4.0.1",
         "rbush": "^4.0.0",
-        "zarrita": "^0.6.0"
+        "zarrita": "^0.7.1"
       },
       "devDependencies": {
         "@codemirror/lang-javascript": "^6.2.2",
@@ -3497,13 +3497,13 @@
       "dev": true
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.4.tgz",
-      "integrity": "sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
-        "unzipit": "1.4.3"
+        "unzipit": "2.0.0"
       }
     },
     "node_modules/@zxing/text-encoding": {
@@ -13147,15 +13147,12 @@
       }
     },
     "node_modules/unzipit": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
-      "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
       "license": "MIT",
-      "dependencies": {
-        "uzip-module": "^1.0.2"
-      },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -13251,12 +13248,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/uzip-module": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
-      "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
-      "license": "MIT"
     },
     "node_modules/varint": {
       "version": "6.0.0",
@@ -14368,12 +14359,12 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.6.2.tgz",
-      "integrity": "sha512-8IV+2bWt5yiHNVK9GVEVK1tscpqDcJj8iz5cIKFOiWiWYUsK4V5njgMtnpkvKu6L7K+Og6zUShd8f+dwb6LvTA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.1.tgz",
+      "integrity": "sha512-Nu4liRKJES1kkIjWALXSryglJf2+WJURUxgndklfX+mTBCd0lk4MV797p00lt4NzmU3Bbdbs10uxeN8LWwPyWA==",
       "license": "MIT",
       "dependencies": {
-        "@zarrita/storage": "^0.1.4",
+        "@zarrita/storage": "^0.2.0",
         "numcodecs": "^0.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "geotiff": "^3.0.5",
     "pbf": "4.0.1",
     "rbush": "^4.0.0",
-    "zarrita": "^0.6.0"
+    "zarrita": "^0.7.1"
   },
   "devDependencies": {
     "@codemirror/lang-javascript": "^6.2.2",

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -2,7 +2,7 @@
  * @module ol/source/GeoZarr
  */
 
-import {FetchStore, get, open, slice} from 'zarrita';
+import {FetchStore, get, open, slice, withRangeCoalescing} from 'zarrita';
 import {warn} from '../console.js';
 import {getCenter} from '../extent.js';
 import {get as getProjection, toUserCoordinate, toUserExtent} from '../proj.js';
@@ -195,7 +195,9 @@ export default class GeoZarr extends DataTileSource {
   }
 
   async configure_() {
-    const store = new FetchStore(this.url_);
+    const store = /** @type {FetchStore} */ (
+      withRangeCoalescing(new FetchStore(this.url_))
+    );
 
     // Fetch group zarr.json once for both opening the group and extracting
     // consolidated metadata. Without this, open() and the manual metadata

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -89,7 +89,8 @@ function stubFetchWithAttrs(consolidatedMetadata, groupAttrs) {
     [`${ZARR_URL}/zarr.json`]: JSON.stringify(groupZarrJson),
   };
 
-  return sinonStub(window, 'fetch').callsFake(function (url) {
+  return sinonStub(window, 'fetch').callsFake(function (input) {
+    const url = input instanceof Request ? input.url : input;
     const body = responses[url];
     if (body !== undefined) {
       return Promise.resolve(new Response(body, {status: 200}));
@@ -550,7 +551,8 @@ describe('ol/source/GeoZarr', function () {
       for (const [k, v] of Object.entries(group2Meta || {})) {
         metadata[`extra/${k}`] = v;
       }
-      return sinonStub(window, 'fetch').callsFake(function (url) {
+      return sinonStub(window, 'fetch').callsFake(function (input) {
+        const url = input instanceof Request ? input.url : input;
         if (url === `${ZARR_ROOT_URL}/zarr.json`) {
           return Promise.resolve(
             new Response(


### PR DESCRIPTION
Closes #17368.

Wraps the `FetchStore` used by GeoZarr with `withRangeCoalescing` from zarrita 0.7.1 to batch concurrent `getRange()` calls within a microtask tick and merge adjacent byte ranges (default 32 KB gap). Motivated by multi-band tile loads that fire dozens of independent byte-range requests against the same shard files.

`AbortSignal` merging is handled internally by zarrita via `AbortSignal.any`, so OL's tile cancellation propagates correctly across callers sharing a batch.

*AI (Claude) supported my development of this PR.*