### PR TITLE
fix(test): handle image load errors in ImageLayer CORS test

### DIFF
--- a/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/ImageLayer.test.js
@@ -120,6 +120,9 @@ describe('ol/renderer/canvas/ImageLayer', function () {
             done();
           }
         });
+        source.once('imageloaderror', function () {
+          done(new Error('Image failed to load'));
+        });
       });
     });
 


### PR DESCRIPTION
The `beforeEach` hook in the ImageLayer CORS test loads two remote images from `https://openlayers.org/` but only listens for `imageloadend`. If either request fails (network issues in CI), `done()` is never called and Mocha times out at 2500ms. Adding an `imageloaderror` listener makes the test fail immediately with a clear message instead of timing out.

This showed up as the only failure in #17369's CI run (1 of 2918 tests, [run log](https://github.com/openlayers/openlayers/actions/runs/22691777122/job/65795581856)).