### PR TITLE
Remove separate group option for the GeoZarr source

### DIFF
--- a/examples/geozarr-sparse.js
+++ b/examples/geozarr-sparse.js
@@ -10,8 +10,7 @@ import GeoZarr from '../src/ol/source/GeoZarr.js';
 import OSM from '../src/ol/source/OSM.js';
 
 const source = new GeoZarr({
-  url: 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr',
-  group: 'measurements/reflectance',
+  url: 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance',
   bands: ['b11', 'b03', 'b02'],
 });
 

--- a/examples/geozarr-stretch.js
+++ b/examples/geozarr-stretch.js
@@ -31,8 +31,7 @@ function getVariables() {
 }
 
 const source = new GeoZarr({
-  url: 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr',
-  group: 'measurements/reflectance',
+  url: 'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance',
   bands: ['b04', 'b03', 'b02', 'b11'],
 });
 

--- a/examples/geozarr.html
+++ b/examples/geozarr.html
@@ -12,8 +12,8 @@ docs: >
   Reflectance values from 0 to 0.5 are stretched to values between 0 and 255 for the RGB color channels. A gamma correction is also made to brighten the image.
 
 
-  To try different scenes, browse to the [Sentinel-2 Level-2A](https://api.explorer.eopf.copernicus.eu/browser/external/api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a) catalog of the EOPF Explorer, find a Zarr store, and paste the url after selecting "Custom..." from the dropdown above.
-  Note that only GeoZarrs with a 'measurements/reflectance' group and bands 'b02', 'b03', and 'b04' will work without changes to the source code.
+  To try different scenes, browse to the [Sentinel-2 Level-2A](https://api.explorer.eopf.copernicus.eu/browser/external/api.explorer.eopf.copernicus.eu/stac/collections/sentinel-2-l2a) catalog of the EOPF Explorer, find a Zarr store, and paste the url including the group path (e.g. `store.zarr/measurements/reflectance`) after selecting "Custom..." from the dropdown above.
+  Note that only GeoZarrs with bands 'b02', 'b03', and 'b04' will work without changes to the source code.
 
 tags: "zarr, geozarr, sentinel-2"
 experimental: true
@@ -24,8 +24,8 @@ experimental: true
     <div class="input-group">
       <label class="input-group-text" for="url-select">URL</label>
       <select class="form-select" id="url-select">
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260120T084301_N0511_R064_T36UXA_20260120T122910.zarr">Sentinel-2 L2A (Krasnokuts'k)</option>
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr">Sentinel-2 L2A (Hvolsvöllur)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260120T084301_N0511_R064_T36UXA_20260120T122910.zarr/measurements/reflectance">Sentinel-2 L2A (Krasnokuts'k)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance">Sentinel-2 L2A (Hvolsvöllur)</option>
         <option value="custom">Custom...</option>
       </select>
       <input type="text" class="form-control" id="custom-url" placeholder="Enter Zarr URL" style="display: none; width: 300px;">

--- a/examples/geozarr.js
+++ b/examples/geozarr.js
@@ -37,7 +37,6 @@ function render() {
 
   const source = new GeoZarr({
     url: url,
-    group: 'measurements/reflectance',
     bands: ['b04', 'b03', 'b02'],
   });
 

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -22,8 +22,7 @@ const REQUIRED_ZARR_CONVENTIONS = [
 
 /**
  * @typedef {Object} Options
- * @property {string} url The Zarr URL.
- * @property {string} group The group with arrays to render.
+ * @property {string} url The Zarr URL including the multiscales group path (e.g. `'https://example.com/store.zarr/measurements/reflectance'`).
  * @property {Array<string>} bands The band names to render.
  * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoZarr metadata
  * will be read for projection information.
@@ -33,6 +32,12 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * @property {ResampleMethod} [resample='nearest'] Resamplilng method if bands are not available for all multi-scale levels.
  */
 
+/**
+ * Source that supports GeoZarr stores with metadata for the following conventions:
+ * - Zarr multiscales convention (https://github.com/zarr-conventions/multiscales)
+ * - Geospatial projection convention (https://github.com/zarr-conventions/geo-proj)
+ * - Spatial convention (https://github.com/zarr-conventions/spatial)
+ */
 export default class GeoZarr extends DataTileSource {
   /**
    * @param {Options} options The options.
@@ -53,12 +58,6 @@ export default class GeoZarr extends DataTileSource {
     this.url_ = options.url;
 
     /**
-     * @type {string}
-     * @private
-     */
-    this.group_ = options.group;
-
-    /**
      * @type {Error|null}
      */
     this.error_ = null;
@@ -67,7 +66,7 @@ export default class GeoZarr extends DataTileSource {
      * @type {import('zarrita').Group<any>}
      * @private
      */
-    this.root_ = null;
+    this.group_ = null;
 
     /**
      * @type {any|null}
@@ -134,14 +133,14 @@ export default class GeoZarr extends DataTileSource {
   async configure_() {
     const store = new FetchStore(this.url_);
 
-    // Fetch root zarr.json once for both opening the root and extracting
+    // Fetch group zarr.json once for both opening the group and extracting
     // consolidated metadata. Without this, open() and the manual metadata
     // read would each make a separate HTTP request for the same file.
-    const rootBytes = await store.get('/zarr.json');
-    if (rootBytes) {
+    const groupBytes = await store.get('/zarr.json');
+    if (groupBytes) {
       try {
         this.consolidatedMetadata_ = JSON.parse(
-          new TextDecoder().decode(rootBytes),
+          new TextDecoder().decode(groupBytes),
         ).consolidated_metadata.metadata;
       } catch {
         // no consolidated metadata
@@ -151,15 +150,15 @@ export default class GeoZarr extends DataTileSource {
     // Wrap the store so that child metadata (groups, arrays) is served from
     // the consolidated metadata instead of making per-child HTTP requests.
     const cachedStore = this.consolidatedMetadata_
-      ? createCachedStore(store, rootBytes, this.consolidatedMetadata_)
+      ? createCachedStore(store, groupBytes, this.consolidatedMetadata_)
       : store;
 
-    this.root_ = await open(cachedStore, {kind: 'group'});
-
-    const group = await open(this.root_.resolve(this.group_), {kind: 'group'});
+    this.group_ = await open(cachedStore, {kind: 'group'});
 
     const attributes =
-      /** @type {LegacyDatasetAttributes | DatasetAttributes} */ (group.attrs);
+      /** @type {LegacyDatasetAttributes | DatasetAttributes} */ (
+        this.group_.attrs
+      );
 
     let hasTileSizes = false;
     if (
@@ -174,7 +173,6 @@ export default class GeoZarr extends DataTileSource {
         getTileGridInfoFromAttributes(
           /** @type {DatasetAttributes} */ (attributes),
           this.consolidatedMetadata_,
-          this.group_,
           this.bands_,
         );
       this.bandsByLevel_ = bandsByLevel;
@@ -271,7 +269,7 @@ export default class GeoZarr extends DataTileSource {
       const maxRow = Math.round((origin[1] - tileExtent[1]) / bandResolution);
 
       bandInfos.push({
-        path: `${this.group_}/${bandMatrixId}/${band}`,
+        path: `${bandMatrixId}/${band}`,
         minRow,
         maxRow,
         minCol,
@@ -287,7 +285,7 @@ export default class GeoZarr extends DataTileSource {
         if (!this.arrayCache_.has(path)) {
           this.arrayCache_.set(
             path,
-            open(this.root_.resolve(path), {kind: 'array'}).catch((err) => {
+            open(this.group_.resolve(path), {kind: 'array'}).catch((err) => {
               this.arrayCache_.delete(path);
               throw err;
             }),
@@ -326,13 +324,13 @@ export default class GeoZarr extends DataTileSource {
  * Create a store wrapper that serves Zarr v3 metadata from consolidated
  * metadata, avoiding per-child HTTP requests.
  * @param {import('zarrita').FetchStore} store The underlying store.
- * @param {Uint8Array} rootBytes The already-fetched root zarr.json bytes.
+ * @param {Uint8Array} groupBytes The already-fetched group zarr.json bytes.
  * @param {Object} consolidatedMetadata The parsed consolidated_metadata.metadata entries.
  * @return {Object} A store-compatible object.
  */
-function createCachedStore(store, rootBytes, consolidatedMetadata) {
+function createCachedStore(store, groupBytes, consolidatedMetadata) {
   const cache = new Map();
-  cache.set('/zarr.json', rootBytes);
+  cache.set('/zarr.json', groupBytes);
   const encoder = new TextEncoder();
   for (const [key, value] of Object.entries(consolidatedMetadata)) {
     cache.set(`/${key}/zarr.json`, encoder.encode(JSON.stringify(value)));
@@ -460,14 +458,12 @@ function getTileSizeForShard(shardSize, innerChunkSize) {
 /**
  * @param {DatasetAttributes} attributes The dataset attributes.
  * @param {any} consolidatedMetadata The consolidated metadata.
- * @param {string} wantedGroup The path to the wanted group.
  * @param {Array<string>} wantedBands The wanted bands.
  * @return {TileGridInfo} The tile grid info.
  */
 function getTileGridInfoFromAttributes(
   attributes,
   consolidatedMetadata,
-  wantedGroup,
   wantedBands,
 ) {
   const multiscales = attributes.multiscales;
@@ -488,8 +484,7 @@ function getTileGridInfoFromAttributes(
     if (consolidatedMetadata) {
       const availableBands = [];
       for (const band of wantedBands) {
-        const bandArray =
-          consolidatedMetadata[`${wantedGroup}/${matrixId}/${band}`];
+        const bandArray = consolidatedMetadata[`${matrixId}/${band}`];
         if (bandArray) {
           availableBands.push(band);
           if (fillValue === undefined) {

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -2,8 +2,7 @@ import {stub as sinonStub} from 'sinon';
 import {get} from '../../../../../src/ol/proj.js';
 import GeoZarr from '../../../../../src/ol/source/GeoZarr.js';
 
-const ZARR_URL = 'http://test-zarr/test.zarr';
-const GROUP = 'data';
+const ZARR_URL = 'http://test-zarr/test.zarr/data';
 
 /**
  * Create a Zarr v3 array metadata object with optional sharding codec.
@@ -54,17 +53,6 @@ function createArrayMeta({fillValue, shardShape, innerChunkShape} = {}) {
  * @return {import('sinon').SinonStub} The fetch stub.
  */
 function stubFetch(consolidatedMetadata) {
-  const rootZarrJson = {
-    zarr_format: 3,
-    node_type: 'group',
-    attributes: {},
-  };
-  if (consolidatedMetadata) {
-    rootZarrJson.consolidated_metadata = {
-      metadata: consolidatedMetadata,
-    };
-  }
-
   const groupZarrJson = {
     zarr_format: 3,
     node_type: 'group',
@@ -86,10 +74,14 @@ function stubFetch(consolidatedMetadata) {
       'proj:code': 'EPSG:4326',
     },
   };
+  if (consolidatedMetadata) {
+    groupZarrJson.consolidated_metadata = {
+      metadata: consolidatedMetadata,
+    };
+  }
 
   const responses = {
-    [`${ZARR_URL}/zarr.json`]: JSON.stringify(rootZarrJson),
-    [`${ZARR_URL}/${GROUP}/zarr.json`]: JSON.stringify(groupZarrJson),
+    [`${ZARR_URL}/zarr.json`]: JSON.stringify(groupZarrJson),
   };
 
   return sinonStub(window, 'fetch').callsFake(function (url) {
@@ -105,8 +97,7 @@ describe('ol/source/GeoZarr', function () {
   describe('constructor', function () {
     it('can be constructed with basic options', function () {
       const source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: ['b04', 'b03', 'b02'],
       });
       expect(source).to.be.a(GeoZarr);
@@ -115,8 +106,7 @@ describe('ol/source/GeoZarr', function () {
 
     it('defaults to wrapX: false', function () {
       const source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: ['b04', 'b03'],
       });
       expect(source.getWrapX()).to.be(false);
@@ -124,8 +114,7 @@ describe('ol/source/GeoZarr', function () {
 
     it('respects the wrapX option', function () {
       const source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: ['b04', 'b03'],
         wrapX: true,
       });
@@ -135,8 +124,7 @@ describe('ol/source/GeoZarr', function () {
     it('accepts projection option', function () {
       const projection = 'EPSG:3857';
       const source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: ['b04', 'b03'],
         projection: projection,
       });
@@ -146,8 +134,7 @@ describe('ol/source/GeoZarr', function () {
     it('stores band configuration and sets bandCount', function () {
       const bands = ['b05', 'b04'];
       const source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: bands,
       });
       expect(source.bands_).to.eql(bands);
@@ -160,8 +147,7 @@ describe('ol/source/GeoZarr', function () {
 
     beforeEach(function () {
       source = new GeoZarr({
-        url: 'https://example.com/test.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://example.com/test.zarr/measurements/reflectance',
         bands: ['b05', 'b04'], // NIR, Red for NDVI testing
       });
     });
@@ -194,7 +180,6 @@ describe('ol/source/GeoZarr', function () {
       fetchStub = stubFetch(null);
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['band1'],
       });
       expect(source.nodataBandIndex).to.be(undefined);
@@ -203,12 +188,11 @@ describe('ol/source/GeoZarr', function () {
 
     it('sets nodataBandIndex and increments bandCount when fillValue is present', function (done) {
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: {fill_value: 'NaN'},
-        [`${GROUP}/level0/b03`]: {fill_value: 'NaN'},
+        ['level0/b04']: {fill_value: 'NaN'},
+        ['level0/b03']: {fill_value: 'NaN'},
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04', 'b03'],
       });
       source.on('change', function () {
@@ -224,7 +208,6 @@ describe('ol/source/GeoZarr', function () {
       fetchStub = stubFetch(null);
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -240,8 +223,7 @@ describe('ol/source/GeoZarr', function () {
   describe('error handling', function () {
     it('should handle configuration errors gracefully', function () {
       const source = new GeoZarr({
-        url: 'https://invalid-url.com/nonexistent.zarr',
-        group: 'measurements/reflectance',
+        url: 'https://invalid-url.com/nonexistent.zarr/measurements/reflectance',
         bands: ['b04'],
       });
 
@@ -264,14 +246,13 @@ describe('ol/source/GeoZarr', function () {
 
     it('uses shard shape for tile size when ≤ 512', function (done) {
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [512, 512],
           innerChunkShape: [128, 128],
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -285,14 +266,13 @@ describe('ol/source/GeoZarr', function () {
 
     it('caps tile size at 512 for large shards', function (done) {
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [2048, 2048],
           innerChunkShape: [256, 256],
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -306,14 +286,13 @@ describe('ol/source/GeoZarr', function () {
 
     it('finds largest divisor ≤ 512 for non-power-of-two shards', function (done) {
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [1000, 1000],
           innerChunkShape: [100, 100],
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -330,7 +309,6 @@ describe('ol/source/GeoZarr', function () {
       fetchStub = stubFetch(null);
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -346,14 +324,13 @@ describe('ol/source/GeoZarr', function () {
       // Arrays without sharding_indexed codec should not affect tile size,
       // even when consolidated metadata has chunk_grid info
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [64, 64],
           // no innerChunkShape → no sharding_indexed codec
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -367,14 +344,13 @@ describe('ol/source/GeoZarr', function () {
 
     it('floors tile size to 64 for small shards', function (done) {
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [32, 32],
           innerChunkShape: [8, 8],
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {
@@ -393,14 +369,13 @@ describe('ol/source/GeoZarr', function () {
       // No exact divisor → falls back to shardSize which is > MAX_TILE_SIZE,
       // so uses maxChunks*384 = 1*384 = 384.
       fetchStub = stubFetch({
-        [`${GROUP}/level0/b04`]: createArrayMeta({
+        ['level0/b04']: createArrayMeta({
           shardShape: [2048, 2048],
           innerChunkShape: [384, 384],
         }),
       });
       const source = new GeoZarr({
         url: ZARR_URL,
-        group: GROUP,
         bands: ['b04'],
       });
       source.on('change', function () {


### PR DESCRIPTION
The purpose of this pull request is to avoid confusion, as pointed out in https://github.com/EOPF-Explorer/data-model/issues/124.

By removing the `group` option, users can now provide a `url` that points to a group with the multiscales just below them, e.g. https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr/measurements/reflectance instead of https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2B_MSIL2A_20260120T125339_N0511_R138_T27VWL_20260120T131151.zarr.