### PR TITLE
Fix issue 17380 - Call reprioritize conditionally in handlePostRender

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1238,16 +1238,19 @@ class Map extends BaseObject {
     if (!tileQueue.isEmpty()) {
       let maxTotalLoading = this.maxTilesLoading_;
       let maxNewLoads = maxTotalLoading;
-      if (frameState) {
-        const hints = frameState.viewHints;
-        if (hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING]) {
-          const lowOnFrameBudget = Date.now() - frameState.time > 8;
-          maxTotalLoading = lowOnFrameBudget ? 0 : 8;
-          maxNewLoads = lowOnFrameBudget ? 0 : 2;
-        }
+      const hints = frameState ? frameState.viewHints : undefined;
+      const animatingOrInteracting = hints
+        ? hints[ViewHint.ANIMATING] || hints[ViewHint.INTERACTING]
+        : false;
+      if (animatingOrInteracting) {
+        const lowOnFrameBudget = Date.now() - frameState.time > 8;
+        maxTotalLoading = lowOnFrameBudget ? 0 : 8;
+        maxNewLoads = lowOnFrameBudget ? 0 : 2;
       }
       if (tileQueue.getTilesLoading() < maxTotalLoading) {
-        tileQueue.reprioritize(); // FIXME only call if view has changed
+        if (animatingOrInteracting) {
+          tileQueue.reprioritize();
+        }
         tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);
       }
     }

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1176,6 +1176,54 @@ describe('ol/Map', function () {
     });
   });
 
+  describe('#handlePostRender()', function () {
+    let map, target;
+
+    beforeEach(function () {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        view: new View({center: [0, 0], zoom: 1}),
+      });
+      map.renderSync();
+    });
+
+    afterEach(function () {
+      disposeMap(map, target);
+    });
+
+    it('loads tiles when animating with calling reprioritize', function () {
+      const reprioritizeSpy = sinonSpy(map.tileQueue_, 'reprioritize');
+      const loadSpy = sinonSpy(map.tileQueue_, 'loadMoreTiles');
+      sinonStub(map.tileQueue_, 'isEmpty').returns(false);
+      sinonStub(map.tileQueue_, 'getTilesLoading').returns(0);
+
+      map.frameState_.viewHints = [1, 0];
+      map.frameState_.time = Infinity; // guarantee lowOnFrameBudget is false
+      map.handlePostRender();
+
+      expect(loadSpy.callCount).to.be(1);
+      expect(reprioritizeSpy.callCount).to.be(1);
+    });
+
+    it('loads tiles after animation ends without calling reprioritize', function () {
+      const reprioritizeSpy = sinonSpy(map.tileQueue_, 'reprioritize');
+      const loadSpy = sinonSpy(map.tileQueue_, 'loadMoreTiles');
+      sinonStub(map.tileQueue_, 'isEmpty').returns(false);
+      sinonStub(map.tileQueue_, 'getTilesLoading').returns(0);
+
+      map.frameState_.viewHints = [0, 0];
+      map.frameState_.time = Infinity; // guarantee lowOnFrameBudget is false
+      map.handlePostRender();
+
+      expect(loadSpy.callCount).to.be(1);
+      expect(reprioritizeSpy.callCount).to.be(0);
+    });
+  });
+
   describe('dispose', function () {
     let map;
 


### PR DESCRIPTION
Fixes #17380

**Problem description from issue:**

Map can get permanently stuck with `loaded_ = false` and loadend never fires after view animation when frames exceed 8ms budget

**Suggested solution:**

Call `tileChangeCallback_` in `reprioritize` of `TileQueue` class.