### PR TITLE
Fix Draw#getFreehand

### DIFF
--- a/src/ol/interaction/Draw.js
+++ b/src/ol/interaction/Draw.js
@@ -551,13 +551,13 @@ class Draw extends PointerInteraction {
      * @type {import("../events/condition.js").Condition}
      */
     this.freehandCondition_;
-    if (options.freehand) {
-      this.freehandCondition_ = always;
-    } else {
-      this.freehandCondition_ = options.freehandCondition
-        ? options.freehandCondition
-        : shiftKeyOnly;
-    }
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.freehandMode_;
+    this.setFreehand(options.freehand ?? false);
 
     /**
      * @type {import("../events/condition.js").Condition}
@@ -618,8 +618,8 @@ class Draw extends PointerInteraction {
    * @api
    */
   setFreehand(freehand) {
-    this.freehand_ = freehand;
-    if (this.freehand_) {
+    this.freehandMode_ = freehand;
+    if (freehand) {
       this.freehandCondition_ = always;
     } else {
       this.freehandCondition_ =
@@ -644,7 +644,7 @@ class Draw extends PointerInteraction {
    * @api
    */
   getFreehand() {
-    return this.freehand_;
+    return this.freehandMode_;
   }
 
   /**

--- a/test/browser/spec/ol/interaction/Draw.test.js
+++ b/test/browser/spec/ol/interaction/Draw.test.js
@@ -1682,7 +1682,7 @@ describe('ol/interaction/Draw', function () {
   describe('#getFreehand()', function () {
     it('returns the freehand mode', function () {
       const draw = new Draw({type: 'LineString'});
-      expect(draw.getFreehand()).to.eql(draw.freehand_);
+      expect(draw.getFreehand()).to.eql(draw.freehandMode_);
     });
   });
 


### PR DESCRIPTION
`getFreehand` returns wrong value
https://github.com/openlayers/openlayers/blob/c0c736216eb633f990cb06e539b695a3aba59510/src/ol/interaction/Draw.js#L646-L648

`freehand_` set here:
https://github.com/openlayers/openlayers/blob/c0c736216eb633f990cb06e539b695a3aba59510/src/ol/interaction/Draw.js#L620-L621

but reset here when handling an event
https://github.com/openlayers/openlayers/blob/c0c736216eb633f990cb06e539b695a3aba59510/src/ol/interaction/Draw.js#L657-L662