### PR TITLE
Use correct tileUrlFunction when loading source tiles

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -189,9 +189,10 @@ class VectorTile extends UrlTile {
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection").default} projection Projection.
    * @param {VectorRenderTile} tile Vector render tile.
+   * @param {import("../Tile.js").UrlFunction} [tileUrlFunction] Tile URL function.
    * @return {Array<import("../VectorTile").default>} Tile keys.
    */
-  getSourceTiles(pixelRatio, projection, tile) {
+  getSourceTiles(pixelRatio, projection, tile, tileUrlFunction) {
     if (tile.getState() === TileState.IDLE) {
       tile.setState(TileState.LOADING);
       const urlTileCoord = tile.wrappedTileCoord;
@@ -230,12 +231,9 @@ class VectorTile extends UrlTile {
         this.zDirection,
       );
 
+      const urlFunction = tileUrlFunction || this.tileUrlFunction;
       sourceTileGrid.forEachTileCoord(extent, sourceZ, (sourceTileCoord) => {
-        const tileUrl = this.tileUrlFunction(
-          sourceTileCoord,
-          pixelRatio,
-          projection,
-        );
+        const tileUrl = urlFunction(sourceTileCoord, pixelRatio, projection);
         if (!this.sourceTiles_[tileUrl]) {
           this.sourceTiles_[tileUrl] = new this.tileClass(
             sourceTileCoord,
@@ -402,11 +400,13 @@ class VectorTile extends UrlTile {
         },
       );
     }
+    const tileUrlFunction = this.tileUrlFunction;
     const newTile = new VectorRenderTile(
       tileCoord,
       empty ? TileState.EMPTY : TileState.IDLE,
       urlTileCoord,
-      this.getSourceTiles.bind(this, pixelRatio, projection),
+      (tile) =>
+        this.getSourceTiles(pixelRatio, projection, tile, tileUrlFunction),
       this.removeSourceTiles.bind(this),
     );
     newTile.key = this.getKey();

--- a/test/browser/spec/ol/source/VectorTile.test.js
+++ b/test/browser/spec/ol/source/VectorTile.test.js
@@ -436,5 +436,26 @@ describe('ol/source/VectorTile', function () {
       map.renderSync();
       expect(Object.keys(source.sourceTiles_).length).to.be(0);
     });
+
+    it('uses the tileUrlFunction from tile creation time', function () {
+      // Simulates the race condition where a tile enqueued for key A
+      // is loaded after the source URL changed to B.
+      const testSource = new VectorTileSource({
+        format: new MVT(),
+        url: '{z}/{x}/{y}/A',
+      });
+      const projection = testSource.getProjection();
+      const tile = testSource.getTile(0, 0, 0, 1, projection);
+      expect(tile.getState()).to.be(TileState.IDLE);
+
+      // Change URL, which changes the source key
+      testSource.setUrl('{z}/{x}/{y}/B');
+
+      // When the tile loads, it should use the original URL function (A),
+      // not the current one (B).
+      tile.load();
+      expect(tile.sourceTiles.length).to.be(1);
+      expect(tile.sourceTiles[0].getTileUrl()).to.contain('/A');
+    });
   });
 });


### PR DESCRIPTION
Fixes #17389 

The problem claimed in #17389 was mostly an issue with incorrect API usage, but it revealed a problem with the way source tiles are loaded for a `VectorRenderTile`: the `getSourceTiles()` method used the current `tileUrlFunction` of the source, causing source tiles to be loaded from incorrect urls when the source's url changed during tile loading.

This pull request fixes that by using the `tileUrlFunction` of the source by the time a `VectorRenderTile` was constructed.