### PR TITLE
More efficient loading of striped GeoTIFFs and reprojected WebGL tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
-        "geotiff": "^3.0.4",
+        "geotiff": "^3.0.5",
         "pbf": "4.0.1",
         "rbush": "^4.0.0",
         "zarrita": "^0.6.0"
@@ -6933,9 +6933,9 @@
       "dev": true
     },
     "node_modules/geotiff": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.4.tgz",
-      "integrity": "sha512-lzcQkSZ5XYAYgDVVCKrPPn6OyzFFEmewYc4PzQyzrKdf7KxCG5WPCnwvpkKNrz1nHQD1HkyYXo7ZRFAmlMrTOw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.0.5.tgz",
+      "integrity": "sha512-OWcL9S9+yDZ6iAlXMt32T1iwUApJM8UiD47xbm6ZP1h33d10fqkPs14EG/ttT5EnefpZSx3G15iDFC5FxUNUwA==",
       "license": "MIT",
       "dependencies": {
         "@petamoriken/float16": "^3.9.3",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@types/rbush": "4.0.0",
     "earcut": "^3.0.0",
-    "geotiff": "^3.0.4",
+    "geotiff": "^3.0.5",
     "pbf": "4.0.1",
     "rbush": "^4.0.0",
     "zarrita": "^0.6.0"

--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -5,7 +5,7 @@ import TileRange from '../../TileRange.js';
 import TileState from '../../TileState.js';
 import {descending} from '../../array.js';
 import {getIntersection, getRotatedViewport, isEmpty} from '../../extent.js';
-import {fromUserExtent} from '../../proj.js';
+import {equivalent, fromUserExtent} from '../../proj.js';
 import {toSize} from '../../size.js';
 import LRUCache from '../../structs/LRUCache.js';
 import {
@@ -213,6 +213,12 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
      * @type {import("../../proj/Projection.js").default}
      */
     this.renderedProjection_ = undefined;
+
+    /**
+     * @private
+     * @type {import("../../structs/LRUCache.js").default<import("../../Tile.js").default>|null}
+     */
+    this.sourceTileCache_ = null;
   }
 
   /**
@@ -348,12 +354,19 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
             !tileRepresentation ||
             tileRepresentation.tile.key !== tileSource.getKey()
           ) {
+            const sourceProjection = tileSource.getProjection();
+            const sourceTileCache =
+              sourceProjection &&
+              !equivalent(sourceProjection, viewState.projection)
+                ? this.getSourceTileCache_()
+                : undefined;
             tile = tileSource.getTile(
               z,
               x,
               y,
               frameState.pixelRatio,
               viewState.projection,
+              sourceTileCache,
             );
             if (!tile) {
               continue;
@@ -793,6 +806,20 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
   /**
    * @override
    */
+  /**
+   * @return {import("../../structs/LRUCache.js").default<import("../../Tile.js").default>} Source tile cache.
+   * @private
+   */
+  getSourceTileCache_() {
+    if (!this.sourceTileCache_) {
+      this.sourceTileCache_ = new LRUCache(512);
+    }
+    return this.sourceTileCache_;
+  }
+
+  /**
+   * @override
+   */
   clearCache() {
     super.clearCache();
 
@@ -801,6 +828,7 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
       tileRepresentation.dispose(),
     );
     tileRepresentationCache.clear();
+    this.sourceTileCache_?.clear();
   }
 
   /**

--- a/src/ol/source/DataTile.js
+++ b/src/ol/source/DataTile.js
@@ -4,12 +4,15 @@
 import DataTile from '../DataTile.js';
 import TileState from '../TileState.js';
 import EventType from '../events/EventType.js';
+import {getHeight, getWidth} from '../extent.js';
 import {toPromise} from '../functions.js';
 import {equivalent, get as getProjection} from '../proj.js';
 import ReprojDataTile from '../reproj/DataTile.js';
 import {toSize} from '../size.js';
 import {getCacheKey} from '../tilecoord.js';
+import {DEFAULT_TILE_SIZE} from '../tilegrid/common.js';
 import {
+  createForProjection,
   createXYZ,
   extentFromProjection,
   getForProjection as getTileGridForProjection,
@@ -417,8 +420,34 @@ class DataTileSource extends TileSource {
 
     const projKey = getUid(projection);
     if (!(projKey in this.tileGridForProjection_)) {
-      this.tileGridForProjection_[projKey] =
-        getTileGridForProjection(projection);
+      if (this.tileGrid && thisProj && !equivalent(thisProj, projection)) {
+        // Limit the target tile grid's zoom levels based on the source's
+        // finest available resolution to avoid creating excessive target
+        // tiles that all map to the same source data.
+        const sourceResolutions = this.tileGrid.getResolutions();
+        const sourceFinestRes = sourceResolutions[sourceResolutions.length - 1];
+        const sourceMetersPerUnit = thisProj.getMetersPerUnit() || 1;
+        const targetMetersPerUnit = projection.getMetersPerUnit() || 1;
+        const targetFinestRes =
+          (sourceFinestRes * sourceMetersPerUnit) / targetMetersPerUnit;
+        const extent = extentFromProjection(projection);
+        const tileSize = DEFAULT_TILE_SIZE;
+        const maxResolution = Math.max(
+          getWidth(extent) / tileSize,
+          getHeight(extent) / tileSize,
+        );
+        const maxZoom = Math.max(
+          0,
+          Math.ceil(Math.log2(maxResolution / targetFinestRes)) + 1,
+        );
+        this.tileGridForProjection_[projKey] = createForProjection(
+          projection,
+          maxZoom,
+        );
+      } else {
+        this.tileGridForProjection_[projKey] =
+          getTileGridForProjection(projection);
+      }
     }
     return this.tileGridForProjection_[projKey];
   }

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -296,7 +296,34 @@ function getImagesForSource(source, options) {
   } else {
     request = tiffFromUrl(source.url, options);
   }
-  return request.then(getImagesForTIFF);
+  return request.then(getImagesForTIFF).then(function (images) {
+    // For non-tiled (strip-encoded) images served over HTTP, re-open with a
+    // blockSize large enough to cover all strips needed for one render tile.
+    // This coalesces what would be thousands of individual HTTP range requests
+    // into roughly one per tile.
+    const image = images[0];
+    if (
+      source.url &&
+      !source.blob &&
+      image.getTileWidth() !== image.getTileHeight() &&
+      image.getTileHeight() < defaultTileSize
+    ) {
+      const bytesPerPixel = image.getBytesPerPixel();
+      const blockSize = image.getWidth() * bytesPerPixel * defaultTileSize;
+      const reopenOptions = Object.assign({}, options, {blockSize});
+      let reopened;
+      if (source.loader) {
+        const client = createCustomClient(source.url, source.loader);
+        reopened = tiffFromCustomClient(client, reopenOptions);
+      } else if (source.overviews) {
+        reopened = tiffFromUrls(source.url, source.overviews, reopenOptions);
+      } else {
+        reopened = tiffFromUrl(source.url, reopenOptions);
+      }
+      return reopened.then(getImagesForTIFF);
+    }
+    return images;
+  });
 }
 
 /**

--- a/test/rendering/cases/cog-rotation/main.js
+++ b/test/rendering/cases/cog-rotation/main.js
@@ -20,7 +20,7 @@ const source = new GeoTIFF({
   transition: 0,
 });
 
-new Map({
+const map = new Map({
   layers: [
     new TileLayer({
       source: source,
@@ -34,6 +34,8 @@ new Map({
   view: source.getView(),
 });
 
-render({
-  message: 'works with geotiffs that include a ModelTransformation rotation',
+map.once('rendercomplete', () => {
+  render({
+    message: 'works with geotiffs that include a ModelTransformation rotation',
+  });
 });


### PR DESCRIPTION
Fixes #16961 

For striped GeoTIFFs, this pull request implements a fix along the lines of what @tschaub suggested.

It also adds a source tile cache to the webgl tile layer renderer, like the canvas renderer had already - to avoid duplicate reproj tile creation across render tiles.

Finally, the flaky cog-rotation rendering test is fixed by waiting until rendering is complete. Although this is not as crucial as before this pull request, becasue of the drastically reduced number of requests.