### PR TITLE
Fix for #17335 - OL VectorSource loading-state issue

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -270,6 +270,13 @@ class VectorSource extends Source {
     this.loadingExtentsCount_ = 0;
 
     /**
+     * Extent keys that just failed and were removed from the loaded extents cache.
+     * @private
+     * @type {Set<string>}
+     */
+    this.pendingFailedExtents_ = new Set();
+
+    /**
      * @private
      * @type {!Object<string, FeatureType>}
      */
@@ -991,21 +998,16 @@ class VectorSource extends Source {
    * @param {import("../proj/Projection.js").default} projection Projection.
    */
   loadFeatures(extent, resolution, projection) {
-    const loadedExtentsRtree = this.loadedExtentsRtree_;
     const extentsToLoad = this.strategy_(extent, resolution, projection);
     for (let i = 0, ii = extentsToLoad.length; i < ii; ++i) {
       const extentToLoad = extentsToLoad[i];
-      const alreadyLoaded = loadedExtentsRtree.forEachInExtent(
-        extentToLoad,
-        /**
-         * @param {{extent: import("../extent.js").Extent}} object Object.
-         * @return {boolean} Contains.
-         */
-        function (object) {
-          return containsExtent(object.extent, extentToLoad);
-        },
-      );
+      const alreadyLoaded = this.isExtentLoaded_(extentToLoad);
       if (!alreadyLoaded) {
+        if (this.pendingFailedExtents_.delete(extentToLoad.join(','))) {
+          // This extent just failed to load in a previous render cycle, and was removed from the loaded extents cache to allow retry.
+          // Skip loading it again immediately to prevent a tight retry loop.
+          continue;
+        }
         ++this.loadingExtentsCount_;
         this.dispatchEvent(
           new VectorSourceEvent(VectorEventType.FEATURESLOADSTART),
@@ -1020,6 +1022,8 @@ class VectorSource extends Source {
            */
           (features) => {
             --this.loadingExtentsCount_;
+            // Update before dispatching so listeners observe the correct state.
+            this.loading = this.loadingExtentsCount_ > 0;
             this.dispatchEvent(
               new VectorSourceEvent(
                 VectorEventType.FEATURESLOADEND,
@@ -1027,19 +1031,59 @@ class VectorSource extends Source {
                 features,
               ),
             );
+            // Trigger a render cycle so the map re-evaluates its loading state
+            // and fires loadend even if loader returned an empty response.
+            this.changed();
           },
           () => {
             --this.loadingExtentsCount_;
+            // Update before dispatching so listeners observe the correct state.
+            this.loading = this.loadingExtentsCount_ > 0;
             this.dispatchEvent(
               new VectorSourceEvent(VectorEventType.FEATURESLOADERROR),
             );
+
+            const isExtentLoaded = this.isExtentLoaded_(extentToLoad);
+            if (!isExtentLoaded) {
+              // If the extent was removed (e.g. via removeLoadedExtent to allow
+              // retry), record it so the immediate render triggered by changed()
+              // skips this extent once, preventing a reload loop.
+              // Subsequent renders will retry.
+              this.pendingFailedExtents_.add(extentToLoad.join(','));
+            }
+            // Trigger a render cycle so the map re-evaluates its loading state
+            // and fires loadend.
+            this.changed();
           },
         );
-        loadedExtentsRtree.insert(extentToLoad, {extent: extentToLoad.slice()});
+        this.loadedExtentsRtree_.insert(extentToLoad, {
+          extent: extentToLoad.slice(),
+        });
       }
     }
     this.loading =
       this.loader_.length < 4 ? false : this.loadingExtentsCount_ > 0;
+    this.pendingFailedExtents_.clear();
+  }
+
+  /**
+   * Returns true if the provided extent is already loaded.
+   * @return {boolean} True if the extent was loaded, false if it was not.
+   *
+   * @param {import("../extent.js").Extent} extentToLoad Extent.
+   * @private
+   */
+  isExtentLoaded_(extentToLoad) {
+    return this.loadedExtentsRtree_.forEachInExtent(
+      extentToLoad,
+      /**
+       * @param {{extent: import("../extent.js").Extent}} object Object.
+       * @return {boolean} Contains.
+       */
+      function (object) {
+        return containsExtent(object.extent, extentToLoad);
+      },
+    );
   }
 
   /**
@@ -1048,6 +1092,7 @@ class VectorSource extends Source {
   refresh() {
     this.clear(true);
     this.loadedExtentsRtree_.clear();
+    this.pendingFailedExtents_.clear();
     super.refresh();
   }
 

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -852,6 +852,103 @@ describe('ol/source/Vector', function () {
           getProjection('EPSG:3857'),
         );
       });
+      it('clears loading state and map fires loadend after failure', function (done) {
+        const source = new VectorSource();
+        source.on('featuresloaderror', function () {
+          expect(source.loading).to.be(false);
+        });
+        source.setLoader(
+          function (bbox, resolution, projection, success, failure) {
+            setTimeout(failure, 0);
+          },
+        );
+
+        const target = document.createElement('div');
+        target.style.width = '100px';
+        target.style.height = '100px';
+        document.body.appendChild(target);
+        const map = new Map({
+          target: target,
+          layers: [new VectorLayer({source: source})],
+          view: new View({center: [0, 0], zoom: 0}),
+        });
+
+        map.once('loadend', function () {
+          expect(source.loading).to.be(false);
+          disposeMap(map);
+          done();
+        });
+      });
+
+      it('retries and fires loadend after removeLoadedExtent and failure', function (done) {
+        const source = new VectorSource();
+        let loadCount = 0;
+        source.setLoader(
+          function (bbox, resolution, projection, success, failure) {
+            loadCount++;
+            if (loadCount === 1) {
+              setTimeout(function () {
+                source.removeLoadedExtent(bbox);
+                failure();
+              }, 0);
+            } else {
+              setTimeout(function () {
+                success([]);
+              }, 0);
+            }
+          },
+        );
+
+        const target = document.createElement('div');
+        target.style.width = '100px';
+        target.style.height = '100px';
+        document.body.appendChild(target);
+        const map = new Map({
+          target: target,
+          layers: [new VectorLayer({source: source})],
+          view: new View({center: [0, 0], zoom: 0}),
+        });
+
+        map.once('loadend', function () {
+          // First loadend fires after the failure, no immediate retry
+          expect(loadCount).to.be(1);
+          expect(source.loading).to.be(false);
+
+          // Trigger a new render cycle (e.g. user interaction) to retry
+          map.once('loadend', function () {
+            expect(loadCount).to.be(2);
+            disposeMap(map);
+            done();
+          });
+          source.changed();
+        });
+      });
+
+      it('clears loading state and map fires loadend with empty success', function (done) {
+        const source = new VectorSource();
+        source.on('featuresloadend', function () {
+          expect(source.loading).to.be(false);
+        });
+        source.setLoader(function (bbox, resolution, projection, success) {
+          setTimeout(() => success([]), 0);
+        });
+
+        const target = document.createElement('div');
+        target.style.width = '100px';
+        target.style.height = '100px';
+        document.body.appendChild(target);
+        const map = new Map({
+          target: target,
+          layers: [new VectorLayer({source: source})],
+          view: new View({center: [0, 0], zoom: 0}),
+        });
+
+        map.once('loadend', function () {
+          expect(source.loading).to.be(false);
+          disposeMap(map);
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Fix for #17335 - OL VectorSource loading-state issue

### Changes:

- Set loading before dispatching event for success and success and failure callbacks
- Always call changed() after success/failure, so that a new render cycle re-evaluates its loading state and fires loadend
- Added pendingFailedExtents_ to avoid infinite reload loop
- Without pendingFailedExtents_, calling removeLoadedExtent() before failure() caused an infinite reload loop: failure() → changed() → render → extent missing from cache → load again → fail again → repeat
- Add unit tests covering the changes