### PR TITLE
Inflate trackpad pinch-to-zoom deltas

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -3,6 +3,7 @@
  */
 import EventType from '../events/EventType.js';
 import {all, always, focusWithTabindex} from '../events/condition.js';
+import {listen, unlistenByKey} from '../events.js';
 import {clamp} from '../math.js';
 import Interaction, {zoomByDelta} from './Interaction.js';
 
@@ -162,6 +163,46 @@ class MouseWheelZoom extends Interaction {
      * @type {number}
      */
     this.deltaPerZoom_ = 300;
+
+    /**
+     * Tracks whether the Ctrl key is physically held down (as opposed to the
+     * browser synthesizing ctrlKey=true for pinch-to-zoom trackpad gestures).
+     * @private
+     * @type {boolean}
+     */
+    this.ctrlKeyPressed_ = false;
+
+    /**
+     * @private
+     * @type {Array<import('../events.js').EventsKey>}
+     */
+    this.ctrlKeyListenerKeys_ = [];
+  }
+
+  /**
+   * @param {import('../Map.js').default|null} map Map.
+   * @override
+   */
+  setMap(map) {
+    this.ctrlKeyListenerKeys_.forEach(unlistenByKey);
+    this.ctrlKeyListenerKeys_.length = 0;
+    this.ctrlKeyPressed_ = false;
+    super.setMap(map);
+    if (map) {
+      const doc = map.getOwnerDocument();
+      this.ctrlKeyListenerKeys_.push(
+        listen(doc, 'keydown', (/** @type {KeyboardEvent} */ e) => {
+          if (e.key === 'Control') {
+            this.ctrlKeyPressed_ = true;
+          }
+        }),
+        listen(doc, 'keyup', (/** @type {KeyboardEvent} */ e) => {
+          if (e.key === 'Control') {
+            this.ctrlKeyPressed_ = false;
+          }
+        }),
+      );
+    }
   }
 
   /**
@@ -202,6 +243,11 @@ class MouseWheelZoom extends Interaction {
       mapBrowserEvent.originalEvent
     );
     wheelEvent.preventDefault();
+
+    const isPinchToZoom = wheelEvent.ctrlKey && !this.ctrlKeyPressed_;
+    if (!wheelEvent.ctrlKey) {
+      this.ctrlKeyPressed_ = false;
+    }
 
     if (this.useAnchor_) {
       this.lastAnchor_ = mapBrowserEvent.pixel;
@@ -254,8 +300,7 @@ class MouseWheelZoom extends Interaction {
         this.endInteraction_.bind(this),
         this.timeout_,
       );
-      if (mapBrowserEvent?.originalEvent?.ctrlKey === true) {
-        // it's pinch-to-zoom
+      if (isPinchToZoom) {
         delta = delta * DELTA_TRACKPAD_PINCH_TO_ZOOM_MULTIPLIER;
       }
       view.adjustZoom(

--- a/test/browser/spec/ol/interaction/mousewheelzoom.test.js
+++ b/test/browser/spec/ol/interaction/mousewheelzoom.test.js
@@ -62,6 +62,58 @@ describe('ol.interaction.MouseWheelZoom', function () {
     });
   });
 
+  describe('pinch-to-zoom vs ctrl+scroll', function () {
+    /** @type {View} */
+    let view;
+
+    beforeEach(function () {
+      view = map.getView();
+      sinonSpy(view, 'adjustZoom');
+    });
+
+    afterEach(function () {
+      view.adjustZoom.restore();
+    });
+
+    /**
+     * @param {boolean} ctrlKey Whether the ctrl key is pressed.
+     * @return {MapBrowserEvent} A trackpad wheel event.
+     */
+    function makeTrackpadWheelEvent(ctrlKey) {
+      const event = new MapBrowserEvent('wheel', map, {
+        type: 'wheel',
+        deltaMode: WheelEvent.DOM_DELTA_PIXEL,
+        deltaY: 1,
+        ctrlKey: ctrlKey,
+        target: map.getViewport(),
+        preventDefault: Event.prototype.preventDefault,
+      });
+      event.coordinate = map.getView().getCenter();
+      event.pixel = map.getPixelFromCoordinate(event.coordinate);
+      return event;
+    }
+
+    it('applies 3x multiplier for pinch-to-zoom (ctrlKey synthesized by browser)', function () {
+      map.handleMapBrowserEvent(makeTrackpadWheelEvent(true));
+      expect(view.adjustZoom.calledOnce).to.be(true);
+      expect(view.adjustZoom.getCall(0).args[0]).to.roughlyEqual(
+        -3 / 300,
+        1e-10,
+      );
+    });
+
+    it('does not apply 3x multiplier when ctrl key is physically pressed', function () {
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'Control'}));
+      map.handleMapBrowserEvent(makeTrackpadWheelEvent(true));
+      document.dispatchEvent(new KeyboardEvent('keyup', {key: 'Control'}));
+      expect(view.adjustZoom.calledOnce).to.be(true);
+      expect(view.adjustZoom.getCall(0).args[0]).to.roughlyEqual(
+        -1 / 300,
+        1e-10,
+      );
+    });
+  });
+
   describe('handleEvent()', function () {
     it('works in DOM_DELTA_PIXEL mode (trackpad)', function (done) {
       map.once('postrender', function () {


### PR DESCRIPTION
Browsers treat trackpad pinch-to-zoom the same as a trackpad-scroll event. However, the deltas emitted by pinch-to-zoom are smaller than the scroll events. This change adds a multiplier so that the results of trackpad-pinch-to-zoom are more similar to trackpad scroll. 

This is in response to issue #15423 

Happy for any feedback on the PR - this is my first to open source. 