### PR TITLE
Same trackpad zoom feel with and without constrainResolution

### DIFF
--- a/src/ol/interaction/MouseWheelZoom.js
+++ b/src/ol/interaction/MouseWheelZoom.js
@@ -215,9 +215,12 @@ class MouseWheelZoom extends Interaction {
       return;
     }
     const view = map.getView();
+    const direction = this.lastDelta_ ? (this.lastDelta_ > 0 ? 1 : -1) : 0;
     view.endInteraction(
-      undefined,
-      this.lastDelta_ ? (this.lastDelta_ > 0 ? 1 : -1) : 0,
+      this.constrainResolution_ || view.getConstrainResolution()
+        ? 100
+        : undefined,
+      direction,
       this.lastAnchor_ ? map.getCoordinateFromPixel(this.lastAnchor_) : null,
     );
   }
@@ -284,10 +287,7 @@ class MouseWheelZoom extends Interaction {
     }
 
     const view = map.getView();
-    if (
-      this.mode_ === 'trackpad' &&
-      !(view.getConstrainResolution() || this.constrainResolution_)
-    ) {
+    if (this.mode_ === 'trackpad') {
       if (this.trackpadTimeoutId_) {
         clearTimeout(this.trackpadTimeoutId_);
       } else {


### PR DESCRIPTION
Fixes #15423 

This pull request changes the trackpad zoom behavior when `constrainResolution` is true: it does the same now as without `constrainResolution`, but with a pronounced snap animation to the closest integer zoom when the trackpad inertia ends.

To try it out, go to https://deploy-preview-17407--ol-site.netlify.app/en/latest/examples/pinch-zoom.html

This fix is similar to the one proposed in #15425, but simpler.