### PR TITLE
Add support for setting response format in Sentinelhub

### DIFF
--- a/examples/sentinel-hub-custom-format.css
+++ b/examples/sentinel-hub-custom-format.css
@@ -1,0 +1,16 @@
+dialog {
+  top: 13rem;
+}
+
+#auth-form {
+  display: flex;
+  flex-direction: column;
+}
+
+#auth-form > label {
+  margin-bottom: 1rem;
+}
+
+#auth-form > input[type=submit] {
+  margin-top: 1rem;
+}

--- a/examples/sentinel-hub-custom-format.html
+++ b/examples/sentinel-hub-custom-format.html
@@ -1,0 +1,35 @@
+---
+layout: example.html
+title: Sentinel Hub Custom Format
+shortdesc: Updating the format used by the Sentinel Hub source.
+docs: >
+  This example demonstrates how a custom format can be used to render tiles from Sentinel Hub.
+  Select a format from the dropdown and click the update button to change the format.
+  See the Sentinel Hub [Examples](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/examples/#true-color-multi-part-reponse-different-formats-and-sampletype) for more information.
+tags: "Sentinel Hub, process"
+---
+<div id="map" class="map"></div>
+<form id="format-form">
+  <label>Image format:
+    <br>
+    <select name="format" id="format">
+      <option value="image/png">image/png</option>
+      <option value="image/jpeg">image/jpeg</option>
+      <option value="image/webp">image/webp</option>
+    </select>
+  </label>
+  <input type="submit" value="update">
+</form>
+<dialog id="auth-dialog" open>
+  <form method="dialog" id="auth-form">
+    <label>Client id
+      <br>
+      <input type="text" name="id" autofocus value="fa02a066-fc80-4cb4-af26-aae0af26cbf1">
+    </label>
+    <label>Client secret
+      <br>
+      <input type="password" name="secret" value="rate_limit_secret">
+    </label>
+    <input type="submit" value="show map">
+  </form>
+</dialog>

--- a/examples/sentinel-hub-custom-format.js
+++ b/examples/sentinel-hub-custom-format.js
@@ -1,0 +1,65 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import {useGeographic} from '../src/ol/proj.js';
+import SentinelHub from '../src/ol/source/SentinelHub.js';
+
+useGeographic();
+
+const source = new SentinelHub({
+  data: [
+    {
+      type: 'sentinel-2-l2a',
+      dataFilter: {
+        timeRange: {
+          from: '2024-05-30T00:00:00Z',
+          to: '2024-06-01T00:00:00Z',
+        },
+      },
+    },
+  ],
+  evalscript: {
+    setup: () => ({
+      input: ['B12', 'B08', 'B04'],
+      output: {bands: 3},
+    }),
+    evaluatePixel: (sample) => [
+      2.5 * sample.B12,
+      2 * sample.B08,
+      2 * sample.B04,
+    ],
+  },
+  format: 'image/png',
+});
+
+const map = new Map({
+  layers: [new TileLayer({source})],
+  target: 'map',
+  view: new View({
+    center: [-121.75, 46.85],
+    zoom: 10,
+    minZoom: 7,
+    maxZoom: 13,
+  }),
+});
+
+document.getElementById('auth-form').addEventListener('submit', (event) => {
+  const clientId = event.target.elements['id'].value;
+  const clientSecret = event.target.elements['secret'].value;
+  source.setAuth({clientId, clientSecret});
+});
+
+const format = document.getElementById('format');
+
+function updateInputData() {
+  source.setFormat(format.value);
+}
+
+format.addEventListener('change', () => updateInputData());
+updateInputData();
+
+source.on('change', () => {
+  if (source.getState() === 'error') {
+    alert(source.getError());
+  }
+});

--- a/src/ol/source/SentinelHub.js
+++ b/src/ol/source/SentinelHub.js
@@ -16,6 +16,21 @@ const defaultTokenUrl =
 const defaultEvalscriptVersion = '3';
 
 /**
+ * @type {Object<string, boolean>}
+ */
+const knownImageMediaTypes = {
+  'image/png': true,
+  'image/jpeg': true,
+  'image/webp': true,
+};
+
+/**
+ * Default process API tile MIME type (`responses[].format.type`).
+ * @type {string}
+ */
+const defaultFormat = 'image/png';
+
+/**
  * @type {import('../size.js').Size}
  */
 const defaultTileSize = [512, 512];
@@ -372,6 +387,7 @@ export function serializeFunction(name, func) {
  * @property {boolean} [wrapX=true] Wrap the world horizontally.
  * @property {number} [transition] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
+ * @property {string} [format='image/png'] MIME type for each process response (`responses[].format.type`), for example `image/png` or `image/jpeg`.
  */
 
 /**
@@ -392,6 +408,12 @@ class SentinelHub extends DataTileSource {
    * @param {Options} [options] Sentinel Hub options.
    */
   constructor(options) {
+    if (!knownImageMediaTypes[options.format]) {
+      throw new Error(
+        `Unsupported format: ${options.format}. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,
+      );
+    }
+
     /**
      * @type {Options}
      */
@@ -431,6 +453,12 @@ class SentinelHub extends DataTileSource {
      * @private
      */
     this.processUrl_ = config.url || defaultProcessUrl;
+
+    /**
+     * @type {string}
+     * @private
+     */
+    this.format_ = config.format || defaultFormat;
 
     /**
      * @type {string}
@@ -512,6 +540,22 @@ class SentinelHub extends DataTileSource {
   }
 
   /**
+   * Set the MIME type for process API tile responses (`responses[].format.type`).
+   *
+   * @param {string} format Format type (for example `image/png` or `image/jpeg`).
+   * @api
+   */
+  setFormat(format) {
+    if (!knownImageMediaTypes[format]) {
+      throw new Error(
+        `Unsupported format: ${format}. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,
+      );
+    }
+    this.format_ = format;
+    this.fireWhenReady_();
+  }
+
+  /**
    * Set or update the Evalscript used to process the data.  Either a process object or a string
    * Evalscript can be provided.  If a process object is provided, it will be serialized to produce the
    * Evalscript string.  Because these functions will be serialized and executed by the Processing API,
@@ -552,7 +596,12 @@ class SentinelHub extends DataTileSource {
   }
 
   getKeyForConfig_() {
-    return this.token_ + this.evalscript_ + JSON.stringify(this.inputData_);
+    return (
+      this.token_ +
+      this.evalscript_ +
+      JSON.stringify(this.inputData_) +
+      this.format_
+    );
   }
 
   /**
@@ -583,6 +632,14 @@ class SentinelHub extends DataTileSource {
       output: {
         width: tileSize[0],
         height: tileSize[1],
+        responses: [
+          {
+            identifier: 'default',
+            format: {
+              type: this.format_,
+            },
+          },
+        ],
       },
       evalscript: this.evalscript_,
     };


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This MR adds support for setting response format in SentinelHub with the parameter.

SentinelHub class supports only 1 output (`"default"`), so this MR adds to this. It does not add support for multiple outputs (multiple files returned from the API), even though the Sentinel Hub Process API supports that.

A check for supported formats is performed on the format parameter (supported formats are listed in the [Sentinel Hub docs](https://docs.sentinel-hub.com/api/latest/reference/#tag/process/operation/process) under `output -> responses` request parameters)


