### PR TITLE
Raster source improvements

### DIFF
--- a/src/ol/source/Raster.js
+++ b/src/ol/source/Raster.js
@@ -478,6 +478,8 @@ export class RasterSourceEvent extends Event {
  * @property {Operation} [operation] Raster operation.
  * The operation will be called with data from input sources
  * and the output will be assigned to the raster source.
+ * @property {boolean} [interpolate=true] Use interpolated values when resampling. By default,
+ * linear interpolation is used when resampling. Set to `false` to use the nearest neighbor instead.
  * @property {Object} [lib] Functions that will be made available to operations run in a worker.
  * @property {number} [threads] By default, operations will be run in a single worker thread.
  * To avoid using workers altogether, set `threads: 0`.  For pixel operations, operations can
@@ -519,6 +521,7 @@ class RasterSource extends ImageSource {
    */
   constructor(options) {
     super({
+      interpolate: options.interpolate,
       projection: null,
     });
 
@@ -785,8 +788,11 @@ class RasterSource extends ImageSource {
   processSources_() {
     const frameState = this.requestedFrameState_;
     const len = this.layers_.length;
+    const sourceRevisions = new Array(len);
     const imageDatas = new Array(len);
     for (let i = 0; i < len; ++i) {
+      const source = this.layers_[i].getSource();
+      sourceRevisions[i] = source.getRevision();
       frameState.layerIndex = i;
       frameState.renderTargets = {};
       const imageData = getImageData(this.layers_[i], frameState);
@@ -804,19 +810,20 @@ class RasterSource extends ImageSource {
     this.processor_.process(
       imageDatas,
       data,
-      this.onWorkerComplete_.bind(this, frameState),
+      this.onWorkerComplete_.bind(this, frameState, sourceRevisions),
     );
   }
 
   /**
    * Called when pixel processing is complete.
    * @param {import("../Map.js").FrameState} frameState The frame state.
+   * @param {Array<number>} sourceRevisions Source revisions when processing started.
    * @param {Error} err Any error during processing.
    * @param {ImageData} output The output image data.
    * @param {Object|Array<Object>} data The user data (or an array if more than one thread).
    * @private
    */
-  onWorkerComplete_(frameState, err, output, data) {
+  onWorkerComplete_(frameState, sourceRevisions, err, output, data) {
     if (err || !output) {
       return;
     }
@@ -829,6 +836,13 @@ class RasterSource extends ImageSource {
       !equals(extent, this.requestedFrameState_.extent)
     ) {
       return;
+    }
+    // do nothing if any input source's revision changed
+    for (let i = 0; i < this.layers_.length; ++i) {
+      const source = this.layers_[i].getSource();
+      if (sourceRevisions[i] !== source.getRevision()) {
+        return;
+      }
     }
 
     let context;

--- a/test/browser/spec/ol/source/raster.test.js
+++ b/test/browser/spec/ol/source/raster.test.js
@@ -228,6 +228,20 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
       view.setCenter([0, 0]);
       view.setZoom(0);
     });
+
+    it('passes the interpolate option to the parent source', function () {
+      const source = new RasterSource({
+        threads: 0,
+        interpolate: false,
+        sources: [redSource],
+        operation: function (inputs) {
+          return inputs[0];
+        },
+      });
+
+      expect(source.getInterpolate()).to.be(false);
+      source.dispose();
+    });
   });
 
   describe('config option `attributions`', function () {
@@ -434,6 +448,66 @@ where('Uint8ClampedArray').describe('ol.source.Raster', function () {
         expect(event.data).to.have.length(threads);
         expect(event.data[0].prop).to.equal('value');
         done();
+      });
+
+      const view = map.getView();
+      view.setCenter([0, 0]);
+      view.setZoom(0);
+    });
+
+    it('discards stale worker results when a source changes mid-pass', function (done) {
+      const vectorSource = new VectorSource();
+      const source = new RasterSource({
+        threads: 0,
+        sources: [
+          new VectorImageLayer({
+            source: vectorSource,
+            style: new Style({
+              image: new Circle({
+                radius: 3,
+                fill: new Fill({color: 'blue'}),
+              }),
+            }),
+          }),
+        ],
+        operation: function (inputs) {
+          return inputs[0];
+        },
+      });
+
+      layer.setSource(source);
+
+      const worker = source.processor_.workers_[0];
+      const postMessage = worker.postMessage;
+      let workerCompleteCount = 0;
+      worker.postMessage = function () {
+        const args = arguments;
+        setTimeout(function () {
+          ++workerCompleteCount;
+          postMessage.apply(worker, args);
+        }, 32);
+      };
+
+      let afterCount = 0;
+      source.on('afteroperations', function () {
+        ++afterCount;
+      });
+
+      setTimeout(function () {
+        vectorSource.addFeature(new Feature(new Point([0, 0])));
+      }, 16);
+
+      source.once('afteroperations', function () {
+        setTimeout(function () {
+          expect(workerCompleteCount).to.be(2);
+          expect(afterCount).to.be(1);
+          const image = source.renderedImageCanvas_.getImage();
+          const context = image.getContext('2d');
+          expect(Array.from(context.getImageData(1, 1, 1, 1).data)).to.eql([
+            0, 0, 255, 255,
+          ]);
+          done();
+        }, 80);
       });
 
       const view = map.getView();


### PR DESCRIPTION
This pull request makes two improvements to the raster source:
* Add the `interpolate` option like in other image sources, to allow for nearest neighbor (`interpolate: false`)
* Avoid stale return data from the worker by keeping track of the current source revisions