### PR TITLE
Clear target canvas at the beginning of renderFrame()

### DIFF
--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -163,6 +163,7 @@ class CompositeMapRenderer extends MapRenderer {
     if (isCanvas(mapCanvas)) {
       // Canvas composition when container is a canvas
       const mapContext = mapCanvas.getContext('2d');
+      mapContext.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
       for (const container of this.children_) {
         const canvas = container.firstElementChild || container;
         const backgroundColor = container.style.backgroundColor;

--- a/test/browser/spec/ol/renderer/Map.test.js
+++ b/test/browser/spec/ol/renderer/Map.test.js
@@ -954,4 +954,33 @@ describe('ol/renderer/Map.js', function () {
       spy.restore();
     });
   });
+
+  describe('canvas target', function () {
+    it('clears the canvas before each render when target is a canvas element', function () {
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      const feature = new Feature(fromExtent([-1e6, -1e6, 1e6, 1e6]));
+      const layer = new VectorLayer({
+        source: new VectorSource({features: [feature]}),
+        style: new Style({
+          fill: new Fill({color: 'rgba(255, 0, 0, 0.5)'}),
+        }),
+      });
+      const map = new Map({
+        target: canvas,
+        pixelRatio: 1,
+        layers: [layer],
+        view: new View({center: [0, 0], zoom: 1}),
+      });
+      map.renderSync();
+      const ctx = canvas.getContext('2d');
+      const firstRender = ctx.getImageData(50, 50, 1, 1).data;
+      // Render again — alpha should not accumulate
+      map.renderSync();
+      const secondRender = ctx.getImageData(50, 50, 1, 1).data;
+      expect(secondRender[3]).to.be(firstRender[3]);
+      map.dispose();
+    });
+  });
 });


### PR DESCRIPTION
This pull request fixes an issue with maps that are configured with a canvas as `target`: That canvas needs to be cleared between render cycles.