### PR TITLE
Render dirctly to target canvas, if possible

### DIFF
--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -126,8 +126,20 @@ class CompositeMapRenderer extends MapRenderer {
 
     this.children_.length = 0;
 
+    const map = this.getMap();
+    const mapCanvas = map.getTargetElement();
+    /** @type {CanvasRenderingContext2D|undefined} */
+    let mapContext;
+    if (isCanvas(mapCanvas)) {
+      mapContext = /** @type {CanvasRenderingContext2D} */ (
+        mapCanvas.getContext('2d')
+      );
+      mapContext.setTransform(1, 0, 0, 1, 0, 0);
+      mapContext.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
+    }
+
     const renderedLayerStates = [];
-    let previousElement = null;
+    let previousElement = mapContext ? mapCanvas : null;
     for (let i = 0, ii = layerStatesArray.length; i < ii; ++i) {
       const layerState = layerStatesArray[i];
       frameState.layerIndex = i;
@@ -158,40 +170,39 @@ class CompositeMapRenderer extends MapRenderer {
 
     replaceChildren(this.element_, this.children_);
 
-    const map = this.getMap();
-    const mapCanvas = map.getTargetElement();
-    if (isCanvas(mapCanvas)) {
-      // Canvas composition when container is a canvas
-      const mapContext = mapCanvas.getContext('2d');
-      mapContext.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
-      for (const container of this.children_) {
-        const canvas = container.firstElementChild || container;
-        const backgroundColor = container.style.backgroundColor;
-        if (backgroundColor && (!isCanvas(canvas) || canvas.width > 0)) {
-          mapContext.fillStyle = backgroundColor;
-          mapContext.fillRect(0, 0, mapCanvas.width, mapCanvas.height);
-        }
-        if (isCanvas(canvas) && canvas.width > 0) {
-          mapContext.save();
-          const opacity = container.style.opacity || canvas.style.opacity;
-          mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
-          const transform = canvas.style.transform;
-          if (transform) {
-            // Get the transform parameters from the style's transform matrix
-            mapContext.transform(
-              .../** @type {[number, number, number, number, number, number]} */ (
-                fromString(transform)
-              ),
-            );
-          } else {
-            const w = parseFloat(canvas.style.width) / canvas.width;
-            const h = parseFloat(canvas.style.height) / canvas.height;
-            mapContext.transform(w, 0, 0, h, 0, 0);
-          }
-          mapContext.drawImage(canvas, 0, 0);
-          mapContext.restore();
-        }
+    for (const container of mapContext ? this.children_ : []) {
+      const canvas = container.firstElementChild || container;
+      const backgroundColor = container.style.backgroundColor;
+      if (backgroundColor && (!isCanvas(canvas) || canvas.width > 0)) {
+        mapContext.fillStyle = backgroundColor;
+        mapContext.fillRect(
+          0,
+          0,
+          mapContext.canvas.width,
+          mapContext.canvas.height,
+        );
       }
+      if (!isCanvas(canvas) || canvas.width === 0) {
+        continue;
+      }
+      mapContext.save();
+      const opacity = container.style.opacity || canvas.style.opacity;
+      mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity);
+      const transform = canvas.style.transform;
+      if (transform) {
+        // Get the transform parameters from the style's transform matrix
+        mapContext.transform(
+          .../** @type {[number, number, number, number, number, number]} */ (
+            fromString(transform)
+          ),
+        );
+      } else {
+        const w = parseFloat(canvas.style.width) / canvas.width;
+        const h = parseFloat(canvas.style.height) / canvas.height;
+        mapContext.transform(w, 0, 0, h, 0, 0);
+      }
+      mapContext.drawImage(canvas, 0, 0);
+      mapContext.restore();
     }
 
     this.dispatchRenderEvent(RenderEventType.POSTCOMPOSE, frameState);

--- a/src/ol/renderer/canvas/Layer.js
+++ b/src/ol/renderer/canvas/Layer.js
@@ -156,9 +156,34 @@ class CanvasLayerRenderer extends LayerRenderer {
    * @param {HTMLElement} target Potential render target.
    * @param {string} transform CSS transform matrix.
    * @param {string} [backgroundColor] Background color.
+   * @param {number} [width] Physical pixel width of the rendering canvas.
+   * @param {number} [height] Physical pixel height of the rendering canvas.
    */
-  useContainer(target, transform, backgroundColor) {
-    // renderer canvas to target canvas
+  useContainer(target, transform, backgroundColor, width, height) {
+    // Render directly into the target canvas when there is no rotation or
+    // offset (no CSS transform needed) and the physical dimensions match.
+    if (
+      isCanvas(target) &&
+      this.pixelTransform[1] === 0 &&
+      this.pixelTransform[2] === 0 &&
+      this.pixelTransform[4] === 0 &&
+      this.pixelTransform[5] === 0 &&
+      target.width === width &&
+      target.height === height
+    ) {
+      const targetCanvas = /** @type {HTMLCanvasElement} */ (target);
+      const context = targetCanvas.getContext('2d');
+      if (context) {
+        this.container = target;
+        this.context = context;
+        this.containerReused = true;
+        if (backgroundColor) {
+          context.fillStyle = backgroundColor;
+          context.fillRect(0, 0, targetCanvas.width, targetCanvas.height);
+        }
+        return;
+      }
+    }
     const layerClassName = this.getLayer().getClassName();
     let container, context;
     if (
@@ -276,7 +301,8 @@ class CanvasLayerRenderer extends LayerRenderer {
     makeInverse(this.inversePixelTransform, this.pixelTransform);
 
     const canvasTransform = toTransformString(this.pixelTransform);
-    this.useContainer(target, canvasTransform, this.getBackground(frameState));
+    const backgroundColor = this.getBackground(frameState);
+    this.useContainer(target, canvasTransform, backgroundColor, width, height);
     if (!this.containerReused) {
       const canvas = this.context.canvas;
       if (canvas.width != width || canvas.height != height) {

--- a/test/browser/spec/ol/renderer/Map.test.js
+++ b/test/browser/spec/ol/renderer/Map.test.js
@@ -982,5 +982,33 @@ describe('ol/renderer/Map.js', function () {
       expect(secondRender[3]).to.be(firstRender[3]);
       map.dispose();
     });
+
+    [1, 2].forEach((pixelRatio) => {
+      it(`renders layers directly onto the canvas when dimensions match (pixelRatio=${pixelRatio})`, function () {
+        const canvas = document.createElement('canvas');
+        // Size the canvas at physical pixels and pre-scale the context so
+        // updateSize() reports 100 CSS pixels, matching what prepareContainer expects
+        canvas.width = 100 * pixelRatio;
+        canvas.height = 100 * pixelRatio;
+        canvas.getContext('2d').scale(pixelRatio, pixelRatio);
+        const feature = new Feature(fromExtent([-1e6, -1e6, 1e6, 1e6]));
+        const layer = new VectorLayer({
+          source: new VectorSource({features: [feature]}),
+          style: new Style({fill: new Fill({color: 'red'})}),
+        });
+        const map = new Map({
+          target: canvas,
+          pixelRatio,
+          layers: [layer],
+          view: new View({center: [0, 0], zoom: 1, rotation: 0}),
+        });
+        const spy = sinonSpy(CanvasRenderingContext2D.prototype, 'drawImage');
+        map.renderSync();
+        // No drawImage call means the layer drew directly onto the target canvas
+        expect(spy.callCount).to.be(0);
+        spy.restore();
+        map.dispose();
+      });
+    });
   });
 });


### PR DESCRIPTION
This pull request adds an optimized code path for maps with a canvas as target: when no transform is needed, the layer renderers can render directly to the target canvas, instead of a separate layer canvas with composition onto the target canvas.

This optimization is relevant in worker scenarios on iOS, where available canvas space is strictly limited.