### PR TITLE
bugfix: ignore global declutter on plain vectorlayers

### DIFF
--- a/src/ol/renderer/canvas/VectorLayer.js
+++ b/src/ol/renderer/canvas/VectorLayer.js
@@ -182,6 +182,17 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
   }
 
   /**
+   * @param {import("../../Map.js").FrameState} frameState Frame state.
+   * @return {import("../../Map.js").FrameState} Frame state for this layer.
+   */
+  getLayerFrameState(frameState) {
+    if (!frameState.declutter || this.getLayer().getDeclutter()) {
+      return frameState;
+    }
+    return Object.assign({}, frameState, {declutter: null});
+  }
+
+  /**
    * @param {ExecutorGroup} executorGroup Executor group.
    * @param {import("../../Map.js").FrameState} frameState Frame state.
    * @param {boolean} [declutterable] `true` to only render declutterable items,
@@ -316,6 +327,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @override
    */
   renderFrame(frameState, target) {
+    frameState = this.getLayerFrameState(frameState);
     const layerState = frameState.layerStatesArray[frameState.layerIndex];
     this.opacity_ = layerState.opacity;
     const viewState = frameState.viewState;
@@ -586,6 +598,7 @@ class CanvasVectorLayerRenderer extends CanvasLayerRenderer {
    * @override
    */
   prepareFrame(frameState) {
+    frameState = this.getLayerFrameState(frameState);
     const vectorLayer = this.getLayer();
     const vectorSource = vectorLayer.getSource();
     if (!vectorSource) {

--- a/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
+++ b/test/browser/spec/ol/renderer/canvas/VectorLayer.test.js
@@ -15,6 +15,8 @@ import {get as getProjection} from '../../../../../../src/ol/proj.js';
 import {checkedFonts} from '../../../../../../src/ol/render/canvas.js';
 import CanvasVectorLayerRenderer from '../../../../../../src/ol/renderer/canvas/VectorLayer.js';
 import VectorSource from '../../../../../../src/ol/source/Vector.js';
+import Circle from '../../../../../../src/ol/style/Circle.js';
+import Fill from '../../../../../../src/ol/style/Fill.js';
 import Style from '../../../../../../src/ol/style/Style.js';
 import Text from '../../../../../../src/ol/style/Text.js';
 import {createFontStyle} from '../../../util.js';
@@ -456,7 +458,7 @@ describe('ol/renderer/canvas/VectorLayer', function () {
       expect(renderer.replayGroupChanged).to.be(false);
       frameState.declutter = {};
       renderer.prepareFrame(frameState);
-      expect(renderer.replayGroupChanged).to.be(true);
+      expect(renderer.replayGroupChanged).to.be(false);
       frameState.pixelRatio = 2;
       renderer.prepareFrame(frameState);
       expect(renderer.replayGroupChanged).to.be(true);
@@ -609,6 +611,47 @@ describe('ol/renderer/canvas/VectorLayer', function () {
       }
       expect(renderer.renderWorlds.callCount).to.be(1);
       expect(renderer.clipUnrotated.callCount).to.be(0);
+    });
+
+    it('does not enter deferred rendering for non-declutter layers when the frame declutters', function () {
+      const layer = new VectorLayer({
+        source: new VectorSource({
+          features: [new Feature(new Point([0, 0]))],
+        }),
+        style: new Style({
+          image: new Circle({
+            radius: 8,
+            fill: new Fill({color: 'rgba(255, 0, 0, 1)'}),
+          }),
+        }),
+      });
+      renderer = layer.getRenderer();
+      const frameState = {
+        pixelRatio: 1,
+        time: 1000000000000,
+        viewState: {
+          center: [0, 0],
+          projection: projection,
+          resolution: 1,
+          rotation: 0,
+        },
+        animate: false,
+        coordinateToPixelTransform: [1, 0, 0, 1, 0, 0],
+        declutter: {},
+        extent: [-50, -50, 50, 50],
+        index: 0,
+        layerStatesArray: [layer.getLayerState()],
+        layerIndex: 0,
+        pixelToCoordinateTransform: [1, 0, 0, 1, 0, 0],
+        size: [100, 100],
+        viewHints: [],
+      };
+
+      if (renderer.prepareFrame(frameState)) {
+        renderer.renderFrame(frameState, null);
+      }
+
+      expect(renderer.replayGroup_.getDeferredZIndexContexts()).to.eql({});
     });
   });
 


### PR DESCRIPTION
Only declutter-enabled vector layers should enter deferred rendering. This avoids hiding non-declutter vector features on the first frame when another layer enables decluttering. #17456 

