### PR TITLE
Generate API docs for symbols with @override

### DIFF
--- a/config/jsdoc/api/conf.json
+++ b/config/jsdoc/api/conf.json
@@ -17,6 +17,7 @@
     "jsdoc-plugin-intersection",
     "config/jsdoc/plugins/markdown.cjs",
     "jsdoc-plugin-typescript",
+    "config/jsdoc/plugins/strip-override-comments.cjs",
     "config/jsdoc/plugins/inline-options.cjs",
     "config/jsdoc/plugins/events.cjs",
     "config/jsdoc/plugins/observable.cjs",

--- a/config/jsdoc/plugins/strip-override-comments.cjs
+++ b/config/jsdoc/plugins/strip-override-comments.cjs
@@ -1,0 +1,14 @@
+/**
+ * Strips JSDoc block comments that contain only `@override` before parsing.
+ *
+ * By removing these comments, we allow JSDoc's built-in augmentation process
+ * to automatically detect and create inherited doclets from parent classes
+ * when an overridden method is present without its own documentation.
+ */
+exports.handlers = {
+  beforeParse: function (e) {
+    // Remove JSDoc comments whose only content is @override.
+    // [\s*]+ matches whitespace and the leading * characters in block comments.
+    e.source = e.source.replace(/\/\*\*[\s*]+@override[\s*]+\*\//g, '');
+  },
+};


### PR DESCRIPTION
This pull request adds a plugin that removes `@override` annotations from symbols that are only annotated with `@override`. This ensures that JSDoc documents them. An example where this was not the case is the `refresh()` method for `ol/source/Vector`.