### PR TITLE
VectorSource now removes loaded extents by overlap rather than exact match

### DIFF
--- a/src/ol/extent.js
+++ b/src/ol/extent.js
@@ -630,6 +630,73 @@ export function getIntersection(extent1, extent2, dest) {
 }
 
 /**
+ * Get the difference between two extents, i.e. the area(s) of `extent1` that
+ * are not covered by `extent2`.  Returns an array of between 0 and 4 extents.
+ *
+ * When the extents do not intersect the returned array contains `extent1` as
+ * its only element.  When `extent2` completely contains `extent1` the returned
+ * array is empty.  Otherwise up to four non-overlapping extents are returned
+ * that together cover exactly the parts of `extent1` outside `extent2`.
+ *
+ * The decomposition used is:
+ *
+ * ```
+ * ┌────┬─────────┬────┐  ← y2
+ * │    │   top   │    │
+ * │    ├─────────┤    │  ← iy2
+ * │left│ (gone)  │right│
+ * │    ├─────────┤    │  ← iy1
+ * │    │ bottom  │    │
+ * └────┴─────────┴────┘  ← y1
+ * x1  ix1       ix2   x2
+ * ```
+ *
+ * The left and right strips span the full height of `extent1` while the top
+ * and bottom strips are clamped horizontally to the intersection, so the four
+ * rectangles tile perfectly without overlap or gaps.
+ *
+ * @param {Extent} extent1 Extent to subtract from.
+ * @param {Extent} extent2 Extent to subtract.
+ * @return {Array<Extent>} Remaining extents (0–4 elements).
+ * @api
+ */
+export function getDifference(extent1, extent2) {
+  if (!intersects(extent1, extent2)) {
+    return [extent1.slice()];
+  }
+  if (containsExtent(extent2, extent1)) {
+    return [];
+  }
+
+  const [x1, y1, x2, y2] = extent1;
+  const ix1 = Math.max(x1, extent2[0]);
+  const iy1 = Math.max(y1, extent2[1]);
+  const ix2 = Math.min(x2, extent2[2]);
+  const iy2 = Math.min(y2, extent2[3]);
+
+  const result = [];
+
+  // Left strip  (full height of extent1)
+  if (ix1 > x1) {
+    result.push([x1, y1, ix1, y2]);
+  }
+  // Right strip (full height of extent1)
+  if (ix2 < x2) {
+    result.push([ix2, y1, x2, y2]);
+  }
+  // Bottom strip (between the left and right strips)
+  if (iy1 > y1) {
+    result.push([ix1, y1, ix2, iy1]);
+  }
+  // Top strip (between the left and right strips)
+  if (iy2 < y2) {
+    result.push([ix1, iy2, ix2, y2]);
+  }
+
+  return result;
+}
+
+/**
  * @param {Extent} extent Extent.
  * @return {number} Margin.
  */

--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -10,7 +10,7 @@ import {assert} from '../asserts.js';
 import {listen, unlistenByKey} from '../events.js';
 import Event from '../events/Event.js';
 import EventType from '../events/EventType.js';
-import {containsExtent, equals, wrapAndSliceX} from '../extent.js';
+import {containsExtent, getDifference, wrapAndSliceX} from '../extent.js';
 import {xhr} from '../featureloader.js';
 import {TRUE, VOID} from '../functions.js';
 import {all as allStrategy} from '../loadingstrategy.js';
@@ -1062,20 +1062,28 @@ class VectorSource extends Source {
   }
 
   /**
-   * Remove an extent from the list of loaded extents.
-   * @param {import("../extent.js").Extent} extent Extent.
+   * Marks an extent as not loaded, preserving any loaded areas outside it.
+   *
+   * Any previously loaded extent overlapping the given extent is split into its
+   * remaining non-overlapping parts using {@link module:ol/extent~getDifference getDifference()},
+   * which are then re-inserted into the tree.
+   *
+   * @param {import("../extent.js").Extent} extent Extent to mark as not loaded.
    * @api
    */
   removeLoadedExtent(extent) {
     const loadedExtentsRtree = this.loadedExtentsRtree_;
-    const obj = loadedExtentsRtree.forEachInExtent(extent, function (object) {
-      if (equals(object.extent, extent)) {
-        return object;
+    const intersectingExtents = [];
+    loadedExtentsRtree.forEachInExtent(extent, function (object) {
+      intersectingExtents.push(object);
+    });
+    intersectingExtents.forEach((intersectingExtent) => {
+      loadedExtentsRtree.remove(intersectingExtent);
+      const remainders = getDifference(intersectingExtent.extent, extent);
+      for (const remainder of remainders) {
+        loadedExtentsRtree.insert(remainder, {extent: remainder});
       }
     });
-    if (obj) {
-      loadedExtentsRtree.remove(obj);
-    }
   }
 
   /**

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -824,6 +824,30 @@ describe('ol/source/Vector', function () {
         );
       });
 
+      it('removes infinite extent from loadedExtentsRtree after multiple load requests', function (done) {
+        const source = new VectorSource();
+        source.setLoader(async () => []);
+
+        // Make multiple load requests with different extents
+        source.loadFeatures([-10, -10, 10, 10], 1, getProjection('EPSG:3857'));
+        source.loadFeatures([0, 0, 10, 10], 1, getProjection('EPSG:3857'));
+        source.loadFeatures([10, 10, 20, 20], 1, getProjection('EPSG:3857'));
+
+        // Wait for all loader callbacks to complete
+        setTimeout(() => {
+          // Verify we have loaded extents in the tree
+          const initialExtents = source.loadedExtentsRtree_.getAll();
+          expect(initialExtents.length).to.be.greaterThan(0);
+
+          // Remove the infinite extent
+          source.removeLoadedExtent([-Infinity, -Infinity, Infinity, Infinity]);
+
+          // Verify the tree is empty after removal
+          expect(source.loadedExtentsRtree_.getAll()).to.have.length(0);
+          done();
+        }, 0);
+      });
+
       it('fires the FEATURESLOADEND event if the load function uses the callback', function (done) {
         const source = new VectorSource();
         const spy = sinonSpy();

--- a/test/node/ol/extent.test.js
+++ b/test/node/ol/extent.test.js
@@ -1049,3 +1049,57 @@ describe('ol/extent.js', function () {
     });
   });
 });
+
+describe('getDifference', function () {
+  it('returns a copy of extent1 when the extents do not intersect', function () {
+    const extent1 = [0, 0, 10, 10];
+    const extent2 = [20, 20, 30, 30];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result.length).to.be(1);
+    expect(result[0]).to.eql(extent1);
+    expect(result[0]).not.to.be(extent1);
+  });
+
+  it('returns an empty array when extent2 contains extent1', function () {
+    const extent1 = [5, 5, 15, 15];
+    const extent2 = [0, 0, 20, 20];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result).to.eql([]);
+  });
+
+  it('returns one strip when extent2 overlaps a single side', function () {
+    const extent1 = [0, 0, 10, 10];
+    const extent2 = [5, 0, 20, 10];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result.length).to.be(1);
+    expect(result[0]).to.eql([0, 0, 5, 10]);
+  });
+
+  it('returns two strips when extent2 overlaps a corner', function () {
+    const extent1 = [0, 0, 10, 10];
+    const extent2 = [5, 5, 20, 20];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result.length).to.be(2);
+    expect(result[0]).to.eql([0, 0, 5, 10]); // left strip
+    expect(result[1]).to.eql([5, 0, 10, 5]); // bottom strip
+  });
+
+  it('returns four strips when extent2 lies inside extent1', function () {
+    const extent1 = [0, 0, 10, 10];
+    const extent2 = [3, 3, 7, 7];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result.length).to.be(4);
+    expect(result[0]).to.eql([0, 0, 3, 10]); // left strip
+    expect(result[1]).to.eql([7, 0, 10, 10]); // right strip
+    expect(result[2]).to.eql([3, 0, 7, 3]); // bottom strip
+    expect(result[3]).to.eql([3, 7, 7, 10]); // top strip
+  });
+
+  it('returns extent1 unchanged when extent2 only touches an edge', function () {
+    const extent1 = [0, 0, 10, 10];
+    const extent2 = [10, 0, 20, 10];
+    const result = _ol_extent_.getDifference(extent1, extent2);
+    expect(result.length).to.be(1);
+    expect(result[0]).to.eql([0, 0, 10, 10]);
+  });
+});


### PR DESCRIPTION
Closes #17032.

Previously, `VectorSource.removeLoadedExtent()` had to be called with the exact same extent that was loaded, otherwise the overlapping loaded extent would stay in the tree untouched, causing the source to skip re-fetching areas that should be reloaded.

This PR changes `removeLoadedExtent()` to split any overlapping loaded extent into its remaining non-overlapping parts and re-insert them into the tree. It also adds a `getDifference()` helper function to `ol/extent` that returns the parts of one extent not covered by another (0–4 rectangles), which `removeLoadedExtent()` uses to compute the split.