### PR TITLE
fix ImageArcGISRest and TileArcGISRest to support ArcREST case sensitivity

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -20,9 +20,9 @@ import {createLoader} from './arcgisRest.js';
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
  * linear interpolation is used when resampling.  Set to false to use the nearest neighbor instead.
  * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service
- * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
- * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`, and `IMAGESR`
- * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
+ * defaults will be used for any fields not specified. `format` is `png32` by default. `f` is
+ * `image` by default. `transparent` is `true` by default.  `bbox`, `size`, `bboxSR`, and `imageSR`
+ * will be set dynamically. Set `layers` to override the default service layer visibility. See
  * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is the view projection.

--- a/src/ol/source/TileArcGISRest.js
+++ b/src/ol/source/TileArcGISRest.js
@@ -20,9 +20,9 @@ import {getRequestUrl} from './arcgisRest.js';
  * @property {boolean} [interpolate=true] Use interpolated values when resampling.  By default,
  * linear interpolation is used when resampling.  Set to false to use the nearest neighbor instead.
  * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service defaults will be
- * used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is `IMAGE` by
- * default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`,
- * and `IMAGESR` will be set dynamically. Set `LAYERS` to
+ * used for any fields not specified. `format` is `png32` by default. `f` is `image` by
+ * default. `transparent` is `true` by default.  `bbox`, `size`, `bboxSR`,
+ * and `imageSR` will be set dynamically. Set `layers` to
  * override the default service layer visibility. See
  * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
@@ -236,9 +236,9 @@ class TileArcGISRest extends TileImage {
 
     // Apply default params and override with user specified values.
     const baseParams = {
-      'F': 'image',
-      'FORMAT': 'PNG32',
-      'TRANSPARENT': true,
+      'f': 'image',
+      'format': 'png32',
+      'transparent': true,
     };
     Object.assign(baseParams, this.params_);
 

--- a/src/ol/source/arcgisRest.js
+++ b/src/ol/source/arcgisRest.js
@@ -67,7 +67,7 @@ export function getRequestUrl(
  * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service
  * defaults will be used for any fields not specified. `format` is `png32` by default. `f` is
  * `image` by default. `transparent` is `true` by default.  `bbox`, `size`, `bboxSR`, and `imageSR`
- * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
+ * will be set dynamically. Set `layers` to override the default service layer visibility. See
  * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
  * @property {import("../proj.js").ProjectionLike} [projection] Projection. Default is 'EPSG:3857'.

--- a/src/ol/source/arcgisRest.js
+++ b/src/ol/source/arcgisRest.js
@@ -42,12 +42,12 @@ export function getRequestUrl(
     round(getHeight(extent) / imageResolution, DECIMALS),
   ];
 
-  params['SIZE'] = imageSize[0] + ',' + imageSize[1];
-  params['BBOX'] = extent.join(',');
-  params['BBOXSR'] = srid;
-  params['IMAGESR'] = srid;
-  params['DPI'] = Math.round(
-    params['DPI'] ? params['DPI'] * pixelRatio : 90 * pixelRatio,
+  params['size'] = imageSize[0] + ',' + imageSize[1];
+  params['bbox'] = extent.join(',');
+  params['bboxSR'] = srid;
+  params['imageSR'] = srid;
+  params['dpi'] = Math.round(
+    params['dpi'] ? params['dpi'] * pixelRatio : 90 * pixelRatio,
   );
 
   const modifiedUrl = baseUrl
@@ -65,8 +65,8 @@ export function getRequestUrl(
  * @property {boolean} [hidpi=true] Use the `ol/Map#pixelRatio` value when requesting the image from
  * the remote server.
  * @property {Object<string,*>} [params] ArcGIS Rest parameters. This field is optional. Service
- * defaults will be used for any fields not specified. `FORMAT` is `PNG32` by default. `F` is
- * `IMAGE` by default. `TRANSPARENT` is `true` by default.  `BBOX`, `SIZE`, `BBOXSR`, and `IMAGESR`
+ * defaults will be used for any fields not specified. `format` is `png32` by default. `f` is
+ * `image` by default. `transparent` is `true` by default.  `bbox`, `size`, `bboxSR`, and `imageSR`
  * will be set dynamically. Set `LAYERS` to override the default service layer visibility. See
  * https://developers.arcgis.com/rest/services-reference/export-map.htm
  * for further reference.
@@ -99,9 +99,9 @@ export function createLoader(options) {
     pixelRatio = options.hidpi ? pixelRatio : 1;
 
     const params = {
-      'F': 'image',
-      'FORMAT': 'PNG32',
-      'TRANSPARENT': true,
+      'f': 'image',
+      'format': 'png32',
+      'transparent': true,
     };
     Object.assign(params, options.params);
 

--- a/test/browser/spec/ol/source/ImageArcGISRest.test.js
+++ b/test/browser/spec/ol/source/ImageArcGISRest.test.js
@@ -50,15 +50,15 @@ describe('ol/source/ImageArcGISRest', function () {
       expect(uri.pathname).to.be('/MapServer/export');
 
       const queryData = uri.searchParams;
-      expect(queryData.get('SIZE')).to.be('150,16');
-      expect(queryData.get('BBOX')).to.be('-9.5,0.7,5.5,2.3');
-      expect(queryData.get('FORMAT')).to.be('PNG32');
-      expect(queryData.get('IMAGESR')).to.be('3857');
-      expect(queryData.get('BBOXSR')).to.be('3857');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('size')).to.be('150,16');
+      expect(queryData.get('bbox')).to.be('-9.5,0.7,5.5,2.3');
+      expect(queryData.get('format')).to.be('png32');
+      expect(queryData.get('imageSR')).to.be('3857');
+      expect(queryData.get('bboxSR')).to.be('3857');
+      expect(queryData.get('transparent')).to.be('true');
     });
 
-    it('returns a non floating point DPI value', function () {
+    it('returns a non floating point dpi value', function () {
       const source = new ImageArcGISRest(options);
       const image = source.getImage(
         [3, 2, -7, 1.12],
@@ -69,7 +69,7 @@ describe('ol/source/ImageArcGISRest', function () {
       image.load();
       const uri = new URL(image.getImage().src);
       const queryData = uri.searchParams;
-      expect(queryData.get('DPI')).to.be('91');
+      expect(queryData.get('dpi')).to.be('91');
     });
 
     it('returns a image with the expected URL for ImageServer', function () {
@@ -87,16 +87,16 @@ describe('ol/source/ImageArcGISRest', function () {
       expect(uri.hostname).to.be(window.location.hostname);
       expect(uri.pathname).to.be('/ImageServer/exportImage');
       const queryData = uri.searchParams;
-      expect(queryData.get('BBOX')).to.be('-9.5,0.7,5.5,2.3');
-      expect(queryData.get('FORMAT')).to.be('PNG32');
-      expect(queryData.get('IMAGESR')).to.be('3857');
-      expect(queryData.get('BBOXSR')).to.be('3857');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('bbox')).to.be('-9.5,0.7,5.5,2.3');
+      expect(queryData.get('format')).to.be('png32');
+      expect(queryData.get('imageSR')).to.be('3857');
+      expect(queryData.get('bboxSR')).to.be('3857');
+      expect(queryData.get('transparent')).to.be('true');
     });
 
     it('allows various parameters to be overridden', function () {
-      options.params.FORMAT = 'png';
-      options.params.TRANSPARENT = false;
+      options.params.format = 'png';
+      options.params.transparent = false;
       const source = new ImageArcGISRest(options);
       const image = source.getImage(
         [3, 2, -3, 1],
@@ -107,8 +107,8 @@ describe('ol/source/ImageArcGISRest', function () {
       image.load();
       const uri = new URL(image.getImage().src);
       const queryData = uri.searchParams;
-      expect(queryData.get('FORMAT')).to.be('png');
-      expect(queryData.get('TRANSPARENT')).to.be('false');
+      expect(queryData.get('format')).to.be('png');
+      expect(queryData.get('transparent')).to.be('false');
     });
 
     it('allows adding rest option', function () {

--- a/test/browser/spec/ol/source/TileArcGISRest.test.js
+++ b/test/browser/spec/ol/source/TileArcGISRest.test.js
@@ -21,34 +21,34 @@ describe('ol/source/TileArcGISRest', function () {
       expect(uri.hostname).to.be('example.com');
       expect(uri.pathname).to.be('/MapServer/export');
       const queryData = uri.searchParams;
-      const bbox = queryData.get('BBOX').split(',').map(parseFloat);
+      const bbox = queryData.get('bbox').split(',').map(parseFloat);
       expect(bbox[0]).roughlyEqual(-10018754.171394622, 1e-9);
       expect(bbox[1]).roughlyEqual(-15028131.257091936, 1e-9);
       expect(bbox[2]).roughlyEqual(-5009377.085697311, 1e-9);
       expect(bbox[3]).roughlyEqual(-10018754.171394624, 1e-9);
-      expect(queryData.get('FORMAT')).to.be('PNG32');
-      expect(queryData.get('SIZE')).to.be('256,256');
-      expect(queryData.get('IMAGESR')).to.be('3857');
-      expect(queryData.get('BBOXSR')).to.be('3857');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('format')).to.be('png32');
+      expect(queryData.get('size')).to.be('256,256');
+      expect(queryData.get('imageSR')).to.be('3857');
+      expect(queryData.get('bboxSR')).to.be('3857');
+      expect(queryData.get('transparent')).to.be('true');
     });
 
-    it('returns a non floating point DPI value', function () {
+    it('returns a non floating point dpi value', function () {
       const source = new TileArcGISRest(options);
       const tile = source.getTile(3, 2, 6, 1.12, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
-      expect(queryData.get('DPI')).to.be('101');
+      expect(queryData.get('dpi')).to.be('101');
     });
 
-    it('takes DPI from params if specified', function () {
-      options.params.DPI = 96;
+    it('takes dpi from params if specified', function () {
+      options.params.dpi = 96;
       const source = new TileArcGISRest(options);
       const tile = source.getTile(3, 2, 6, 1.12, getProjection('EPSG:3857'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
-      expect(queryData.get('DPI')).to.be('108');
-      delete options.params.DPI;
+      expect(queryData.get('dpi')).to.be('108');
+      delete options.params.dpi;
     });
 
     it('returns a tile with the expected URL with url list', function () {
@@ -65,16 +65,16 @@ describe('ol/source/TileArcGISRest', function () {
       expect(uri.hostname).to.match(/test[12]\.com/);
       expect(uri.pathname).to.be('/MapServer/export');
       const queryData = uri.searchParams;
-      const bbox = queryData.get('BBOX').split(',').map(parseFloat);
+      const bbox = queryData.get('bbox').split(',').map(parseFloat);
       expect(bbox[0]).roughlyEqual(-10018754.171394622, 1e-9);
       expect(bbox[1]).roughlyEqual(-15028131.257091936, 1e-9);
       expect(bbox[2]).roughlyEqual(-5009377.085697311, 1e-9);
       expect(bbox[3]).roughlyEqual(-10018754.171394624, 1e-9);
-      expect(queryData.get('FORMAT')).to.be('PNG32');
-      expect(queryData.get('SIZE')).to.be('256,256');
-      expect(queryData.get('IMAGESR')).to.be('3857');
-      expect(queryData.get('BBOXSR')).to.be('3857');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('format')).to.be('png32');
+      expect(queryData.get('size')).to.be('256,256');
+      expect(queryData.get('imageSR')).to.be('3857');
+      expect(queryData.get('bboxSR')).to.be('3857');
+      expect(queryData.get('transparent')).to.be('true');
     });
 
     it('returns a tile with the expected URL for ImageServer', function () {
@@ -87,36 +87,36 @@ describe('ol/source/TileArcGISRest', function () {
       expect(uri.hostname).to.be('example.com');
       expect(uri.pathname).to.be('/ImageServer/exportImage');
       const queryData = uri.searchParams;
-      const bbox = queryData.get('BBOX').split(',').map(parseFloat);
+      const bbox = queryData.get('bbox').split(',').map(parseFloat);
       expect(bbox[0]).roughlyEqual(-10018754.171394622, 1e-9);
       expect(bbox[1]).roughlyEqual(-15028131.257091936, 1e-9);
       expect(bbox[2]).roughlyEqual(-5009377.085697311, 1e-9);
       expect(bbox[3]).roughlyEqual(-10018754.171394624, 1e-9);
-      expect(queryData.get('FORMAT')).to.be('PNG32');
-      expect(queryData.get('SIZE')).to.be('256,256');
-      expect(queryData.get('IMAGESR')).to.be('3857');
-      expect(queryData.get('BBOXSR')).to.be('3857');
-      expect(queryData.get('TRANSPARENT')).to.be('true');
+      expect(queryData.get('format')).to.be('png32');
+      expect(queryData.get('size')).to.be('256,256');
+      expect(queryData.get('imageSR')).to.be('3857');
+      expect(queryData.get('bboxSR')).to.be('3857');
+      expect(queryData.get('transparent')).to.be('true');
     });
 
     it('allows various parameters to be overridden', function () {
-      options.params.FORMAT = 'png';
-      options.params.TRANSPARENT = false;
+      options.params.format = 'png';
+      options.params.transparent = false;
       const source = new TileArcGISRest(options);
       const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
-      expect(queryData.get('FORMAT')).to.be('png');
-      expect(queryData.get('TRANSPARENT')).to.be('false');
+      expect(queryData.get('format')).to.be('png');
+      expect(queryData.get('transparent')).to.be('false');
     });
 
     it('allows adding rest option', function () {
-      options.params.LAYERS = 'show:1,3,4';
+      options.params.layers = 'show:1,3,4';
       const source = new TileArcGISRest(options);
       const tile = source.getTile(3, 2, 2, 1, getProjection('EPSG:4326'));
       const uri = new URL(tile.src_);
       const queryData = uri.searchParams;
-      expect(queryData.get('LAYERS')).to.be('show:1,3,4');
+      expect(queryData.get('layers')).to.be('show:1,3,4');
     });
   });
 


### PR DESCRIPTION
# Description
Newer ArcServer instances are returning errors for 'export' requests from ImageArcGISRest and TileArcGISRest layers. In particular, they are now case-sensitive about the `bbox` field, and do not recognize OpenLayers' `BBOX` value. This patch updates the ArcGISRest files and their tests to use the capitalization as laid out in [Esri's documentation](https://developers.arcgis.com/rest/services-reference/enterprise/export-map/):
* `BBOX` -> `bbox`
* `LAYERS` -> `layers`
* `SIZE` -> `size`
* `BBOXSR` -> `bboxSR`
* `IMAGESR` -> `imageSR`
* `FORMAT` -> `format`
* `F` -> `f`
* `DPI` -> `dpi`

This also changes some of the default values' cases:
* `PNG32` -> `png32`
* `IMAGE` -> `image`

In response to issue #17205, it seems to have been a long time since ArcREST required uppercase fields, and newer versions seem to require lowercase for some fields (at least `bbox`) for [export map](https://developers.arcgis.com/rest/services-reference/enterprise/export-map/) queries. This issue is also found [on Esri forums](https://community.esri.com/t5/arcgis-rest-apis-and-services-questions/esri-traffic-maps-do-not-work-lowercase-parameter/td-p/1688941) as well.

Fixes #17205.
