### PR TITLE
Handle OGC tileMatrixSetLimits with minzoom

### DIFF
--- a/src/ol/source/ogcTileUtil.js
+++ b/src/ol/source/ogcTileUtil.js
@@ -331,6 +331,9 @@ export function parseTileMatrixSet(
 
   for (let i = 0; i < length; ++i) {
     const id = matrixIds[i];
+    if (id === undefined) {
+      continue;
+    }
     const matrix = matrixLookup[id];
     const origin = matrix.pointOfOrigin;
     if (backwards) {

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -67,17 +67,22 @@ class TileGrid {
    * @param {Options} options Tile grid options.
    */
   constructor(options) {
+    let minZoom = options.minZoom;
+    const resolutions = options.resolutions;
+    if (minZoom === undefined && resolutions) {
+      minZoom = resolutions.findIndex((resolution) => resolution !== undefined);
+    }
     /**
      * @protected
      * @type {number}
      */
-    this.minZoom = options.minZoom !== undefined ? options.minZoom : 0;
+    this.minZoom = minZoom !== undefined ? minZoom : 0;
 
     /**
      * @private
      * @type {!Array<number>}
      */
-    this.resolutions_ = options.resolutions;
+    this.resolutions_ = resolutions;
     assert(
       isSorted(
         this.resolutions_,

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -11,6 +11,7 @@ import TileGrid from './TileGrid.js';
  * outside this extent will be requested by {@link module:ol/source/Tile~TileSource} sources.
  * When no `origin` or `origins` are configured, the `origin` will be set to the
  * top-left corner of the extent.
+ * @property {number} [minZoom=0] Minimum zoom.
  * @property {import("../coordinate.js").Coordinate} [origin] The tile grid origin, i.e.
  * where the `x` and `y` axes meet (`[z, 0, 0]`). Tile coordinates increase left
  * to right and downwards. If not specified, `extent` or `origins` must be provided.
@@ -55,6 +56,7 @@ class WMTSTileGrid extends TileGrid {
       tileSize: options.tileSize,
       tileSizes: options.tileSizes,
       sizes: options.sizes,
+      minZoom: options.minZoom,
     });
 
     /**

--- a/test/node/ol/source/ogcTileUtil.test.js
+++ b/test/node/ol/source/ogcTileUtil.test.js
@@ -11,6 +11,7 @@ import {
   getMapTileUrlTemplate,
   getTileSetInfo,
   getVectorTileUrlTemplate,
+  parseTileMatrixSet,
 } from '../../../../src/ol/source/ogcTileUtil.js';
 import TileGrid from '../../../../src/ol/tilegrid/TileGrid.js';
 import expect from '../../expect.js';
@@ -404,6 +405,24 @@ describe('ol/source/ogcTileUtil.js', () => {
       expect(appendedUrl).to.be(
         '/ogcapi/tiles/WebMercatorQuad.json?collections=foo%2Cbar,baz',
       );
+    });
+  });
+
+  describe('parseTileMatrixSet()', () => {
+    it('handles minZoom correctly', async () => {
+      const tileSet = await fse.readJSON(
+        path.join(getDataDir(), 'ogcapi/tiles/WebMercatorQuad.json'),
+      );
+      const tileMatrixSet = await fse.readJSON(
+        path.join(getDataDir(), 'ogcapi/tileMatrixSets/WebMercatorQuad.json'),
+      );
+      const tileInfo = parseTileMatrixSet(
+        {},
+        tileMatrixSet,
+        undefined,
+        tileSet.tileMatrixSetLimits,
+      );
+      expect(tileInfo.grid.getMinZoom()).to.be(6);
     });
   });
 });

--- a/test/node/ol/tilegrid/TileGrid.test.js
+++ b/test/node/ol/tilegrid/TileGrid.test.js
@@ -379,6 +379,16 @@ describe('ol/tilegrid/TileGrid.js', function () {
     });
   });
 
+  it('calculates implicit minZoom from resolutions', function () {
+    resolutions.unshift(undefined, undefined);
+    const tileGrid = new TileGrid({
+      resolutions,
+      origin,
+      tileSize,
+    });
+    expect(tileGrid.getMinZoom()).to.be(2);
+  });
+
   describe('createForExtent', function () {
     it('allows creation of tile grid from extent', function () {
       const extent = createOrUpdate(-100, -100, 100, 100);


### PR DESCRIPTION
Fixes #17466

This pull request fixes parsing of TileMatrixSetLimits in ogcTileUtil.js for the case where the first TileMatrix is not the first one available (i.e. minzoom !== 0). It also makes it so TileGrid.js can handle resolutions arrays with leading `undefined` entries, which is what it gets when TileMatrixSetLimits do not cover the full zoom level range.

I also added the `minZoom` option to WMTSTileGrid.js, because it was mentioned in the options already but not passed to the super.