### PR TITLE
docs: add workletjs library to 3rd party resources

### DIFF
--- a/site/src/3rd-party/index.hbs
+++ b/site/src/3rd-party/index.hbs
@@ -136,8 +136,8 @@ layout: default.hbs
         <td><a href="https://github.com/qulle">Daniel</a></td>
        </tr>
        <tr>
-        <td><a href="https://github.com/workletjs/workletjs">workletjs</a></td>
-        <td>A modern map component library built with Angular(Signals) and OpenLayers</td>
+        <td><a href="https://github.com/workletjs/workletjs">WorkletJS</a></td>
+        <td>A modern map component library built with Angular (Signals) and OpenLayers</td>
         <td><a href="https://github.com/Jonnytoshen">Chao</a></td>
        </tr>
     </tbody>

--- a/site/src/3rd-party/index.hbs
+++ b/site/src/3rd-party/index.hbs
@@ -135,6 +135,11 @@ layout: default.hbs
         <td>OLTB is a Vanilla JS, portable mobile friendly GIS Toolbar/Editor, developed using OpenLayers 10.5.0</td>
         <td><a href="https://github.com/qulle">Daniel</a></td>
        </tr>
+       <tr>
+        <td><a href="https://github.com/workletjs/workletjs">workletjs</a></td>
+        <td>A modern map component library built with Angular(Signals) and OpenLayers</td>
+        <td><a href="https://github.com/Jonnytoshen">Chao</a></td>
+       </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
Add WorkletJS to the third-party resources page.

### What changed
- Added a WorkletJS entry to the third-party libraries list in `site/src/3rd-party/index.hbs`.

### Validation
- `npm run preflight`: not available in this repository.
- `npm run lint`: fails on this branch baseline with existing unrelated import-order issues across many files.
