### PR TITLE
GeoZarr: add support for proj:projjson and proj:wkt2

### DIFF
--- a/src/ol/proj/proj4.js
+++ b/src/ol/proj/proj4.js
@@ -162,6 +162,33 @@ export async function fromProjectionCode(code) {
 }
 
 /**
+ * @param {*} def Projection definition.
+ * @return {Projection} The projection.
+ */
+export function fromProjectionDefinition(def) {
+  const proj4 = registered;
+  if (!proj4) {
+    throw new Error('Proj4 must be registered first with register(proj4)');
+  }
+  // Fallback code is the whole def...
+  let code = JSON.stringify(def);
+  proj4.defs(code, def);
+  const proj4Def = proj4.defs(code);
+  if (proj4Def.title) {
+    // ...but use authority:code if available
+    proj4.defs(code, null);
+    code = proj4Def.title;
+    const projection = getCachedProjection(code);
+    if (projection) {
+      return projection;
+    }
+    proj4.defs(code, def);
+  }
+  register(proj4);
+  return getCachedProjection(code);
+}
+
+/**
  * @param {number} code The EPSG code.
  * @return {Promise<string>} The proj4 or WKT definition.
  * @deprecated Use {@link module:ol/proj/proj4.projLookup} instead.

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -6,6 +6,7 @@ import {FetchStore, get, open, slice, withRangeCoalescing} from 'zarrita';
 import {warn} from '../console.js';
 import {getCenter} from '../extent.js';
 import {get as getProjection, toUserCoordinate, toUserExtent} from '../proj.js';
+import {fromProjectionDefinition} from '../proj/proj4.js';
 import {toSize} from '../size.js';
 import WMTSTileGrid from '../tilegrid/WMTS.js';
 import DataTileSource from './DataTile.js';
@@ -297,7 +298,7 @@ export default class GeoZarr extends DataTileSource {
         const extent = attributes['spatial:bbox'];
         const resolution = (extent[2] - extent[0]) / shape[1];
         if (!this.projection) {
-          this.projection = getProjection(attributes['proj:code']);
+          this.projection = getProjectionFromAttributes(attributes);
         }
         if (consolidatedMetadata) {
           this.bandsByLevel_ = {level0: []};
@@ -582,7 +583,9 @@ function createCachedStore(store, groupBytes, consolidatedMetadata) {
  *   zarr_conventions: Array<{uuid: string}>,
  *   'spatial:bbox': import("../extent.js").Extent,
  *   'spatial:shape': Array<number>,
- *   'proj:code': string,
+ *   'proj:wkt2'?: string,
+ *   'proj:projjson'?: Object,
+ *   'proj:code'?: string | null,
  * }} DatasetAttributes
  */
 
@@ -702,7 +705,7 @@ function getTileGridInfoFromAttributes(
 ) {
   const multiscales = attributes.multiscales;
   const extent = attributes['spatial:bbox'];
-  const projection = getProjection(attributes['proj:code']);
+  const projection = getProjectionFromAttributes(attributes);
   const extentWidth = extent[2] - extent[0];
   const origin = [extent[0], extent[3]];
   /** @type {Array<{matrixId: string, resolution: number, origin: import("../coordinate.js").Coordinate, tileSize: import("../size.js").Size|undefined}>} */
@@ -907,4 +910,17 @@ function composeData(
     }
   }
   return tileData;
+}
+
+/**
+ * @param {DatasetAttributes} attributes Attriutes.
+ * @return {import("../proj/Projection.js").default} The projection.
+ */
+function getProjectionFromAttributes(attributes) {
+  const projCode = attributes['proj:code'];
+  if (projCode) {
+    return getProjection(projCode);
+  }
+  const projDef = attributes['proj:projjson'] || attributes['proj:wkt2'];
+  return fromProjectionDefinition(projDef);
 }

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -1,5 +1,7 @@
+import proj4 from 'proj4';
 import {stub as sinonStub} from 'sinon';
 import {get} from '../../../../../src/ol/proj.js';
+import {register, unregister} from '../../../../../src/ol/proj/proj4.js';
 import GeoZarr from '../../../../../src/ol/source/GeoZarr.js';
 
 const ZARR_URL = 'http://test-zarr/test.zarr/data';
@@ -465,6 +467,72 @@ describe('ol/source/GeoZarr', function () {
           }
           done();
         }
+      });
+    });
+
+    describe('proj:projjson', function () {
+      before(function () {
+        register(proj4);
+      });
+
+      after(function () {
+        unregister();
+      });
+
+      it('reads projection from proj:projjson attribute', function (done) {
+        // https://spatialreference.org/ref/epsg/4326/projjson.json
+        fetchStub = stubFetchWithAttrs(null, {
+          'proj:code': undefined,
+          'proj:projjson': {
+            $schema: 'https://proj.org/schemas/v0.7/projjson.schema.json',
+            type: 'GeographicCRS',
+            name: 'WGS 84',
+            datum_ensemble: {
+              name: 'World Geodetic System 1984 ensemble',
+              members: [
+                {
+                  name: 'World Geodetic System 1984 (Transit)',
+                  id: {authority: 'EPSG', code: 1166},
+                },
+              ],
+              ellipsoid: {
+                name: 'WGS 84',
+                semi_major_axis: 6378137,
+                inverse_flattening: 298.257223563,
+              },
+              accuracy: '2.0',
+              id: {authority: 'EPSG', code: 6326},
+            },
+            coordinate_system: {
+              subtype: 'ellipsoidal',
+              axis: [
+                {
+                  name: 'Geodetic latitude',
+                  abbreviation: 'Lat',
+                  direction: 'north',
+                  unit: 'degree',
+                },
+                {
+                  name: 'Geodetic longitude',
+                  abbreviation: 'Lon',
+                  direction: 'east',
+                  unit: 'degree',
+                },
+              ],
+            },
+            id: {authority: 'EPSG', code: 4326},
+          },
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['b04'],
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            expect(source.getProjection()).to.be(get('EPSG:4326'));
+            done();
+          }
+        });
       });
     });
   });

--- a/test/node/ol/proj/proj4.test.js
+++ b/test/node/ol/proj/proj4.test.js
@@ -2,11 +2,13 @@ import proj4 from 'proj4';
 import {
   addCommon,
   clearAllProjections,
+  get,
   transform,
 } from '../../../../src/ol/proj.js';
 import Projection from '../../../../src/ol/proj/Projection.js';
 import {
   fromProjectionCode,
+  fromProjectionDefinition,
   getProjectionCodeLookup,
   isRegistered,
   register,
@@ -14,6 +16,132 @@ import {
   unregister,
 } from '../../../../src/ol/proj/proj4.js';
 import expect from '../../expect.js';
+
+// https://spatialreference.org/ref/epsg/4326/projjson.json
+const EPSG4326_PROJJSON = {
+  $schema: 'https://proj.org/schemas/v0.7/projjson.schema.json',
+  type: 'GeographicCRS',
+  name: 'WGS 84',
+  datum_ensemble: {
+    name: 'World Geodetic System 1984 ensemble',
+    members: [
+      {
+        name: 'World Geodetic System 1984 (Transit)',
+        id: {authority: 'EPSG', code: 1166},
+      },
+      {
+        name: 'World Geodetic System 1984 (G730)',
+        id: {authority: 'EPSG', code: 1152},
+      },
+      {
+        name: 'World Geodetic System 1984 (G873)',
+        id: {authority: 'EPSG', code: 1153},
+      },
+      {
+        name: 'World Geodetic System 1984 (G1150)',
+        id: {authority: 'EPSG', code: 1154},
+      },
+      {
+        name: 'World Geodetic System 1984 (G1674)',
+        id: {authority: 'EPSG', code: 1155},
+      },
+      {
+        name: 'World Geodetic System 1984 (G1762)',
+        id: {authority: 'EPSG', code: 1156},
+      },
+      {
+        name: 'World Geodetic System 1984 (G2139)',
+        id: {authority: 'EPSG', code: 1309},
+      },
+      {
+        name: 'World Geodetic System 1984 (G2296)',
+        id: {authority: 'EPSG', code: 1383},
+      },
+    ],
+    ellipsoid: {
+      name: 'WGS 84',
+      semi_major_axis: 6378137,
+      inverse_flattening: 298.257223563,
+    },
+    accuracy: '2.0',
+    id: {authority: 'EPSG', code: 6326},
+  },
+  coordinate_system: {
+    subtype: 'ellipsoidal',
+    axis: [
+      {
+        name: 'Geodetic latitude',
+        abbreviation: 'Lat',
+        direction: 'north',
+        unit: 'degree',
+      },
+      {
+        name: 'Geodetic longitude',
+        abbreviation: 'Lon',
+        direction: 'east',
+        unit: 'degree',
+      },
+    ],
+  },
+  scope: 'Horizontal component of 3D system.',
+  area: 'World.',
+  bbox: {
+    south_latitude: -90,
+    west_longitude: -180,
+    north_latitude: 90,
+    east_longitude: 180,
+  },
+  id: {authority: 'EPSG', code: 4326},
+};
+
+// https://spatialreference.org/ref/epsg/32632/prettywkt2.txt
+const EPSG32632_WKT2 = `PROJCRS["WGS 84 / UTM zone 32N",
+    BASEGEOGCRS["WGS 84",
+        ENSEMBLE["World Geodetic System 1984 ensemble",
+            MEMBER["World Geodetic System 1984 (Transit)"],
+            MEMBER["World Geodetic System 1984 (G730)"],
+            MEMBER["World Geodetic System 1984 (G873)"],
+            MEMBER["World Geodetic System 1984 (G1150)"],
+            MEMBER["World Geodetic System 1984 (G1674)"],
+            MEMBER["World Geodetic System 1984 (G1762)"],
+            MEMBER["World Geodetic System 1984 (G2139)"],
+            MEMBER["World Geodetic System 1984 (G2296)"],
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1]],
+            ENSEMBLEACCURACY[2.0]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433]],
+        ID["EPSG",4326]],
+    CONVERSION["UTM zone 32N",
+        METHOD["Transverse Mercator",
+            ID["EPSG",9807]],
+        PARAMETER["Latitude of natural origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8801]],
+        PARAMETER["Longitude of natural origin",9,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8802]],
+        PARAMETER["Scale factor at natural origin",0.9996,
+            SCALEUNIT["unity",1],
+            ID["EPSG",8805]],
+        PARAMETER["False easting",500000,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8806]],
+        PARAMETER["False northing",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8807]]],
+    CS[Cartesian,2],
+        AXIS["(E)",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1]],
+        AXIS["(N)",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1]],
+    USAGE[
+        SCOPE["Navigation and medium accuracy spatial referencing."],
+        AREA["Between 6\u00b0E and 12\u00b0E, northern hemisphere between equator and 84\u00b0N, onshore and offshore."],
+        BBOX[0,6,84,12]],
+    ID["EPSG",32632]]`;
 
 const epsgDefinitions = {
   'EPSG:32721':
@@ -143,6 +271,45 @@ describe('ol/proj/proj4.js', () => {
       expect(error.message).to.be(
         'Proj4 must be registered first with register(proj4)',
       );
+    });
+  });
+
+  describe('fromProjectionDefinition()', () => {
+    it('throws when proj4 is not registered', () => {
+      let error;
+      try {
+        fromProjectionDefinition(EPSG4326_PROJJSON);
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an(Error);
+      expect(error.message).to.be(
+        'Proj4 must be registered first with register(proj4)',
+      );
+    });
+
+    describe('with proj4 registered', () => {
+      beforeEach(() => {
+        register(proj4);
+      });
+
+      it('returns the cached EPSG:4326 projection for WGS 84 PROJJSON', () => {
+        const cached = get('EPSG:4326');
+        const projection = fromProjectionDefinition(EPSG4326_PROJJSON);
+        expect(projection).to.be(cached);
+      });
+
+      it('creates a projection with code EPSG:32632 for UTM zone 32N WKT2', () => {
+        const projection = fromProjectionDefinition(EPSG32632_WKT2);
+        expect(projection.getCode()).to.be('EPSG:32632');
+        expect(projection.getUnits()).to.be('m');
+      });
+
+      it('returns the same projection instance for repeated calls', () => {
+        const p1 = fromProjectionDefinition(EPSG32632_WKT2);
+        const p2 = fromProjectionDefinition(EPSG32632_WKT2);
+        expect(p1).to.be(p2);
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request adds support for projections advertised as projjson or wkt2, in addition to the existing support for a projection code.

To make this work, a new `fromProjectionDefinition()` function is added to the proj4 module.