### PR TITLE
Use configured featureClass in GeoJSON reader to instanciate a new Feature

### DIFF
--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -2,7 +2,6 @@
  * @module ol/format/GeoJSON
  */
 
-import Feature from '../Feature.js';
 import {getLayoutForStride} from '../geom/SimpleGeometry.js';
 import {
   deflateCoordinatesArray,
@@ -141,7 +140,10 @@ class GeoJSON extends JSONFeature {
       );
     }
 
-    const feature = new Feature();
+    const FeatureClass = /** @type {typeof import("../Feature.js").default} */ (
+      this.featureClass
+    );
+    const feature = new FeatureClass();
     if (this.geometryName_) {
       feature.setGeometryName(this.geometryName_);
     } else if (this.extractGeometryName_ && geoJSONFeature['geometry_name']) {

--- a/test/node/ol/format/GeoJSON.test.js
+++ b/test/node/ol/format/GeoJSON.test.js
@@ -19,6 +19,8 @@ import Projection from '../../../../src/ol/proj/Projection.js';
 import RenderFeature from '../../../../src/ol/render/Feature.js';
 import expect from '../../expect.js';
 
+class TestFeature extends Feature {}
+
 describe('ol/format/GeoJSON.js', function () {
   let format;
   beforeEach(function () {
@@ -201,6 +203,15 @@ describe('ol/format/GeoJSON.js', function () {
       const geometry = feature.getGeometry();
       expect(geometry).to.be.an(Point);
       expect(geometry.getCoordinates()).to.eql([102.0, 0.5]);
+      expect(feature.get('prop0')).to.be('value0');
+    });
+
+    it('uses the configured featureClass', function () {
+      const feature = new GeoJSON({featureClass: TestFeature}).readFeature(
+        pointGeoJSON,
+      );
+      expect(feature).to.be.a(TestFeature);
+      expect(feature.getGeometry()).to.be.a(Point);
       expect(feature.get('prop0')).to.be('value0');
     });
 


### PR DESCRIPTION
Fixes #17476  This pull request addresses an issue in the GeoJSON formatter where it is possible to pass a custom feature class, but it is never used to instantiate the actual feature.