### PR TITLE
Automatically sort images in multi-page geotiffs

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -683,6 +683,9 @@ class GeoTIFFSource extends DataTile {
         );
       }
 
+      images.sort((i1, i2) => i2.getWidth() - i1.getWidth());
+      masks.sort((m1, m2) => m2.getWidth() - m1.getWidth());
+
       let sourceExtent;
       let sourceOrigin;
       const sourceTileSizes = new Array(imageCount);


### PR DESCRIPTION
When loading a GeoTIFF file, the order of the resulting source imagery is [asserted during the construction of the tile grid](https://github.com/openlayers/openlayers/blob/8788cf1a31c2040e5926da6becd33713ca81767f/src/ol/tilegrid/TileGrid.js#L86-L98) to be descending in terms of resolution. I have, on the other hand, recently received a file [(`tile-8-3.tif`)](https://github.com/user-attachments/files/28116480/tile-8-3.tif) that does not satisfy this requirement. It is said to have been created as a result of drone ortophotography using Agisoft Metashape.

I have tried to look at the official standards, but couldn't find anything regarding the order. While it does indeed seem to be the convention to put the highest resolution image first and then the rest of the _"overview pyramid"_ in descending order, other GeoTIFF viewers seem to handle opening the file attached above without issues.

> [!NOTE]
> To be completely fair, while inspecting the file using `tiffdump` and `tiffinfo` I found that it definitely breaks the standards too (as well as the ordering convention), as the `NewSubfileType` bitfield incorrectly specifies all subfiles (even the highest resolution version at the end) to be of the so-called _"reduced-resolution"_ kind.

As I have [previously outlined the problem](https://github.com/openlayers/openlayers/issues/17143#issuecomment-4396318254) in #17143 and got a [response](https://github.com/openlayers/openlayers/issues/17143#issuecomment-4396565872) stating that _"Sorting them in the GeoTIFF source should be fine."_, I started figuring out the least disruptive way to add the reordering logic without unnecessarily affecting anything else. Currently [line 678 of `src/ol/source/GeoTIFF.js`](https://github.com/openlayers/openlayers/blob/8788cf1a31c2040e5926da6becd33713ca81767f/src/ol/source/GeoTIFF.js#L678) seems to me like the right place to add this extra step, as this way all further processing would be done with the correct order afterwards.

I can see several different approaches from here:
- In terms of sorting criteria:
  - Find the full-resolution variant using the `NewSubfileType` bitfield to get the reference image and call `getResolutions(...)` (Which seems to be more in line with the spec, wouldn't work correctly in case of the attached file...)
  - Use `getWidth()` (Or `getHeight()`, or their product? 🤔) instead, as it will lead to the correct results even in case of incorrect metadata
- In terms of implementation:
  - Pair up images and masks into temporary objects, sort and then later extract them into the two separate arrays
  - Sort the images and masks separately, assuming that there's only a single one for each resolution, so this will not break the indexing later on

I have currently done the latter from each and created this PR as a draft, as I feel like there's potentially room for further discussion, but let me know if I'm overthinking / overcomplicating the topic! I'm happy to accept the fact that fixing bad input files is out of scope for OpenLayers, but would also be happy to try and improve / broaden compatibility in the spirit of the [robustness principle](https://en.wikipedia.org/wiki/Robustness_principle).