### PR TITLE
Fix incorrect VectorTile source resolution calculation

### DIFF
--- a/src/ol/source/VectorTile.js
+++ b/src/ol/source/VectorTile.js
@@ -186,6 +186,25 @@ class VectorTile extends UrlTile {
   }
 
   /**
+   * @param {number} resolution Resolution.
+   * @param {import("../proj/Projection.js").default} projection Projection.
+   * @param {number|import("../array.js").NearestDirectionFunction} zDirection Z direction.
+   * @return {number} Source z.
+   * @private
+   */
+  getSourceZ_(resolution, projection, zDirection) {
+    const sourceProjection = this.projection;
+    const sourceResolution =
+      projection &&
+      sourceProjection &&
+      !equivalent(projection, sourceProjection)
+        ? (resolution / sourceProjection.getMetersPerUnit()) *
+          projection.getMetersPerUnit()
+        : resolution;
+    return this.tileGrid.getZForResolution(sourceResolution, zDirection);
+  }
+
+  /**
    * @param {number} pixelRatio Pixel ratio.
    * @param {import("../proj/Projection.js").default} projection Projection.
    * @param {VectorRenderTile} tile Vector render tile.
@@ -215,21 +234,7 @@ class VectorTile extends UrlTile {
       if (sourceExtent) {
         getIntersection(extent, sourceExtent, extent);
       }
-      let sourceResolution = resolution;
-      if (
-        projection &&
-        sourceProjection &&
-        !equivalent(projection, sourceProjection)
-      ) {
-        sourceResolution =
-          resolution /
-          sourceProjection.getMetersPerUnit() /
-          projection.getMetersPerUnit();
-      }
-      const sourceZ = sourceTileGrid.getZForResolution(
-        sourceResolution,
-        this.zDirection,
-      );
+      const sourceZ = this.getSourceZ_(resolution, projection, this.zDirection);
 
       const urlFunction = tileUrlFunction || this.tileUrlFunction;
       sourceTileGrid.forEachTileCoord(extent, sourceZ, (sourceTileCoord) => {
@@ -367,18 +372,7 @@ class VectorTile extends UrlTile {
     if (urlTileCoord !== null) {
       const sourceTileGrid = this.tileGrid;
       const resolution = tileGrid.getResolution(z);
-      let sourceResolution = resolution;
-      if (
-        projection &&
-        sourceProjection &&
-        !equivalent(projection, sourceProjection)
-      ) {
-        sourceResolution =
-          resolution /
-          sourceProjection.getMetersPerUnit() /
-          projection.getMetersPerUnit();
-      }
-      const sourceZ = sourceTileGrid.getZForResolution(sourceResolution, 1);
+      const sourceZ = this.getSourceZ_(resolution, projection, 1);
       // make extent 1 pixel smaller so we don't load tiles for < 0.5 pixel render space
       const extent = tileGrid.getTileCoordExtent(urlTileCoord);
       bufferExtent(extent, -resolution, extent);

--- a/test/browser/spec/ol/source/VectorTile.test.js
+++ b/test/browser/spec/ol/source/VectorTile.test.js
@@ -233,6 +233,40 @@ describe('ol/source/VectorTile', function () {
       expect(tile.getState()).to.be(TileState.LOADING);
     });
 
+    it('uses the expected source z when reprojecting', function () {
+      const sourceTileCoords = [];
+      const source = new VectorTileSource({
+        projection: 'EPSG:3857',
+        tileUrlFunction: function (tileCoord) {
+          sourceTileCoords.push(tileCoord.slice());
+          return tileCoord.join('/');
+        },
+        tileLoadFunction: function (tile) {
+          tile.setLoader(function () {});
+        },
+      });
+      const projection = getProjection('EPSG:4326');
+      const sourceProjection = source.getProjection();
+      const z = 4;
+      const tileGrid = source.getTileGridForProjection(projection);
+      const resolution = tileGrid.getResolution(z);
+      const expectedSourceResolution =
+        (resolution / sourceProjection.getMetersPerUnit()) *
+        projection.getMetersPerUnit();
+      const expectedSourceZ = source
+        .getTileGrid()
+        .getZForResolution(expectedSourceResolution, 1);
+      const tileCoord = tileGrid.getTileCoordForCoordAndZ([0, 0], z);
+
+      const tile = source.getTile(z, tileCoord[1], tileCoord[2], 1, projection);
+
+      expect(tile.getState()).to.be(TileState.IDLE);
+      expect(sourceTileCoords.length).to.be.greaterThan(0);
+      sourceTileCoords.forEach(function (sourceTileCoord) {
+        expect(sourceTileCoord[0]).to.be(expectedSourceZ);
+      });
+    });
+
     it('creates new tile when source key changes', function () {
       source.setKey('key1');
       const tile1 = source.getTile(0, 0, 0, 1, getProjection('EPSG:3857'));


### PR DESCRIPTION
Fixes #17487.

While fixing the `sourceResolution` calculation, I created a shared `getSourceZ_()` method to avoid the code duplication in `getTile()` and `getSourceTiles()`.