### PR TITLE
Fix using default output format for SentinelHub when no format is provided

### DIFF
--- a/examples/sentinel-hub-custom-format.html
+++ b/examples/sentinel-hub-custom-format.html
@@ -16,9 +16,10 @@ tags: "Sentinel Hub, process"
       <option value="image/png">image/png</option>
       <option value="image/jpeg">image/jpeg</option>
       <option value="image/webp">image/webp</option>
+      <option value="">None (will use service's default format)</option>
+      <option value="not supported">not supported (will throw an error)</option>
     </select>
   </label>
-  <input type="submit" value="update">
 </form>
 <dialog id="auth-dialog" open>
   <form method="dialog" id="auth-form">

--- a/examples/sentinel-hub-custom-format.html
+++ b/examples/sentinel-hub-custom-format.html
@@ -4,7 +4,7 @@ title: Sentinel Hub Custom Format
 shortdesc: Updating the format used by the Sentinel Hub source.
 docs: >
   This example demonstrates how a custom format can be used to render tiles from Sentinel Hub.
-  Select a format from the dropdown and click the update button to change the format.
+  Select a format from the dropdown to change the format.
   See the Sentinel Hub [Examples](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/examples/#true-color-multi-part-reponse-different-formats-and-sampletype) for more information.
 tags: "Sentinel Hub, process"
 ---
@@ -16,8 +16,8 @@ tags: "Sentinel Hub, process"
       <option value="image/png">image/png</option>
       <option value="image/jpeg">image/jpeg</option>
       <option value="image/webp">image/webp</option>
-      <option value="">None (will use service's default format)</option>
-      <option value="not supported">not supported (will throw an error)</option>
+      <option value="">None (will result in an error)</option>
+      <option value="not supported">not supported (will result in an error)</option>
     </select>
   </label>
 </form>

--- a/examples/sentinel-hub-custom-format.html
+++ b/examples/sentinel-hub-custom-format.html
@@ -1,18 +1,19 @@
 ---
 layout: example.html
 title: Sentinel Hub Custom Format
-shortdesc: Updating the format used by the Sentinel Hub source.
+shortdesc: Initializing and updating the format used by the Sentinel Hub source.
 docs: >
   This example demonstrates how a custom format can be used to render tiles from Sentinel Hub.
-  Select a format from the dropdown to change the format.
+  Choose an initial format before showing the map to configure the format used when the source is constructed,
+  then use the "Image format" dropdown to update the format afterwards.
   See the Sentinel Hub [Examples](https://docs.sentinel-hub.com/api/latest/data/sentinel-2-l2a/examples/#true-color-multi-part-reponse-different-formats-and-sampletype) for more information.
 tags: "Sentinel Hub, process"
 ---
 <div id="map" class="map"></div>
 <form id="format-form">
-  <label>Image format:
+  <label>Change image format:
     <br>
-    <select name="format" id="format">
+    <select name="format" id="format" disabled>
       <option value="image/png">image/png</option>
       <option value="image/jpeg">image/jpeg</option>
       <option value="image/webp">image/webp</option>
@@ -30,6 +31,16 @@ tags: "Sentinel Hub, process"
     <label>Client secret
       <br>
       <input type="password" name="secret" value="rate_limit_secret">
+    </label>
+    <label>Initial image format:
+      <br>
+      <select name="initFormat" id="init-format">
+        <option value="image/png">image/png</option>
+        <option value="image/jpeg">image/jpeg</option>
+        <option value="image/webp">image/webp</option>
+        <option value="">None (will use the default format)</option>
+        <option value="not supported">not supported (will result in an error)</option>
+      </select>
     </label>
     <input type="submit" value="show map">
   </form>

--- a/examples/sentinel-hub-custom-format.js
+++ b/examples/sentinel-hub-custom-format.js
@@ -6,62 +6,68 @@ import SentinelHub from '../src/ol/source/SentinelHub.js';
 
 useGeographic();
 
-const source = new SentinelHub({
-  data: [
-    {
-      type: 'sentinel-2-l2a',
-      dataFilter: {
-        timeRange: {
-          from: '2024-05-30T00:00:00Z',
-          to: '2024-06-01T00:00:00Z',
-        },
-      },
-    },
-  ],
-  evalscript: {
-    setup: () => ({
-      input: ['B12', 'B08', 'B04'],
-      output: {bands: 3},
-    }),
-    evaluatePixel: (sample) => [
-      2.5 * sample.B12,
-      2 * sample.B08,
-      2 * sample.B04,
-    ],
-  },
-  format: 'image/png',
-});
+let source;
 
-const map = new Map({
-  layers: [new TileLayer({source})],
-  target: 'map',
-  view: new View({
-    center: [-121.75, 46.85],
-    zoom: 10,
-    minZoom: 7,
-    maxZoom: 13,
-  }),
+function reportError() {
+  if (source.getState() === 'error') {
+    alert(source.getError());
+  }
+}
+
+const formatDropdown = document.getElementById('format');
+
+formatDropdown.addEventListener('change', () => {
+  const newFormat =
+    formatDropdown.value === '' ? undefined : formatDropdown.value;
+  source.setFormat(newFormat);
 });
 
 document.getElementById('auth-form').addEventListener('submit', (event) => {
   const clientId = event.target.elements['id'].value;
   const clientSecret = event.target.elements['secret'].value;
-  source.setAuth({clientId, clientSecret});
-});
+  const initFormatValue = event.target.elements['initFormat'].value;
+  const initFormat = initFormatValue === '' ? undefined : initFormatValue;
 
-const formatDropdown = document.getElementById('format');
+  source = new SentinelHub({
+    data: [
+      {
+        type: 'sentinel-2-l2a',
+        dataFilter: {
+          timeRange: {
+            from: '2024-05-30T00:00:00Z',
+            to: '2024-06-01T00:00:00Z',
+          },
+        },
+      },
+    ],
+    evalscript: {
+      setup: () => ({
+        input: ['B12', 'B08', 'B04'],
+        output: {bands: 3},
+      }),
+      evaluatePixel: (sample) => [
+        2.5 * sample.B12,
+        2 * sample.B08,
+        2 * sample.B04,
+      ],
+    },
+    format: initFormat,
+    auth: {clientId, clientSecret},
+  });
+  source.on('change', reportError);
+  reportError();
 
-function updateInputData() {
-  const newFormat =
-    formatDropdown.value === '' ? undefined : formatDropdown.value;
-  source.setFormat(newFormat);
-}
+  new Map({
+    layers: [new TileLayer({source})],
+    target: 'map',
+    view: new View({
+      center: [-121.75, 46.85],
+      zoom: 10,
+      minZoom: 7,
+      maxZoom: 13,
+    }),
+  });
 
-formatDropdown.addEventListener('change', () => updateInputData());
-updateInputData();
-
-source.on('change', () => {
-  if (source.getState() === 'error') {
-    alert(source.getError());
-  }
+  formatDropdown.value = initFormatValue;
+  formatDropdown.disabled = false;
 });

--- a/examples/sentinel-hub-custom-format.js
+++ b/examples/sentinel-hub-custom-format.js
@@ -49,13 +49,15 @@ document.getElementById('auth-form').addEventListener('submit', (event) => {
   source.setAuth({clientId, clientSecret});
 });
 
-const format = document.getElementById('format');
+const formatDropdown = document.getElementById('format');
 
 function updateInputData() {
-  source.setFormat(format.value);
+  const newFormat =
+    formatDropdown.value === '' ? undefined : formatDropdown.value;
+  source.setFormat(newFormat);
 }
 
-format.addEventListener('change', () => updateInputData());
+formatDropdown.addEventListener('change', () => updateInputData());
 updateInputData();
 
 source.on('change', () => {

--- a/src/ol/source/SentinelHub.js
+++ b/src/ol/source/SentinelHub.js
@@ -25,10 +25,12 @@ const knownImageMediaTypes = {
 };
 
 /**
- * Default process API tile MIME type (`responses[].format.type`).
+ * Default process API tile MIME type (`responses[].format.type`), used when no
+ * format is provided to the {@link module:ol/source/SentinelHub~SentinelHub} constructor.
  * @type {string}
+ * @api
  */
-const defaultFormat = 'image/png';
+export const SENTINEL_HUB_DEFAULT_FORMAT = 'image/png';
 
 /**
  * @type {import('../size.js').Size}
@@ -408,12 +410,6 @@ class SentinelHub extends DataTileSource {
    * @param {Options} [options] Sentinel Hub options.
    */
   constructor(options) {
-    if (!knownImageMediaTypes[options.format]) {
-      throw new Error(
-        `Unsupported format: ${options.format}. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,
-      );
-    }
-
     /**
      * @type {Options}
      */
@@ -458,7 +454,10 @@ class SentinelHub extends DataTileSource {
      * @type {string}
      * @private
      */
-    this.format_ = config.format || defaultFormat;
+    this.format_ = SENTINEL_HUB_DEFAULT_FORMAT;
+    if (config.format) {
+      this.setFormat(config.format);
+    }
 
     /**
      * @type {string}
@@ -541,21 +540,28 @@ class SentinelHub extends DataTileSource {
 
   /**
    * Set the MIME type for process API tile responses (`responses[].format.type`).
+   * If no format or an unsupported format is provided, the source state will be set
+   * to `error` (see {@link module:ol/source/SentinelHub~SentinelHub#getError}) and the
+   * previously configured format is kept.
    *
    * @param {string} format Format type (for example `image/png` or `image/jpeg`).
    * @api
    */
   setFormat(format) {
     if (!format) {
-      this.format_ = defaultFormat;
-      this.fireWhenReady_();
+      this.error_ = new Error(
+        `No format provided. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,
+      );
+      this.setState('error');
       return;
     }
 
     if (!knownImageMediaTypes[format]) {
-      throw new Error(
+      this.error_ = new Error(
         `Unsupported format: ${format}. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,
       );
+      this.setState('error');
+      return;
     }
     this.format_ = format;
     this.fireWhenReady_();

--- a/src/ol/source/SentinelHub.js
+++ b/src/ol/source/SentinelHub.js
@@ -546,6 +546,12 @@ class SentinelHub extends DataTileSource {
    * @api
    */
   setFormat(format) {
+    if (!format) {
+      this.format_ = defaultFormat;
+      this.fireWhenReady_();
+      return;
+    }
+
     if (!knownImageMediaTypes[format]) {
       throw new Error(
         `Unsupported format: ${format}. Supported formats are: ${Object.keys(knownImageMediaTypes).join(', ')}`,

--- a/src/ol/source/SentinelHub.js
+++ b/src/ol/source/SentinelHub.js
@@ -598,13 +598,14 @@ class SentinelHub extends DataTileSource {
     if (!this.token_ || !this.evalscript_ || !this.inputData_) {
       return;
     }
-    this.setKey(this.getKeyForConfig_());
-    const state = this.getState();
-    if (state === 'ready') {
-      this.changed();
-      return;
+    const alreadyReady = this.getState() === 'ready';
+    if (!alreadyReady) {
+      this.setState('ready');
     }
-    this.setState('ready');
+    this.setKey(this.getKeyForConfig_());
+    if (alreadyReady) {
+      this.changed();
+    }
   }
 
   getKeyForConfig_() {

--- a/test/node/ol/source/SentinelHub.test.js
+++ b/test/node/ol/source/SentinelHub.test.js
@@ -91,6 +91,27 @@ describe('ol/source/SentinelHub.js', () => {
       assert.equal(source.getState(), 'error');
       assert.match(source.getError().message, /Unsupported format/);
     });
+
+    it('never reports the error state on a change event when recovering with a valid format', () => {
+      const source = new SentinelHub();
+      source.setAuth('token');
+      source.setData([{type: 'sentinel-2-l2a'}]);
+      source.setEvalscript({
+        setup: () => ({input: ['B04'], output: {bands: 1}}),
+        evaluatePixel: (sample) => [sample.B04],
+      });
+      assert.equal(source.getState(), 'ready');
+
+      source.setFormat('not-a-format');
+      assert.equal(source.getState(), 'error');
+
+      const states = [];
+      source.on('change', () => states.push(source.getState()));
+      source.setFormat('image/jpeg');
+
+      assert.equal(source.getState(), 'ready');
+      assert.notInclude(states, 'error');
+    });
   });
 
   describe('getProjectionIdentifier', () => {

--- a/test/node/ol/source/SentinelHub.test.js
+++ b/test/node/ol/source/SentinelHub.test.js
@@ -1,6 +1,7 @@
 import {assert} from 'chai';
 import {get as getProjection} from '../../../../src/ol/proj.js';
-import {
+import SentinelHub, {
+  SENTINEL_HUB_DEFAULT_FORMAT,
   getProjectionIdentifier,
   parseTokenClaims,
   serializeFunction,
@@ -33,6 +34,62 @@ describe('ol/source/SentinelHub.js', () => {
         clientHost: '224.123.123.155',
         account: '3fee1b29-f15b-a423-c6c1-29a02ff2face',
       });
+    });
+  });
+
+  describe('constructor', () => {
+    it('defaults to the default format when called with no options', () => {
+      const source = new SentinelHub();
+      assert.equal(source.format_, SENTINEL_HUB_DEFAULT_FORMAT);
+      assert.equal(source.getState(), 'loading');
+    });
+
+    it('defaults to the default format when no format option is provided', () => {
+      const source = new SentinelHub({});
+      assert.equal(source.format_, SENTINEL_HUB_DEFAULT_FORMAT);
+      assert.equal(source.getState(), 'loading');
+    });
+
+    it('accepts a known format', () => {
+      const source = new SentinelHub({format: 'image/jpeg'});
+      assert.equal(source.format_, 'image/jpeg');
+      assert.equal(source.getState(), 'loading');
+    });
+
+    it('sets the state to error for an unsupported format', () => {
+      const source = new SentinelHub({format: 'not-a-format'});
+      assert.equal(source.format_, SENTINEL_HUB_DEFAULT_FORMAT);
+      assert.equal(source.getState(), 'error');
+      assert.match(source.getError().message, /Unsupported format/);
+    });
+  });
+
+  describe('setFormat', () => {
+    it('sets the state to error and describes supported formats when called with no argument', () => {
+      const source = new SentinelHub({format: 'image/jpeg'});
+      source.setFormat();
+      assert.equal(source.format_, 'image/jpeg');
+      assert.equal(source.getState(), 'error');
+      assert.match(source.getError().message, /No format provided/);
+      assert.match(
+        source.getError().message,
+        /image\/png, image\/jpeg, image\/webp/,
+      );
+    });
+
+    it('updates the format for a known format', () => {
+      const source = new SentinelHub();
+      source.setFormat('image/webp');
+      assert.equal(source.format_, 'image/webp');
+      assert.equal(source.getState(), 'loading');
+    });
+
+    it('sets the state to error and keeps the previous format for an unsupported format', () => {
+      const source = new SentinelHub({format: 'image/jpeg'});
+      source.setFormat('not-a-format');
+      assert.equal(source.format_, 'image/jpeg');
+      assert.equal(source.getState(), 'error');
+      assert.match(source.getError().message, /Unsupported format/);
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->

This MR fixes a case where the format is not provided. 

This case was not handled completely correctly in https://github.com/openlayers/openlayers/pull/17418.
This is now fixed by using default output format when it's not provided in the parameters or when it's `undefined`.

This MR also adds additional options (no format, unsupported format) in the example for setting output format.