### PR TITLE
Improve type determination when parsing style expressions

### DIFF
--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -12,6 +12,10 @@ import {
 import {ColorType, LiteralExpression, Ops, parse} from './expression.js';
 
 /**
+ * @typedef {import('./expression.js').ValueType} ValueType
+ */
+
+/**
  * @fileoverview This module includes functions to build expressions for evaluation on the CPU.
  * Building is composed of two steps: parsing and compiling.  The parsing step takes an encoded
  * expression and returns an instance of one of the expression classes.  The compiling step takes
@@ -79,7 +83,7 @@ export function newEvaluationContext() {
 
 /**
  * @param {import('./expression.js').EncodedExpression} encoded The encoded expression.
- * @param {number} type The expected type.
+ * @param {ValueType} type The expected type.
  * @param {import('./expression.js').ParsingContext} context The parsing context.
  * @return {ExpressionEvaluator} The expression evaluator.
  */

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -135,6 +135,10 @@ import {toSize} from '../size.js';
  * @api
  */
 
+/**
+ * @typedef {number} ValueType
+ */
+
 let numTypes = 0;
 export const NoneType = 0;
 export const BooleanType = 1 << numTypes++;
@@ -157,7 +161,7 @@ const typeNames = {
 const namedTypes = Object.keys(typeNames).map(Number).sort(ascending);
 
 /**
- * @param {number} type The type.
+ * @param {ValueType} type The type.
  * @return {boolean} The type is one of the specific types (not any or a union type).
  */
 function isSpecific(type) {
@@ -166,7 +170,7 @@ function isSpecific(type) {
 
 /**
  * Get a string representation for a type.
- * @param {number} type The type.
+ * @param {ValueType} type The type.
  * @return {string} The type name.
  */
 export function typeName(type) {
@@ -186,8 +190,8 @@ export function typeName(type) {
 }
 
 /**
- * @param {number} broad The broad type.
- * @param {number} specific The specific type.
+ * @param {ValueType} broad The broad type.
+ * @param {ValueType} specific The specific type.
  * @return {boolean} The broad type includes the specific type.
  */
 export function includesType(broad, specific) {
@@ -195,8 +199,8 @@ export function includesType(broad, specific) {
 }
 
 /**
- * @param {number} oneType One type.
- * @param {number} otherType Another type.
+ * @param {ValueType} oneType One type.
+ * @param {ValueType} otherType Another type.
  * @return {boolean} The set of types overlap (share a common specific type)
  */
 export function overlapsType(oneType, otherType) {
@@ -204,8 +208,8 @@ export function overlapsType(oneType, otherType) {
 }
 
 /**
- * @param {number} type The type.
- * @param {number} expected The expected type.
+ * @param {ValueType} type The type.
+ * @param {ValueType} expected The expected type.
  * @return {boolean} The given type is exactly the expected type.
  */
 export function isType(type, expected) {
@@ -218,7 +222,7 @@ export function isType(type, expected) {
 
 export class LiteralExpression {
   /**
-   * @param {number} type The value type.
+   * @param {ValueType} type The value type.
    * @param {LiteralValue} value The literal value.
    */
   constructor(type, value) {
@@ -234,7 +238,7 @@ export class LiteralExpression {
 
 export class CallExpression {
   /**
-   * @param {number} type The return type.
+   * @param {ValueType} type The return type.
    * @param {string} operator The operator.
    * @param {...Expression} args The arguments.
    */
@@ -251,8 +255,8 @@ export class CallExpression {
 
 /**
  * @typedef {Object} ParsingContext
- * @property {Set<string>} variables Variables referenced with the 'var' operator.
- * @property {Set<string>} properties Properties referenced with the 'get' operator.
+ * @property {Map<string, ValueType>} variables Variables referenced with the 'var' operator; key is name, value is type.
+ * @property {Map<string, ValueType>} properties Properties referenced with the 'get' operator; key is name, value is type.
  * @property {boolean} featureId The style uses the feature id.
  * @property {boolean} geometryType The style uses the feature geometry type.
  * @property {boolean} mCoordinate The style uses the M coordinate of geometries
@@ -264,8 +268,8 @@ export class CallExpression {
  */
 export function newParsingContext() {
   return {
-    variables: new Set(),
-    properties: new Set(),
+    variables: new Map(),
+    properties: new Map(),
     featureId: false,
     geometryType: false,
     mCoordinate: false,
@@ -279,7 +283,7 @@ export function newParsingContext() {
 
 /**
  * @param {EncodedExpression} encoded The encoded expression.
- * @param {number} expectedType The expected type.
+ * @param {ValueType} expectedType The expected type.
  * @param {ParsingContext} context The parsing context.
  * @return {Expression} The parsed expression result.
  */
@@ -603,7 +607,7 @@ const parsers = {
 };
 
 /**
- * @typedef {function(Array<EncodedExpression>, number, ParsingContext):Array<Expression>|void} ArgValidator
+ * @typedef {function(Array<EncodedExpression>, ValueType, ParsingContext):Array<Expression>|void} ArgValidator
  *
  * An argument validator applies various checks to an encoded expression arguments and
  * returns the parsed arguments if any.  The second argument is the return type of the call expression.
@@ -633,7 +637,7 @@ function withGetArgs(encoded, returnType, context) {
       }
     }
     if (i === 0) {
-      context.properties.add(String(key));
+      context.properties.set(String(key), returnType);
     }
   }
   return args;
@@ -647,7 +651,7 @@ function withVarArgs(encoded, returnType, context) {
   if (typeof name !== 'string') {
     throw new Error('expected a string argument for var operation');
   }
-  context.variables.add(name);
+  context.variables.set(name, returnType);
 
   return [new LiteralExpression(StringType, name)];
 }
@@ -736,7 +740,7 @@ function withArgsOfReturnType(encoded, returnType, context) {
 }
 
 /**
- * @param {number} argType The argument type.
+ * @param {ValueType} argType The argument type.
  * @return {ArgValidator} The argument validator
  */
 function withArgsOfType(argType) {
@@ -919,7 +923,7 @@ function withInArgs(encoded, returnType, context) {
     );
   }
   /**
-   * @type {number}
+   * @type {ValueType}
    */
   let needleType;
 
@@ -1025,7 +1029,7 @@ function createCallExpressionParser(...validators) {
 
 /**
  * @param {Array} encoded The encoded expression.
- * @param {number} returnType The expected return type of the call expression.
+ * @param {ValueType} returnType The expected return type of the call expression.
  * @param {ParsingContext} context The parsing context.
  * @return {Expression} The parsed expression.
  */

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -470,11 +470,11 @@ const parsers = {
   ),
   [Ops.Equal]: createCallExpressionParser(
     hasArgsCount(2, 2),
-    withArgsOfType(AnyType),
+    withArgsOfIdenticalType(),
   ),
   [Ops.NotEqual]: createCallExpressionParser(
     hasArgsCount(2, 2),
-    withArgsOfType(AnyType),
+    withArgsOfIdenticalType(),
   ),
   [Ops.GreaterThan]: createCallExpressionParser(
     hasArgsCount(2, 2),
@@ -759,6 +759,36 @@ function withArgsOfType(argType) {
 }
 
 /**
+ * @return {ArgValidator} The argument validator
+ */
+function withArgsOfIdenticalType() {
+  return function (encoded, returnType, context) {
+    const operation = encoded[0];
+    const argCount = encoded.length - 1;
+    /**
+     * @type {Array<Expression>}
+     */
+    const args = new Array(argCount);
+    let commonType = AnyType;
+    for (let i = 0; i < argCount; ++i) {
+      const expression = parse(encoded[i + 1], commonType, context);
+      commonType &= expression.type;
+    }
+    if (commonType === NoneType) {
+      throw new Error(
+        `no common type was found among the arguments of ${operation}`,
+      );
+    }
+    // second loop to compile actual args
+    for (let i = 0; i < argCount; ++i) {
+      const expression = parse(encoded[i + 1], commonType, context);
+      args[i] = expression;
+    }
+    return args;
+  };
+}
+
+/**
  * @type {ArgValidator}
  */
 function hasOddArgs(encoded, returnType, context) {
@@ -790,16 +820,31 @@ function hasEvenArgs(encoded, returnType, context) {
 function withMatchArgs(encoded, returnType, context) {
   const argsCount = encoded.length - 1;
 
-  const inputType = StringType | NumberType | BooleanType;
-
-  const input = parse(encoded[1], inputType, context);
-
   const fallback = parse(encoded[encoded.length - 1], returnType, context);
 
+  let inputType = StringType | NumberType | BooleanType;
   const args = new Array(argsCount - 2);
+
+  // first round to determine input type
   for (let i = 0; i < argsCount - 2; i += 2) {
     try {
-      const match = parse(encoded[i + 2], input.type, context);
+      const match = parse(encoded[i + 2], inputType, context);
+      inputType &= match.type;
+    } catch (err) {
+      throw new Error(
+        `failed to parse argument ${i + 1} of match expression: ${err.message}`,
+      );
+    }
+    if (inputType === NoneType) {
+      throw new Error(
+        `no common type was found among the arguments of match expression`,
+      );
+    }
+  }
+
+  for (let i = 0; i < argsCount - 2; i += 2) {
+    try {
+      const match = parse(encoded[i + 2], inputType, context);
       args[i] = match;
     } catch (err) {
       throw new Error(
@@ -815,6 +860,8 @@ function withMatchArgs(encoded, returnType, context) {
       );
     }
   }
+
+  const input = parse(encoded[1], inputType, context);
 
   return [input, ...args, fallback];
 }

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -433,6 +433,7 @@ ${ifBlocks}
   // Ops.Coalesce
   // Ops.Concat
   // Ops.ToString
+  // Ops.Has
 };
 
 /**

--- a/src/ol/expr/gpu.js
+++ b/src/ol/expr/gpu.js
@@ -20,6 +20,10 @@ import {
 } from './expression.js';
 
 /**
+ * @typedef {import('./expression.js').ValueType} ValueType
+ */
+
+/**
  * @param {string} operator Operator
  * @param {CompilationContext} context Compilation context
  * @return {string} A function name based on the operator, unique in the given context
@@ -126,13 +130,13 @@ export function uniformNameForVariable(variableName) {
 /**
  * @typedef {Object} CompilationContextProperty
  * @property {string} name Name
- * @property {number} type Resolved property type
+ * @property {ValueType} type Resolved property type
  */
 
 /**
  * @typedef {Object} CompilationContextVariable
  * @property {string} name Name
- * @property {number} type Resolved variable type
+ * @property {ValueType} type Resolved variable type
  */
 
 /**
@@ -457,7 +461,7 @@ ${ifBlocks}
 
 /**
  * @param {Expression} expression The expression.
- * @param {number} returnType The expected return type.
+ * @param {ValueType} returnType The expected return type.
  * @param {CompilationContext} context The compilation context.
  * @return {CompiledExpression} The compiled expression
  */

--- a/src/ol/layer/Flow.js
+++ b/src/ol/layer/Flow.js
@@ -298,17 +298,16 @@ function parseStyle(style) {
     pipeline.push(`color = ${color};`);
   }
 
-  const variableNames = Object.keys(context.variables);
-  if (variableNames.length > 1 && !style.variables) {
+  if (context.variables.size > 1 && !style.variables) {
     throw new Error(
-      `Missing variables in style (expected ${context.variables})`,
+      `Missing variables in style (expected ${Array.from(context.variables.keys())})`,
     );
   }
 
   /** @type {Object<string,import("../webgl/Helper.js").UniformValue>} */
   const uniforms = {};
 
-  for (const variableName of variableNames) {
+  for (const [variableName] of context.variables.entries()) {
     if (!(variableName in style.variables)) {
       throw new Error(`Missing '${variableName}' in style variables`);
     }

--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -3,9 +3,9 @@
  */
 import {ColorType, NumberType} from '../expr/expression.js';
 import {
-  PALETTE_TEXTURE_ARRAY,
   getStringNumberEquivalent,
   newCompilationContext,
+  PALETTE_TEXTURE_ARRAY,
   uniformNameForVariable,
 } from '../expr/gpu.js';
 import LayerProperty from '../layer/Property.js';
@@ -175,21 +175,20 @@ function parseStyle(style, bandCount, nodataBandIndex) {
   /** @type {Object<string,import("../webgl/Helper.js").UniformValue>} */
   const uniforms = {};
 
-  const numVariables = Object.keys(context.variables).length;
+  const numVariables = context.variables.size;
   if (numVariables > 1 && !style.variables) {
     throw new Error(
-      `Missing variables in style (expected ${context.variables})`,
+      `Missing variables in style (expected ${Array.from(context.variables.keys())})`,
     );
   }
 
-  for (let i = 0; i < numVariables; ++i) {
-    const variable = context.variables[Object.keys(context.variables)[i]];
-    if (!(variable.name in style.variables)) {
-      throw new Error(`Missing '${variable.name}' in style variables`);
+  for (const [variableName] of context.variables.entries()) {
+    if (!(variableName in style.variables)) {
+      throw new Error(`Missing '${variableName}' in style variables`);
     }
-    const uniformName = uniformNameForVariable(variable.name);
+    const uniformName = uniformNameForVariable(variableName);
     uniforms[uniformName] = function () {
-      let value = style.variables[variable.name];
+      let value = style.variables[variableName];
       if (typeof value === 'string') {
         value = getStringNumberEquivalent(value);
       }

--- a/src/ol/render/webgl/compileUtil.js
+++ b/src/ol/render/webgl/compileUtil.js
@@ -5,10 +5,12 @@
 
 import {asArray} from '../../color.js';
 import {
+  BooleanType,
   ColorType,
+  newParsingContext,
   NumberArrayType,
   SizeType,
-  newParsingContext,
+  StringType,
 } from '../../expr/expression.js';
 import {
   buildExpression,
@@ -115,11 +117,11 @@ export function getGlslTypeFromType(type) {
  */
 export function applyContextToBuilder(builder, context) {
   // define one uniform per variable
-  for (const varName in context.variables) {
-    const variable = context.variables[varName];
-    const uniformName = uniformNameForVariable(variable.name);
-    let glslType = getGlslTypeFromType(variable.type);
-    if (variable.type === ColorType) {
+  for (const entry of context.variables.entries()) {
+    const [varName, varType] = entry;
+    const uniformName = uniformNameForVariable(varName);
+    let glslType = getGlslTypeFromType(varType);
+    if (varType === ColorType) {
       // we're not packing colors when they're passed as uniforms
       glslType = 'vec4';
     }
@@ -128,11 +130,11 @@ export function applyContextToBuilder(builder, context) {
 
   // for each feature attribute used in the fragment shader, define a varying that will be used to pass data
   // from the vertex to the fragment shader, as well as an attribute in the vertex shader (if not already present)
-  for (const propName in context.properties) {
-    const property = context.properties[propName];
-    const glslType = getGlslTypeFromType(property.type);
-    const attributeName = `a_prop_${property.name}`;
-    if (property.type === ColorType) {
+  for (const entry of context.properties.entries()) {
+    const [propName, propType] = entry;
+    const glslType = getGlslTypeFromType(propType);
+    const attributeName = `a_prop_${propName}`;
+    if (propType === ColorType) {
       builder.addAttribute(
         attributeName,
         glslType,
@@ -163,28 +165,27 @@ export function generateUniformsFromContext(context, variables) {
   const uniforms = {};
 
   // define one uniform per variable
-  for (const varName in context.variables) {
-    const variable = context.variables[varName];
-    const uniformName = uniformNameForVariable(variable.name);
+  for (const entry of context.variables.entries()) {
+    const [varName, varType] = entry;
+    const uniformName = uniformNameForVariable(varName);
 
     uniforms[uniformName] = () => {
-      const value = variables[variable.name];
-      if (typeof value === 'number') {
-        return value;
-      }
-      if (typeof value === 'boolean') {
+      const value = variables[varName];
+      if (varType === BooleanType) {
         return value ? 1 : 0;
       }
-      if (variable.type === ColorType) {
-        const color = [...asArray(value || '#eee')];
+      if (varType === ColorType) {
+        const colorValue =
+          /** @type {string|import('../../color.js').Color} */ (value);
+        const color = [...asArray(colorValue || '#eee')];
         color[0] /= 255;
         color[1] /= 255;
         color[2] /= 255;
         color[3] ??= 1;
         return color;
       }
-      if (typeof value === 'string') {
-        return getStringNumberEquivalent(value);
+      if (varType === StringType) {
+        return getStringNumberEquivalent(/** @type {string} */ (value));
       }
       return value;
     };
@@ -206,24 +207,24 @@ export function generateAttributesFromContext(context) {
   const attributes = {};
 
   // Define attributes with their callback for each property used in the vertex shader
-  for (const propName in context.properties) {
-    const property = context.properties[propName];
+  for (const entry of context.properties.entries()) {
+    const [propName, propType] = entry;
     const callback = (feature) => {
-      const value = feature.get(property.name);
-      if (property.type === ColorType) {
+      const value = feature.get(propName);
+      if (propType === ColorType) {
         return packColor([...asArray(value || '#eee')]);
       }
-      if (typeof value === 'string') {
-        return getStringNumberEquivalent(value);
-      }
-      if (typeof value === 'boolean') {
+      if (propType === BooleanType) {
         return value ? 1 : 0;
+      }
+      if (propType === StringType) {
+        return getStringNumberEquivalent(/** @type {string} */ (value));
       }
       return value;
     };
 
-    attributes[`prop_${property.name}`] = {
-      size: getGlslSizeFromType(property.type),
+    attributes[`prop_${propName}`] = {
+      size: getGlslSizeFromType(propType),
       callback,
     };
   }

--- a/src/ol/webgl/Helper.js
+++ b/src/ol/webgl/Helper.js
@@ -4,10 +4,7 @@
 import Disposable from '../Disposable.js';
 import {assert} from '../asserts.js';
 import {clear} from '../obj.js';
-import {
-  compose as composeTransform,
-  create as createTransform,
-} from '../transform.js';
+import {compose as composeTransform} from '../transform.js';
 import {getUid} from '../util.js';
 import {create, fromTransform} from '../vec/mat4.js';
 import {
@@ -374,18 +371,6 @@ class WebGLHelper extends Disposable {
       ContextEventType.RESTORED,
       this.boundHandleWebGLContextRestored_,
     );
-
-    /**
-     * @private
-     * @type {import("../transform.js").Transform}
-     */
-    this.offsetRotateMatrix_ = createTransform();
-
-    /**
-     * @private
-     * @type {import("../transform.js").Transform}
-     */
-    this.offsetScaleMatrix_ = createTransform();
 
     /**
      * @private

--- a/test/browser/spec/ol/expr/expression.test.js
+++ b/test/browser/spec/ol/expr/expression.test.js
@@ -3,12 +3,11 @@ import {
   BooleanType,
   CallExpression,
   ColorType,
-  LiteralExpression,
-  NumberType,
-  StringType,
   includesType,
   isType,
+  LiteralExpression,
   newParsingContext,
+  NumberType,
   parse,
   typeName,
 } from '../../../../../src/ol/expr/expression.js';
@@ -86,9 +85,7 @@ describe('ol/expr/expression.js', () => {
         expect(expression.operator).to.be('match');
         expect(isType(expression.type, ColorType)).to.be(true);
         expect(expression.args).to.have.length(6);
-        expect(typeName(expression.args[0].type)).to.be(
-          typeName(BooleanType | StringType | NumberType),
-        );
+        expect(typeName(expression.args[0].type)).to.be(typeName(NumberType));
         expect(isType(expression.args[1].type, NumberType)).to.be(true);
         expect(isType(expression.args[2].type, ColorType)).to.be(true);
         expect(isType(expression.args[3].type, NumberType)).to.be(true);

--- a/test/browser/spec/ol/expr/gpu.test.js
+++ b/test/browser/spec/ol/expr/gpu.test.js
@@ -2,8 +2,6 @@ import {
   AnyType,
   BooleanType,
   ColorType,
-  NumberType,
-  StringType,
   newParsingContext,
 } from '../../../../../src/ol/expr/expression.js';
 import {
@@ -162,22 +160,16 @@ describe('ol/expr/gpu', () => {
           },
         },
         expected:
-          '(u_var_selected == false ? vec4(1.0, 0.0, 0.0, 1.0) : (u_var_selected == a_prop_validValue ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : ((u_time < 10000.0) ? u_var_oldColor : u_var_newColor)))',
+          '((u_var_selected > 0.0) == false ? vec4(1.0, 0.0, 0.0, 1.0) : ((u_var_selected > 0.0) == (a_prop_validValue > 0.0) ? vec4(0.0, 0.5019607843137255, 0.0, 1.0) : ((u_time < 10000.0) ? u_var_oldColor : u_var_newColor)))',
         contextAssertion: (context) => {
-          expect(context.properties).to.eql({
-            validValue: {
-              name: 'validValue',
-              type: StringType | NumberType | BooleanType,
-            },
-          });
-          expect(context.variables).to.eql({
-            selected: {
-              name: 'selected',
-              type: StringType | NumberType | BooleanType,
-            },
-            newColor: {name: 'newColor', type: ColorType},
-            oldColor: {name: 'oldColor', type: ColorType},
-          });
+          expect(Array.from(context.properties)).to.eql([
+            ['validValue', BooleanType],
+          ]);
+          expect(Array.from(context.variables)).to.eql([
+            ['newColor', ColorType],
+            ['oldColor', ColorType],
+            ['selected', BooleanType],
+          ]);
         },
       },
     ];

--- a/test/browser/spec/ol/render/webgl/compileUtil.test.js
+++ b/test/browser/spec/ol/render/webgl/compileUtil.test.js
@@ -46,9 +46,9 @@ describe('ol/render/webgl/compileUtil', () => {
       );
 
       expect(glsl).to.be('(a_prop_size * 3.0 * u_zoom)');
-      expect(compilationContext.properties).to.eql({
-        size: {name: 'size', type: NumberType},
-      });
+      expect(Array.from(compilationContext.properties)).to.eql([
+        ['size', NumberType],
+      ]);
     });
   });
 
@@ -81,11 +81,11 @@ describe('ol/render/webgl/compileUtil', () => {
         addFragmentShaderFunction: sinonStub(),
       };
       const context = {
-        variables: {myColor: {name: 'myColor', type: ColorType}},
-        properties: {
-          colorProp: {name: 'colorProp', type: ColorType},
-          stringProp: {name: 'stringProp', type: StringType},
-        },
+        variables: new Map([['myColor', ColorType]]),
+        properties: new Map([
+          ['colorProp', ColorType],
+          ['stringProp', StringType],
+        ]),
         functions: {myFunction: 'function myFunction() { return 1.0; }'},
       };
 
@@ -121,13 +121,13 @@ describe('ol/render/webgl/compileUtil', () => {
   describe('generateUniformsFromContext', () => {
     it('generates uniforms', () => {
       const context = {
-        variables: {
-          colorVar: {name: 'colorVar', type: ColorType},
-          anotherColorVar: {name: 'anotherColorVar', type: ColorType},
-          stringVar: {name: 'stringVar', type: StringType},
-          arrayVar: {name: 'arrayVar', type: NumberArrayType},
-          booleanVar: {name: 'booleanVar', type: BooleanType},
-        },
+        variables: new Map([
+          ['colorVar', ColorType],
+          ['anotherColorVar', ColorType],
+          ['stringVar', StringType],
+          ['arrayVar', NumberArrayType],
+          ['booleanVar', BooleanType],
+        ]),
       };
       const styleVariables = {
         colorVar: '#FFF',
@@ -154,12 +154,12 @@ describe('ol/render/webgl/compileUtil', () => {
   describe('generateAttributesFromContext', () => {
     it('generates attributes', () => {
       const context = {
-        properties: {
-          colorProp: {name: 'colorProp', type: ColorType},
-          stringProp: {name: 'stringProp', type: StringType},
-          arrayProp: {name: 'arrayProp', type: NumberArrayType},
-          booleanProp: {name: 'booleanProp', type: BooleanType},
-        },
+        properties: new Map([
+          ['colorProp', ColorType],
+          ['stringProp', StringType],
+          ['arrayProp', NumberArrayType],
+          ['booleanProp', BooleanType],
+        ]),
       };
       const attributes = generateAttributesFromContext(context);
 

--- a/test/browser/spec/ol/render/webgl/style.test.js
+++ b/test/browser/spec/ol/render/webgl/style.test.js
@@ -1247,13 +1247,6 @@ describe('ol/render/webgl/style', () => {
             varyingExpression: 'unpackColor(a_prop_color)',
           },
           {
-            name: 'a_prop_lineType',
-            type: 'float',
-            varyingName: 'v_prop_lineType',
-            varyingType: 'float',
-            varyingExpression: 'a_prop_lineType',
-          },
-          {
             name: 'a_prop_lineWidth',
             type: 'float',
             varyingName: 'v_prop_lineWidth',
@@ -1261,11 +1254,11 @@ describe('ol/render/webgl/style', () => {
             varyingExpression: 'a_prop_lineWidth',
           },
           {
-            name: 'a_prop_transparent',
+            name: 'a_prop_lineType',
             type: 'float',
-            varyingName: 'v_prop_transparent',
+            varyingName: 'v_prop_lineType',
             varyingType: 'float',
-            varyingExpression: 'a_prop_transparent',
+            varyingExpression: 'a_prop_lineType',
           },
           {
             name: 'a_prop_fillColor',
@@ -1273,6 +1266,13 @@ describe('ol/render/webgl/style', () => {
             varyingName: 'v_prop_fillColor',
             varyingType: 'vec4',
             varyingExpression: 'unpackColor(a_prop_fillColor)',
+          },
+          {
+            name: 'a_prop_transparent',
+            type: 'float',
+            varyingName: 'v_prop_transparent',
+            varyingType: 'float',
+            varyingExpression: 'a_prop_transparent',
           },
         ]);
       });
@@ -1355,20 +1355,20 @@ describe('ol/render/webgl/style', () => {
         expect(parseResult.builder.uniforms_).to.eql([
           {name: 'u_var_iconSize', type: 'vec2'},
           {name: 'u_var_color', type: 'vec4'},
-          {name: 'u_var_lineType', type: 'float'},
           {name: 'u_var_lineWidth', type: 'float'},
-          {name: 'u_var_transparent', type: 'float'},
+          {name: 'u_var_lineType', type: 'float'},
           {name: 'u_var_fillColor', type: 'vec4'},
+          {name: 'u_var_transparent', type: 'float'},
         ]);
       });
       it('returns uniforms in the result', () => {
         expect(Object.keys(parseResult.uniforms)).to.eql([
           'u_var_iconSize',
           'u_var_color',
-          'u_var_lineType',
           'u_var_lineWidth',
-          'u_var_transparent',
+          'u_var_lineType',
           'u_var_fillColor',
+          'u_var_transparent',
         ]);
       });
       it('processes uniforms according to their types', () => {

--- a/test/node/ol/expr/cpu.test.js
+++ b/test/node/ol/expr/cpu.test.js
@@ -5,10 +5,10 @@ import {
 import {
   BooleanType,
   ColorType,
+  newParsingContext,
   NumberArrayType,
   NumberType,
   StringType,
-  newParsingContext,
 } from '../../../../src/ol/expr/expression.js';
 import expect from '../../expect.js';
 

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -3,17 +3,17 @@ import {
   BooleanType,
   CallExpression,
   ColorType,
-  LiteralExpression,
-  NoneType,
-  NumberArrayType,
-  NumberType,
-  SizeType,
-  StringType,
   computeGeometryType,
   includesType,
   isType,
+  LiteralExpression,
   newParsingContext,
+  NoneType,
+  NumberArrayType,
+  NumberType,
   parse,
+  SizeType,
+  StringType,
   typeName,
 } from '../../../../src/ol/expr/expression.js';
 import Circle from '../../../../src/ol/geom/Circle.js';
@@ -123,7 +123,14 @@ describe('ol/expr/expression.js', () => {
       expect(expression).to.be.a(CallExpression);
       expect(expression.operator).to.be('get');
       expect(isType(expression.type, AnyType)).to.be(true);
-      expect(context.properties.has('foo')).to.be(true);
+      expect(context.properties.get('foo')).to.be(AnyType);
+    });
+
+    it('parses a get expression with a specific type', () => {
+      const context = newParsingContext();
+      const expression = parse(['get', 'foo'], NumberArrayType, context);
+      expect(isType(expression.type, NumberArrayType)).to.be(true);
+      expect(context.properties.get('foo')).to.be(NumberArrayType);
     });
 
     it('parses a var expression', () => {
@@ -132,7 +139,7 @@ describe('ol/expr/expression.js', () => {
       expect(expression).to.be.a(CallExpression);
       expect(expression.operator).to.be('var');
       expect(isType(expression.type, AnyType)).to.be(true);
-      expect(context.variables.has('foo')).to.be(true);
+      expect(context.variables.get('foo')).to.be(AnyType);
     });
 
     it('parses an expression relying on map state', () => {
@@ -159,7 +166,7 @@ describe('ol/expr/expression.js', () => {
       expect(expression).to.be.a(CallExpression);
       expect(expression.operator).to.be('concat');
       expect(isType(expression.type, StringType));
-      expect(context.properties.has('foo')).to.be(true);
+      expect(context.properties.get('foo')).to.be(StringType);
     });
 
     it('is ok to have a concat expression with a string and number', () => {
@@ -187,7 +194,7 @@ describe('ol/expr/expression.js', () => {
       expect(expression).to.be.a(CallExpression);
       expect(expression.operator).to.be('coalesce');
       expect(isType(expression.type, StringType));
-      expect(context.properties.has('foo')).to.be(true);
+      expect(context.properties.get('foo')).to.be(StringType);
     });
 
     it('parses id expression', () => {
@@ -212,10 +219,10 @@ describe('ol/expr/expression.js', () => {
       expect(isType(expression.type, BooleanType)).to.be(true);
       expect(expression.args).to.have.length(2);
       expect(expression.args[0]).to.be.a(CallExpression);
-      expect(isType(expression.args[0].type, AnyType)).to.be(true);
+      expect(isType(expression.args[0].type, StringType)).to.be(true);
       expect(expression.args[1]).to.be.a(LiteralExpression);
       expect(isType(expression.args[1].type, StringType)).to.be(true);
-      expect(context.properties.has('foo')).to.be(true);
+      expect(context.properties.get('foo')).to.be(StringType);
     });
 
     describe('case operation', () => {
@@ -272,12 +279,14 @@ describe('ol/expr/expression.js', () => {
 
     describe('match operation', () => {
       it('respects the return type (string)', () => {
+        const context = newParsingContext();
         const expression = parse(
           ['match', ['get', 'attr'], 0, 'red', 1, 'yellow', 'not_a_color'],
           StringType,
-          newParsingContext(),
+          context,
         );
         expect(isType(expression.type, StringType)).to.be(true);
+        expect(context.properties.get('attr')).to.be(NumberType);
       });
 
       it('respects the return type (color array)', () => {
@@ -290,12 +299,14 @@ describe('ol/expr/expression.js', () => {
       });
 
       it('respects the return type (size)', () => {
+        const context = newParsingContext();
         const expression = parse(
           ['match', ['get', 'shape'], 'light', 0.5, 0.7],
           SizeType,
-          newParsingContext(),
+          context,
         );
         expect(isType(expression.type, SizeType)).to.be(true);
+        expect(context.properties.get('shape')).to.be(StringType);
       });
     });
 
@@ -315,6 +326,7 @@ describe('ol/expr/expression.js', () => {
         expect(isType(expression.args[1].type, NumberType)).to.be(true);
         expect(isType(expression.args[2].type, NumberType)).to.be(true);
         expect(isType(expression.args[3].type, NumberType)).to.be(true);
+        expect(context.properties.get('attr')).to.be(NumberType);
       });
 
       it('respects the return type (number haystack using literal operator)', () => {
@@ -350,15 +362,17 @@ describe('ol/expr/expression.js', () => {
         expect(isType(expression.args[2].type, StringType)).to.be(true);
         expect(isType(expression.args[3].type, StringType)).to.be(true);
         expect(isType(expression.args[4].type, StringType)).to.be(true);
+        expect(context.properties.get('attr')).to.be(StringType);
       });
     });
 
     describe('array operator', () => {
       it('respects the return type (number array)', () => {
+        const context = newParsingContext();
         const expression = parse(
           ['array', 1, 2, ['get', 'third'], 4, 5],
           NumberArrayType,
-          newParsingContext(),
+          context,
         );
         expect(expression.operator).to.be('array');
         expect(isType(expression.type, NumberArrayType)).to.be(true);
@@ -368,19 +382,22 @@ describe('ol/expr/expression.js', () => {
         expect(isType(expression.args[2].type, NumberType)).to.be(true);
         expect(isType(expression.args[3].type, NumberType)).to.be(true);
         expect(isType(expression.args[4].type, NumberType)).to.be(true);
+        expect(context.properties.get('third')).to.be(NumberType);
       });
 
       it('respects the return type (color)', () => {
+        const context = newParsingContext();
         const expression = parse(
           ['array', 1, 2, ['get', 'blue']],
           ColorType,
-          newParsingContext(),
+          context,
         );
         expect(isType(expression.type, ColorType)).to.be(true);
         expect(expression.args).to.have.length(3);
         expect(isType(expression.args[0].type, NumberType)).to.be(true);
         expect(isType(expression.args[1].type, NumberType)).to.be(true);
         expect(isType(expression.args[2].type, NumberType)).to.be(true);
+        expect(context.properties.get('blue')).to.be(NumberType);
       });
     });
   });

--- a/test/node/ol/expr/gpu.test.js
+++ b/test/node/ol/expr/gpu.test.js
@@ -1,6 +1,5 @@
 import {
   AnyType,
-  BooleanType,
   ColorType,
   NumberArrayType,
   NumberType,
@@ -138,9 +137,7 @@ describe('ol/expr/gpu.js', () => {
           },
         },
         contextAssertion: (context) => {
-          const variable = context.variables['myVar'];
-          expect(variable.name).to.equal('myVar');
-          expect(variable.type).to.equal(AnyType);
+          expect(context.variables.get('myVar')).to.equal(AnyType);
         },
       },
       {
@@ -644,34 +641,12 @@ describe('ol/expr/gpu.js', () => {
         },
         expected: `((u_var_symbolType == ${stringToGlsl('dynamic')}) ? vec2((a_prop_type == ${stringToGlsl('low')} ? u_var_lowHeight : (a_prop_type == ${stringToGlsl('medium')} ? u_var_mediumHeight : a_prop_height)), 10.0) : u_var_fixedSize)`,
         contextAssertion: (context) => {
-          expect(context.properties).to.eql({
-            type: {
-              name: 'type',
-              type: StringType | NumberType | BooleanType,
-            },
-            height: {
-              name: 'height',
-              type: NumberType,
-            },
-          });
-          expect(context.variables).to.eql({
-            fixedSize: {
-              name: 'fixedSize',
-              type: NumberArrayType,
-            },
-            symbolType: {
-              name: 'symbolType',
-              type: AnyType,
-            },
-            mediumHeight: {
-              name: 'mediumHeight',
-              type: NumberType,
-            },
-            lowHeight: {
-              name: 'lowHeight',
-              type: NumberType,
-            },
-          });
+          expect(context.properties.get('type')).to.eql(StringType);
+          expect(context.properties.get('height')).to.eql(NumberType);
+          expect(context.variables.get('fixedSize')).to.eql(NumberArrayType);
+          expect(context.variables.get('symbolType')).to.eql(StringType);
+          expect(context.variables.get('mediumHeight')).to.eql(NumberType);
+          expect(context.variables.get('lowHeight')).to.eql(NumberType);
         },
       },
       {
@@ -700,7 +675,6 @@ describe('ol/expr/gpu.js', () => {
         const compilationContext = c.context
           ? {...newCompilationContext(), ...c.context}
           : newCompilationContext();
-        parsingContext.style = compilationContext.style;
         const result = buildExpression(
           c.expression,
           c.type,
@@ -807,7 +781,6 @@ describe('ol/expr/gpu.js', () => {
         const compilationContext = c.context
           ? {...newCompilationContext(), ...c.context}
           : newCompilationContext();
-        parsingContext.style = compilationContext.style;
         const build = () =>
           buildExpression(
             c.expression,


### PR DESCRIPTION
This is a breakout PR from https://github.com/openlayers/openlayers/pull/16693

This PR:
* makes it so that the type for properties and variables is determined in the parsing stage; this means that it will be more precise later on when compiling for gpu or cpu
* adapts the code downstream for this change
* makes type determination stronger with the `match`, `==` and `!=` operators

