### PR TITLE
fix(webgl): renderer return null value if buffers not exist

### DIFF
--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -325,7 +325,7 @@ class VectorStyleRenderer {
   /**
    * @param {import('./MixedGeometryBatch.js').default} geometryBatch Geometry batch
    * @param {import("../../transform.js").Transform} transform Transform to apply to coordinates
-   * @return {Promise<WebGLBuffers>} A promise resolving to WebGL buffers; buffer sets are empty if nothing to render
+   * @return {Promise<WebGLBuffers>} A promise resolving to WebGL buffers; buffer sets are set to `null` if nothing to render
    */
   async generateBuffers(geometryBatch, transform) {
     // also return the inverse of the transform that was applied when generating buffers

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -68,9 +68,9 @@ export const Attributes = {
 
 /**
  * @typedef {Object} WebGLBuffers
- * @property {WebGLArrayBufferSet} polygonBuffers Array containing indices and vertices buffers for polygons
- * @property {WebGLArrayBufferSet} lineStringBuffers Array containing indices and vertices buffers for line strings
- * @property {WebGLArrayBufferSet} pointBuffers Array containing indices and vertices buffers for points
+ * @property {WebGLArrayBufferSet|null} polygonBuffers Array containing indices and vertices buffers for polygons
+ * @property {WebGLArrayBufferSet|null} lineStringBuffers Array containing indices and vertices buffers for line strings
+ * @property {WebGLArrayBufferSet|null} pointBuffers Array containing indices and vertices buffers for points
  * @property {import("../../transform.js").Transform} invertVerticesTransform Inverse of the transform applied when generating buffers
  */
 
@@ -325,11 +325,22 @@ class VectorStyleRenderer {
   /**
    * @param {import('./MixedGeometryBatch.js').default} geometryBatch Geometry batch
    * @param {import("../../transform.js").Transform} transform Transform to apply to coordinates
-   * @return {Promise<WebGLBuffers|null>} A promise resolving to WebGL buffers; returns null if buffers are empty
+   * @return {Promise<WebGLBuffers>} A promise resolving to WebGL buffers; buffer sets are empty if nothing to render
    */
   async generateBuffers(geometryBatch, transform) {
+    // also return the inverse of the transform that was applied when generating buffers
+    const invertVerticesTransform = makeInverseTransform(
+      createTransform(),
+      transform,
+    );
+
     if (geometryBatch.isEmpty()) {
-      return null;
+      return {
+        polygonBuffers: null,
+        lineStringBuffers: null,
+        pointBuffers: null,
+        invertVerticesTransform: invertVerticesTransform,
+      };
     }
     const renderInstructions = this.generateRenderInstructions_(
       geometryBatch,
@@ -353,11 +364,6 @@ class VectorStyleRenderer {
           transform,
         ),
       ],
-    );
-    // also return the inverse of the transform that was applied when generating buffers
-    const invertVerticesTransform = makeInverseTransform(
-      createTransform(),
-      transform,
     );
     return {
       polygonBuffers: polygonBuffers,
@@ -505,6 +511,7 @@ class VectorStyleRenderer {
   render(buffers, frameState, preRenderCallback) {
     for (const renderPass of this.renderPasses_) {
       renderPass.fillRenderPass &&
+        buffers.polygonBuffers &&
         this.renderInternal_(
           buffers.polygonBuffers[0],
           buffers.polygonBuffers[1],
@@ -514,6 +521,7 @@ class VectorStyleRenderer {
           preRenderCallback,
         );
       renderPass.strokeRenderPass &&
+        buffers.lineStringBuffers &&
         this.renderInternal_(
           buffers.lineStringBuffers[0],
           buffers.lineStringBuffers[1],
@@ -523,6 +531,7 @@ class VectorStyleRenderer {
           preRenderCallback,
         );
       renderPass.symbolRenderPass &&
+        buffers.pointBuffers &&
         this.renderInternal_(
           buffers.pointBuffers[0],
           buffers.pointBuffers[1],

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -356,6 +356,21 @@ describe('VectorStyleRenderer', () => {
       );
     });
     describe('generateBuffers', () => {
+      it('returns null buffers with invertVerticesTransform when the geometry batch is empty', async () => {
+        const emptyBatch = new MixedGeometryBatch();
+        const generatedBuffers = await vectorStyleRenderer.generateBuffers(
+          emptyBatch,
+          SAMPLE_TRANSFORM,
+        );
+        expect(generatedBuffers).not.to.be(null);
+        expect(generatedBuffers.polygonBuffers).to.be(null);
+        expect(generatedBuffers.lineStringBuffers).to.be(null);
+        expect(generatedBuffers.pointBuffers).to.be(null);
+        expect(generatedBuffers.invertVerticesTransform).to.eql(
+          makeInverseTransform(createTransform(), SAMPLE_TRANSFORM),
+        );
+      });
+
       let buffers;
       beforeEach(async () => {
         buffers = await vectorStyleRenderer.generateBuffers(


### PR DESCRIPTION
## Fix WebGL crash on empty vector tiles

This MR fixes a crash in `WebGLVectorTileLayer` when rendering empty vector tiles with the WebGL renderer.

When a vector tile contains no features, `generateBuffers()` returns `null`. However, during the upload step, the tile representation is still marked as `ready`.

Later, `renderTileMask()` only checks whether the tile representation is ready and assumes that `buffers` exists. It then tries to access:

```js
buffers.invertVerticesTransform
```

This causes the following runtime error:

```txt
TypeError: Cannot read properties of null (reading 'invertVerticesTransform')
```

The fix adds a guard to return early when the tile representation is ready but has no buffers:

```js
if (!tileRepresentation.ready || !tileRepresentation.buffers) {
  return;
}
```

Since an empty tile has no geometry to mask, skipping mask rendering is safe and prevents the WebGL render loop from crashing.

