### PR TITLE
Respect TileMatrixSetLimits when creating WMTS tile grids

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,17 @@
 
 ### Next Release
 
+#### `createFromCapabilitiesMatrixSet` now respects `TileMatrixSetLimits`
+
+When a `matrixLimits` array is passed to `createFromCapabilitiesMatrixSet`, the returned
+tile grid will now restrict tile requests to the `MinTileRow`/`MaxTileRow`/`MinTileCol`/`MaxTileCol`
+bounds advertised for each zoom level. Previously those bounds were ignored and the full
+matrix extent was used, causing tile requests outside the layer's data extent.
+
+If you were passing `matrixLimits` only to filter zoom levels and relied on the full matrix
+range being loaded at each level, you can omit the `matrixLimits` argument or pass an empty
+array to restore the previous behavior.
+
 ### 10.7.0
 
 #### Deprecation of ol/array's stableSort

--- a/src/ol/tilegrid/TileGrid.js
+++ b/src/ol/tilegrid/TileGrid.js
@@ -49,6 +49,9 @@ const DECIMALS = 5;
  * for which tile requests are made by sources. If the bottom-left corner of
  * an extent is used as `origin` or `origins`, then the `y` value must be
  * negative because OpenLayers tile coordinates use the top left as the origin.
+ * @property {Array<import("../TileRange.js").default>} [tileRanges] Pre-built tile ranges for each
+ * zoom level. When provided, these are used directly as the full tile ranges instead of computing
+ * them from `sizes`. Useful for setting per-level tile index bounds (e.g. from WMTS `TileMatrixSetLimits`).
  * @property {number|import("../size.js").Size} [tileSize] Tile size.
  * Default is `[256, 256]`.
  * @property {Array<number|import("../size.js").Size>} [tileSizes] Tile sizes. If given, the array length
@@ -207,7 +210,9 @@ class TileGrid {
      */
     this.tmpExtent_ = [0, 0, 0, 0];
 
-    if (options.sizes !== undefined) {
+    if (options.tileRanges !== undefined) {
+      this.fullTileRanges_ = options.tileRanges;
+    } else if (options.sizes !== undefined) {
       this.fullTileRanges_ = options.sizes.map((size, z) => {
         const tileRange = new TileRange(
           Math.min(0, size[0]),

--- a/src/ol/tilegrid/WMTS.js
+++ b/src/ol/tilegrid/WMTS.js
@@ -2,6 +2,7 @@
  * @module ol/tilegrid/WMTS
  */
 
+import TileRange from '../TileRange.js';
 import {get as getProjection} from '../proj.js';
 import TileGrid from './TileGrid.js';
 
@@ -33,6 +34,8 @@ import TileGrid from './TileGrid.js';
  * which tile requests are made by sources. If the bottom-left corner of
  * an extent is used as `origin` or `origins`, then the `y` value must be
  * negative because OpenLayers tile coordinates use the top left as the origin.
+ * @property {Array<import("../TileRange.js").default>} [tileRanges] Pre-built tile ranges for each
+ * zoom level. When provided, used instead of `sizes` to set per-level tile index bounds.
  * @property {number|import("../size.js").Size} [tileSize] Tile size.
  * @property {Array<number|import("../size.js").Size>} [tileSizes] Tile sizes. The length of
  * this array needs to match the length of the `resolutions` array.
@@ -56,6 +59,7 @@ class WMTSTileGrid extends TileGrid {
       tileSize: options.tileSize,
       tileSizes: options.tileSizes,
       sizes: options.sizes,
+      tileRanges: options.tileRanges,
       minZoom: options.minZoom,
     });
 
@@ -113,6 +117,8 @@ export function createFromCapabilitiesMatrixSet(
   const tileSizes = [];
   /** @type {!Array<import("../size.js").Size>} */
   const sizes = [];
+  /** @type {!Array<import("../TileRange.js").default>} */
+  const tileRanges = [];
 
   matrixLimits = matrixLimits !== undefined ? matrixLimits : [];
 
@@ -176,6 +182,16 @@ export function createFromCapabilitiesMatrixSet(
         tileWidth == tileHeight ? tileWidth : [tileWidth, tileHeight],
       );
       sizes.push([elt['MatrixWidth'], elt['MatrixHeight']]);
+      if (matrixLimits.length > 0) {
+        tileRanges.push(
+          new TileRange(
+            matrixAvailable['MinTileCol'],
+            matrixAvailable['MaxTileCol'],
+            matrixAvailable['MinTileRow'],
+            matrixAvailable['MaxTileRow'],
+          ),
+        );
+      }
     }
   });
 
@@ -185,6 +201,7 @@ export function createFromCapabilitiesMatrixSet(
     resolutions: resolutions,
     matrixIds: matrixIds,
     tileSizes: tileSizes,
-    sizes: sizes,
+    sizes: tileRanges.length === 0 ? sizes : undefined,
+    tileRanges: tileRanges.length > 0 ? tileRanges : undefined,
   });
 }

--- a/test/browser/spec/ol/tilegrid/wmts.test.js
+++ b/test/browser/spec/ol/tilegrid/wmts.test.js
@@ -143,6 +143,11 @@ describe('ol.tilegrid.WMTS', function () {
       expect(tileGrid.tileSizes_).to.eql(
         Array.apply(null, Array(22)).map(Number.prototype.valueOf, 256),
       );
+
+      // Without limits, full matrix ranges start at [0, 0]
+      const r0 = tileGrid.getFullTileRange(0);
+      expect(r0.minX).to.equal(0);
+      expect(r0.minY).to.equal(0);
     });
 
     it('can create tileGrid for EPSG:3857 with matrixLimits', function () {
@@ -204,6 +209,34 @@ describe('ol.tilegrid.WMTS', function () {
       expect(tileGrid.tileSizes_).to.eql(
         Array.apply(null, Array(20)).map(Number.prototype.valueOf, 256),
       );
+
+      // z=0 → TileMatrix '0': all-zero minimums
+      const r0 = tileGrid.getFullTileRange(0);
+      expect(r0.minX).to.equal(0);
+      expect(r0.maxX).to.equal(1);
+      expect(r0.minY).to.equal(0);
+      expect(r0.maxY).to.equal(1);
+
+      // z=6 → TileMatrix '6': MinTileRow=1 (non-zero row minimum)
+      const r6 = tileGrid.getFullTileRange(6);
+      expect(r6.minX).to.equal(0);
+      expect(r6.maxX).to.equal(64);
+      expect(r6.minY).to.equal(1);
+      expect(r6.maxY).to.equal(64);
+
+      // z=13 → TileMatrix '13': both MinTileRow and MinTileCol non-zero
+      const r13 = tileGrid.getFullTileRange(13);
+      expect(r13.minX).to.equal(41);
+      expect(r13.maxX).to.equal(7917);
+      expect(r13.minY).to.equal(2739);
+      expect(r13.maxY).to.equal(4628);
+
+      // z=19 → TileMatrix '19': large non-zero offsets
+      const r19 = tileGrid.getFullTileRange(19);
+      expect(r19.minX).to.equal(170159);
+      expect(r19.maxX).to.equal(343473);
+      expect(r19.minY).to.equal(175302);
+      expect(r19.maxY).to.equal(294060);
     });
 
     it('can use prefixed matrixLimits', function () {
@@ -239,6 +272,20 @@ describe('ol.tilegrid.WMTS', function () {
       expect(tileGrid.tileSizes_).to.eql(
         Array.apply(null, Array(2)).map(Number.prototype.valueOf, 256),
       );
+
+      // Prefixed:0 limits
+      const r0 = tileGrid.getFullTileRange(0);
+      expect(r0.minX).to.equal(0);
+      expect(r0.maxX).to.equal(1);
+      expect(r0.minY).to.equal(0);
+      expect(r0.maxY).to.equal(1);
+
+      // Prefixed:1 limits
+      const r1 = tileGrid.getFullTileRange(1);
+      expect(r1.minX).to.equal(0);
+      expect(r1.maxX).to.equal(2);
+      expect(r1.minY).to.equal(0);
+      expect(r1.maxY).to.equal(2);
     });
   });
 });


### PR DESCRIPTION
When matrixLimits are passed to createFromCapabilitiesMatrixSet, use the per-level MinTileRow/MaxTileRow/MinTileCol/MaxTileCol bounds to restrict tile requests instead of loading the full matrix extent.

Fixes #9949

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
