### PR TITLE
Fix VectorSource#hasFeature to use identity check when feature has an id

### DIFF
--- a/src/ol/source/Vector.js
+++ b/src/ol/source/Vector.js
@@ -956,7 +956,11 @@ class VectorSource extends Source {
   hasFeature(feature) {
     const id = feature.getId();
     if (id !== undefined) {
-      return id in this.idIndex_;
+      const indexed = this.idIndex_[String(id)];
+      if (Array.isArray(indexed)) {
+        return indexed.includes(feature);
+      }
+      return indexed === feature;
     }
     return getUid(feature) in this.uidIndex_;
   }

--- a/test/browser/spec/ol/interaction/select.test.js
+++ b/test/browser/spec/ol/interaction/select.test.js
@@ -416,6 +416,31 @@ describe('ol.interaction.Select', function () {
       expect(features.getArray()).to.be.empty();
       expect(interaction.getLayer(feature)).to.be(undefined);
     });
+
+    it('returns the correct layer when two layers have features with the same id', function () {
+      const featureA = new Feature();
+      featureA.setId('shared-id');
+      const sourceA = new VectorSource({features: [featureA]});
+      const layerA = new VectorLayer({source: sourceA});
+
+      const featureB = new Feature();
+      featureB.setId('shared-id');
+      const sourceB = new VectorSource({features: [featureB]});
+      const layerB = new VectorLayer({source: sourceB});
+
+      map.addLayer(layerA);
+      map.addLayer(layerB);
+
+      interaction.getFeatures().push(featureA);
+      expect(interaction.getLayer(featureA)).to.equal(layerA);
+
+      interaction.getFeatures().clear();
+      interaction.getFeatures().push(featureB);
+      expect(interaction.getLayer(featureB)).to.equal(layerB);
+
+      map.removeLayer(layerA);
+      map.removeLayer(layerB);
+    });
   });
 
   describe('#setActive()', function () {

--- a/test/browser/spec/ol/source/vector.test.js
+++ b/test/browser/spec/ol/source/vector.test.js
@@ -156,6 +156,15 @@ describe('ol/source/Vector', function () {
         const feature = new Feature();
         expect(vectorSource.hasFeature(feature)).to.be(false);
       });
+
+      it('returns false for a different feature with the same id', function () {
+        const feature = new Feature();
+        feature.setId('1');
+        vectorSource.addFeature(feature);
+        const otherFeature = new Feature();
+        otherFeature.setId('1');
+        expect(vectorSource.hasFeature(otherFeature)).to.be(false);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #16858

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
