### PR TITLE
Deprecate BingMaps source and migrate mobile-full-screen example to OSM

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,26 @@
 
 ### Next Release
 
+#### Deprecation of `ol/source/BingMaps`
+
+Bing Maps for Enterprise is being retired on June 30th, 2028. The `BingMaps` source
+has been deprecated. Use `ol/source/ImageTile` with the Azure Maps tile API instead.
+See the [azure-maps example](https://openlayers.org/en/latest/examples/azure-maps.html) for guidance.
+
+```js
+// Before
+new BingMaps({
+  key: 'YOUR_BING_MAPS_KEY',
+  imagerySet: 'RoadOnDemand',
+})
+
+// After
+new ImageTile({
+  url: `https://atlas.microsoft.com/map/tile?subscription-key=YOUR_AZURE_MAPS_KEY&api-version=2.0&tilesetId=microsoft.base.road&zoom={z}&x={x}&y={y}&tileSize=256`,
+  attributions: `© ${new Date().getFullYear()} TomTom, Microsoft`,
+})
+```
+
 #### `createFromCapabilitiesMatrixSet` now respects `TileMatrixSetLimits`
 
 When a `matrixLimits` array is passed to `createFromCapabilitiesMatrixSet`, the returned

--- a/examples/mobile-full-screen.html
+++ b/examples/mobile-full-screen.html
@@ -3,9 +3,6 @@ layout: example-verbatim.html
 title: Full-Screen Mobile
 shortdesc: Example of a full screen map.
 tags: "fullscreen, geolocation, mobile"
-cloak:
-  - key: AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN
-    value: Your Bing Maps Key from https://www.bingmapsportal.com/ here
 ---
 <!DOCTYPE html>
 <html lang="en">

--- a/examples/mobile-full-screen.js
+++ b/examples/mobile-full-screen.js
@@ -2,7 +2,7 @@ import Geolocation from '../src/ol/Geolocation.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
-import BingMaps from '../src/ol/source/BingMaps.js';
+import OSM from '../src/ol/source/OSM.js';
 
 const view = new View({
   center: [0, 0],
@@ -12,10 +12,7 @@ const view = new View({
 const map = new Map({
   layers: [
     new TileLayer({
-      source: new BingMaps({
-        key: 'AlEoTLTlzFB6Uf4Sy-ugXcRO21skQO7K8eObA5_L-8d20rjqZJLs2nkO1RMjGSPN',
-        imagerySet: 'RoadOnDemand',
-      }),
+      source: new OSM(),
     }),
   ],
   target: 'map',

--- a/src/ol/source/BingMaps.js
+++ b/src/ol/source/BingMaps.js
@@ -114,6 +114,9 @@ const TOS_ATTRIBUTION =
 /**
  * @classdesc
  * Layer source for Bing Maps tile data.
+ * @deprecated Bing Maps for Enterprise is being retired on June 30th, 2028. Use
+ * `ol/source/ImageTile` with the Azure Maps tile API instead. See the azure-maps
+ * example for guidance.
  * @api
  */
 class BingMaps extends TileImage {


### PR DESCRIPTION
Bing Maps for Enterprise is being retired on June 30th, 2028. Mark BingMaps source as deprecated and update the mobile-full-screen example to use OSM instead.

fixes #15853

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
