### PR TITLE
Add wrapX option to getPixelFromCoordinate and getCoordinateFromPixel

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -18,6 +18,7 @@ import {equals} from './array.js';
 import {assert} from './asserts.js';
 import {warn} from './console.js';
 import {defaults as defaultControls} from './control/defaults.js';
+import {wrapX as wrapXCoordinate, wrapXNearest} from './coordinate.js';
 import {isCanvas} from './dom.js';
 import {listen, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
@@ -38,7 +39,11 @@ import {defaults as defaultInteractions} from './interaction/defaults.js';
 import LayerGroup, {GroupEvent} from './layer/Group.js';
 import Layer from './layer/Layer.js';
 import PointerEventType from './pointer/EventType.js';
-import {fromUserCoordinate, toUserCoordinate} from './proj.js';
+import {
+  fromUserCoordinate,
+  getUserProjection,
+  toUserCoordinate,
+} from './proj.js';
 import RenderEventType from './render/EventType.js';
 import CompositeMapRenderer from './renderer/Composite.js';
 import {hasArea} from './size.js';
@@ -91,6 +96,21 @@ import {getUid} from './util.js';
  * inside the radius around the given position will be checked for features.
  * @property {boolean} [checkWrapped=true] Check-Wrapped Will check for wrapped geometries inside the range of
  *   +/- 1 world width. Works only if a projection is used that can be wrapped.
+ */
+
+/**
+ * @typedef {Object} PixelToCoordinateOptions
+ * @property {boolean} [wrapX=false] Whether to wrap the coordinate to the
+ * projection extent. If `true`, the returned coordinate's longitude will be
+ * within the extent of the projection (e.g. `-180` to `180` for EPSG:4326).
+ */
+
+/**
+ * @typedef {Object} CoordinateToPixelOptions
+ * @property {boolean} [wrapX=false] Whether to find the pixel for the
+ * world copy of the coordinate nearest to the view center. If `true`, the
+ * returned pixel will be within the map viewport even if the coordinate is
+ * in a different world copy.
  */
 
 /**
@@ -877,14 +897,20 @@ class Map extends BaseObject {
    * Get the coordinate for a given pixel.  This returns a coordinate in the
    * user projection.
    * @param {import("./pixel.js").Pixel} pixel Pixel position in the map viewport.
+   * @param {PixelToCoordinateOptions} [options] Options.
    * @return {import("./coordinate.js").Coordinate} The coordinate for the pixel position.
    * @api
    */
-  getCoordinateFromPixel(pixel) {
-    return toUserCoordinate(
+  getCoordinateFromPixel(pixel, options) {
+    const coordinate = toUserCoordinate(
       this.getCoordinateFromPixelInternal(pixel),
       this.getView().getProjection(),
     );
+    if (options?.wrapX && coordinate) {
+      const projection = getUserProjection() || this.getView().getProjection();
+      wrapXCoordinate(coordinate, projection);
+    }
+    return coordinate;
   }
 
   /**
@@ -1009,14 +1035,21 @@ class Map extends BaseObject {
    * Get the pixel for a coordinate.  This takes a coordinate in the user
    * projection and returns the corresponding pixel.
    * @param {import("./coordinate.js").Coordinate} coordinate A map coordinate.
+   * @param {CoordinateToPixelOptions} [options] Options.
    * @return {import("./pixel.js").Pixel} A pixel position in the map viewport.
    * @api
    */
-  getPixelFromCoordinate(coordinate) {
-    const viewCoordinate = fromUserCoordinate(
-      coordinate,
-      this.getView().getProjection(),
-    );
+  getPixelFromCoordinate(coordinate, options) {
+    const view = this.getView();
+    const projection = view.getProjection();
+    let viewCoordinate = fromUserCoordinate(coordinate, projection);
+    if (options?.wrapX && this.frameState_) {
+      viewCoordinate = wrapXNearest(
+        viewCoordinate.slice(),
+        projection,
+        this.frameState_.viewState.center[0],
+      );
+    }
     return this.getPixelFromCoordinateInternal(viewCoordinate);
   }
 

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -18,6 +18,7 @@ import {equals} from './array.js';
 import {assert} from './asserts.js';
 import {warn} from './console.js';
 import {defaults as defaultControls} from './control/defaults.js';
+import {wrapX as wrapXCoordinate, wrapXNearest} from './coordinate.js';
 import {isCanvas} from './dom.js';
 import {listen, unlistenByKey} from './events.js';
 import EventType from './events/EventType.js';
@@ -38,7 +39,11 @@ import {defaults as defaultInteractions} from './interaction/defaults.js';
 import LayerGroup, {GroupEvent} from './layer/Group.js';
 import Layer from './layer/Layer.js';
 import PointerEventType from './pointer/EventType.js';
-import {fromUserCoordinate, toUserCoordinate} from './proj.js';
+import {
+  fromUserCoordinate,
+  getUserProjection,
+  toUserCoordinate,
+} from './proj.js';
 import RenderEventType from './render/EventType.js';
 import CompositeMapRenderer from './renderer/Composite.js';
 import {hasArea} from './size.js';
@@ -91,6 +96,21 @@ import {getUid} from './util.js';
  * inside the radius around the given position will be checked for features.
  * @property {boolean} [checkWrapped=true] Check-Wrapped Will check for wrapped geometries inside the range of
  *   +/- 1 world width. Works only if a projection is used that can be wrapped.
+ */
+
+/**
+ * @typedef {Object} PixelToCoordinateOptions
+ * @property {boolean} [wrapX=false] Whether to wrap the coordinate to the
+ * projection extent. If `true`, the returned coordinate's longitude will be
+ * within the extent of the projection (e.g. `-180` to `180` for EPSG:4326).
+ */
+
+/**
+ * @typedef {Object} CoordinateToPixelOptions
+ * @property {boolean} [wrapX=false] Whether to find the pixel for the
+ * world copy of the coordinate nearest to the view center. If `true`, the
+ * returned pixel will be within the map viewport even if the coordinate is
+ * in a different world copy.
  */
 
 /**
@@ -903,16 +923,22 @@ class Map extends BaseObject {
    * Get the coordinate for a given pixel.  This returns a coordinate in the
    * user projection.
    * @param {import("./pixel.js").Pixel} pixel Pixel position in the map viewport.
+   * @param {PixelToCoordinateOptions} [options] Options.
    * @return {import("./coordinate.js").Coordinate} The coordinate for the pixel position.
    * @api
    */
-  getCoordinateFromPixel(pixel) {
-    return toUserCoordinate(
+  getCoordinateFromPixel(pixel, options) {
+    const coordinate = toUserCoordinate(
       /** @type {import("./coordinate.js").Coordinate} */ (
         this.getCoordinateFromPixelInternal(pixel)
       ),
       this.getView().getProjection(),
     );
+    if (options?.wrapX && coordinate) {
+      const projection = getUserProjection() || this.getView().getProjection();
+      wrapXCoordinate(coordinate, projection);
+    }
+    return coordinate;
   }
 
   /**
@@ -1053,14 +1079,21 @@ class Map extends BaseObject {
    * Get the pixel for a coordinate.  This takes a coordinate in the user
    * projection and returns the corresponding pixel.
    * @param {import("./coordinate.js").Coordinate} coordinate A map coordinate.
+   * @param {CoordinateToPixelOptions} [options] Options.
    * @return {import("./pixel.js").Pixel} A pixel position in the map viewport.
    * @api
    */
-  getPixelFromCoordinate(coordinate) {
-    const viewCoordinate = fromUserCoordinate(
-      coordinate,
-      this.getView().getProjection(),
-    );
+  getPixelFromCoordinate(coordinate, options) {
+    const view = this.getView();
+    const projection = view.getProjection();
+    let viewCoordinate = fromUserCoordinate(coordinate, projection);
+    if (options?.wrapX && this.frameState_) {
+      viewCoordinate = wrapXNearest(
+        viewCoordinate.slice(),
+        projection,
+        this.frameState_.viewState.center[0],
+      );
+    }
     return /** @type {import("./pixel.js").Pixel} */ (
       this.getPixelFromCoordinateInternal(viewCoordinate)
     );

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -515,7 +515,7 @@ class Overlay extends BaseObject {
       return;
     }
 
-    const pixel = map.getPixelFromCoordinate(position);
+    const pixel = map.getPixelFromCoordinate(position, {wrapX: true});
     const mapSize = map.getSize();
     this.updateRenderedPosition(pixel, mapSize);
   }

--- a/src/ol/Overlay.js
+++ b/src/ol/Overlay.js
@@ -528,7 +528,7 @@ class Overlay extends BaseObject {
       return;
     }
 
-    const pixel = map.getPixelFromCoordinate(position);
+    const pixel = map.getPixelFromCoordinate(position, {wrapX: true});
     const mapSize = map.getSize();
     this.updateRenderedPosition(pixel, mapSize);
   }

--- a/src/ol/coordinate.js
+++ b/src/ol/coordinate.js
@@ -418,6 +418,27 @@ export function wrapX(coordinate, projection) {
   return coordinate;
 }
 /**
+ * Modifies the provided coordinate in-place to be the world copy nearest to
+ * the given reference X position. Useful for getting the screen pixel of a
+ * coordinate when the map has been panned past the antimeridian.
+ *
+ * @param {Coordinate} coordinate Coordinate (modified in place).
+ * @param {import("./proj/Projection.js").default} projection Projection.
+ * @param {number} referenceX Reference X position to find the nearest world to.
+ * @return {Coordinate} The coordinate in the nearest world copy.
+ */
+export function wrapXNearest(coordinate, projection, referenceX) {
+  if (projection.canWrapX()) {
+    const worldWidth = getWidth(projection.getExtent());
+    const n = Math.round((referenceX - coordinate[0]) / worldWidth);
+    if (n !== 0) {
+      coordinate[0] += n * worldWidth;
+    }
+  }
+  return coordinate;
+}
+
+/**
  * @param {Coordinate} coordinate Coordinate.
  * @param {import("./proj/Projection.js").default} projection Projection.
  * @param {number} [sourceExtentWidth] Width of the source extent.

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1707,6 +1707,64 @@ describe('ol/Map', function () {
         done();
       });
     });
+
+    describe('getCoordinateFromPixel() and getPixelFromCoordinate() with wrapX', function () {
+      let target, map;
+
+      beforeEach(function () {
+        target = document.createElement('div');
+        target.style.width = '100px';
+        target.style.height = '100px';
+        document.body.appendChild(target);
+
+        useGeographic();
+
+        map = new Map({
+          target: target,
+          view: new View({
+            center: [200, 0],
+            zoom: 1,
+          }),
+          layers: [],
+        });
+      });
+
+      afterEach(function () {
+        disposeMap(map);
+        clearUserProjection();
+      });
+
+      it('getPixelFromCoordinate with wrapX returns screen pixel for wrapped coordinate', function (done) {
+        map.renderSync();
+        const size = map.getSize();
+        const centerPixel = [size[0] / 2, size[1] / 2];
+        // lon=-160 is one world (360°) to the left of view center lon=200
+        // without wrapX the pixel is far off-screen; with wrapX it maps to center
+        const coordinate = [-160, 0];
+        const pixelWithoutWrap = map.getPixelFromCoordinate(coordinate);
+        const pixelWithWrap = map.getPixelFromCoordinate(coordinate, {
+          wrapX: true,
+        });
+        expect(pixelWithoutWrap[0]).to.not.roughlyEqual(centerPixel[0], 1);
+        expect(pixelWithWrap[0]).to.roughlyEqual(centerPixel[0], 1);
+        expect(pixelWithWrap[1]).to.roughlyEqual(centerPixel[1], 1);
+        done();
+      });
+
+      it('getCoordinateFromPixel with wrapX returns canonical coordinate', function (done) {
+        map.renderSync();
+        const size = map.getSize();
+        const centerPixel = [size[0] / 2, size[1] / 2];
+        // center pixel maps to lon=200 (extended); wrapX wraps it to lon=-160
+        const coordinateWithoutWrap = map.getCoordinateFromPixel(centerPixel);
+        const coordinateWithWrap = map.getCoordinateFromPixel(centerPixel, {
+          wrapX: true,
+        });
+        expect(coordinateWithoutWrap[0]).to.roughlyEqual(200, 1e-5);
+        expect(coordinateWithWrap[0]).to.roughlyEqual(-160, 1e-5);
+        done();
+      });
+    });
   });
 
   describe('#handleMapBrowserEvent()', function () {

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1819,6 +1819,62 @@ describe('ol/Map', function () {
           resolve();
         }));
     });
+
+    describe('getCoordinateFromPixel() and getPixelFromCoordinate() with wrapX', function () {
+      let target, map;
+
+      beforeEach(function () {
+        target = document.createElement('div');
+        target.style.width = '100px';
+        target.style.height = '100px';
+        document.body.appendChild(target);
+
+        useGeographic();
+
+        map = new Map({
+          target: target,
+          view: new View({
+            center: [200, 0],
+            zoom: 1,
+          }),
+          layers: [],
+        });
+      });
+
+      afterEach(function () {
+        disposeMap(map);
+        clearUserProjection();
+      });
+
+      it('getPixelFromCoordinate with wrapX returns screen pixel for wrapped coordinate', function () {
+        map.renderSync();
+        const size = map.getSize();
+        const centerPixel = [size[0] / 2, size[1] / 2];
+        // lon=-160 is one world (360°) to the left of view center lon=200
+        // without wrapX the pixel is far off-screen; with wrapX it maps to center
+        const coordinate = [-160, 0];
+        const pixelWithoutWrap = map.getPixelFromCoordinate(coordinate);
+        const pixelWithWrap = map.getPixelFromCoordinate(coordinate, {
+          wrapX: true,
+        });
+        expect(pixelWithoutWrap[0]).to.not.be.closeTo(centerPixel[0], 1);
+        expect(pixelWithWrap[0]).to.be.closeTo(centerPixel[0], 1);
+        expect(pixelWithWrap[1]).to.be.closeTo(centerPixel[1], 1);
+      });
+
+      it('getCoordinateFromPixel with wrapX returns canonical coordinate', function () {
+        map.renderSync();
+        const size = map.getSize();
+        const centerPixel = [size[0] / 2, size[1] / 2];
+        // center pixel maps to lon=200 (extended); wrapX wraps it to lon=-160
+        const coordinateWithoutWrap = map.getCoordinateFromPixel(centerPixel);
+        const coordinateWithWrap = map.getCoordinateFromPixel(centerPixel, {
+          wrapX: true,
+        });
+        expect(coordinateWithoutWrap[0]).to.be.closeTo(200, 1e-5);
+        expect(coordinateWithWrap[0]).to.be.closeTo(-160, 1e-5);
+      });
+    });
   });
 
   describe('#handleMapBrowserEvent()', function () {


### PR DESCRIPTION
Adds a `wrapX` option to `Map#getPixelFromCoordinate` (to return the screen pixel for the world copy of a coordinate nearest to the view center) and `Map#getCoordinateFromPixel` (to wrap the result to the projection extent). Adds a `wrapXNearest` helper to `ol/coordinate` for reuse.

Also fixes `Overlay` to use `{wrapX: true}` so overlays appear at the visible world copy nearest to the view center when the map is panned past the antimeridian.

Fixes #3944. Fixes #4498. Fixes #16462.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
