### PR TITLE
Use the correct GeoTIFF alpha band in WebGLTile layer

### DIFF
--- a/src/ol/layer/WebGLTile.js
+++ b/src/ol/layer/WebGLTile.js
@@ -268,6 +268,8 @@ function parseStyle(style, bandCount, nodataBandIndex) {
         Uniforms.TILE_TEXTURE_ARRAY
       }[0],  v_textureCoord);
 
+      ${nodataBandIndex && style.color === undefined ? `color.a = getBandValue(${nodataBandIndex}.0, 0.0, 0.0);` : ''}
+
       ${nodataBandIndex ? `if (getBandValue(${nodataBandIndex}.0, 0.0, 0.0) == 0.0) { discard; }` : ''}
 
       ${pipeline.join('\n')}

--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -865,6 +865,7 @@ class GeoTIFFSource extends DataTile {
       bandCount += samplesPerPixel[sourceIndex];
     }
     this.bandCount = bandCount;
+    this.nodataBandIndex = this.addAlpha_ ? this.bandCount : undefined;
 
     const tileGrid = new TileGrid({
       extent: extent,

--- a/test/browser/spec/ol/layer/WebGLTile.test.js
+++ b/test/browser/spec/ol/layer/WebGLTile.test.js
@@ -605,6 +605,50 @@ describe('ol/layer/WebGLTile', function () {
       nodataLayer.dispose();
     });
 
+    it('uses the nodata band for default alpha when it is outside the first texture', function () {
+      const source = new DataTileSource({
+        bandCount: 5,
+        loader(z, x, y) {
+          return new Float32Array(256 * 256 * 5);
+        },
+      });
+      source.nodataBandIndex = 5;
+
+      const nodataLayer = new WebGLTileLayer({
+        source: source,
+      });
+
+      map.addLayer(nodataLayer);
+
+      const compileShaderSpy = sinonSpy(WebGLHelper.prototype, 'compileShader');
+      const renderer = nodataLayer.getRenderer();
+      const viewState = map.getView().getState();
+      const size = map.getSize();
+      const frameState = {
+        viewState: viewState,
+        extent: getForViewAndSize(
+          viewState.center,
+          viewState.resolution,
+          viewState.rotation,
+          size,
+        ),
+        layerStatesArray: map.getLayerGroup().getLayerStatesArray(),
+        layerIndex: 0,
+      };
+      renderer.prepareFrame(frameState);
+      compileShaderSpy.restore();
+
+      const fragmentShader = compileShaderSpy.getCall(0).args[0];
+      expect(fragmentShader).to.contain(
+        'color.a = getBandValue(5.0, 0.0, 0.0);',
+      );
+      expect(fragmentShader).to.contain(
+        'if (getBandValue(5.0, 0.0, 0.0) == 0.0) { discard; }',
+      );
+
+      nodataLayer.dispose();
+    });
+
     it('does not add discard when source has no nodataBandIndex', function () {
       const source = new DataTileSource({
         bandCount: 3,

--- a/test/browser/spec/ol/source/GeoTIFF.test.js
+++ b/test/browser/spec/ol/source/GeoTIFF.test.js
@@ -205,6 +205,7 @@ describe('ol/source/GeoTIFF', function () {
       source.on('change', () => {
         expect(source.addAlpha_).to.be(true);
         expect(source.bandCount).to.be(4);
+        expect(source.nodataBandIndex).to.be(4);
         expect(source.nodataValues_).to.eql([[0]]);
         expect(source.getTileGrid().getResolutions().length).to.be(1);
         expect(source.projection.getCode()).to.be('EPSG:4326');


### PR DESCRIPTION
An user of STAC Browser reported "washed out" GeoTIFF visualizations specifically for images that were RGB but had additional bands while pure RGB images were fine. See https://github.com/radiantearth/stac-browser/issues/898 for context.

After investigation in the depths of ol and geotiff.js, it looked like OpenLayers requires data to be passed via the DataTile classes with 4 bands (as red, green, blue, alpha) but the GeoTiff Source when e.g. provided with a 4 band image (e.g. red, green, blue, nir) adds the alpha at the end (red, green, blue, nir, alpha). This means that the nir bands is used as alpha band, which is obviously incorrect and lead to the washed out effect as the nir values were use for alpha transparency.

With some help of AI for the WebGL related changes, I came up with the solution proposed in this PR. Not sure whether it's the best solution, but if it's not ideal I hope this leads others into the right direction for a fix.