### PR TITLE
Hide black areas outside of the footprint of GeoTiffs without nodata value

### DIFF
--- a/src/ol/source/GeoTIFF.js
+++ b/src/ol/source/GeoTIFF.js
@@ -731,6 +731,16 @@ class GeoTIFFSource extends DataTile {
 
         sourceTileSizes[level] = sourceTileSize;
 
+        // Edge tiles can include out-of-bounds pixels when image dimensions
+        // are not exact multiples of the tile size. Add alpha so these pixels
+        // can render transparent instead of opaque black.
+        if (
+          image.getWidth() % sourceTileSize[0] !== 0 ||
+          image.getHeight() % sourceTileSize[1] !== 0
+        ) {
+          this.addAlpha_ = true;
+        }
+
         const aspectRatio = imageResolutions[0] / Math.abs(imageResolutions[1]);
         renderTileSizes[level] = [
           sourceTileSize[0],
@@ -987,6 +997,36 @@ class GeoTIFFSource extends DataTile {
       const maskIndex = sourceCount + sourceIndex;
       const mask = this.sourceMasks_[sourceIndex][z];
       if (!mask) {
+        if (this.addAlpha_) {
+          const width = image.getWidth();
+          const height = image.getHeight();
+          if (
+            pixelBounds[0] < 0 ||
+            pixelBounds[1] < 0 ||
+            pixelBounds[2] > width ||
+            pixelBounds[3] > height
+          ) {
+            const syntheticMask = new Uint8Array(
+              sourceTileSize[0] * sourceTileSize[1],
+            );
+            let maskDataIndex = 0;
+            for (let row = 0; row < sourceTileSize[1]; ++row) {
+              const sourceY = pixelBounds[1] + row;
+              for (let column = 0; column < sourceTileSize[0]; ++column) {
+                const sourceX = pixelBounds[0] + column;
+                syntheticMask[maskDataIndex++] =
+                  sourceX >= 0 &&
+                  sourceX < width &&
+                  sourceY >= 0 &&
+                  sourceY < height
+                    ? 1
+                    : 0;
+              }
+            }
+            requests[maskIndex] = Promise.resolve([syntheticMask]);
+            continue;
+          }
+        }
         requests[maskIndex] = Promise.resolve(null);
         continue;
       }


### PR DESCRIPTION
A user of STAC Browser reported several GeoTIFF visualizations issues for GeoTiff images. See https://github.com/radiantearth/stac-browser/issues/901, point 3 for context.

When I display a GeoTIff that has no nodata value set, it shows the data correctly within the footprint of the data. The extents may not align with the map tiles though (i.e. is usually smaller) and the area outside of the footprint for all tiles that have any data, shows as black (nodata). The area outside of the footprint should not show black but transparent.
While investigating, I set the nodata value (here: 0) manually and it worked without issues, so the approach here is to just create a mask when no nodata value is set for outside the image footprint. Implemented with AI assistance.

Potentially closes #15737. 