### PR TITLE
Make resize observer cross-realm safe for maps in a separate window

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1404,7 +1404,7 @@ class Map extends BaseObject {
             this,
           ),
         ];
-        if (targetElement instanceof HTMLElement) {
+        if (!isCanvas(targetElement)) {
           const rootNode = targetElement.getRootNode();
           if (rootNode instanceof ShadowRoot) {
             this.resizeObserver_.observe(rootNode.host);

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1841,6 +1841,23 @@ describe('ol/Map', function () {
           }, 100);
         });
       });
+      it('observes size changes of a map in a separate window', (done) => {
+        document.body.removeChild(map.getTargetElement());
+        map.setTarget(null);
+        const win = iframe.contentWindow;
+        win.addEventListener('DOMContentLoaded', () => {
+          const externalTarget = iframe.contentDocument.getElementById('map');
+          map.setTarget(externalTarget);
+          map.once('change:size', () => {
+            expect(map.getSize()).to.eql([50, 50]);
+            done();
+          });
+          // Trigger a resize in the external window; the ResizeObserver must
+          // pick this up even though the target belongs to another realm.
+          iframe.width = '50';
+          iframe.height = '50';
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Between v10.6.1 and v10.7.0, the https://openlayers.org/en/v10.7.0/examples/external-map.html example broke (ddcfc05d9c730c40d54b8b7004b1ce0d2ba005c9): the external map cannot be resized any more.

This pull request fixes that.