### PR TITLE
Fix LinearRing extent intersections

### DIFF
--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -163,8 +163,7 @@ class LinearRing extends SimpleGeometry {
 
   /**
    * Test if the geometry and the passed extent intersect. A linear ring is
-   * treated as a closed line string for this test; only the ring boundary is
-   * considered.
+   * treated as a line string for this test.
    * @param {import("../extent.js").Extent} extent Extent.
    * @return {boolean} `true` if the geometry and the extent intersect.
    * @api

--- a/src/ol/geom/LinearRing.js
+++ b/src/ol/geom/LinearRing.js
@@ -7,6 +7,7 @@ import {linearRing as linearRingArea} from './flat/area.js';
 import {assignClosestPoint, maxSquaredDelta} from './flat/closest.js';
 import {deflateCoordinates} from './flat/deflate.js';
 import {inflateCoordinates} from './flat/inflate.js';
+import {intersectsLineString} from './flat/intersectsextent.js';
 import {douglasPeucker} from './flat/simplify.js';
 
 /**
@@ -161,14 +162,22 @@ class LinearRing extends SimpleGeometry {
   }
 
   /**
-   * Test if the geometry and the passed extent intersect.
+   * Test if the geometry and the passed extent intersect. A linear ring is
+   * treated as a closed line string for this test; only the ring boundary is
+   * considered.
    * @param {import("../extent.js").Extent} extent Extent.
    * @return {boolean} `true` if the geometry and the extent intersect.
    * @api
    * @override
    */
   intersectsExtent(extent) {
-    return false;
+    return intersectsLineString(
+      this.flatCoordinates,
+      0,
+      this.flatCoordinates.length,
+      this.stride,
+      extent,
+    );
   }
 
   /**

--- a/test/node/ol/geom/LinearRing.test.js
+++ b/test/node/ol/geom/LinearRing.test.js
@@ -1,0 +1,29 @@
+import LinearRing from '../../../../src/ol/geom/LinearRing.js';
+import expect from '../../expect.js';
+
+describe('ol/geom/LinearRing.js', function () {
+  describe('#intersectsExtent', function () {
+    let linearRing;
+    beforeEach(function () {
+      linearRing = new LinearRing([
+        [0, 0],
+        [10, 0],
+        [10, 10],
+        [0, 10],
+        [0, 0],
+      ]);
+    });
+
+    it('returns true when the extent intersects the boundary', function () {
+      expect(linearRing.intersectsExtent([4, -1, 6, 1])).to.be(true);
+    });
+
+    it('returns false when the extent is inside the ring boundary', function () {
+      expect(linearRing.intersectsExtent([2, 2, 3, 3])).to.be(false);
+    });
+
+    it("returns true for the geom's own extent", function () {
+      expect(linearRing.intersectsExtent(linearRing.getExtent())).to.be(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #17519.

Summary:
- Implement `LinearRing#intersectsExtent()` by testing the ring boundary as a closed line string.
- Document that extent intersection only considers the ring boundary.
- Add regression coverage for boundary intersections and contained extents.

Test plan:
- `npx mocha test/node/ol/geom/LinearRing.test.js`
- `npm run lint`
- `git diff --check`
