### PR TITLE
Fix type regression in withArgsOfIdenticalType for var/get comparisons

### DIFF
--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -769,8 +769,19 @@ function withArgsOfIdenticalType() {
      * @type {Array<Expression>}
      */
     const args = new Array(argCount);
+    // When a var/get arg has a type already established by a previous clause, seed
+    // commonType with it *before* parse() runs, so the type isn't lost to a later
+    // polymorphic clause (e.g. ['==', ['var', 'x'], ['get', 'y']]).
     let commonType = AnyType;
     for (let i = 0; i < argCount; ++i) {
+      const arg = encoded[i + 1];
+      if (Array.isArray(arg)) {
+        if (arg[0] === Ops.Var) {
+          commonType &= context.variables.get(arg[1]) ?? AnyType;
+        } else if (arg[0] === Ops.Get) {
+          commonType &= context.properties.get(arg[1]) ?? AnyType;
+        }
+      }
       const expression = parse(encoded[i + 1], commonType, context);
       commonType &= expression.type;
     }

--- a/test/node/ol/expr/expression.test.js
+++ b/test/node/ol/expr/expression.test.js
@@ -225,6 +225,23 @@ describe('ol/expr/expression.js', () => {
       expect(context.properties.get('foo')).to.be(StringType);
     });
 
+    it('propagates var type from an earlier == clause to a later == clause comparing var with get', () => {
+      // Regression: ['==', ['var', 'x'], ['get', 'y']] must inherit the StringType
+      // established for 'x' by the preceding ['==', ['var', 'x'], 'hello'] clause.
+      const context = newParsingContext();
+      parse(
+        [
+          'any',
+          ['==', ['var', 'x'], 'hello'],
+          ['==', ['var', 'x'], ['get', 'y']],
+        ],
+        BooleanType,
+        context,
+      );
+      expect(context.variables.get('x')).to.be(StringType);
+      expect(context.properties.get('y')).to.be(StringType);
+    });
+
     describe('case operation', () => {
       it('respects the return type (string)', () => {
         const expression = parse(


### PR DESCRIPTION
When two polymorphic expressions (e.g. ['var', x] and ['get', y]) are compared with == or !=, the first-pass type determination loop concluded AnyType for both, overwriting a more specific type (e.g. StringType) that had been established by an earlier clause in the same expression.

Pre-seed commonType from already-known variable/property types in the context before the first-pass loop, so that the determined type of a previous clause propagates correctly to later ones.

fixes #17528
