### PR TITLE
Guard WebGL vector layer buffer disposal against a removed helper

### DIFF
--- a/examples/webgl-points-layer.html
+++ b/examples/webgl-points-layer.html
@@ -4,7 +4,7 @@ title: WebGL points layer
 shortdesc: Using a WebGL-optimized layer to render a large quantities of points
 docs: >
   <p>
-    This example shows how to use a `WebGLPointsLayer` to show a large amount of points on the map.
+    This example shows how to use a `WebGLVectorLayer` to show a large amount of points on the map.
     The layer is given a style in JSON format which allows a certain level of customization of the final representation.
   </p>
 

--- a/src/ol/renderer/webgl/VectorLayer.js
+++ b/src/ol/renderer/webgl/VectorLayer.js
@@ -500,6 +500,10 @@ class WebGLVectorLayerRenderer extends WebGLLayerRenderer {
    * @param {import('../../render/webgl/VectorStyleRenderer.js').WebGLBuffers} buffers Buffers
    */
   disposeBuffers(buffers) {
+    if (!this.helper) {
+      return;
+    }
+
     /**
      * @param {Array<import('../../webgl/Buffer.js').default>} typeBuffers Buffers
      */


### PR DESCRIPTION
When a WebGLVectorLayer is removed from its map and then disposed (as the webgl-points-layer example does when switching styles), the helper has already been released by Layer#onMapChanged_, so disposeBuffers threw "Cannot read properties of undefined (reading 'deleteBuffer')". The helper owns the buffers and frees them on its own disposal, so skip the per-buffer cleanup when the helper is gone.

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
