### PR TITLE
Fix ZIndexContext instructions desynchronization

### DIFF
--- a/src/ol/render/canvas/ZIndexContext.js
+++ b/src/ol/render/canvas/ZIndexContext.js
@@ -37,8 +37,12 @@ class ZIndexContext {
             // we only accept calling functions on the proxy, not accessing properties
             return undefined;
           }
-          this.push_(property);
-          return this.pushMethodArgs_;
+          /**
+           * @param {...*} args Arguments to function with name in property
+           */
+          return (...args) => {
+            this.push_(property, args);
+          };
         },
         set: (target, property, value) => {
           this.push_(property, value);
@@ -60,14 +64,6 @@ class ZIndexContext {
     }
     instructions[index].push(...args);
   }
-
-  /**
-   * @private
-   * @param {...*} args Args.
-   */
-  pushMethodArgs_ = (...args) => {
-    this.push_(args);
-  };
 
   /**
    * Push a function that renders to the context directly.

--- a/src/ol/render/canvas/ZIndexContext.js
+++ b/src/ol/render/canvas/ZIndexContext.js
@@ -27,6 +27,14 @@ class ZIndexContext {
     this.offset_ = 0;
 
     /**
+     * Name of the method last accessed on the proxy, pushed together with its
+     * arguments when the method is actually called.
+     * @private
+     * @type {string|symbol}
+     */
+    this.pendingMethod_;
+
+    /**
      * @private
      * @type {ZIndexContextProxy}
      */
@@ -37,12 +45,8 @@ class ZIndexContext {
             // we only accept calling functions on the proxy, not accessing properties
             return undefined;
           }
-          /**
-           * @param {...*} args Arguments to function with name in property
-           */
-          return (...args) => {
-            this.push_(property, args);
-          };
+          this.pendingMethod_ = property;
+          return this.pushMethodArgs_;
         },
         set: (target, property, value) => {
           this.push_(property, value);
@@ -64,6 +68,16 @@ class ZIndexContext {
     }
     instructions[index].push(...args);
   }
+
+  /**
+   * Pushes the method name captured at access time together with the arguments
+   * passed at call time. Reused across all proxied method calls.
+   * @param {...*} args Args.
+   * @private
+   */
+  pushMethodArgs_ = (...args) => {
+    this.push_(this.pendingMethod_, args);
+  };
 
   /**
    * Push a function that renders to the context directly.

--- a/src/ol/render/canvas/ZIndexContext.js
+++ b/src/ol/render/canvas/ZIndexContext.js
@@ -33,10 +33,7 @@ class ZIndexContext {
     this.context_ = /** @type {ZIndexContextProxy} */ (
       new Proxy(getSharedCanvasContext2D(), {
         get: (target, property) => {
-          if (
-            typeof (/** @type {*} */ (getSharedCanvasContext2D())[property]) !==
-            'function'
-          ) {
+          if (typeof (/** @type {*} */ (target)[property]) !== 'function') {
             // we only accept calling functions on the proxy, not accessing properties
             return undefined;
           }
@@ -67,11 +64,9 @@ class ZIndexContext {
   /**
    * @private
    * @param {...*} args Args.
-   * @return {ZIndexContext} This.
    */
   pushMethodArgs_ = (...args) => {
     this.push_(args);
-    return this;
   };
 
   /**
@@ -107,11 +102,9 @@ class ZIndexContext {
         const instructionAtIndex = instructionsAtIndex[++i];
         if (typeof (/** @type {*} */ (context)[property]) === 'function') {
           /** @type {*} */ (context)[property](...instructionAtIndex);
+        } else if (typeof instructionAtIndex === 'function') {
+          /** @type {*} */ (context)[property] = instructionAtIndex(context);
         } else {
-          if (typeof instructionAtIndex === 'function') {
-            /** @type {*} */ (context)[property] = instructionAtIndex(context);
-            continue;
-          }
           /** @type {*} */ (context)[property] = instructionAtIndex;
         }
       }


### PR DESCRIPTION
I received an automatic error report …
>TypeError: CanvasRenderingContext2D.clip: Argument 1 is not an object.
draw/<@[...]/ol.js:1:256309
draw@[...]/ol.js:1:256167
renderDeferred/<@[...]/ol.js:1:268897
renderDeferred@[...]/ol.js:1:268883
renderDeferredInternal@[...]/ol.js:1:288652
renderDeferred@[...]/ol.js:1:286887
renderDeferred@[...]/ol.js:1:102400
declutter/<@[...]/ol.js:1:159761
declutter@[...]/ol.js:1:159742
renderFrame@[...]/ol.js:1:158776
Nr@[...]/ol.js:1:171246
sr@[...]/ol.js:1:169944

… which corresponds to:
https://github.com/openlayers/openlayers/blob/41883b4135a45224b5b47e3c95df52dea78940d1/src/ol/render/canvas/ZIndexContext.js#L108-L109

With the help of Claude I tracked it down to …
https://github.com/openlayers/openlayers/blob/41883b4135a45224b5b47e3c95df52dea78940d1/src/ol/render/canvas/ZIndexContext.js#L43-L44
… where the function is recorded when accessed, but its arguments only when actually called.

Now this shouldn't cause an issue normally, but when opening the debugging tools and hovering over any canvas method calls, this will add the method name without arguments to the instructions. On replay of the instructions in `draw` the added method names mess with the expected order for method calls 

To fix this, push the method name together with the arguments, only when it is actually called.