### PR TITLE
Add non-spatial dimension selection to the GeoZarr source

### DIFF
--- a/examples/geozarr-dimensions.html
+++ b/examples/geozarr-dimensions.html
@@ -14,9 +14,40 @@ docs: >
   `dimensions` option, e.g. `{time: 0}`.
 
 
-  The dataset is a Sentinel-1 GRD RTC cube whose `ascending`/`descending` orbit groups are picked
-  with the **Group** dropdown. A dual-polarization composite is rendered (vv → red, vh → green,
+  The example dataset is a Sentinel-1 GRD RTC cube. A cube can carry `ascending`/`descending` orbit groups,
+  picked with the **Group** dropdown (shown only when a cube has more than one); single-direction
+  cubes are auto-selected. A dual-polarization composite is rendered (vv → red, vh → green,
   vv/vh → blue), each channel rescaled from a fixed value range to the display.
+
+
+  *Swiss Alps — the Valais (32TLS)*: the default scene, and the only one here carrying both `ascending`
+  and `descending` groups. Over the Rhône valley from Lake Geneva up into the high Alps, radiometric
+  terrain correction (RTC) evens out the slope-driven brightness of raw SAR, so the lakes read radar-dark
+  while forest, rock and snow separate by surface roughness. Switch the **Group** to compare how the two
+  look directions light the valleys.
+
+
+  The **URL** dropdown offers four event scenarios; step through the **time** slider to watch each unfold:
+
+
+  *Valencia DANA flood (30SYJ, ascending)*, 26 → 31 Oct 2024: floodwater across the plain and the
+  Albufera lagoon turns radar-dark while the built-up city stays bright, imaged straight through the
+  storm cloud that blinded optical satellites.
+
+
+  *La Palma — Cumbre Vieja eruption (28RBS, descending)*, Sep–Dec 2021: fresh, rough lava scatters
+  radar strongly and glows bright as the new lava delta grows into the Atlantic, day or night.
+
+
+  *Strait of Hormuz — Fujairah anchorage (40RDN, descending)*, 2026: the Gulf's main tanker anchorage
+  just outside the Strait of Hormuz, one of the world's busiest bunkering hubs. Every frame reveals the
+  fleet at anchor — on the radar-dark sea each tanker is a bright point target, with Fujairah port at the
+  coast. SAR sees the whole fleet through cloud and darkness, day or night, when optical imagery and AIS
+  can't.
+
+
+  *Bay of Bothnia sea ice (34WET, descending)*, Feb–Mar 2025: landfast ice locks the Luleå archipelago
+  while floes drift offshore; smooth new ice reads dark, ridged ice bright, shifting pass to pass.
 
 tags: "zarr, geozarr, sentinel-1, time, dimensions"
 experimental: true
@@ -28,7 +59,11 @@ experimental: true
     <div class="input-group">
       <label class="input-group-text" for="url-select">URL</label>
       <select class="form-select" id="url-select">
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-32TLS.zarr">Sentinel-1 GRD RTC (32TLS)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-32TLS.zarr">S1 — Swiss Alps / Valais (32TLS, asc + desc)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-30SYJ.zarr">S1 — Valencia DANA flood, Oct 2024 (30SYJ, ascending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-40RDN.zarr">S1 — Strait of Hormuz / Fujairah tanker anchorage, 2026 (40RDN, descending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-28RBS.zarr">S1 — La Palma lava delta, 2021 (28RBS, descending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-34WET.zarr">S1 — Bay of Bothnia sea ice, 2025 (34WET, descending)</option>
         <option value="custom">Custom...</option>
       </select>
       <input type="text" class="form-control" id="custom-url" placeholder="Enter Zarr URL" style="display: none; width: 300px;">

--- a/examples/geozarr-dimensions.html
+++ b/examples/geozarr-dimensions.html
@@ -1,80 +1,31 @@
 ---
 layout: example.html
 title: GeoZarr dimensions
-shortdesc: Selecting a slice of a multi-dimensional GeoZarr (Sentinel-1 RTC time cube).
+shortdesc: Stepping through the time dimension of a GeoZarr cube with a slider.
 docs: >
 
-  A GeoZarr array can have non-spatial dimensions such as `time`, `band`, or `altitude`. This
-  example shows how to render a single slice of such a cube with the `ol/source/GeoZarr` source.
+  A GeoZarr array can have non-spatial dimensions such as `time`. This example steps through the
+  `time` axis of a Sentinel-1 radar cube with a slider: `getDimensions()` reports the axis with its
+  size and units, `updateDimensions()` reloads the chosen slice in place, and `getValue` reads the
+  axis value to label it with the acquisition date.
 
 
-  The `source.getDimensions()` method reports the non-spatial dimensions and their sizes once the
-  source is ready; the example builds a dropdown for each (labeling the options with the decoded
-  coordinate values, e.g. dates), and passes the chosen index back to the source through its
-  `dimensions` option, e.g. `{time: 0}`.
-
-
-  The example dataset is a Sentinel-1 GRD RTC cube. A cube can carry `ascending`/`descending` orbit groups,
-  picked with the **Group** dropdown (shown only when a cube has more than one); single-direction
-  cubes are auto-selected. A dual-polarization composite is rendered (vv → red, vh → green,
-  vv/vh → blue), each channel rescaled from a fixed value range to the display.
-
-
-  *Swiss Alps — the Valais (32TLS)*: the default scene, and the only one here carrying both `ascending`
-  and `descending` groups. Over the Rhône valley from Lake Geneva up into the high Alps, radiometric
-  terrain correction (RTC) evens out the slope-driven brightness of raw SAR, so the lakes read radar-dark
-  while forest, rock and snow separate by surface roughness. Switch the **Group** to compare how the two
-  look directions light the valleys.
-
-
-  The **URL** dropdown offers four event scenarios; step through the **time** slider to watch each unfold:
-
-
-  *Valencia DANA flood (30SYJ, ascending)*, 26 → 31 Oct 2024: floodwater across the plain and the
-  Albufera lagoon turns radar-dark while the built-up city stays bright, imaged straight through the
-  storm cloud that blinded optical satellites.
-
-
-  *La Palma — Cumbre Vieja eruption (28RBS, descending)*, Sep–Dec 2021: fresh, rough lava scatters
-  radar strongly and glows bright as the new lava delta grows into the Atlantic, day or night.
-
-
-  *Strait of Hormuz — Fujairah anchorage (40RDN, descending)*, 2026: the Gulf's main tanker anchorage
-  just outside the Strait of Hormuz, one of the world's busiest bunkering hubs. Every frame reveals the
-  fleet at anchor — on the radar-dark sea each tanker is a bright point target, with Fujairah port at the
-  coast. SAR sees the whole fleet through cloud and darkness, day or night, when optical imagery and AIS
-  can't.
-
-
-  *Bay of Bothnia sea ice (34WET, descending)*, Feb–Mar 2025: landfast ice locks the Luleå archipelago
-  while floes drift offshore; smooth new ice reads dark, ridged ice bright, shifting pass to pass.
+  The cube images the 2021 Cumbre Vieja eruption on La Palma as a dual-polarization composite: the
+  VV and VH bands (vertical transmit, vertical vs. horizontal receive) map to red and green, and
+  their ratio to blue.
 
 tags: "zarr, geozarr, sentinel-1, time, dimensions"
 experimental: true
 ---
 <div id="map" class="map"></div>
-<div id="error" class="alert alert-danger mt-2" style="display: none;"></div>
-<div class="row mt-2 g-2">
+<div class="row mt-2 g-2 align-items-center">
   <div class="col-auto">
-    <div class="input-group">
-      <label class="input-group-text" for="url-select">URL</label>
-      <select class="form-select" id="url-select">
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-32TLS.zarr">S1 — Swiss Alps / Valais (32TLS, asc + desc)</option>
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-30SYJ.zarr">S1 — Valencia DANA flood, Oct 2024 (30SYJ, ascending)</option>
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-40RDN.zarr">S1 — Strait of Hormuz / Fujairah tanker anchorage, 2026 (40RDN, descending)</option>
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-28RBS.zarr">S1 — La Palma lava delta, 2021 (28RBS, descending)</option>
-        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-34WET.zarr">S1 — Bay of Bothnia sea ice, 2025 (34WET, descending)</option>
-        <option value="custom">Custom...</option>
-      </select>
-      <input type="text" class="form-control" id="custom-url" placeholder="Enter Zarr URL" style="display: none; width: 300px;">
-      <button class="btn btn-outline-secondary" id="load-url" type="button">Load</button>
-    </div>
+    <label class="col-form-label" for="time">Time</label>
   </div>
-  <div class="col-auto" id="group-col" style="display: none;">
-    <div class="input-group">
-      <label class="input-group-text" for="group-select">Group</label>
-      <select class="form-select" id="group-select"></select>
-    </div>
+  <div class="col-auto">
+    <input type="range" class="form-range align-middle" id="time" min="0" max="0" value="0" step="1" style="width: 220px;" disabled>
   </div>
-  <div class="col-auto" id="dims"></div>
+  <div class="col-auto">
+    <span id="time-label" class="text-body-secondary">loading…</span>
+  </div>
 </div>

--- a/examples/geozarr-dimensions.html
+++ b/examples/geozarr-dimensions.html
@@ -1,0 +1,45 @@
+---
+layout: example.html
+title: GeoZarr dimensions
+shortdesc: Selecting a slice of a multi-dimensional GeoZarr (Sentinel-1 RTC time cube).
+docs: >
+
+  A GeoZarr array can have non-spatial dimensions such as `time`, `band`, or `altitude`. This
+  example shows how to render a single slice of such a cube with the `ol/source/GeoZarr` source.
+
+
+  The `source.getDimensions()` method reports the non-spatial dimensions and their sizes once the
+  source is ready; the example builds a dropdown for each (labeling the options with the decoded
+  coordinate values, e.g. dates), and passes the chosen index back to the source through its
+  `dimensions` option, e.g. `{time: 0}`.
+
+
+  The dataset is a Sentinel-1 GRD RTC cube whose `ascending`/`descending` orbit groups are picked
+  with the **Group** dropdown. A dual-polarization composite is rendered (vv → red, vh → green,
+  vv/vh → blue), each channel rescaled from a fixed value range to the display.
+
+tags: "zarr, geozarr, sentinel-1, time, dimensions"
+experimental: true
+---
+<div id="map" class="map"></div>
+<div id="error" class="alert alert-danger mt-2" style="display: none;"></div>
+<div class="row mt-2 g-2">
+  <div class="col-auto">
+    <div class="input-group">
+      <label class="input-group-text" for="url-select">URL</label>
+      <select class="form-select" id="url-select">
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-32TLS.zarr">Sentinel-1 GRD RTC (32TLS)</option>
+        <option value="custom">Custom...</option>
+      </select>
+      <input type="text" class="form-control" id="custom-url" placeholder="Enter Zarr URL" style="display: none; width: 300px;">
+      <button class="btn btn-outline-secondary" id="load-url" type="button">Load</button>
+    </div>
+  </div>
+  <div class="col-auto" id="group-col" style="display: none;">
+    <div class="input-group">
+      <label class="input-group-text" for="group-select">Group</label>
+      <select class="form-select" id="group-select"></select>
+    </div>
+  </div>
+  <div class="col-auto" id="dims"></div>
+</div>

--- a/examples/geozarr-dimensions.js
+++ b/examples/geozarr-dimensions.js
@@ -192,12 +192,18 @@ async function coordinateLabels(dimName, size) {
   const isTime =
     meta.attributes?.standard_name === 'time' || /\bsince\b/i.test(units || '');
   const labels = [];
+  // The live array may disagree with the consolidated metadata read at page
+  // load (the store may have been rewritten since), so `data[i]` can be
+  // missing and a decoded date can be invalid; fall back to a plain value or
+  // index label instead of letting `toISOString()` throw.
   for (let i = 0; i < size; ++i) {
-    const ms = isTime ? cfTimeToMs(data[i], units) : null;
+    const value = data[i];
+    const ms = isTime ? cfTimeToMs(value, units) : null;
+    const date = ms === null ? null : new Date(ms);
     labels.push(
-      ms === null
-        ? String(data[i])
-        : new Date(ms).toISOString().slice(0, 16).replace('T', ' '),
+      date && !isNaN(date.getTime())
+        ? date.toISOString().slice(0, 16).replace('T', ' ')
+        : String(value ?? i),
     );
   }
   return labels;
@@ -206,11 +212,15 @@ async function coordinateLabels(dimName, size) {
 /**
  * Build one dropdown per non-spatial dimension reported by the source, labeling
  * each option with the real coordinate value (e.g. a date) when available.
+ * The container is only touched after all labels are loaded and only when this
+ * render is still the current one, so a superseded render cannot append stale
+ * selectors after a newer render cleared the container.
  * @param {Array<{name: string, size: number}>} dimensions The selectable dimensions.
+ * @param {number} token The render token this rebuild belongs to.
  * @return {Promise<void>} Resolves when the selectors are built.
  */
-async function buildDimensionSelectors(dimensions) {
-  dimsContainer.innerHTML = '';
+async function buildDimensionSelectors(dimensions, token) {
+  const columns = [];
   for (const {name, size} of dimensions) {
     const labels = await coordinateLabels(name, size);
     const group = document.createElement('div');
@@ -233,8 +243,12 @@ async function buildDimensionSelectors(dimensions) {
     const col = document.createElement('div');
     col.className = 'col-auto';
     col.appendChild(group);
-    dimsContainer.appendChild(col);
+    columns.push(col);
   }
+  if (token !== renderToken) {
+    return;
+  }
+  dimsContainer.replaceChildren(...columns);
 }
 
 /**
@@ -311,7 +325,7 @@ async function render(rebuildDimensions) {
       return; // a newer render started; drop this stale one
     }
     if (rebuildDimensions) {
-      await buildDimensionSelectors(source.getDimensions());
+      await buildDimensionSelectors(source.getDimensions(), token);
       if (token !== renderToken) {
         return;
       }

--- a/examples/geozarr-dimensions.js
+++ b/examples/geozarr-dimensions.js
@@ -45,6 +45,7 @@ const COMPOSITE_RESCALE = {
 };
 
 let map;
+let dataLayer; // the GeoZarr composite layer; its source is swapped on a time change
 let rootUrl = ''; // the entered store url (root); the source opens this in multi-group mode
 let rootMetadata = {}; // consolidated metadata of the store root (covers every group)
 let rootAttributes = {}; // attributes of the store root
@@ -331,23 +332,30 @@ async function render(rebuildDimensions) {
       }
     }
     hideError();
-    if (map) {
-      map.setTarget(null);
+    // A time-slice change stays on the same group/cube (same extent and
+    // projection), so swap the layer's source in place and keep the map — the
+    // user's pan/zoom is preserved. Only (re)build the map, fitting the view to
+    // the data extent, on the first load or a group/cube change, where the
+    // extent may differ.
+    if (map && dataLayer && !rebuildDimensions) {
+      dataLayer.setSource(source);
+    } else {
+      if (map) {
+        map.setTarget(null);
+      }
+      dataLayer = new TileLayer({style: compositeStyle(), source});
+      map = new Map({
+        layers: [new TileLayer({source: new OSM()}), dataLayer],
+        target: 'map',
+        view: getView(
+          source,
+          withLowerResolutions(1),
+          withHigherResolutions(2),
+          withExtentCenter(),
+          withZoom(2),
+        ),
+      });
     }
-    map = new Map({
-      layers: [
-        new TileLayer({source: new OSM()}),
-        new TileLayer({style: compositeStyle(), source}),
-      ],
-      target: 'map',
-      view: getView(
-        source,
-        withLowerResolutions(1),
-        withHigherResolutions(2),
-        withExtentCenter(),
-        withZoom(2),
-      ),
-    });
   } catch (error) {
     if (token === renderToken) {
       showError(error);
@@ -416,9 +424,10 @@ async function load() {
       option.textContent = path || '(root)';
       groupSelect.appendChild(option);
     }
-    // Only show the group selector when there is a real choice of subgroups.
-    groupCol.style.display =
-      groups.length === 1 && groups[0] === '' ? 'none' : '';
+    // Only show the group selector when there is a real choice of subgroups
+    // (2+ groups). A single group -- whether the bare root or one orbit
+    // direction, e.g. a descending-only S1 cube -- is auto-selected, no dropdown.
+    groupCol.style.display = groups.length < 2 ? 'none' : '';
     await loadGroup();
   } catch (error) {
     showError(error);

--- a/examples/geozarr-dimensions.js
+++ b/examples/geozarr-dimensions.js
@@ -1,0 +1,417 @@
+import {FetchStore, get, open, root} from 'zarrita';
+import Map from '../src/ol/Map.js';
+import {
+  getView,
+  withExtentCenter,
+  withHigherResolutions,
+  withLowerResolutions,
+  withZoom,
+} from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import GeoZarr from '../src/ol/source/GeoZarr.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const urlSelect = document.getElementById('url-select');
+const customUrl = document.getElementById('custom-url');
+const loadButton = document.getElementById('load-url');
+const groupCol = document.getElementById('group-col');
+const groupSelect = document.getElementById('group-select');
+const dimsContainer = document.getElementById('dims');
+const errorBox = document.getElementById('error');
+
+/**
+ * Show a non-fatal error message above the map.
+ * @param {Error} error The error to display.
+ */
+function showError(error) {
+  errorBox.textContent = error.message || String(error);
+  errorBox.style.display = '';
+}
+
+/** Clear any displayed error message. */
+function hideError() {
+  errorBox.textContent = '';
+  errorBox.style.display = 'none';
+}
+
+// Sentinel-1 RTC dual-polarization composite: vv -> R, vh -> G, vv/vh -> B.
+const BANDS = ['vv', 'vh'];
+
+// Fixed [low, high] value range per composite channel, each mapped to [0, 255].
+const COMPOSITE_RESCALE = {
+  vv: [0, 0.4], // red
+  vh: [0, 0.1], // green
+  ratio: [1, 15], // blue (vv / vh)
+};
+
+let map;
+let rootUrl = ''; // the entered store url (root); the source opens this in multi-group mode
+let rootMetadata = {}; // consolidated metadata of the store root (covers every group)
+let rootAttributes = {}; // attributes of the store root
+let groupPath = ''; // selected child group ('' = the root is itself the multiscales group)
+let storeUrl = ''; // url of the selected group, for direct coordinate reads
+let metadata = {}; // consolidated metadata scoped to the selected group
+let layout = null; // multiscales layout of the selected group
+let renderToken = 0; // guards against overlapping (re)renders clobbering the map
+
+function getUrl() {
+  return urlSelect.value === 'custom' ? customUrl.value : urlSelect.value;
+}
+
+urlSelect.addEventListener('change', () => {
+  const custom = urlSelect.value === 'custom';
+  customUrl.style.display = custom ? '' : 'none';
+  if (custom) {
+    customUrl.focus();
+  }
+});
+
+/**
+ * The finest multiscales level (the one with the most pixels).
+ * @return {string|null} The level (asset) id.
+ */
+function finestLevelAsset() {
+  if (!layout) {
+    return null;
+  }
+  return layout.reduce((a, b) => {
+    const sa = a['spatial:shape']?.[0] ?? 0;
+    const sb = b['spatial:shape']?.[0] ?? 0;
+    return sb > sa ? b : a;
+  }).asset;
+}
+
+/**
+ * Path of a band array at a level (or the band itself for a single-scale group).
+ * @param {string|null} asset The level id.
+ * @param {string} band The band name.
+ * @return {string} The array path relative to the group.
+ */
+function bandPath(asset, band) {
+  return asset ? `${asset}/${band}` : band;
+}
+
+/**
+ * Slice consolidated metadata to a group, returning keys relative to that group.
+ * @param {Object} cm The consolidated metadata.
+ * @param {string} prefix The group path.
+ * @return {Object} Metadata with keys relative to the group.
+ */
+function subMetadata(cm, prefix) {
+  const start = `${prefix}/`;
+  const sub = {};
+  for (const key of Object.keys(cm)) {
+    if (key.startsWith(start)) {
+      sub[key.slice(start.length)] = cm[key];
+    }
+  }
+  return sub;
+}
+
+/**
+ * Current value of every dimension selector.
+ * @return {Object<string, number>} The selected index per dimension name.
+ */
+function currentDimensions() {
+  const dimensions = {};
+  for (const select of dimsContainer.querySelectorAll('select')) {
+    dimensions[select.dataset.dim] = Number(select.value);
+  }
+  return dimensions;
+}
+
+/**
+ * Convert a CF time value to milliseconds since the Unix epoch.
+ * @param {number|bigint} value The encoded time value.
+ * @param {string} units A CF units string, e.g. `'nanoseconds since 1970-01-01'`.
+ * @return {number|null} Milliseconds since the epoch, or null if not decodable.
+ */
+function cfTimeToMs(value, units) {
+  const match = /^\s*(\w+)\s+since\s+(.+?)\s*$/i.exec(units || '');
+  if (!match) {
+    return null;
+  }
+  const perUnitMs = {
+    nanosecond: 1e-6,
+    nanoseconds: 1e-6,
+    microsecond: 1e-3,
+    microseconds: 1e-3,
+    millisecond: 1,
+    milliseconds: 1,
+    second: 1000,
+    seconds: 1000,
+    minute: 60000,
+    minutes: 60000,
+    hour: 3600000,
+    hours: 3600000,
+    day: 86400000,
+    days: 86400000,
+  }[match[1].toLowerCase()];
+  if (perUnitMs === undefined) {
+    return null;
+  }
+  let refMs = Date.parse(match[2]);
+  if (Number.isNaN(refMs)) {
+    refMs = Date.parse(`${match[2].replace(' ', 'T')}Z`);
+  }
+  if (Number.isNaN(refMs)) {
+    return null;
+  }
+  return Number(value) * perUnitMs + refMs;
+}
+
+/**
+ * Read a dimension's coordinate array and format its values as option labels,
+ * decoding CF time to dates. Returns null when no usable coordinate array is
+ * present, so the caller falls back to plain indices.
+ * @param {string} dimName The dimension name.
+ * @param {number} size The dimension length.
+ * @return {Promise<Array<string>|null>} One label per index, or null.
+ */
+async function coordinateLabels(dimName, size) {
+  const path = bandPath(finestLevelAsset(), dimName);
+  const meta = metadata[path];
+  if (
+    !meta ||
+    !Array.isArray(meta.shape) ||
+    meta.shape.length !== 1 ||
+    meta.shape[0] !== size
+  ) {
+    return null;
+  }
+  let data;
+  try {
+    const array = await open(root(new FetchStore(storeUrl)).resolve(path), {
+      kind: 'array',
+    });
+    data = (await get(array)).data;
+  } catch {
+    return null;
+  }
+  const units = meta.attributes?.units;
+  const isTime =
+    meta.attributes?.standard_name === 'time' || /\bsince\b/i.test(units || '');
+  const labels = [];
+  for (let i = 0; i < size; ++i) {
+    const ms = isTime ? cfTimeToMs(data[i], units) : null;
+    labels.push(
+      ms === null
+        ? String(data[i])
+        : new Date(ms).toISOString().slice(0, 16).replace('T', ' '),
+    );
+  }
+  return labels;
+}
+
+/**
+ * Build one dropdown per non-spatial dimension reported by the source, labeling
+ * each option with the real coordinate value (e.g. a date) when available.
+ * @param {Array<{name: string, size: number}>} dimensions The selectable dimensions.
+ * @return {Promise<void>} Resolves when the selectors are built.
+ */
+async function buildDimensionSelectors(dimensions) {
+  dimsContainer.innerHTML = '';
+  for (const {name, size} of dimensions) {
+    const labels = await coordinateLabels(name, size);
+    const group = document.createElement('div');
+    group.className = 'input-group';
+    const label = document.createElement('label');
+    label.className = 'input-group-text';
+    label.textContent = isNaN(Number(name)) ? name : `dim ${name}`;
+    const select = document.createElement('select');
+    select.className = 'form-select';
+    select.dataset.dim = name;
+    for (let i = 0; i < size; ++i) {
+      const option = document.createElement('option');
+      option.value = String(i);
+      option.textContent = labels ? labels[i] : String(i);
+      select.appendChild(option);
+    }
+    select.addEventListener('change', () => render(false));
+    group.appendChild(label);
+    group.appendChild(select);
+    const col = document.createElement('div');
+    col.className = 'col-auto';
+    col.appendChild(group);
+    dimsContainer.appendChild(col);
+  }
+}
+
+/**
+ * Resolve once the source is ready (or reject on error).
+ * @param {GeoZarr} source The source.
+ * @return {Promise<void>} Resolves when ready.
+ */
+function whenReady(source) {
+  return new Promise((resolve, reject) => {
+    function check() {
+      const state = source.getState();
+      if (state === 'ready') {
+        resolve();
+      } else if (state === 'error') {
+        reject(source.error_ || new Error('GeoZarr source failed to load'));
+      }
+    }
+    source.on('change', check);
+    check();
+  });
+}
+
+/**
+ * WebGL style for the dual-polarization composite: vv -> red, vh -> green,
+ * vv/vh -> blue, each rescaled from its fixed [low, high] range (see
+ * `COMPOSITE_RESCALE`) to [0, 255].
+ * @return {Object} The WebGLTile style.
+ */
+function compositeStyle() {
+  const channel = (value, [low, high]) => [
+    'interpolate',
+    ['linear'],
+    value,
+    low,
+    0,
+    high,
+    255,
+  ];
+  return {
+    color: [
+      'color',
+      channel(['band', 1], COMPOSITE_RESCALE.vv),
+      channel(['band', 2], COMPOSITE_RESCALE.vh),
+      channel(['/', ['band', 1], ['band', 2]], COMPOSITE_RESCALE.ratio),
+    ],
+  };
+}
+
+/**
+ * (Re)render the map for the current group and dimension selections.
+ * @param {boolean} rebuildDimensions Rebuild the dimension selectors (after a
+ *     group change).
+ */
+async function render(rebuildDimensions) {
+  if (!storeUrl) {
+    return;
+  }
+  const token = ++renderToken;
+  // On a group change the dimension selectors still describe the previous group
+  // (they are rebuilt below once the new source is ready), so their selected
+  // indices may be out of range for the new group. Start the new group at index
+  // 0 and let the rebuilt selectors drive later renders.
+  const dimensions = rebuildDimensions ? {} : currentDimensions();
+  // Open the store root in multi-group mode (bands carry the orbit group). The
+  // root's consolidated metadata covers every group, so this works even when a
+  // child group's own zarr.json was not consolidated.
+  const bands = groupPath
+    ? BANDS.map((name) => ({name, group: groupPath}))
+    : BANDS;
+  const source = new GeoZarr({url: rootUrl, bands, dimensions});
+  try {
+    await whenReady(source);
+    if (token !== renderToken) {
+      return; // a newer render started; drop this stale one
+    }
+    if (rebuildDimensions) {
+      await buildDimensionSelectors(source.getDimensions());
+      if (token !== renderToken) {
+        return;
+      }
+    }
+    hideError();
+    if (map) {
+      map.setTarget(null);
+    }
+    map = new Map({
+      layers: [
+        new TileLayer({source: new OSM()}),
+        new TileLayer({style: compositeStyle(), source}),
+      ],
+      target: 'map',
+      view: getView(
+        source,
+        withLowerResolutions(1),
+        withHigherResolutions(2),
+        withExtentCenter(),
+        withZoom(2),
+      ),
+    });
+  } catch (error) {
+    if (token === renderToken) {
+      showError(error);
+    }
+  }
+}
+
+/**
+ * Discover the renderable groups in a store: the store's own group when it is a
+ * multiscales group, otherwise its immediate child groups that are multiscales
+ * groups (e.g. the `ascending`/`descending` orbit groups of an S1 RTC cube).
+ * @param {Object} group The parsed store-root group zarr.json.
+ * @return {Array<string>} Group paths relative to the entered url ('' = the url itself).
+ */
+function discoverGroups(group) {
+  if (group.attributes?.multiscales?.layout) {
+    return [''];
+  }
+  const consolidated = group.consolidated_metadata?.metadata ?? {};
+  const groups = [];
+  for (const key of Object.keys(consolidated)) {
+    if (
+      !key.includes('/') &&
+      consolidated[key]?.node_type === 'group' &&
+      consolidated[key]?.attributes?.multiscales?.layout
+    ) {
+      groups.push(key);
+    }
+  }
+  return groups.length > 0 ? groups : [''];
+}
+
+/** Scope the metadata/layout to the selected group, then render. */
+async function loadGroup() {
+  groupPath = groupSelect.value;
+  storeUrl = groupPath ? `${rootUrl}/${groupPath}` : rootUrl;
+  metadata = groupPath ? subMetadata(rootMetadata, groupPath) : rootMetadata;
+  const groupAttributes = groupPath
+    ? rootMetadata[groupPath]?.attributes
+    : rootAttributes;
+  layout = groupAttributes?.multiscales?.layout ?? null;
+  await render(true);
+}
+
+/** Load the entered store: read its (root) metadata, discover groups, render. */
+async function load() {
+  rootUrl = getUrl();
+  if (!rootUrl) {
+    return;
+  }
+  try {
+    const response = await fetch(`${rootUrl}/zarr.json`);
+    if (!response.ok) {
+      throw new Error(
+        `Could not read ${rootUrl}/zarr.json (${response.status})`,
+      );
+    }
+    const rootJson = await response.json();
+    rootMetadata = rootJson.consolidated_metadata?.metadata ?? {};
+    rootAttributes = rootJson.attributes ?? {};
+    const groups = discoverGroups(rootJson);
+    groupSelect.innerHTML = '';
+    for (const path of groups) {
+      const option = document.createElement('option');
+      option.value = path;
+      option.textContent = path || '(root)';
+      groupSelect.appendChild(option);
+    }
+    // Only show the group selector when there is a real choice of subgroups.
+    groupCol.style.display =
+      groups.length === 1 && groups[0] === '' ? 'none' : '';
+    await loadGroup();
+  } catch (error) {
+    showError(error);
+  }
+}
+
+groupSelect.addEventListener('change', loadGroup);
+loadButton.addEventListener('click', load);
+
+load();

--- a/examples/geozarr-dimensions.js
+++ b/examples/geozarr-dimensions.js
@@ -1,4 +1,3 @@
-import {FetchStore, get, open, root} from 'zarrita';
 import Map from '../src/ol/Map.js';
 import {
   getView,
@@ -11,430 +10,65 @@ import TileLayer from '../src/ol/layer/WebGLTile.js';
 import GeoZarr from '../src/ol/source/GeoZarr.js';
 import OSM from '../src/ol/source/OSM.js';
 
-const urlSelect = document.getElementById('url-select');
-const customUrl = document.getElementById('custom-url');
-const loadButton = document.getElementById('load-url');
-const groupCol = document.getElementById('group-col');
-const groupSelect = document.getElementById('group-select');
-const dimsContainer = document.getElementById('dims');
-const errorBox = document.getElementById('error');
+// Point the url straight at the cube's `descending` orbit group, which keeps
+// this a plain single-group source whose only non-spatial dimension is time.
+const url =
+  'https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-28RBS.zarr/descending';
+const source = new GeoZarr({url, bands: ['vv', 'vh']});
 
-/**
- * Show a non-fatal error message above the map.
- * @param {Error} error The error to display.
- */
-function showError(error) {
-  errorBox.textContent = error.message || String(error);
-  errorBox.style.display = '';
-}
-
-/** Clear any displayed error message. */
-function hideError() {
-  errorBox.textContent = '';
-  errorBox.style.display = 'none';
-}
-
-// Sentinel-1 RTC dual-polarization composite: vv -> R, vh -> G, vv/vh -> B.
-const BANDS = ['vv', 'vh'];
-
-// Fixed [low, high] value range per composite channel, each mapped to [0, 255].
-const COMPOSITE_RESCALE = {
-  vv: [0, 0.4], // red
-  vh: [0, 0.1], // green
-  ratio: [1, 15], // blue (vv / vh)
+// Dual-polarization composite from two geo-bands: VV -> red, VH -> green, and
+// their ratio VV/VH -> blue. Radar backscatter is a small float, so each
+// channel is rescaled from a fixed [low, high] range to the 0-255 display range.
+const style = {
+  color: [
+    'color',
+    ['interpolate', ['linear'], ['band', 1], 0, 0, 0.4, 255], // VV
+    ['interpolate', ['linear'], ['band', 2], 0, 0, 0.1, 255], // VH
+    ['interpolate', ['linear'], ['/', ['band', 1], ['band', 2]], 1, 0, 15, 255], // VV/VH
+  ],
 };
 
-let map;
-let dataLayer; // the GeoZarr composite layer; its source is swapped on a time change
-let rootUrl = ''; // the entered store url (root); the source opens this in multi-group mode
-let rootMetadata = {}; // consolidated metadata of the store root (covers every group)
-let rootAttributes = {}; // attributes of the store root
-let groupPath = ''; // selected child group ('' = the root is itself the multiscales group)
-let storeUrl = ''; // url of the selected group, for direct coordinate reads
-let metadata = {}; // consolidated metadata scoped to the selected group
-let layout = null; // multiscales layout of the selected group
-let renderToken = 0; // guards against overlapping (re)renders clobbering the map
-
-function getUrl() {
-  return urlSelect.value === 'custom' ? customUrl.value : urlSelect.value;
-}
-
-urlSelect.addEventListener('change', () => {
-  const custom = urlSelect.value === 'custom';
-  customUrl.style.display = custom ? '' : 'none';
-  if (custom) {
-    customUrl.focus();
-  }
+const map = new Map({
+  target: 'map',
+  layers: [new TileLayer({source: new OSM()}), new TileLayer({style, source})],
+  view: getView(
+    source,
+    withLowerResolutions(1),
+    withHigherResolutions(2),
+    withExtentCenter(),
+    withZoom(2),
+  ),
 });
 
-/**
- * The finest multiscales level (the one with the most pixels).
- * @return {string|null} The level (asset) id.
- */
-function finestLevelAsset() {
-  if (!layout) {
-    return null;
-  }
-  return layout.reduce((a, b) => {
-    const sa = a['spatial:shape']?.[0] ?? 0;
-    const sb = b['spatial:shape']?.[0] ?? 0;
-    return sb > sa ? b : a;
-  }).asset;
-}
+const slider = document.getElementById('time');
+const label = document.getElementById('time-label');
 
-/**
- * Path of a band array at a level (or the band itself for a single-scale group).
- * @param {string|null} asset The level id.
- * @param {string} band The band name.
- * @return {string} The array path relative to the group.
- */
-function bandPath(asset, band) {
-  return asset ? `${asset}/${band}` : band;
-}
+source
+  .getDimensions()
+  .then(async ({time}) => {
+    const {units} = time.attributes;
+    // units is something like "nanoseconds since 1970-01-01",
+    const epoch = Date.parse(units.split(' since ')[1]);
+    const toDate = (value) => new Date(epoch + Number(value) / 1e6);
 
-/**
- * Slice consolidated metadata to a group, returning keys relative to that group.
- * @param {Object} cm The consolidated metadata.
- * @param {string} prefix The group path.
- * @return {Object} Metadata with keys relative to the group.
- */
-function subMetadata(cm, prefix) {
-  const start = `${prefix}/`;
-  const sub = {};
-  for (const key of Object.keys(cm)) {
-    if (key.startsWith(start)) {
-      sub[key.slice(start.length)] = cm[key];
-    }
-  }
-  return sub;
-}
-
-/**
- * Current value of every dimension selector.
- * @return {Object<string, number>} The selected index per dimension name.
- */
-function currentDimensions() {
-  const dimensions = {};
-  for (const select of dimsContainer.querySelectorAll('select')) {
-    dimensions[select.dataset.dim] = Number(select.value);
-  }
-  return dimensions;
-}
-
-/**
- * Convert a CF time value to milliseconds since the Unix epoch.
- * @param {number|bigint} value The encoded time value.
- * @param {string} units A CF units string, e.g. `'nanoseconds since 1970-01-01'`.
- * @return {number|null} Milliseconds since the epoch, or null if not decodable.
- */
-function cfTimeToMs(value, units) {
-  const match = /^\s*(\w+)\s+since\s+(.+?)\s*$/i.exec(units || '');
-  if (!match) {
-    return null;
-  }
-  const perUnitMs = {
-    nanosecond: 1e-6,
-    nanoseconds: 1e-6,
-    microsecond: 1e-3,
-    microseconds: 1e-3,
-    millisecond: 1,
-    milliseconds: 1,
-    second: 1000,
-    seconds: 1000,
-    minute: 60000,
-    minutes: 60000,
-    hour: 3600000,
-    hours: 3600000,
-    day: 86400000,
-    days: 86400000,
-  }[match[1].toLowerCase()];
-  if (perUnitMs === undefined) {
-    return null;
-  }
-  let refMs = Date.parse(match[2]);
-  if (Number.isNaN(refMs)) {
-    refMs = Date.parse(`${match[2].replace(' ', 'T')}Z`);
-  }
-  if (Number.isNaN(refMs)) {
-    return null;
-  }
-  return Number(value) * perUnitMs + refMs;
-}
-
-/**
- * Read a dimension's coordinate array and format its values as option labels,
- * decoding CF time to dates. Returns null when no usable coordinate array is
- * present, so the caller falls back to plain indices.
- * @param {string} dimName The dimension name.
- * @param {number} size The dimension length.
- * @return {Promise<Array<string>|null>} One label per index, or null.
- */
-async function coordinateLabels(dimName, size) {
-  const path = bandPath(finestLevelAsset(), dimName);
-  const meta = metadata[path];
-  if (
-    !meta ||
-    !Array.isArray(meta.shape) ||
-    meta.shape.length !== 1 ||
-    meta.shape[0] !== size
-  ) {
-    return null;
-  }
-  let data;
-  try {
-    const array = await open(root(new FetchStore(storeUrl)).resolve(path), {
-      kind: 'array',
-    });
-    data = (await get(array)).data;
-  } catch {
-    return null;
-  }
-  const units = meta.attributes?.units;
-  const isTime =
-    meta.attributes?.standard_name === 'time' || /\bsince\b/i.test(units || '');
-  const labels = [];
-  // The live array may disagree with the consolidated metadata read at page
-  // load (the store may have been rewritten since), so `data[i]` can be
-  // missing and a decoded date can be invalid; fall back to a plain value or
-  // index label instead of letting `toISOString()` throw.
-  for (let i = 0; i < size; ++i) {
-    const value = data[i];
-    const ms = isTime ? cfTimeToMs(value, units) : null;
-    const date = ms === null ? null : new Date(ms);
-    labels.push(
-      date && !isNaN(date.getTime())
-        ? date.toISOString().slice(0, 16).replace('T', ' ')
-        : String(value ?? i),
+    const slices = await Promise.all(
+      [...Array(time.size).keys()].map(async (index) => ({
+        index,
+        date: toDate(await source.getValue('time', index)),
+      })),
     );
-  }
-  return labels;
-}
+    // The cube stores its time slices out of chronological order, so sort them.
+    slices.sort((a, b) => a.date - b.date);
 
-/**
- * Build one dropdown per non-spatial dimension reported by the source, labeling
- * each option with the real coordinate value (e.g. a date) when available.
- * The container is only touched after all labels are loaded and only when this
- * render is still the current one, so a superseded render cannot append stale
- * selectors after a newer render cleared the container.
- * @param {Array<{name: string, size: number}>} dimensions The selectable dimensions.
- * @param {number} token The render token this rebuild belongs to.
- * @return {Promise<void>} Resolves when the selectors are built.
- */
-async function buildDimensionSelectors(dimensions, token) {
-  const columns = [];
-  for (const {name, size} of dimensions) {
-    const labels = await coordinateLabels(name, size);
-    const group = document.createElement('div');
-    group.className = 'input-group';
-    const label = document.createElement('label');
-    label.className = 'input-group-text';
-    label.textContent = isNaN(Number(name)) ? name : `dim ${name}`;
-    const select = document.createElement('select');
-    select.className = 'form-select';
-    select.dataset.dim = name;
-    for (let i = 0; i < size; ++i) {
-      const option = document.createElement('option');
-      option.value = String(i);
-      option.textContent = labels ? labels[i] : String(i);
-      select.appendChild(option);
+    function showSlice(position) {
+      const {index, date} = slices[position];
+      source.updateDimensions({time: index});
+      label.textContent = date.toISOString().slice(0, 16).replace('T', ' ');
     }
-    select.addEventListener('change', () => render(false));
-    group.appendChild(label);
-    group.appendChild(select);
-    const col = document.createElement('div');
-    col.className = 'col-auto';
-    col.appendChild(group);
-    columns.push(col);
-  }
-  if (token !== renderToken) {
-    return;
-  }
-  dimsContainer.replaceChildren(...columns);
-}
 
-/**
- * Resolve once the source is ready (or reject on error).
- * @param {GeoZarr} source The source.
- * @return {Promise<void>} Resolves when ready.
- */
-function whenReady(source) {
-  return new Promise((resolve, reject) => {
-    function check() {
-      const state = source.getState();
-      if (state === 'ready') {
-        resolve();
-      } else if (state === 'error') {
-        reject(source.error_ || new Error('GeoZarr source failed to load'));
-      }
-    }
-    source.on('change', check);
-    check();
-  });
-}
-
-/**
- * WebGL style for the dual-polarization composite: vv -> red, vh -> green,
- * vv/vh -> blue, each rescaled from its fixed [low, high] range (see
- * `COMPOSITE_RESCALE`) to [0, 255].
- * @return {Object} The WebGLTile style.
- */
-function compositeStyle() {
-  const channel = (value, [low, high]) => [
-    'interpolate',
-    ['linear'],
-    value,
-    low,
-    0,
-    high,
-    255,
-  ];
-  return {
-    color: [
-      'color',
-      channel(['band', 1], COMPOSITE_RESCALE.vv),
-      channel(['band', 2], COMPOSITE_RESCALE.vh),
-      channel(['/', ['band', 1], ['band', 2]], COMPOSITE_RESCALE.ratio),
-    ],
-  };
-}
-
-/**
- * (Re)render the map for the current group and dimension selections.
- * @param {boolean} rebuildDimensions Rebuild the dimension selectors (after a
- *     group change).
- */
-async function render(rebuildDimensions) {
-  if (!storeUrl) {
-    return;
-  }
-  const token = ++renderToken;
-  // On a group change the dimension selectors still describe the previous group
-  // (they are rebuilt below once the new source is ready), so their selected
-  // indices may be out of range for the new group. Start the new group at index
-  // 0 and let the rebuilt selectors drive later renders.
-  const dimensions = rebuildDimensions ? {} : currentDimensions();
-  // Open the store root in multi-group mode (bands carry the orbit group). The
-  // root's consolidated metadata covers every group, so this works even when a
-  // child group's own zarr.json was not consolidated.
-  const bands = groupPath
-    ? BANDS.map((name) => ({name, group: groupPath}))
-    : BANDS;
-  const source = new GeoZarr({url: rootUrl, bands, dimensions});
-  try {
-    await whenReady(source);
-    if (token !== renderToken) {
-      return; // a newer render started; drop this stale one
-    }
-    if (rebuildDimensions) {
-      await buildDimensionSelectors(source.getDimensions(), token);
-      if (token !== renderToken) {
-        return;
-      }
-    }
-    hideError();
-    // A time-slice change stays on the same group/cube (same extent and
-    // projection), so swap the layer's source in place and keep the map — the
-    // user's pan/zoom is preserved. Only (re)build the map, fitting the view to
-    // the data extent, on the first load or a group/cube change, where the
-    // extent may differ.
-    if (map && dataLayer && !rebuildDimensions) {
-      dataLayer.setSource(source);
-    } else {
-      if (map) {
-        map.setTarget(null);
-      }
-      dataLayer = new TileLayer({style: compositeStyle(), source});
-      map = new Map({
-        layers: [new TileLayer({source: new OSM()}), dataLayer],
-        target: 'map',
-        view: getView(
-          source,
-          withLowerResolutions(1),
-          withHigherResolutions(2),
-          withExtentCenter(),
-          withZoom(2),
-        ),
-      });
-    }
-  } catch (error) {
-    if (token === renderToken) {
-      showError(error);
-    }
-  }
-}
-
-/**
- * Discover the renderable groups in a store: the store's own group when it is a
- * multiscales group, otherwise its immediate child groups that are multiscales
- * groups (e.g. the `ascending`/`descending` orbit groups of an S1 RTC cube).
- * @param {Object} group The parsed store-root group zarr.json.
- * @return {Array<string>} Group paths relative to the entered url ('' = the url itself).
- */
-function discoverGroups(group) {
-  if (group.attributes?.multiscales?.layout) {
-    return [''];
-  }
-  const consolidated = group.consolidated_metadata?.metadata ?? {};
-  const groups = [];
-  for (const key of Object.keys(consolidated)) {
-    if (
-      !key.includes('/') &&
-      consolidated[key]?.node_type === 'group' &&
-      consolidated[key]?.attributes?.multiscales?.layout
-    ) {
-      groups.push(key);
-    }
-  }
-  return groups.length > 0 ? groups : [''];
-}
-
-/** Scope the metadata/layout to the selected group, then render. */
-async function loadGroup() {
-  groupPath = groupSelect.value;
-  storeUrl = groupPath ? `${rootUrl}/${groupPath}` : rootUrl;
-  metadata = groupPath ? subMetadata(rootMetadata, groupPath) : rootMetadata;
-  const groupAttributes = groupPath
-    ? rootMetadata[groupPath]?.attributes
-    : rootAttributes;
-  layout = groupAttributes?.multiscales?.layout ?? null;
-  await render(true);
-}
-
-/** Load the entered store: read its (root) metadata, discover groups, render. */
-async function load() {
-  rootUrl = getUrl();
-  if (!rootUrl) {
-    return;
-  }
-  try {
-    const response = await fetch(`${rootUrl}/zarr.json`);
-    if (!response.ok) {
-      throw new Error(
-        `Could not read ${rootUrl}/zarr.json (${response.status})`,
-      );
-    }
-    const rootJson = await response.json();
-    rootMetadata = rootJson.consolidated_metadata?.metadata ?? {};
-    rootAttributes = rootJson.attributes ?? {};
-    const groups = discoverGroups(rootJson);
-    groupSelect.innerHTML = '';
-    for (const path of groups) {
-      const option = document.createElement('option');
-      option.value = path;
-      option.textContent = path || '(root)';
-      groupSelect.appendChild(option);
-    }
-    // Only show the group selector when there is a real choice of subgroups
-    // (2+ groups). A single group -- whether the bare root or one orbit
-    // direction, e.g. a descending-only S1 cube -- is auto-selected, no dropdown.
-    groupCol.style.display = groups.length < 2 ? 'none' : '';
-    await loadGroup();
-  } catch (error) {
-    showError(error);
-  }
-}
-
-groupSelect.addEventListener('change', loadGroup);
-loadButton.addEventListener('click', load);
-
-load();
+    slider.max = String(time.size - 1);
+    slider.disabled = false;
+    slider.addEventListener('input', () => showSlice(Number(slider.value)));
+    showSlice(0);
+  })
+  .catch(() => (label.textContent = 'Failed to load the GeoZarr store.'));

--- a/examples/geozarr-storytelling.html
+++ b/examples/geozarr-storytelling.html
@@ -1,0 +1,70 @@
+---
+layout: example.html
+title: GeoZarr storytelling
+shortdesc: Exploring Sentinel-1 event scenarios across orbit groups and time in GeoZarr cubes.
+docs: >
+
+  A tour of Sentinel-1 radar imaging through a set of event scenarios stored as GeoZarr cubes. Pick
+  a scene from the **URL** dropdown, switch look direction with the **Group** dropdown where a cube
+  has both `ascending` and `descending` orbit passes, and step through **time** to watch each one
+  unfold as a dual-polarization radar composite.
+
+
+  *Swiss Alps — the Valais (32TLS)*: the default scene, and the only one here carrying both `ascending`
+  and `descending` groups. Over the Rhône valley from Lake Geneva up into the high Alps, radiometric
+  terrain correction (RTC) evens out the slope-driven brightness of raw SAR, so the lakes read radar-dark
+  while forest, rock and snow separate by surface roughness. Switch the **Group** to compare how the two
+  look directions light the valleys.
+
+
+  The **URL** dropdown also offers four event scenarios; step through **time** to watch each unfold:
+
+
+  *Valencia DANA flood (30SYJ, ascending)*, 26 → 31 Oct 2024: floodwater across the plain and the
+  Albufera lagoon turns radar-dark while the built-up city stays bright, imaged straight through the
+  storm cloud that blinded optical satellites.
+
+
+  *La Palma — Cumbre Vieja eruption (28RBS, descending)*, Sep–Dec 2021: fresh, rough lava scatters
+  radar strongly and glows bright as the new lava delta grows into the Atlantic, day or night.
+
+
+  *Strait of Hormuz — Fujairah anchorage (40RDN, descending)*, 2026: the Gulf's main tanker anchorage
+  just outside the Strait of Hormuz, one of the world's busiest bunkering hubs. Every frame reveals the
+  fleet at anchor — on the radar-dark sea each tanker is a bright point target, with Fujairah port at the
+  coast. SAR sees the whole fleet through cloud and darkness, day or night, when optical imagery and AIS
+  can't.
+
+
+  *Bay of Bothnia sea ice (34WET, descending)*, Feb–Mar 2025: landfast ice locks the Luleå archipelago
+  while floes drift offshore; smooth new ice reads dark, ridged ice bright, shifting pass to pass.
+
+tags: "zarr, geozarr, sentinel-1, time, dimensions"
+experimental: true
+---
+<div id="map" class="map"></div>
+<div id="error" class="alert alert-danger mt-2" style="display: none;"></div>
+<div class="row mt-2 g-2">
+  <div class="col-auto">
+    <div class="input-group">
+      <label class="input-group-text" for="url-select">URL</label>
+      <select class="form-select" id="url-select">
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-32TLS.zarr">S1 — Swiss Alps / Valais (32TLS, asc + desc)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-30SYJ.zarr">S1 — Valencia DANA flood, Oct 2024 (30SYJ, ascending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-40RDN.zarr">S1 — Strait of Hormuz / Fujairah tanker anchorage, 2026 (40RDN, descending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-28RBS.zarr">S1 — La Palma lava delta, 2021 (28RBS, descending)</option>
+        <option value="https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-1-grd-rtc-staging/s1-rtc-34WET.zarr">S1 — Bay of Bothnia sea ice, 2025 (34WET, descending)</option>
+        <option value="custom">Custom...</option>
+      </select>
+      <input type="text" class="form-control" id="custom-url" placeholder="Enter Zarr URL" style="display: none; width: 300px;">
+      <button class="btn btn-outline-secondary" id="load-url" type="button">Load</button>
+    </div>
+  </div>
+  <div class="col-auto" id="group-col" style="display: none;">
+    <div class="input-group">
+      <label class="input-group-text" for="group-select">Group</label>
+      <select class="form-select" id="group-select"></select>
+    </div>
+  </div>
+  <div class="col-auto" id="dims"></div>
+</div>

--- a/examples/geozarr-storytelling.js
+++ b/examples/geozarr-storytelling.js
@@ -1,0 +1,328 @@
+import Map from '../src/ol/Map.js';
+import {
+  getView,
+  withExtentCenter,
+  withHigherResolutions,
+  withLowerResolutions,
+  withZoom,
+} from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import GeoZarr from '../src/ol/source/GeoZarr.js';
+import OSM from '../src/ol/source/OSM.js';
+
+const urlSelect = document.getElementById('url-select');
+const customUrl = document.getElementById('custom-url');
+const loadButton = document.getElementById('load-url');
+const groupCol = document.getElementById('group-col');
+const groupSelect = document.getElementById('group-select');
+const dimsContainer = document.getElementById('dims');
+const errorBox = document.getElementById('error');
+
+/**
+ * Show a non-fatal error message above the map.
+ * @param {Error} error The error to display.
+ */
+function showError(error) {
+  errorBox.textContent = error.message || String(error);
+  errorBox.style.display = '';
+}
+
+/** Clear any displayed error message. */
+function hideError() {
+  errorBox.textContent = '';
+  errorBox.style.display = 'none';
+}
+
+// The two polarization bands composited by compositeStyle().
+const BANDS = ['vv', 'vh'];
+
+// Fixed [low, high] value range per composite channel, each mapped to [0, 255].
+const COMPOSITE_RESCALE = {
+  vv: [0, 0.4], // red
+  vh: [0, 0.1], // green
+  ratio: [1, 15], // blue (vv / vh)
+};
+
+let map;
+/* The composite layer; its dimensions are updated in place */
+let dataLayer;
+/* The entered store url, opened in multi-group mode */
+let rootUrl = '';
+/* Selected orbit group ('' = the root is the multiscales group) */
+let groupPath = '';
+
+function getUrl() {
+  return urlSelect.value === 'custom' ? customUrl.value : urlSelect.value;
+}
+
+urlSelect.addEventListener('change', () => {
+  const custom = urlSelect.value === 'custom';
+  customUrl.style.display = custom ? '' : 'none';
+  if (custom) {
+    customUrl.focus();
+  }
+});
+
+/**
+ * Current index selected in each dimension dropdown.
+ * @return {Object<string, number>} The selected index per dimension name.
+ */
+function currentDimensions() {
+  const dimensions = {};
+  for (const select of dimsContainer.querySelectorAll('select')) {
+    dimensions[select.dataset.dim] = Number(select.value);
+  }
+  return dimensions;
+}
+
+/**
+ * Convert a CF time value to milliseconds since the Unix epoch.
+ * @param {number|bigint} value The encoded time value.
+ * @param {string} units A CF units string, e.g. `'nanoseconds since 1970-01-01'`.
+ * @return {number|null} Milliseconds since the epoch, or null if not decodable.
+ */
+function cfTimeToMs(value, units) {
+  const match = /^\s*(\w+)\s+since\s+(.+?)\s*$/i.exec(units || '');
+  if (!match) {
+    return null;
+  }
+  const perUnitMs = {
+    nanosecond: 1e-6,
+    nanoseconds: 1e-6,
+    microsecond: 1e-3,
+    microseconds: 1e-3,
+    millisecond: 1,
+    milliseconds: 1,
+    second: 1000,
+    seconds: 1000,
+    minute: 60000,
+    minutes: 60000,
+    hour: 3600000,
+    hours: 3600000,
+    day: 86400000,
+    days: 86400000,
+  }[match[1].toLowerCase()];
+  if (perUnitMs === undefined) {
+    return null;
+  }
+  let refMs = Date.parse(match[2]);
+  if (Number.isNaN(refMs)) {
+    refMs = Date.parse(`${match[2].replace(' ', 'T')}Z`);
+  }
+  if (Number.isNaN(refMs)) {
+    return null;
+  }
+  return Number(value) * perUnitMs + refMs;
+}
+
+/**
+ * Read a dimension's coordinate values through the source and turn them into
+ * dropdown entries, decoding CF time to dates. Entries are sorted by value so
+ * the dropdown lists them in ascending (e.g. chronological) order even when the
+ * cube stores the slices unsorted. Falls back to the plain index when a value is
+ * missing (a dimension without a coordinate array).
+ * @param {GeoZarr} source The source.
+ * @param {string} name The dimension name.
+ * @param {number} size The dimension length.
+ * @param {Object|null} attributes The dimension's coordinate array attributes.
+ * @return {Promise<Array<{index: number, label: string}>>} Entries sorted by value.
+ */
+async function dimensionEntries(source, name, size, attributes) {
+  const units = attributes?.units;
+  const values = await Promise.all(
+    [...Array(size).keys()].map((index) => source.getValue(name, index)),
+  );
+  const entries = values.map((value, index) => {
+    const ms = value === null ? null : cfTimeToMs(value, units);
+    const date = ms === null ? null : new Date(ms);
+    const valid = date && !isNaN(date.getTime());
+    return {
+      index,
+      label: valid
+        ? date.toISOString().slice(0, 16).replace('T', ' ')
+        : String(value ?? index),
+      sortKey: valid ? ms : Number(value ?? index),
+    };
+  });
+  entries.sort((a, b) => a.sortKey - b.sortKey);
+  return entries;
+}
+
+/**
+ * Build one dropdown per non-spatial dimension, labeling each option with the
+ * real coordinate value (e.g. a date) when available.
+ * @param {GeoZarr} source The source.
+ * @param {Object<string, {size: number, attributes: Object|null}>} dimensions The selectable dimensions.
+ * @return {Promise<void>} Resolves when the selectors are built.
+ */
+async function buildDimensionSelectors(source, dimensions) {
+  const columns = [];
+  for (const [name, {size, attributes}] of Object.entries(dimensions)) {
+    const entries = await dimensionEntries(source, name, size, attributes);
+    const group = document.createElement('div');
+    group.className = 'input-group';
+    const label = document.createElement('label');
+    label.className = 'input-group-text';
+    label.textContent = isNaN(Number(name)) ? name : `dim ${name}`;
+    const select = document.createElement('select');
+    select.className = 'form-select';
+    select.dataset.dim = name;
+    for (const entry of entries) {
+      const option = document.createElement('option');
+      option.value = String(entry.index);
+      option.textContent = entry.label;
+      select.appendChild(option);
+    }
+    select.addEventListener('change', () => render(false));
+    group.appendChild(label);
+    group.appendChild(select);
+    const col = document.createElement('div');
+    col.className = 'col-auto';
+    col.appendChild(group);
+    columns.push(col);
+  }
+  dimsContainer.replaceChildren(...columns);
+}
+
+/**
+ * WebGL style for the dual-polarization composite: vv -> red, vh -> green,
+ * vv/vh -> blue, each rescaled from its fixed [low, high] range to [0, 255].
+ * @return {Object} The WebGLTile style.
+ */
+function compositeStyle() {
+  const channel = (value, [low, high]) => [
+    'interpolate',
+    ['linear'],
+    value,
+    low,
+    0,
+    high,
+    255,
+  ];
+  return {
+    color: [
+      'color',
+      channel(['band', 1], COMPOSITE_RESCALE.vv),
+      channel(['band', 2], COMPOSITE_RESCALE.vh),
+      channel(['/', ['band', 1], ['band', 2]], COMPOSITE_RESCALE.ratio),
+    ],
+  };
+}
+
+/**
+ * (Re)render the map. A dimension change (`rebuildDimensions` false) reloads the
+ * current cube's slice in place; a group change or the first load opens a fresh
+ * source and rebuilds the dimension selectors and the map.
+ * @param {boolean} rebuildDimensions Rebuild the dimension selectors.
+ */
+async function render(rebuildDimensions) {
+  if (!rootUrl) {
+    return;
+  }
+  if (!rebuildDimensions) {
+    // Same cube, different slice: reload in place, keeping the map (and the
+    // user's pan/zoom).
+    dataLayer.getSource().updateDimensions(currentDimensions());
+    return;
+  }
+  // Open the store root in multi-group mode when a group is selected, so the
+  // bands carry their orbit group.
+  const bands = groupPath
+    ? BANDS.map((name) => ({name, group: groupPath}))
+    : BANDS;
+  const source = new GeoZarr({url: rootUrl, bands});
+  try {
+    // getDimensions() resolves once the source is ready (and rejects on error),
+    // so it doubles as the readiness gate.
+    const dimensions = await source.getDimensions();
+    await buildDimensionSelectors(source, dimensions);
+    // Match the source to the (chronological) default selection before it is
+    // first rendered.
+    source.updateDimensions(currentDimensions());
+    hideError();
+    if (map) {
+      map.setTarget(null);
+    }
+    dataLayer = new TileLayer({style: compositeStyle(), source});
+    map = new Map({
+      layers: [new TileLayer({source: new OSM()}), dataLayer],
+      target: 'map',
+      view: getView(
+        source,
+        withLowerResolutions(1),
+        withHigherResolutions(2),
+        withExtentCenter(),
+        withZoom(2),
+      ),
+    });
+  } catch (error) {
+    showError(error);
+  }
+}
+
+/**
+ * Discover the renderable groups in a store: the store's own group when it is a
+ * multiscales group, otherwise its immediate child groups that are multiscales
+ * groups (e.g. the `ascending`/`descending` orbit groups of an S1 RTC cube).
+ * @param {Object} group The parsed store-root group zarr.json.
+ * @return {Array<string>} Group paths relative to the entered url ('' = the url itself).
+ */
+function discoverGroups(group) {
+  if (group.attributes?.multiscales?.layout) {
+    return [''];
+  }
+  const consolidated = group.consolidated_metadata?.metadata ?? {};
+  const groups = [];
+  for (const key of Object.keys(consolidated)) {
+    if (
+      !key.includes('/') &&
+      consolidated[key]?.node_type === 'group' &&
+      consolidated[key]?.attributes?.multiscales?.layout
+    ) {
+      groups.push(key);
+    }
+  }
+  return groups.length > 0 ? groups : [''];
+}
+
+/** Select the current group and render. */
+async function loadGroup() {
+  groupPath = groupSelect.value;
+  await render(true);
+}
+
+/** Load the entered store: read its root metadata, discover groups, render. */
+async function load() {
+  rootUrl = getUrl();
+  if (!rootUrl) {
+    return;
+  }
+  try {
+    const response = await fetch(`${rootUrl}/zarr.json`);
+    if (!response.ok) {
+      throw new Error(
+        `Could not read ${rootUrl}/zarr.json (${response.status})`,
+      );
+    }
+    const rootJson = await response.json();
+    const groups = discoverGroups(rootJson);
+    groupSelect.innerHTML = '';
+    for (const path of groups) {
+      const option = document.createElement('option');
+      option.value = path;
+      option.textContent = path || '(root)';
+      groupSelect.appendChild(option);
+    }
+    // Show the group selector only when there is a real choice (2+ groups); a
+    // single group is auto-selected.
+    groupCol.style.display = groups.length < 2 ? 'none' : '';
+    await loadGroup();
+  } catch (error) {
+    showError(error);
+  }
+}
+
+groupSelect.addEventListener('change', loadGroup);
+loadButton.addEventListener('click', load);
+
+load();

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -9,6 +9,7 @@ import {get as getProjection, toUserCoordinate, toUserExtent} from '../proj.js';
 import {fromProjectionDefinition} from '../proj/proj4.js';
 import {toSize} from '../size.js';
 import WMTSTileGrid from '../tilegrid/WMTS.js';
+import {getUid} from '../util.js';
 import DataTileSource from './DataTile.js';
 import {parseTileMatrixSet} from './ogcTileUtil.js';
 
@@ -51,13 +52,11 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
  * @property {ResampleMethod} [resample='nearest'] Resampling method if bands are not available for all multi-scale levels.
  * @property {Object<string, number|string>} [dimensions] Fixed index for each non-spatial
- * dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` to render the first
- * time step of a `[time, y, x]` cube). The two trailing axes are treated as spatial (y, x); each
- * leading axis is a selectable dimension — use the names returned by {@link getDimensions}. Names
- * come from the array's `dimension_names` metadata; when an array has none, a dimension is keyed
- * by its axis position as a string (e.g. `{'0': 1}`), and a single unnamed dimension also accepts
- * any key. Only integer (positional) indices are supported; a string value (e.g. a datetime label)
- * is reserved for a future release and currently throws. Unspecified dimensions default to `0`.
+ * dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` for the first time step
+ * of a `[time, y, x]` cube); unspecified dimensions default to `0`. Names come from each array's
+ * `dimension_names`, or are the axis position as a string when it has none. Only integer indices
+ * are supported. Use the names from {@link getDimensions}, and change the selection on the fly with
+ * {@link module:ol/source/GeoZarr~GeoZarr#updateDimensions}.
  */
 
 /**
@@ -170,18 +169,31 @@ export default class GeoZarr extends DataTileSource {
     this.bands_ = bands;
 
     /**
-     * Per-band template for selecting fixed indices along non-spatial dimensions.
-     * `undefined` for 2-D band arrays; otherwise an array aligned to the array
-     * rank with a fixed integer at each extra axis and `null` at the two spatial
-     * axes (e.g. `[2, null, null]` for a `[time, y, x]` array with `time: 2`).
+     * Per-band selection along non-spatial dimensions: `undefined` for 2-D
+     * arrays, otherwise an array aligned to the array rank with a fixed integer
+     * at each extra axis and `null` at the two spatial axes (e.g. `[2, null,
+     * null]` for a `[time, y, x]` array with `time: 2`).
      * @type {Array<Array<number|null>|undefined>}
      * @private
      */
     this.bandExtraSelection_ = new Array(bands.length).fill(undefined);
 
     /**
-     * Non-spatial dimensions of the bands (`{name, size}`), discovered in
-     * `configure_` and exposed via {@link getDimensions}.
+     * Per-band spatial (y, x) axis positions, as `{row, col}`.
+     * @type {Array<{row: number, col: number}>}
+     * @private
+     */
+    this.bandSpatialAxes_ = new Array(bands.length);
+
+    /**
+     * The two spatial axis names from the group's `spatial:dimensions` (`[y, x]`).
+     * @type {Array<string>|undefined}
+     * @private
+     */
+    this.spatialDimensionNames_;
+
+    /**
+     * Non-spatial dimensions of the bands, exposed via {@link getDimensions}.
      * @type {Array<{name: string, size: number}>}
      * @private
      */
@@ -272,6 +284,13 @@ export default class GeoZarr extends DataTileSource {
         this.groups_[0].attrs
       );
 
+    // The spatial: convention names the two spatial axes (`[y, x]`), so they can
+    // be located by name in each array's `dimension_names`.
+    const spatialDimensions = attributes['spatial:dimensions'];
+    if (Array.isArray(spatialDimensions) && spatialDimensions.length === 2) {
+      this.spatialDimensionNames_ = spatialDimensions;
+    }
+
     // For multi-group mode, use sub-metadata for the first group so that
     // consolidated metadata keys match the expected relative paths.
     const consolidatedMetadata =
@@ -318,20 +337,21 @@ export default class GeoZarr extends DataTileSource {
     }
     if (!this.tileGrid && 'spatial:bbox' in attributes) {
       // Standalone single-scale group: build tile grid directly from
-      // spatial:bbox and spatial:shape (or the array shape from metadata).
-      let shape = attributes['spatial:shape'];
-      if (!shape && consolidatedMetadata) {
+      // spatial:bbox and spatial:shape (`[height, width]`), or the x axis size
+      // from the array metadata.
+      let xSize = attributes['spatial:shape']?.[1];
+      if (xSize === undefined && consolidatedMetadata) {
         for (const band of this.bands_) {
-          if (consolidatedMetadata[band]?.shape) {
-            shape = consolidatedMetadata[band].shape;
+          const bandMeta = consolidatedMetadata[band];
+          if (bandMeta?.shape) {
+            xSize = bandMeta.shape[this.axesOf_(bandMeta).col];
             break;
           }
         }
       }
-      if (shape) {
+      if (xSize !== undefined) {
         const extent = attributes['spatial:bbox'];
-        // The x axis is the last dimension (arrays may be N-D, e.g. [time, y, x]).
-        const resolution = (extent[2] - extent[0]) / shape[shape.length - 1];
+        const resolution = (extent[2] - extent[0]) / xSize;
         if (!this.projection) {
           this.projection = getProjectionFromAttributes(attributes);
         }
@@ -375,14 +395,15 @@ export default class GeoZarr extends DataTileSource {
       throw new Error('Could not determine tile grid');
     }
 
-    // Resolve, per band, the fixed indices for any non-spatial dimensions so
-    // loadTile_ can slice a 2-D view out of N-D (e.g. [time, y, x]) arrays, and
-    // record the selectable dimensions for getDimensions().
+    // Resolve, per band, the spatial axes and the fixed indices for any
+    // non-spatial dimensions, and record the selectable dimensions.
     for (let i = 0, ii = this.bands_.length; i < ii; ++i) {
       const arrayMeta = this.getBandArrayMeta_(
         this.bands_[i],
         this.bandGroupIndex_[i],
       );
+      const {row, col} = this.axesOf_(arrayMeta);
+      this.bandSpatialAxes_[i] = {row, col};
       this.bandExtraSelection_[i] = this.resolveExtraSelection_(arrayMeta);
       if (this.extraDimensions_.length === 0) {
         this.extraDimensions_ = this.extraDimsOf_(arrayMeta);
@@ -479,21 +500,7 @@ export default class GeoZarr extends DataTileSource {
 
     // Open all band arrays in parallel (not sequentially)
     const arrays = await Promise.all(
-      bandInfos.map((info) => {
-        const cacheKey = `${info.groupIndex}:${info.path}`;
-        if (!this.arrayCache_.has(cacheKey)) {
-          this.arrayCache_.set(
-            cacheKey,
-            open(this.groups_[info.groupIndex].resolve(info.path), {
-              kind: 'array',
-            }).catch((err) => {
-              this.arrayCache_.delete(cacheKey);
-              throw err;
-            }),
-          );
-        }
-        return this.arrayCache_.get(cacheKey);
-      }),
+      bandInfos.map((info) => this.openArray_(info.groupIndex, info.path)),
     );
 
     // Fire all get() calls synchronously so getRange() calls from all bands
@@ -508,12 +515,13 @@ export default class GeoZarr extends DataTileSource {
         if (!extra) {
           return get(array, [rowSlice, colSlice]);
         }
-        // `extra` fixes an integer index on each non-spatial axis followed by
-        // null at the two trailing spatial axes (e.g. [timeIndex, null, null]);
-        // keep the fixed indices and append the row/column slices. zarrita
-        // drops the integer axes, returning a 2-D chunk that composeData
-        // consumes unchanged.
-        const selection = [...extra.slice(0, -2), rowSlice, colSlice];
+        // Drop the row/column slices in at the spatial axes; zarrita drops the
+        // integer axes, returning a 2-D chunk that composeData consumes unchanged.
+        const {row, col} = this.bandSpatialAxes_[i];
+        /** @type {Array<number|null|ReturnType<typeof slice>>} */
+        const selection = extra.slice();
+        selection[row] = rowSlice;
+        selection[col] = colSlice;
         return get(array, selection);
       }),
     );
@@ -570,12 +578,10 @@ export default class GeoZarr extends DataTileSource {
           if (this.fillValue_ === undefined) {
             this.fillValue_ = Number(bandMeta['fill_value']);
           }
-          // Derive the band's actual pixel resolution from its array shape so
-          // that loadTile_ can use correct coordinates regardless of the tile
-          // grid zoom level.
+          // Derive the band's pixel resolution from its array shape so loadTile_
+          // uses correct coordinates regardless of the tile grid zoom level.
           const shape = bandMeta['shape'];
-          // The x axis is the last dimension (arrays may be N-D, e.g. [time, y, x]).
-          const xSize = shape && shape[shape.length - 1];
+          const xSize = shape && shape[this.axesOf_(bandMeta).col];
           if (xSize > 0) {
             const extent = this.tileGrid.getExtent();
             this.bandSingleScaleResolution_[i] =
@@ -594,6 +600,41 @@ export default class GeoZarr extends DataTileSource {
   }
 
   /**
+   * Open a Zarr array (path relative to its group) through the shared cache, so
+   * concurrent opens of the same array are deduplicated.
+   * @param {number} groupIndex The band's group index.
+   * @param {string} path The array path relative to the group.
+   * @return {Promise<import('zarrita').Array<import('zarrita').DataType, any>>} The array.
+   * @private
+   */
+  openArray_(groupIndex, path) {
+    const cacheKey = `${groupIndex}:${path}`;
+    let array = this.arrayCache_.get(cacheKey);
+    if (!array) {
+      array = open(this.groups_[groupIndex].resolve(path), {
+        kind: 'array',
+      }).catch((err) => {
+        this.arrayCache_.delete(cacheKey);
+        throw err;
+      });
+      this.arrayCache_.set(cacheKey, array);
+    }
+    return array;
+  }
+
+  /**
+   * Consolidated metadata for a group, with keys relative to that group.
+   * @param {number} groupIndex The group index.
+   * @return {Object} The group's consolidated metadata.
+   * @private
+   */
+  groupMetadata_(groupIndex) {
+    return this.groupPaths_
+      ? getSubMetadata(this.consolidatedMetadata_, this.groupPaths_[groupIndex])
+      : this.consolidatedMetadata_;
+  }
+
+  /**
    * Look up a band's Zarr v3 array metadata from consolidated metadata, trying
    * the multi-scale key (`<matrixId>/<band>`) first and falling back to a
    * single-scale key (`<band>`).
@@ -606,9 +647,7 @@ export default class GeoZarr extends DataTileSource {
     if (!this.consolidatedMetadata_) {
       return undefined;
     }
-    const meta = this.groupPaths_
-      ? getSubMetadata(this.consolidatedMetadata_, this.groupPaths_[groupIndex])
-      : this.consolidatedMetadata_;
+    const meta = this.groupMetadata_(groupIndex);
     if (this.bandsByLevel_) {
       for (const matrixId of Object.keys(this.bandsByLevel_)) {
         if (
@@ -623,25 +662,136 @@ export default class GeoZarr extends DataTileSource {
   }
 
   /**
-   * Get the non-spatial dimensions of the bands (e.g. `time`, `band`) that can
-   * be fixed through the `dimensions` option. The two trailing axes are treated
-   * as spatial (y, x); each remaining (leading) axis is one entry, outermost
-   * first. Each `name` comes from the array's `dimension_names` metadata, or is
-   * the axis position as a string when the array has none. Returns an empty
-   * array for 2-D bands. Available once the source is `ready`.
-   * @return {Array<{name: string, size: number}>} The selectable dimensions.
-   * @api
+   * Locate the 1-D coordinate array for a non-spatial dimension, by name among
+   * the group's 1-D arrays.
+   * @param {string} name The dimension name.
+   * @return {{path: string, groupIndex: number, meta: Object}|null} The path
+   *     (relative to the group), group index, and array metadata; or `null`.
+   * @private
    */
-  getDimensions() {
-    return this.extraDimensions_.map((d) => ({name: d.name, size: d.size}));
+  coordinateArray_(name) {
+    if (!this.consolidatedMetadata_) {
+      return null;
+    }
+    const groupIndex = this.bandGroupIndex_[0];
+    const meta = this.groupMetadata_(groupIndex);
+    const suffix = `/${name}`;
+    for (const path of Object.keys(meta)) {
+      if (path === name || path.endsWith(suffix)) {
+        const arrayMeta = meta[path];
+        if (Array.isArray(arrayMeta?.shape) && arrayMeta.shape.length === 1) {
+          return {path, groupIndex, meta: arrayMeta};
+        }
+      }
+    }
+    return null;
   }
 
   /**
-   * Describe the non-spatial (extra) dimensions of an array: the leading axes
-   * beyond the two trailing spatial (y, x) axes. Each is named by its
+   * Get the non-spatial dimensions of the bands (e.g. `time`) that can be fixed
+   * through the `dimensions` option, keyed by dimension name. Each entry has its
+   * `size` and the `attributes` of its coordinate array (e.g. `units`, for
+   * interpreting the values from {@link getValue}), or `attributes: null` when
+   * there is no coordinate array. Resolves with an empty object for 2-D bands,
+   * once the source is `ready`; rejects if the source fails to load.
+   * @return {Promise<Object<string, {size: number, attributes: Object|null}>>}
+   *     The selectable dimensions.
+   */
+  async getDimensions() {
+    await this.ready();
+    /** @type {Object<string, {size: number, attributes: Object|null}>} */
+    const dimensions = {};
+    for (const dimension of this.extraDimensions_) {
+      const coord = this.coordinateArray_(dimension.name);
+      dimensions[dimension.name] = {
+        size: dimension.size,
+        attributes: coord ? (coord.meta.attributes ?? null) : null,
+      };
+    }
+    return dimensions;
+  }
+
+  /**
+   * Read the coordinate value at an index along a non-spatial dimension (e.g.
+   * the timestamp for a `time` index), for labeling the current selection. The
+   * value is returned raw (as stored, e.g. a `bigint` for a 64-bit integer
+   * axis); use the `attributes` from {@link getDimensions} to interpret it.
+   * Returns `null` for a dimension without a coordinate array. Available once
+   * the source is `ready`.
+   * @param {string} name The dimension name (see {@link getDimensions}).
+   * @param {number} index The index along the dimension.
+   * @return {Promise<number|bigint|null>} The coordinate value, or null.
+   */
+  async getValue(name, index) {
+    await this.ready();
+    const coord = this.coordinateArray_(name);
+    if (!coord) {
+      return null;
+    }
+    const size = coord.meta.shape[0];
+    if (index < 0 || index >= size) {
+      throw new Error(
+        `GeoZarr: index ${index} out of range for dimension "${name}" (size ${size}).`,
+      );
+    }
+    const array = await this.openArray_(coord.groupIndex, coord.path);
+    const chunk = await get(array, [slice(index, index + 1)]);
+    return chunk.data[0];
+  }
+
+  /**
+   * Change the fixed index of one or more non-spatial dimensions (e.g. move to
+   * another `time` slice) without rebuilding the source. Values are merged into
+   * the current selection, so a partial update like `{time: 3}` leaves the other
+   * dimensions untouched. Takes effect immediately when the source is `ready`,
+   * otherwise once it becomes ready.
+   * @param {Object<string, number|string>} dimensions Index per dimension name
+   *     to change; see the `dimensions` constructor option.
+   */
+  updateDimensions(dimensions) {
+    this.dimensions_ = {...this.dimensions_, ...dimensions};
+    if (this.getState() !== 'ready') {
+      // configure_ reads dimensions_ when it resolves; nothing to do yet.
+      return;
+    }
+    // Resolve every band before assigning, so an invalid index throws (via
+    // resolveExtraSelection_) without leaving a half-updated selection.
+    const selection = this.bands_.map((band, i) =>
+      this.resolveExtraSelection_(
+        this.getBandArrayMeta_(band, this.bandGroupIndex_[i]),
+      ),
+    );
+    this.bandExtraSelection_ = selection;
+    // Bump the tile key to reload tiles. Deriving it from the selection (rather
+    // than a counter) keeps prior selections' tiles cached, so revisiting hits.
+    this.setKey(getUid(this) + ':' + JSON.stringify(this.dimensions_));
+  }
+
+  /**
+   * Locate the spatial (y, x) axes of an array (see {@link getSpatialAxes}) and
+   * its remaining non-spatial axes.
+   * @param {Object|undefined} arrayMeta Zarr v3 array metadata.
+   * @return {{row: number, col: number, extra: Array<number>}} The row (y) and
+   *     column (x) axis positions and the remaining extra axes, in array order.
+   * @private
+   */
+  axesOf_(arrayMeta) {
+    const {row, col} = getSpatialAxes(this.spatialDimensionNames_, arrayMeta);
+    const rank = ((arrayMeta && arrayMeta['shape']) || []).length;
+    const extra = [];
+    for (let axis = 0; axis < rank; ++axis) {
+      if (axis !== row && axis !== col) {
+        extra.push(axis);
+      }
+    }
+    return {row, col, extra};
+  }
+
+  /**
+   * Describe the non-spatial dimensions of an array. Each is named by its
    * `dimension_names` entry, or by its axis position when there are none.
-   * @param {Object|undefined} arrayMeta Zarr v3 array metadata (`shape`, optional `dimension_names`).
-   * @return {Array<{name: string, size: number}>} The extra dimensions, outermost first.
+   * @param {Object|undefined} arrayMeta Zarr v3 array metadata.
+   * @return {Array<{name: string, size: number, axis: number}>} The extra dimensions, outermost first.
    * @private
    */
   extraDimsOf_(arrayMeta) {
@@ -652,22 +802,22 @@ export default class GeoZarr extends DataTileSource {
     const dimensionNames = arrayMeta['dimension_names'];
     const hasNames = Array.isArray(dimensionNames);
     const dims = [];
-    for (let axis = 0; axis < shape.length - 2; ++axis) {
+    for (const axis of this.axesOf_(arrayMeta).extra) {
       const raw = hasNames ? dimensionNames[axis] : undefined;
       const name =
         raw === null || raw === undefined ? String(axis) : String(raw);
-      dims.push({name, size: shape[axis]});
+      dims.push({name, size: shape[axis], axis});
     }
     return dims;
   }
 
   /**
-   * Resolve the fixed index for each non-spatial (extra) dimension of a band
-   * array from the `dimensions` option. Returns `undefined` for arrays of rank
-   * <= 2 (no extra dimensions), otherwise an array aligned to the array rank
-   * with a fixed integer at each extra axis and `null` at the two spatial axes
-   * (e.g. `[2, null, null]` for a `[time, y, x]` array with `{time: 2}`).
-   * @param {Object|undefined} arrayMeta Zarr v3 array metadata (`shape`, optional `dimension_names`).
+   * Resolve the fixed index for each non-spatial dimension of a band array from
+   * the `dimensions` option. Returns `undefined` for 2-D arrays, otherwise an
+   * array aligned to the array rank with a fixed integer at each extra axis and
+   * `null` at the two spatial axes (e.g. `[2, null, null]` for a `[time, y, x]`
+   * array with `{time: 2}`).
+   * @param {Object|undefined} arrayMeta Zarr v3 array metadata.
    * @return {Array<number|null>|undefined} The extra-axis selection template.
    * @private
    */
@@ -678,13 +828,12 @@ export default class GeoZarr extends DataTileSource {
     }
     const names = dims.map((d) => d.name);
     const dimKeys = Object.keys(this.dimensions_);
-    // A single dimension without a name is lenient: any single key binds to it
-    // (convenience for cubes lacking `dimension_names`, e.g. `{time: 0}`).
+    // A single unnamed dimension is lenient: any single key binds to it.
     const singleUnnamed =
       dims.length === 1 && !Array.isArray(arrayMeta['dimension_names']);
 
-    // Fail loud on a key matching no dimension — almost certainly a typo that
-    // would otherwise silently render the wrong slice.
+    // Fail loud on a key matching no dimension, rather than silently rendering
+    // the wrong slice.
     for (const key of dimKeys) {
       if (!names.includes(key) && !singleUnnamed) {
         throw new Error(
@@ -694,9 +843,9 @@ export default class GeoZarr extends DataTileSource {
       }
     }
 
-    const selection = new Array(dims.length + 2).fill(null);
-    for (let axis = 0; axis < dims.length; ++axis) {
-      const name = names[axis];
+    const selection = new Array(arrayMeta['shape'].length).fill(null);
+    for (const dim of dims) {
+      const name = dim.name;
       let index;
       if (name in this.dimensions_) {
         index = this.dimensions_[name];
@@ -706,21 +855,19 @@ export default class GeoZarr extends DataTileSource {
         index = 0; // unspecified extra dimension defaults to the first slice
       }
       if (typeof index === 'string') {
-        // Future: a string value will resolve a coordinate label (e.g. a
-        // datetime) to an index by reading and decoding the matching coordinate
-        // array. Only positional integer indices are supported for now.
+        // Datetime-label selection is not implemented yet; only integer indices.
         throw new Error(
           `GeoZarr: datetime-label selection for dimension "${name}" is not yet ` +
             `implemented; pass an integer index in the \`dimensions\` option.`,
         );
       }
-      if (!Number.isInteger(index) || index < 0 || index >= dims[axis].size) {
+      if (!Number.isInteger(index) || index < 0 || index >= dim.size) {
         throw new Error(
           `GeoZarr: invalid index ${index} for dimension "${name}" ` +
-            `(size ${dims[axis].size}).`,
+            `(size ${dim.size}).`,
         );
       }
-      selection[axis] = index;
+      selection[dim.axis] = index;
     }
     return selection;
   }
@@ -776,6 +923,7 @@ function createCachedStore(store, groupBytes, consolidatedMetadata) {
  *   zarr_conventions: Array<{uuid: string}>,
  *   'spatial:bbox': import("../extent.js").Extent,
  *   'spatial:shape': Array<number>,
+ *   'spatial:dimensions'?: Array<string>,
  *   'proj:wkt2'?: string,
  *   'proj:projjson'?: Object,
  *   'proj:code'?: string | null,
@@ -826,15 +974,42 @@ const MIN_TILE_SIZE = 64;
  */
 
 /**
+ * Locate the row (y) and column (x) axis positions of an array by matching the
+ * group's `spatial:dimensions` names (`[y, x]`) against the array's
+ * `dimension_names`, falling back to the two trailing axes when either is absent.
+ * @param {Array<string>|undefined} spatialDimensionNames The `spatial:dimensions` value (`[y, x]` names).
+ * @param {Object|undefined} arrayMeta Zarr v3 array metadata.
+ * @return {{row: number, col: number}} The row (y) and column (x) axis positions.
+ */
+function getSpatialAxes(spatialDimensionNames, arrayMeta) {
+  const rank = ((arrayMeta && arrayMeta['shape']) || []).length;
+  const names = arrayMeta && arrayMeta['dimension_names'];
+  if (
+    Array.isArray(spatialDimensionNames) &&
+    spatialDimensionNames.length === 2 &&
+    Array.isArray(names)
+  ) {
+    const row = names.indexOf(spatialDimensionNames[0]);
+    const col = names.indexOf(spatialDimensionNames[1]);
+    if (row !== -1 && col !== -1) {
+      return {row, col};
+    }
+  }
+  return {row: rank - 2, col: rank - 1};
+}
+
+/**
  * FIXME Remove this when GeoZarr datasets provide correct TileMatrixSet info or similar.
  *
  * Get the shard and inner chunk shapes from the Zarr v3 array metadata.
  * Only returns info when a `sharding_indexed` codec is present, meaning
  * `chunk_grid.configuration.chunk_shape` represents the shard (outer chunk) size.
  * @param {Object} arrayMeta The Zarr v3 array metadata from consolidated metadata.
+ * @param {number} row The row (y) axis position.
+ * @param {number} col The column (x) axis position.
  * @return {ShardInfo|undefined} The shard info, or undefined.
  */
-function getShardInfo(arrayMeta) {
+function getShardInfo(arrayMeta, row, col) {
   const chunkGrid = arrayMeta['chunk_grid'];
   if (!chunkGrid || chunkGrid['name'] !== 'regular') {
     return undefined;
@@ -847,13 +1022,12 @@ function getShardInfo(arrayMeta) {
   if (!shardingCodec) {
     return undefined;
   }
-  // Keep only the two spatial axes (last two). For N-D arrays (e.g. a
-  // [time, y, x] cube) the chunk/shard shapes are also N-D; the leading
-  // (non-spatial) axes are irrelevant to tile sizing. `slice(-2)` is a no-op
-  // for already-2-D shapes.
+  // Keep only the two spatial axes; the chunk/shard shapes are N-D for N-D arrays.
+  const shardShape = chunkGrid['configuration']['chunk_shape'];
+  const innerChunkShape = shardingCodec['configuration']['chunk_shape'];
   return {
-    shardShape: chunkGrid['configuration']['chunk_shape'].slice(-2),
-    innerChunkShape: shardingCodec['configuration']['chunk_shape'].slice(-2),
+    shardShape: [shardShape[row], shardShape[col]],
+    innerChunkShape: [innerChunkShape[row], innerChunkShape[col]],
   };
 }
 
@@ -925,7 +1099,11 @@ function getTileGridInfoFromAttributes(
           }
           //FIXME Remove this when GeoZarr datasets provide correct TileMatrixSet info or similar
           if (!tileSize) {
-            const shardInfo = getShardInfo(bandArray);
+            const {row, col} = getSpatialAxes(
+              attributes['spatial:dimensions'],
+              bandArray,
+            );
+            const shardInfo = getShardInfo(bandArray, row, col);
             if (shardInfo) {
               tileSize = [
                 getTileSizeForShard(

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -50,6 +50,14 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * To disable the opacity transition, pass `transition: 0`.
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
  * @property {ResampleMethod} [resample='nearest'] Resampling method if bands are not available for all multi-scale levels.
+ * @property {Object<string, number|string>} [dimensions] Fixed index for each non-spatial
+ * dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` to render the first
+ * time step of a `[time, y, x]` cube). The two trailing axes are treated as spatial (y, x); each
+ * leading axis is a selectable dimension — use the names returned by {@link getDimensions}. Names
+ * come from the array's `dimension_names` metadata; when an array has none, a dimension is keyed
+ * by its axis position as a string (e.g. `{'0': 1}`), and a single unnamed dimension also accepts
+ * any key. Only integer (positional) indices are supported; a string value (e.g. a datetime label)
+ * is reserved for a future release and currently throws. Unspecified dimensions default to `0`.
  */
 
 /**
@@ -82,6 +90,13 @@ export default class GeoZarr extends DataTileSource {
      * @private
      */
     this.url_ = options.url;
+
+    /**
+     * Fixed index per non-spatial dimension name, from the `dimensions` option.
+     * @type {Object<string, number|string>}
+     * @private
+     */
+    this.dimensions_ = options.dimensions || {};
 
     /**
      * @type {Error|null}
@@ -153,6 +168,24 @@ export default class GeoZarr extends DataTileSource {
      * @private
      */
     this.bands_ = bands;
+
+    /**
+     * Per-band template for selecting fixed indices along non-spatial dimensions.
+     * `undefined` for 2-D band arrays; otherwise an array aligned to the array
+     * rank with a fixed integer at each extra axis and `null` at the two spatial
+     * axes (e.g. `[2, null, null]` for a `[time, y, x]` array with `time: 2`).
+     * @type {Array<Array<number|null>|undefined>}
+     * @private
+     */
+    this.bandExtraSelection_ = new Array(bands.length).fill(undefined);
+
+    /**
+     * Non-spatial dimensions of the bands (`{name, size}`), discovered in
+     * `configure_` and exposed via {@link getDimensions}.
+     * @type {Array<{name: string, size: number}>}
+     * @private
+     */
+    this.extraDimensions_ = [];
 
     /**
      * @type {Object<string, Array<string>> | null}
@@ -297,7 +330,8 @@ export default class GeoZarr extends DataTileSource {
       }
       if (shape) {
         const extent = attributes['spatial:bbox'];
-        const resolution = (extent[2] - extent[0]) / shape[1];
+        // The x axis is the last dimension (arrays may be N-D, e.g. [time, y, x]).
+        const resolution = (extent[2] - extent[0]) / shape[shape.length - 1];
         if (!this.projection) {
           this.projection = getProjectionFromAttributes(attributes);
         }
@@ -339,6 +373,20 @@ export default class GeoZarr extends DataTileSource {
     }
     if (!this.tileGrid) {
       throw new Error('Could not determine tile grid');
+    }
+
+    // Resolve, per band, the fixed indices for any non-spatial dimensions so
+    // loadTile_ can slice a 2-D view out of N-D (e.g. [time, y, x]) arrays, and
+    // record the selectable dimensions for getDimensions().
+    for (let i = 0, ii = this.bands_.length; i < ii; ++i) {
+      const arrayMeta = this.getBandArrayMeta_(
+        this.bands_[i],
+        this.bandGroupIndex_[i],
+      );
+      this.bandExtraSelection_[i] = this.resolveExtraSelection_(arrayMeta);
+      if (this.extraDimensions_.length === 0) {
+        this.extraDimensions_ = this.extraDimsOf_(arrayMeta);
+      }
     }
 
     const extent = this.tileGrid.getExtent();
@@ -454,10 +502,19 @@ export default class GeoZarr extends DataTileSource {
     const bandChunks = await Promise.all(
       arrays.map((array, i) => {
         const info = bandInfos[i];
-        return get(array, [
-          slice(info.minRow, info.maxRow),
-          slice(info.minCol, info.maxCol),
-        ]);
+        const rowSlice = slice(info.minRow, info.maxRow);
+        const colSlice = slice(info.minCol, info.maxCol);
+        const extra = this.bandExtraSelection_[i];
+        if (!extra) {
+          return get(array, [rowSlice, colSlice]);
+        }
+        // `extra` fixes an integer index on each non-spatial axis followed by
+        // null at the two trailing spatial axes (e.g. [timeIndex, null, null]);
+        // keep the fixed indices and append the row/column slices. zarrita
+        // drops the integer axes, returning a 2-D chunk that composeData
+        // consumes unchanged.
+        const selection = [...extra.slice(0, -2), rowSlice, colSlice];
+        return get(array, selection);
       }),
     );
     const [tileColCount, tileRowCount] = toSize(this.tileGrid.getTileSize(z));
@@ -517,10 +574,12 @@ export default class GeoZarr extends DataTileSource {
           // that loadTile_ can use correct coordinates regardless of the tile
           // grid zoom level.
           const shape = bandMeta['shape'];
-          if (shape && shape[1] > 0) {
+          // The x axis is the last dimension (arrays may be N-D, e.g. [time, y, x]).
+          const xSize = shape && shape[shape.length - 1];
+          if (xSize > 0) {
             const extent = this.tileGrid.getExtent();
             this.bandSingleScaleResolution_[i] =
-              (extent[2] - extent[0]) / shape[1];
+              (extent[2] - extent[0]) / xSize;
           }
           foundAtAnyLevel = true;
         }
@@ -532,6 +591,138 @@ export default class GeoZarr extends DataTileSource {
         );
       }
     }
+  }
+
+  /**
+   * Look up a band's Zarr v3 array metadata from consolidated metadata, trying
+   * the multi-scale key (`<matrixId>/<band>`) first and falling back to a
+   * single-scale key (`<band>`).
+   * @param {string} band The band name.
+   * @param {number} groupIndex The index of the band's group.
+   * @return {Object|undefined} The array metadata, or undefined when unavailable.
+   * @private
+   */
+  getBandArrayMeta_(band, groupIndex) {
+    if (!this.consolidatedMetadata_) {
+      return undefined;
+    }
+    const meta = this.groupPaths_
+      ? getSubMetadata(this.consolidatedMetadata_, this.groupPaths_[groupIndex])
+      : this.consolidatedMetadata_;
+    if (this.bandsByLevel_) {
+      for (const matrixId of Object.keys(this.bandsByLevel_)) {
+        if (
+          this.bandsByLevel_[matrixId].includes(band) &&
+          meta[`${matrixId}/${band}`]
+        ) {
+          return meta[`${matrixId}/${band}`];
+        }
+      }
+    }
+    return meta[band];
+  }
+
+  /**
+   * Get the non-spatial dimensions of the bands (e.g. `time`, `band`) that can
+   * be fixed through the `dimensions` option. The two trailing axes are treated
+   * as spatial (y, x); each remaining (leading) axis is one entry, outermost
+   * first. Each `name` comes from the array's `dimension_names` metadata, or is
+   * the axis position as a string when the array has none. Returns an empty
+   * array for 2-D bands. Available once the source is `ready`.
+   * @return {Array<{name: string, size: number}>} The selectable dimensions.
+   * @api
+   */
+  getDimensions() {
+    return this.extraDimensions_.map((d) => ({name: d.name, size: d.size}));
+  }
+
+  /**
+   * Describe the non-spatial (extra) dimensions of an array: the leading axes
+   * beyond the two trailing spatial (y, x) axes. Each is named by its
+   * `dimension_names` entry, or by its axis position when there are none.
+   * @param {Object|undefined} arrayMeta Zarr v3 array metadata (`shape`, optional `dimension_names`).
+   * @return {Array<{name: string, size: number}>} The extra dimensions, outermost first.
+   * @private
+   */
+  extraDimsOf_(arrayMeta) {
+    const shape = arrayMeta && arrayMeta['shape'];
+    if (!Array.isArray(shape) || shape.length <= 2) {
+      return [];
+    }
+    const dimensionNames = arrayMeta['dimension_names'];
+    const hasNames = Array.isArray(dimensionNames);
+    const dims = [];
+    for (let axis = 0; axis < shape.length - 2; ++axis) {
+      const raw = hasNames ? dimensionNames[axis] : undefined;
+      const name =
+        raw === null || raw === undefined ? String(axis) : String(raw);
+      dims.push({name, size: shape[axis]});
+    }
+    return dims;
+  }
+
+  /**
+   * Resolve the fixed index for each non-spatial (extra) dimension of a band
+   * array from the `dimensions` option. Returns `undefined` for arrays of rank
+   * <= 2 (no extra dimensions), otherwise an array aligned to the array rank
+   * with a fixed integer at each extra axis and `null` at the two spatial axes
+   * (e.g. `[2, null, null]` for a `[time, y, x]` array with `{time: 2}`).
+   * @param {Object|undefined} arrayMeta Zarr v3 array metadata (`shape`, optional `dimension_names`).
+   * @return {Array<number|null>|undefined} The extra-axis selection template.
+   * @private
+   */
+  resolveExtraSelection_(arrayMeta) {
+    const dims = this.extraDimsOf_(arrayMeta);
+    if (dims.length === 0) {
+      return undefined;
+    }
+    const names = dims.map((d) => d.name);
+    const dimKeys = Object.keys(this.dimensions_);
+    // A single dimension without a name is lenient: any single key binds to it
+    // (convenience for cubes lacking `dimension_names`, e.g. `{time: 0}`).
+    const singleUnnamed =
+      dims.length === 1 && !Array.isArray(arrayMeta['dimension_names']);
+
+    // Fail loud on a key matching no dimension — almost certainly a typo that
+    // would otherwise silently render the wrong slice.
+    for (const key of dimKeys) {
+      if (!names.includes(key) && !singleUnnamed) {
+        throw new Error(
+          `GeoZarr: unknown dimension "${key}" in the \`dimensions\` option; ` +
+            `available: [${names.join(', ')}].`,
+        );
+      }
+    }
+
+    const selection = new Array(dims.length + 2).fill(null);
+    for (let axis = 0; axis < dims.length; ++axis) {
+      const name = names[axis];
+      let index;
+      if (name in this.dimensions_) {
+        index = this.dimensions_[name];
+      } else if (singleUnnamed && dimKeys.length === 1) {
+        index = this.dimensions_[dimKeys[0]];
+      } else {
+        index = 0; // unspecified extra dimension defaults to the first slice
+      }
+      if (typeof index === 'string') {
+        // Future: a string value will resolve a coordinate label (e.g. a
+        // datetime) to an index by reading and decoding the matching coordinate
+        // array. Only positional integer indices are supported for now.
+        throw new Error(
+          `GeoZarr: datetime-label selection for dimension "${name}" is not yet ` +
+            `implemented; pass an integer index in the \`dimensions\` option.`,
+        );
+      }
+      if (!Number.isInteger(index) || index < 0 || index >= dims[axis].size) {
+        throw new Error(
+          `GeoZarr: invalid index ${index} for dimension "${name}" ` +
+            `(size ${dims[axis].size}).`,
+        );
+      }
+      selection[axis] = index;
+    }
+    return selection;
   }
 }
 
@@ -656,9 +847,13 @@ function getShardInfo(arrayMeta) {
   if (!shardingCodec) {
     return undefined;
   }
+  // Keep only the two spatial axes (last two). For N-D arrays (e.g. a
+  // [time, y, x] cube) the chunk/shard shapes are also N-D; the leading
+  // (non-spatial) axes are irrelevant to tile sizing. `slice(-2)` is a no-op
+  // for already-2-D shapes.
   return {
-    shardShape: chunkGrid['configuration']['chunk_shape'],
-    innerChunkShape: shardingCodec['configuration']['chunk_shape'],
+    shardShape: chunkGrid['configuration']['chunk_shape'].slice(-2),
+    innerChunkShape: shardingCodec['configuration']['chunk_shape'].slice(-2),
   };
 }
 

--- a/src/ol/source/Source.js
+++ b/src/ol/source/Source.js
@@ -163,6 +163,37 @@ class Source extends BaseObject {
   }
 
   /**
+   * Resolve once the source is ready to be used (its state is `ready`), or
+   * reject if it fails to load (its state is `error`). Sources that configure
+   * asynchronously can use this to expose data (e.g. dimensions) through a
+   * promise instead of the `change` event.
+   * @return {Promise<void>} Resolves when the source is ready.
+   * @protected
+   */
+  ready() {
+    const state = this.getState();
+    if (state === 'ready') {
+      return Promise.resolve();
+    }
+    if (state === 'error') {
+      return Promise.reject(new Error('Source failed to load'));
+    }
+    return new Promise((resolve, reject) => {
+      const onChange = () => {
+        const changedState = this.getState();
+        if (changedState === 'ready') {
+          this.un('change', onChange);
+          resolve();
+        } else if (changedState === 'error') {
+          this.un('change', onChange);
+          reject(new Error('Source failed to load'));
+        }
+      };
+      this.on('change', onChange);
+    });
+  }
+
+  /**
    * Get the state of the source, see {@link import("./Source.js").State} for possible states.
    * @return {import("./Source.js").State} State.
    * @api

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -15,6 +15,7 @@ const ZARR_ROOT_URL = 'http://test-zarr/test.zarr';
  * @param {Array<number>} [options.innerChunkShape] The inner chunk shape.
  * @param {Array<number>} [options.shape] The array shape (defaults to a 2-D [10980, 10980]).
  * @param {Array<string>} [options.dimensionNames] The Zarr v3 `dimension_names`.
+ * @param {Object} [options.attributes] The array attributes.
  * @return {Object} The array metadata.
  */
 function createArrayMeta({
@@ -23,6 +24,7 @@ function createArrayMeta({
   innerChunkShape,
   shape,
   dimensionNames,
+  attributes,
 } = {}) {
   const meta = {
     zarr_format: 3,
@@ -41,7 +43,7 @@ function createArrayMeta({
       configuration: {separator: '/'},
     },
     codecs: [],
-    attributes: {},
+    attributes: attributes || {},
   };
   if (dimensionNames) {
     meta.dimension_names = dimensionNames;
@@ -742,48 +744,93 @@ describe('ol/source/GeoZarr', function () {
         });
       }));
 
-    it('reports the non-spatial dimensions via getDimensions()', () =>
+    it('locates the spatial axes by name when they are not trailing', () =>
       new Promise((resolve) => {
-        fetchStub = stubFetch({
-          ['level0/vv']: createArrayMeta({
-            shape: [5, 256, 256],
-            dimensionNames: ['time', 'y', 'x'],
-          }),
+        // A [y, time, x] layout: the spatial axes are the outer and inner axis,
+        // and `spatial:dimensions` names them so they can be found by name.
+        fetchStub = stubFetchWithAttrs(
+          {
+            ['level0/vv']: createArrayMeta({
+              shape: [256, 4, 256],
+              dimensionNames: ['y', 'time', 'x'],
+            }),
+          },
+          {'spatial:dimensions': ['y', 'x']},
+        );
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 3},
         });
-        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
-        source.on('change', function () {
+        source.on('change', async function () {
           if (source.getState() === 'ready') {
-            assert.deepEqual(source.getDimensions(), [{name: 'time', size: 5}]);
+            assert.deepEqual(source.bandSpatialAxes_[0], {row: 0, col: 2});
+            // The fixed index lands on the time axis (position 1), not a
+            // trailing axis.
+            assert.deepEqual(source.bandExtraSelection_[0], [null, 3, null]);
+            assert.deepEqual(await source.getDimensions(), {
+              time: {size: 4, attributes: null},
+            });
             resolve();
           }
         });
       }));
 
-    it('getDimensions() is empty for 2-D bands', () =>
-      new Promise((resolve) => {
-        fetchStub = stubFetch({['level0/b04']: createArrayMeta()});
-        const source = new GeoZarr({url: ZARR_URL, bands: ['b04']});
-        source.on('change', function () {
-          if (source.getState() === 'ready') {
-            assert.deepEqual(source.getDimensions(), []);
-            resolve();
-          }
-        });
-      }));
+    it('reports the non-spatial dimensions via getDimensions()', async () => {
+      fetchStub = stubFetch({
+        ['level0/vv']: createArrayMeta({
+          shape: [5, 256, 256],
+          dimensionNames: ['time', 'y', 'x'],
+        }),
+      });
+      const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+      assert.deepEqual(await source.getDimensions(), {
+        time: {size: 5, attributes: null},
+      });
+    });
 
-    it('getDimensions() names unnamed dimensions by axis position', () =>
-      new Promise((resolve) => {
-        fetchStub = stubFetch({
-          ['level0/vv']: createArrayMeta({shape: [3, 256, 256]}),
-        });
-        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
-        source.on('change', function () {
-          if (source.getState() === 'ready') {
-            assert.deepEqual(source.getDimensions(), [{name: '0', size: 3}]);
-            resolve();
-          }
-        });
-      }));
+    it('getDimensions() includes the coordinate array attributes', async () => {
+      fetchStub = stubFetch({
+        ['level0/vv']: createArrayMeta({
+          shape: [3, 256, 256],
+          dimensionNames: ['time', 'y', 'x'],
+        }),
+        ['level0/time']: createArrayMeta({
+          shape: [3],
+          dimensionNames: ['time'],
+          attributes: {
+            units: 'seconds since 2020-01-01',
+            standard_name: 'time',
+          },
+        }),
+      });
+      const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+      assert.deepEqual(await source.getDimensions(), {
+        time: {
+          size: 3,
+          attributes: {
+            units: 'seconds since 2020-01-01',
+            standard_name: 'time',
+          },
+        },
+      });
+    });
+
+    it('getDimensions() is empty for 2-D bands', async () => {
+      fetchStub = stubFetch({['level0/b04']: createArrayMeta()});
+      const source = new GeoZarr({url: ZARR_URL, bands: ['b04']});
+      assert.deepEqual(await source.getDimensions(), {});
+    });
+
+    it('getDimensions() names unnamed dimensions by axis position', async () => {
+      fetchStub = stubFetch({
+        ['level0/vv']: createArrayMeta({shape: [3, 256, 256]}),
+      });
+      const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+      assert.deepEqual(await source.getDimensions(), {
+        '0': {size: 3, attributes: null},
+      });
+    });
 
     it('selects unnamed dimensions by axis position', () =>
       new Promise((resolve) => {
@@ -944,6 +991,152 @@ describe('ol/source/GeoZarr', function () {
           if (source.getState() === 'error') {
             assert.include(source.error_.message, 'unknown dimension "bogus"');
             resolve();
+          }
+        });
+      }));
+
+    it('updateDimensions() moves to another slice and changes the tile key', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [5, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 0},
+        });
+        let handled = false;
+        source.on('change', function () {
+          if (source.getState() === 'ready' && !handled) {
+            handled = true;
+            const before = source.getKey();
+            source.updateDimensions({time: 3});
+            assert.deepEqual(source.bandExtraSelection_[0], [3, null, null]);
+            assert.notStrictEqual(source.getKey(), before);
+            resolve();
+          }
+        });
+      }));
+
+    it('updateDimensions() merges into the current selection', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({shape: [2, 3, 256, 256]}),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {'0': 1, '1': 2},
+        });
+        let handled = false;
+        source.on('change', function () {
+          if (source.getState() === 'ready' && !handled) {
+            handled = true;
+            source.updateDimensions({'1': 0}); // change only the second axis
+            assert.deepEqual(source.bandExtraSelection_[0], [1, 0, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('updateDimensions() throws on an out-of-range index and keeps the selection', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [5, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 0},
+        });
+        let handled = false;
+        source.on('change', function () {
+          if (source.getState() === 'ready' && !handled) {
+            handled = true;
+            assert.throws(function () {
+              source.updateDimensions({time: 9});
+            }, /invalid index 9/);
+            assert.deepEqual(source.bandExtraSelection_[0], [0, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('updateDimensions() reuses the tile key when revisiting a slice', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [5, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 0},
+        });
+        let handled = false;
+        source.on('change', function () {
+          if (source.getState() === 'ready' && !handled) {
+            handled = true;
+            source.updateDimensions({time: 0});
+            const keyA = source.getKey();
+            source.updateDimensions({time: 3});
+            assert.notStrictEqual(source.getKey(), keyA);
+            source.updateDimensions({time: 0});
+            assert.strictEqual(source.getKey(), keyA);
+            resolve();
+          }
+        });
+      }));
+
+    it('getValue() throws on an out-of-range index', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+          ['level0/time']: createArrayMeta({
+            shape: [3],
+            dimensionNames: ['time'],
+          }),
+        });
+        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            source.getValue('time', 5).then(
+              () => assert.fail('expected a rejection'),
+              (error) => {
+                assert.include(error.message, 'out of range');
+                resolve();
+              },
+            );
+          }
+        });
+      }));
+
+    it('getValue() returns null when there is no coordinate array', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            source.getValue('time', 0).then((value) => {
+              assert.strictEqual(value, null);
+              resolve();
+            });
           }
         });
       }));

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -11,15 +11,23 @@ const ZARR_ROOT_URL = 'http://test-zarr/test.zarr';
  * Create a Zarr v3 array metadata object with optional sharding codec.
  * @param {Object} options Options.
  * @param {number} [options.fillValue] The fill value.
- * @param {Array<number>} [options.shardShape] The shard (outer chunk) shape [rows, cols].
- * @param {Array<number>} [options.innerChunkShape] The inner chunk shape [rows, cols].
+ * @param {Array<number>} [options.shardShape] The shard (outer chunk) shape.
+ * @param {Array<number>} [options.innerChunkShape] The inner chunk shape.
+ * @param {Array<number>} [options.shape] The array shape (defaults to a 2-D [10980, 10980]).
+ * @param {Array<string>} [options.dimensionNames] The Zarr v3 `dimension_names`.
  * @return {Object} The array metadata.
  */
-function createArrayMeta({fillValue, shardShape, innerChunkShape} = {}) {
+function createArrayMeta({
+  fillValue,
+  shardShape,
+  innerChunkShape,
+  shape,
+  dimensionNames,
+} = {}) {
   const meta = {
     zarr_format: 3,
     node_type: 'array',
-    shape: [10980, 10980],
+    shape: shape || [10980, 10980],
     data_type: 'float32',
     fill_value: fillValue !== undefined ? fillValue : 0,
     chunk_grid: {
@@ -35,6 +43,9 @@ function createArrayMeta({fillValue, shardShape, innerChunkShape} = {}) {
     codecs: [],
     attributes: {},
   };
+  if (dimensionNames) {
+    meta.dimension_names = dimensionNames;
+  }
   if (innerChunkShape) {
     meta.codecs = [
       {
@@ -694,6 +705,244 @@ describe('ol/source/GeoZarr', function () {
             assert.strictEqual(source.bandSingleScaleResolution_[0], undefined);
             assert.notEqual(source.bandSingleScaleResolution_[1], undefined);
             assert.include(source.bandsByLevel_['level0'], 'aot');
+            resolve();
+          }
+        });
+      }));
+  });
+
+  describe('dimensions (time-slice / extra dimensions)', function () {
+    let fetchStub;
+
+    afterEach(function () {
+      if (fetchStub) {
+        fetchStub.mockRestore();
+        fetchStub = null;
+      }
+    });
+
+    it('resolves the extra-dimension index from dimension_names', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 2},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.bandExtraSelection_[0], [2, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('reports the non-spatial dimensions via getDimensions()', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [5, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.getDimensions(), [{name: 'time', size: 5}]);
+            resolve();
+          }
+        });
+      }));
+
+    it('getDimensions() is empty for 2-D bands', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({['level0/b04']: createArrayMeta()});
+        const source = new GeoZarr({url: ZARR_URL, bands: ['b04']});
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.getDimensions(), []);
+            resolve();
+          }
+        });
+      }));
+
+    it('getDimensions() names unnamed dimensions by axis position', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({shape: [3, 256, 256]}),
+        });
+        const source = new GeoZarr({url: ZARR_URL, bands: ['vv']});
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.getDimensions(), [{name: '0', size: 3}]);
+            resolve();
+          }
+        });
+      }));
+
+    it('selects unnamed dimensions by axis position', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({shape: [2, 3, 256, 256]}),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {'0': 1, '1': 2},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.bandExtraSelection_[0], [1, 2, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('binds a single extra axis positionally when dimension_names is absent', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({shape: [3, 256, 256]}),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 1},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.bandExtraSelection_[0], [1, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('leaves 2-D arrays unselected (no behavior change)', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/b04']: createArrayMeta(),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['b04'],
+          dimensions: {time: 0},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.strictEqual(source.bandExtraSelection_[0], undefined);
+            resolve();
+          }
+        });
+      }));
+
+    it('supports band-as-dimension (forward-compat for #17474)', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/data']: createArrayMeta({
+            shape: [4, 256, 256],
+            dimensionNames: ['band', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['data'],
+          dimensions: {band: 1},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.bandExtraSelection_[0], [1, null, null]);
+            resolve();
+          }
+        });
+      }));
+
+    it('derives a 2-D-equivalent tile size for a sharded 3-D array', () =>
+      new Promise((resolve) => {
+        // Shard/inner-chunk shapes are 3-D ([1, 512, 512] / [1, 128, 128]); the
+        // leading (time) axis must be ignored so the tile size matches the 2-D case.
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 512, 512],
+            shardShape: [1, 512, 512],
+            innerChunkShape: [1, 128, 128],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 0},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.tileGrid.getTileSize(0), [512, 512]);
+            resolve();
+          }
+        });
+      }));
+
+    it('errors on an out-of-range index', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: 5},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'error') {
+            assert.include(source.error_.message, 'invalid index 5');
+            resolve();
+          }
+        });
+      }));
+
+    it('errors on a string (datetime-label) value as not yet implemented', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {time: '2026-06-16T18:11:16Z'},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'error') {
+            assert.include(source.error_.message, 'not yet implemented');
+            resolve();
+          }
+        });
+      }));
+
+    it('errors on an unknown dimension name', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch({
+          ['level0/vv']: createArrayMeta({
+            shape: [3, 256, 256],
+            dimensionNames: ['time', 'y', 'x'],
+          }),
+        });
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['vv'],
+          dimensions: {bogus: 0},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'error') {
+            assert.include(source.error_.message, 'unknown dimension "bogus"');
             resolve();
           }
         });


### PR DESCRIPTION
Refs #17474

## Summary

Adds support for rendering a single slice of an N-D GeoZarr cube. `ol/source/GeoZarr` previously rendered 2-D `[y, x]` arrays only; this lets it display one slice of an array like a Sentinel-1 `[time, y, x]` cube.

- **`dimensions` option** — fix an integer index on each non-spatial axis, e.g. `{time: 0}`. Keyed by the array's `dimension_names`, or by axis position (`{'0': 0}`) for arrays without them.
- **`getDimensions()`** — new `@api` accessor returning the selectable non-spatial dimensions and their sizes (`[{name, size}]`), so an app can build a UI without knowing the cube shape.
- **Backward compatible** — 2-D arrays behave identically when `dimensions` is omitted; zarrita drops the fixed integer axes so the existing tile-composition path consumes the resulting 2-D chunk unchanged.
- Only positional integer indices are supported; a string (datetime-label) value is reserved for a follow-up and throws a clear error.

**Example** (`examples/geozarr-dimensions.{js,html}`) — renders a Sentinel-1 GRD RTC cube as a dual-polarization composite (vv→red, vh→green, vv/vh→blue) and drives the new API from the UI:

- a **URL** dropdown of real scenes — a Swiss Alps default (32TLS, which carries both `ascending`/`descending` groups) plus four event cubes: the 2024 Valencia DANA flood, the 2021 La Palma eruption, the Fujairah tanker anchorage outside the Strait of Hormuz, and Bay of Bothnia winter sea ice;
- a **Group** dropdown shown only when a cube has more than one orbit group (single-direction cubes auto-select);
- a **time** dropdown per non-spatial dimension, options labelled with the decoded coordinate values (dates), built from `getDimensions()`;
- the source is swapped in place on a time change (preserving the user's pan/zoom) and rebuilt on a group/cube change; guards handle superseded renders and non-decodable time labels.

## For reviewers

- The core change is `src/ol/source/GeoZarr.js` (fixing non-spatial indices + `getDimensions()`); everything else is the example. **Backward compatibility for 2-D arrays is the key invariant** — the no-op path when `dimensions` is omitted deserves a second look.
- 12 new unit tests cover named/positional selection, the 2-D no-op, sharded tile sizing, and the error paths (out-of-range, unknown dimension, unimplemented string value). At the feature commit the full suite was green (`karma`, 2964 tests) with `lint`, `typecheck`, `typecheck-strict`, and `generate-types` passing; the example was verified against the live Sentinel-1 stores. The most recent example edits (scenario list, conditional Group dropdown) pass `eslint`; please re-run the suite before merge.

## Author attestation

- [x] I am a human, these are my changes, and I have reviewed and understood every change and can explain why each is correct.

AI assistance (Claude Code) was used to draft and iterate the feature, tests, and the example scenarios/descriptions; all changes were human-reviewed, linted, and verified against live Sentinel-1 stores.
