### PR TITLE
Fix modify tracing

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -48,6 +48,7 @@ import {
   getCoordinate,
   getTraceTargetUpdate,
   getTraceTargets,
+  interpolateCoordinate,
 } from './tracing.js';
 
 /**
@@ -1195,8 +1196,39 @@ class Modify extends PointerInteraction {
   }
 
   /**
+   * Determine whether a trace from `fromIndex` to `toIndex` passes at least one
+   * vertex of the target (i.e. whether it would add any traced coordinates).
+   * The index math mirrors {@link addTracedCoordinates_}.
+   * @param {number} fromIndex The start index.
+   * @param {number} toIndex The end index.
+   * @return {boolean} At least one target vertex lies between the indices.
+   * @private
+   */
+  tracePassesVertex_(fromIndex, toIndex) {
+    if (fromIndex === toIndex) {
+      return false;
+    }
+    if (fromIndex < toIndex) {
+      const start = Math.ceil(fromIndex);
+      let end = Math.floor(toIndex);
+      if (end === toIndex) {
+        end -= 1;
+      }
+      return start <= end;
+    }
+    const start = Math.floor(fromIndex);
+    let end = Math.ceil(toIndex);
+    if (end === toIndex) {
+      end += 1;
+    }
+    return start >= end;
+  }
+
+  /**
    * Update the trace.
    * @param {import("../MapBrowserEvent.js").default} event Event.
+   * @return {import('../coordinate.js').Coordinate|undefined} The coordinate the
+   * dragged vertex was snapped onto a target edge, if any.
    * @private
    */
   updateTrace_(event) {
@@ -1229,47 +1261,63 @@ class Modify extends PointerInteraction {
       return;
     }
 
-    if (traceState.targetIndex !== updatedTraceTarget.index) {
-      // target changed
-      if (traceState.targetIndex !== -1) {
-        // remove points added during previous trace
-        const oldTarget = traceState.targets[traceState.targetIndex];
-        this.removeTracedCoordinates_(oldTarget.startIndex, oldTarget.endIndex);
-      } else {
-        for (const traceSegment of this.traceSegments_) {
-          const segmentData = traceSegment[0];
-          const geometry = segmentData.geometry;
-          const index = traceSegment[1];
-          const coordinates = geometry.getCoordinates();
-          const coordinatesArray = getCoordinatesArray(
-            coordinates,
-            geometry.getType(),
-            segmentData.depth,
-          );
-          coordinatesArray.splice(segmentData.index + index, 1);
-          geometry.setCoordinates(coordinates);
-          if (index === 0) {
-            segmentData.index -= 1;
-          }
-        }
-      }
-      // add points for the new target
-      const newTarget = traceState.targets[updatedTraceTarget.index];
-      this.addTracedCoordinates_(
-        newTarget,
-        newTarget.startIndex,
+    // Only commit to tracing a target once the drag has passed one of its
+    // vertices.  Before that we still snap the dragged vertex onto the target
+    // edge (below), but we keep `targetIndex` at -1 so that pulling the pointer
+    // beyond the tolerance releases the vertex instead of getting stuck on the
+    // target.
+    let commit = true;
+    if (traceState.targetIndex === -1) {
+      const candidateTarget = traceState.targets[updatedTraceTarget.index];
+      commit = this.tracePassesVertex_(
+        candidateTarget.startIndex,
         updatedTraceTarget.endIndex,
       );
-    } else {
-      // target stayed the same
-      const target = traceState.targets[traceState.targetIndex];
-      this.addOrRemoveTracedCoordinates_(target, updatedTraceTarget.endIndex);
     }
 
-    // modify the state with updated info
-    traceState.targetIndex = updatedTraceTarget.index;
-    const target = traceState.targets[traceState.targetIndex];
-    target.endIndex = updatedTraceTarget.endIndex;
+    if (commit) {
+      if (traceState.targetIndex !== updatedTraceTarget.index) {
+        // target changed
+        if (traceState.targetIndex !== -1) {
+          // remove points added during previous trace
+          const oldTarget = traceState.targets[traceState.targetIndex];
+          this.removeTracedCoordinates_(
+            oldTarget.startIndex,
+            oldTarget.endIndex,
+          );
+        }
+        // add points for the new target
+        const newTarget = traceState.targets[updatedTraceTarget.index];
+        this.addTracedCoordinates_(
+          newTarget,
+          newTarget.startIndex,
+          updatedTraceTarget.endIndex,
+        );
+      } else {
+        // target stayed the same
+        const target = traceState.targets[traceState.targetIndex];
+        this.addOrRemoveTracedCoordinates_(target, updatedTraceTarget.endIndex);
+      }
+
+      // modify the state with updated info
+      traceState.targetIndex = updatedTraceTarget.index;
+      traceState.targets[traceState.targetIndex].endIndex =
+        updatedTraceTarget.endIndex;
+    }
+
+    // Snap the dragged vertex (the moving end of the trace) onto the target
+    // edge so that the trace follows edges, not only vertices, and the geometry
+    // stays consistent with the vertex marker.  Moving all of the dragged
+    // vertex' segments keeps polygon rings closed.
+    const snapTarget = traceState.targets[updatedTraceTarget.index];
+    const snappedVertex = interpolateCoordinate(
+      snapTarget.coordinates,
+      updatedTraceTarget.endIndex,
+    );
+    for (const dragSegment of this.dragSegments_) {
+      this.updateGeometry_(snappedVertex.slice(), dragSegment);
+    }
+    return snappedVertex;
   }
 
   getTraceCandidates_(event) {
@@ -1355,6 +1403,34 @@ class Modify extends PointerInteraction {
   }
 
   /**
+   * Tracing splices coordinates into a ring next to the dragged vertex, but only
+   * adjusts the index of the trace segment itself.  The dragged vertex' other
+   * segments in `dragSegments_` reference the same ring, so their stored index
+   * must be shifted too - otherwise the next {@link updateGeometry_} writes the
+   * dragged vertex to the wrong coordinate and scrambles the ring.
+   * @param {SegmentData} traceSegmentData The trace segment (adjusted by the
+   * caller and skipped here).
+   * @param {number} atIndex Segments at or after this coordinate index shift.
+   * @param {number} delta Coordinates added (positive) or removed (negative).
+   * @private
+   */
+  shiftTracedSegmentIndices_(traceSegmentData, atIndex, delta) {
+    for (const dragSegment of this.dragSegments_) {
+      const segmentData = dragSegment[0];
+      if (
+        segmentData !== traceSegmentData &&
+        segmentData.geometry === traceSegmentData.geometry &&
+        (segmentData.depth === undefined ||
+          traceSegmentData.depth === undefined ||
+          equals(segmentData.depth, traceSegmentData.depth)) &&
+        segmentData.index >= atIndex
+      ) {
+        segmentData.index += delta;
+      }
+    }
+  }
+
+  /**
    * @param {number} fromIndex The start index.
    * @param {number} toIndex The end index.
    * @private
@@ -1397,7 +1473,12 @@ class Modify extends PointerInteraction {
           segmentData.depth,
         );
         coordinatesArray.splice(removeIndex, remove);
-        geometry.setCoordinates(coordinates);
+        this.setGeometryCoordinates_(geometry, coordinates);
+        this.shiftTracedSegmentIndices_(
+          segmentData,
+          removeIndex + remove,
+          -remove,
+        );
         if (index === 1) {
           segmentData.index -= remove;
         }
@@ -1456,7 +1537,12 @@ class Modify extends PointerInteraction {
           segmentData.depth,
         );
         coordinatesArray.splice(insertIndex, 0, ...newCoordinates);
-        geometry.setCoordinates(coordinates);
+        this.setGeometryCoordinates_(geometry, coordinates);
+        this.shiftTracedSegmentIndices_(
+          segmentData,
+          insertIndex,
+          newCoordinates.length,
+        );
         if (index === 1) {
           segmentData.index += newCoordinates.length;
         }
@@ -1624,6 +1710,14 @@ class Modify extends PointerInteraction {
           this.traceSegments_.push(dragSegment);
         }
       }
+      if (this.traceSegments_.length > 1) {
+        // Both segments of the dragged vertex are anchored at the trace start,
+        // i.e. the grabbed vertex is the anchor itself.  Tracing needs a fixed
+        // anchor distinct from the moving vertex, so cancel tracing and let this
+        // drag move the vertex freely.
+        this.deactivateTrace_();
+        this.traceSegments_ = null;
+      }
     }
     for (let i = 0, ii = this.dragSegments_.length; i < ii; ++i) {
       const dragSegment = this.dragSegments_[i];
@@ -1639,8 +1733,15 @@ class Modify extends PointerInteraction {
 
       this.updateGeometry_(vertex, dragSegment);
     }
-    this.updateTrace_(evt);
-    this.createOrUpdateVertexFeature_(vertex, features, geometries, true);
+    // when tracing snaps the dragged vertex onto a target edge, show the vertex
+    // marker at the snapped location rather than at the raw pointer
+    const snappedVertex = this.updateTrace_(evt);
+    this.createOrUpdateVertexFeature_(
+      snappedVertex || vertex,
+      features,
+      geometries,
+      true,
+    );
   }
 
   /**
@@ -1679,8 +1780,17 @@ class Modify extends PointerInteraction {
    * @override
    */
   handleUpEvent(evt) {
+    // Tracing inserts and removes vertices with guarded geometry mutations (so
+    // that dragSegments_ survive the drag). Those guarded mutations skip the
+    // segment rBush rebuild that handleFeatureChange_ would normally do, so the
+    // rBush no longer matches the traced geometry. Collect the affected features
+    // here and rebuild their segment data once the drag is over.
+    const tracedFeatures = this.traceState_.active ? new Set() : null;
     for (let i = this.dragSegments_.length - 1; i >= 0; --i) {
       const segmentData = this.dragSegments_[i][0];
+      if (tracedFeatures) {
+        tracedFeatures.add(segmentData.feature);
+      }
       const geometry = segmentData.geometry;
       if (geometry.getType() === 'Circle') {
         const circle = /** @type {import("../geom/Circle.js").default} */ (
@@ -1714,6 +1824,14 @@ class Modify extends PointerInteraction {
         );
       } else {
         this.rBush_.update(boundingExtent(segmentData.segment), segmentData);
+      }
+    }
+    if (tracedFeatures) {
+      for (const feature of tracedFeatures) {
+        this.removeFeature_(feature);
+        if (this.filter_(feature)) {
+          this.addFeature_(feature);
+        }
       }
     }
     if (this.featuresBeingModified_) {

--- a/test/browser/spec/ol/interaction/modify.test.js
+++ b/test/browser/spec/ol/interaction/modify.test.js
@@ -2001,6 +2001,148 @@ describe('ol.interaction.Modify', function () {
       map.addInteraction(modify);
     });
 
+    it('keeps the ring consistent when the trace direction changes', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // drag 1: drop the [200,0] vertex on the target top edge at [50,-50], which
+      // becomes the trace anchor
+      simulateEvent('pointermove', 200, 0, null, 0);
+      simulateEvent('pointerdown', 200, 0, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+
+      const round = () =>
+        modifyFeature
+          .getGeometry()
+          .getCoordinates()[0]
+          .map((c) => c.map((v) => Math.round(v * 1e6) / 1e6));
+
+      // drag 2: grab the ADJACENT vertex ([250,0]) and trace, moving forward
+      // past a vertex, back before it, then forward past two vertices.  The
+      // traced vertices must appear exactly once and in order - regression test
+      // for the stale segment index that used to scramble the ring.
+      simulateEvent('pointermove', 250, 0, null, 0);
+      simulateEvent('pointerdown', 250, 0, null, 0);
+
+      simulateEvent('pointerdrag', 100, 70, null, 0); // -> [100,-70], past [100,-50]
+      assert.deepEqual(round(), [
+        [50, -50],
+        [100, -50], // traced, once
+        [100, -70], // dragged end
+        [250, -150],
+        [200, -150],
+        [50, -50],
+      ]);
+
+      simulateEvent('pointerdrag', 60, 50, null, 0); // -> [60,-50], back before vertex
+      assert.deepEqual(round(), [
+        [50, -50],
+        [60, -50], // dragged end, traced vertex removed again
+        [250, -150],
+        [200, -150],
+        [50, -50],
+      ]);
+
+      simulateEvent('pointerdrag', 50, 90, null, 0); // -> [50,-90], past two vertices
+      simulateEvent('pointerup', 50, 90, null, 0);
+      assert.deepEqual(round(), [
+        [50, -50],
+        [100, -50], // traced, once
+        [100, -100], // traced, once
+        [50, -100], // dragged end on the bottom edge
+        [250, -150],
+        [200, -150],
+        [50, -50],
+      ]);
+    });
+
+    it('cancels tracing when the trace anchor itself is grabbed', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // drag 1: drop the [200,0] vertex on the target at [50,-50], the anchor
+      simulateEvent('pointermove', 200, 0, null, 0);
+      simulateEvent('pointerdown', 200, 0, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+      assert.strictEqual(modify.traceState_.active, true);
+
+      // drag 2: grab that SAME vertex (the anchor) - tracing must be cancelled,
+      // so the vertex just follows the pointer without inserting traced points
+      simulateEvent('pointermove', 50, 50, null, 0);
+      simulateEvent('pointerdown', 50, 50, null, 0);
+      simulateEvent('pointerdrag', 90, 100, null, 0); // -> [90,-100]
+      assert.strictEqual(modify.traceState_.active, false);
+      assert.strictEqual(modify.traceSegments_, null);
+      assert.deepEqual(modifyFeature.getGeometry().getCoordinates(), [
+        [
+          [90, -100],
+          [250, 0],
+          [250, -150],
+          [200, -150],
+          [90, -100],
+        ],
+      ]);
+      simulateEvent('pointerup', 90, 100, null, 0);
+    });
+
     it('starts tracing with first edge drag, stops tracing with second edge drag', function () {
       const modifyFeature = new Feature(
         // a polygon we'll modify
@@ -2050,16 +2192,292 @@ describe('ol.interaction.Modify', function () {
 
       const geometry = modifyFeature.getGeometry();
 
-      assert.deepEqual(geometry.getCoordinates(), [
+      // the dragged end is snapped exactly onto the target edge, so round away
+      // floating point noise from the interpolation
+      const coordinates = geometry
+        .getCoordinates()[0]
+        .map((c) => c.map((value) => Math.round(value * 1e6) / 1e6));
+
+      assert.deepEqual(coordinates, [
+        [90, -100], // second drag point
+        [250, 0],
+        [250, -150],
+        [200, -150],
+        [50, -50], // first drag point
+        [100, -50], // traced point
+        [100, -100], // traced point
+        [90, -100], // closing vertex (matches the second drag point)
+      ]);
+    });
+
+    it('snaps the dragged vertex onto a target edge and releases it when pulled away', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // first drag activates tracing (onto the top edge of the trace target)
+      simulateEvent('pointermove', 200, 100, null, 0);
+      simulateEvent('pointerdown', 200, 100, null, 0);
+      simulateEvent('pointermove', 50, 50, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+
+      // grab the far corner [250,-150], which is not connected to the trace
+      // start, then drag it NEAR the top edge (y=-50) but 5px off it
+      simulateEvent('pointermove', 250, 150, null, 0);
+      simulateEvent('pointerdown', 250, 150, null, 0);
+      simulateEvent('pointerdrag', 60, 45, null, 0);
+
+      // no target vertex has been passed, so tracing is not committed ...
+      assert.strictEqual(modify.traceState_.targetIndex, -1);
+      // ... but both the geometry vertex and the visible marker snap onto the
+      // target edge
+      assert.deepEqual(
+        modifyFeature.getGeometry().getCoordinates()[0][2],
+        [60, -50],
+      );
+      assert.deepEqual(
+        modify.vertexFeature_.getGeometry().getCoordinates(),
+        [60, -50],
+      );
+
+      // pull far away from the target (beyond the tolerance) -> the vertex is
+      // released and follows the pointer again
+      simulateEvent('pointerdrag', 60, 0, null, 0);
+      simulateEvent('pointerup', 60, 0, null, 0);
+      assert.deepEqual(
+        modifyFeature.getGeometry().getCoordinates()[0][2],
+        [60, 0],
+      );
+    });
+
+    it('keeps the dragged vertex when leaving the target before passing a vertex', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // first drag activates tracing (onto the top edge of the trace target)
+      simulateEvent('pointermove', 200, 100, null, 0);
+      simulateEvent('pointerdown', 200, 100, null, 0);
+      simulateEvent('pointermove', 50, 50, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+
+      assert.strictEqual(modify.traceState_.active, true);
+      assert.strictEqual(modify.traceState_.targetIndex, -1);
+
+      // second drag: onto the target edge, then away without passing a vertex
+      simulateEvent('pointermove', 200, 0, null, 0);
+      simulateEvent('pointerdown', 200, 0, null, 0);
+      simulateEvent('pointerdrag', 70, 50, null, 0); // onto the top edge [70,-50]
+
+      // no target is picked because no target vertex has been passed
+      assert.strictEqual(modify.traceState_.targetIndex, -1);
+
+      simulateEvent('pointerdrag', 70, 30, null, 0); // away again [70,-30]
+      simulateEvent('pointerup', 70, 30, null, 0);
+
+      // the dragged vertex followed the pointer and was not lost
+      assert.deepEqual(modifyFeature.getGeometry().getCoordinates(), [
         [
-          [90, -100], // second drag point
+          [70, -30],
           [250, 0],
           [250, -150],
           [200, -150],
-          [50, -50], // first drag point
-          [100, -50], // traced point
-          [100, -100], // traced point
+          [50, -50],
+          [70, -30],
         ],
+      ]);
+    });
+
+    it('keeps the traced end following the pointer across drag frames', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // first drag activates tracing (onto the top edge of the trace target)
+      simulateEvent('pointermove', 200, 100, null, 0);
+      simulateEvent('pointerdown', 200, 100, null, 0);
+      simulateEvent('pointermove', 50, 50, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+
+      // second drag: cross the [100,-50] vertex, then keep dragging along the
+      // right edge in a second frame
+      simulateEvent('pointermove', 200, 0, null, 0);
+      simulateEvent('pointerdown', 200, 0, null, 0);
+      simulateEvent('pointerdrag', 100, 70, null, 0); // past vertex -> [100,-70]
+      assert.strictEqual(modify.traceState_.targetIndex, 0);
+      simulateEvent('pointerdrag', 100, 90, null, 0); // continue -> [100,-90]
+      simulateEvent('pointerup', 100, 90, null, 0);
+
+      const coordinates = modifyFeature
+        .getGeometry()
+        .getCoordinates()[0]
+        .map((c) => c.map((value) => Math.round(value * 1e6) / 1e6));
+
+      // the traced vertex is inserted and the dragged end followed the pointer
+      // across the second frame (it does not freeze at [100,-70])
+      assert.deepEqual(coordinates, [
+        [100, -90],
+        [250, 0],
+        [250, -150],
+        [200, -150],
+        [50, -50],
+        [100, -50], // traced vertex
+        [100, -90], // closing vertex, follows the pointer
+      ]);
+    });
+
+    it('updates the segment rBush so traced vertices can be modified afterwards', function () {
+      const modifyFeature = new Feature(
+        new Polygon([
+          [
+            [200, 0],
+            [250, 0],
+            [250, -150],
+            [200, -150],
+            [200, 0],
+          ],
+        ]),
+      );
+      const traceSource = new VectorSource({
+        features: [
+          new Feature(
+            new Polygon([
+              [
+                [0, -50],
+                [100, -50],
+                [100, -100],
+                [0, -100],
+                [0, -50],
+              ],
+            ]),
+          ),
+        ],
+      });
+      map.removeInteraction(modify);
+      modify = new Modify({source, trace: true, traceSource});
+      map.addInteraction(modify);
+      source.addFeature(modifyFeature);
+
+      // first drag activates tracing (onto the top edge of the trace target)
+      simulateEvent('pointermove', 200, 100, null, 0);
+      simulateEvent('pointerdown', 200, 100, null, 0);
+      simulateEvent('pointermove', 50, 50, null, 0);
+      simulateEvent('pointerdrag', 50, 50, null, 0);
+      simulateEvent('pointerup', 50, 50, null, 0);
+
+      // second drag: trace across the [100,-50] vertex, inserting it into the
+      // modified geometry, then finish
+      simulateEvent('pointermove', 200, 0, null, 0);
+      simulateEvent('pointerdown', 200, 0, null, 0);
+      simulateEvent('pointerdrag', 100, 90, null, 0); // past vertex -> [100,-90]
+      simulateEvent('pointerup', 100, 90, null, 0);
+      assert.strictEqual(modify.traceState_.active, false);
+
+      // the traced vertex [100,-50] must now be in the segment rBush, so it can
+      // be grabbed and moved by a subsequent drag
+      simulateEvent('pointermove', 100, 50, null, 0);
+      simulateEvent('pointerdown', 100, 50, null, 0);
+      simulateEvent('pointerdrag', 120, 60, null, 0);
+      simulateEvent('pointerup', 120, 60, null, 0);
+
+      const coordinates = modifyFeature
+        .getGeometry()
+        .getCoordinates()[0]
+        .map((c) => c.map((value) => Math.round(value * 1e6) / 1e6));
+
+      // the previously traced vertex moved to the new pointer location
+      assert.deepEqual(coordinates, [
+        [100, -90],
+        [250, 0],
+        [250, -150],
+        [200, -150],
+        [50, -50],
+        [120, -60], // the traced vertex, now dragged to a new location
+        [100, -90],
       ]);
     });
   });


### PR DESCRIPTION
This pull request fixes several issues with the Modify interaction's trace mode:

* When the "first contact" vertex of the source geometry that has been dragged onto the target geometry is clicked again, the vertex is duplicated, corrupting the source geometry.
* When tracing direction is changed before a vertex was added, the source vertex gets deleted
* When tracing, the trace jumps from vertex to vertex, instead of interpolating along edges.

Compare https://deploy-preview-17544--ol-site.netlify.app/en/latest/examples/draw-modify-trace-snap.html with https://openlayers.org/en/latest/examples/draw-modify-trace-snap.html.
