### PR TITLE
Add an optional `options` argument to `defaultTileLoadFunction`

### DIFF
--- a/src/ol/source/TileImage.js
+++ b/src/ol/source/TileImage.js
@@ -332,8 +332,9 @@ class TileImage extends UrlTile {
 /**
  * @param {ImageTile} imageTile Image tile.
  * @param {string} src Source.
+ * @param {RequestInit} options Fetch options.
  */
-export function defaultTileLoadFunction(imageTile, src) {
+export function defaultTileLoadFunction(imageTile, src, options = {}) {
   if (WORKER_OFFSCREEN_CANVAS) {
     // special treatment for offscreen canvas
     const crossOrigin = imageTile.getCrossOrigin();
@@ -350,13 +351,14 @@ export function defaultTileLoadFunction(imageTile, src) {
       credentials = 'include';
     }
 
-    const options = {
+    const _options = {
+      ...options,
       mode,
       credentials,
       referrerPolicy: imageTile.getReferrerPolicy(),
     };
 
-    fetch(src, options)
+    fetch(src, _options)
       .then((response) => {
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);


### PR DESCRIPTION
<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
I added a third optional argument to the exported `defaultTileLoadFunction` function. 

I need to modify the options used by the fetch request (e.g. for adding an AbortController). Rather than creating a completely new tile load function, the existing function can now be adopted and custom fetch options can be passed.
