### PR TITLE
fix typedef for FilterFunction in Select

### DIFF
--- a/src/ol/interaction/Select.js
+++ b/src/ol/interaction/Select.js
@@ -28,7 +28,7 @@ const SelectEventType = {
 /**
  * A function that takes a {@link module:ol/Feature~Feature} and returns `true` if the feature may be
  * selected or `false` otherwise.
- * @typedef {function(import("../Feature.js").default, import("../layer/Layer.js").default<import("../source/Source.js").default>):boolean} FilterFunction
+ * @typedef {function(import("../Feature.js").default, import("../layer/Layer.js").default<import("../source/Source.js").default> | undefined):boolean} FilterFunction
  */
 
 /**


### PR DESCRIPTION
The typedef for `Select`'s `FilterFunction` does not handle the case where the layer is undefined, which could happen if the feature is managed, i.e is created by another interaction (such as Draw) without  being associated with a layer.