### PR TITLE
Do not skip transform on rotated maps

### DIFF
--- a/examples/offscreen-canvas.js
+++ b/examples/offscreen-canvas.js
@@ -33,20 +33,18 @@ function updateContainerTransform() {
     const renderedResolution = renderedViewState.resolution;
     const renderedRotation = renderedViewState.rotation;
     const transform = create();
-    // Skip the extra transform for rotated views, because it will not work
-    // correctly in that case
-    if (!rotation) {
-      compose(
-        transform,
-        (renderedCenter[0] - center[0]) / resolution,
-        (center[1] - renderedCenter[1]) / resolution,
-        renderedResolution / resolution,
-        renderedResolution / resolution,
-        rotation - renderedRotation,
-        0,
-        0,
-      );
-    }
+    const dx = renderedCenter[0] - center[0];
+    const dy = renderedCenter[1] - center[1];
+    compose(
+      transform,
+      (Math.cos(rotation) * dx + Math.sin(rotation) * dy) / resolution,
+      (Math.sin(rotation) * dx - Math.cos(rotation) * dy) / resolution,
+      renderedResolution / resolution,
+      renderedResolution / resolution,
+      rotation - renderedRotation,
+      0,
+      0,
+    );
     transformContainer.style.transform = toTransformString(transform);
   }
 }


### PR DESCRIPTION
This pull request updates the offscreen-canvas example. We now calculate a correct transform also for rotated views. This means that the last worker image can always be transformed to match the current map view — even when the view is rotated. This makes the map feel smooth also when rotated.

Compare zoom/pan/rotation performance on https://deploy-preview-17553--ol-site.netlify.app/en/latest/examples/offscreen-canvas.html with https://openlayers.org/en/latest/examples/offscreen-canvas.html