### PR TITLE
Add stale tile handling to the WebGL tile renderer

### DIFF
--- a/examples/wms-time-webgl.html
+++ b/examples/wms-time-webgl.html
@@ -1,0 +1,16 @@
+---
+layout: example.html
+title: WMS Time (WebGL)
+shortdesc: Smooth tile transitions on a WebGL tile layer when changing the time dimension of a tiled WMS layer.
+docs: >
+  Demonstrates smooth reloading of layers when changing the time dimension continuously. When the source key changes
+  by calling `updateParams()` on the source, the renderer keeps the previous frame's tiles visible until the new ones
+  load, so the animation stays smooth instead of flashing. Data shown: IEM generated CONUS composite of NWS NEXRAD WSR-88D level III base reflectivity.
+tags: "wms, time, dimensions, transition, nexrad, webgl"
+---
+<div id="map" class="map"></div>
+<div role="group" aria-label="Animation controls">
+  <button id="play" type="button">Play</button>
+  <button id="pause" type="button">Pause</button>
+  <span id="info"></span>
+</div>

--- a/examples/wms-time-webgl.js
+++ b/examples/wms-time-webgl.js
@@ -1,0 +1,77 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import {getCenter} from '../src/ol/extent.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import {transformExtent} from '../src/ol/proj.js';
+import StadiaMaps from '../src/ol/source/StadiaMaps.js';
+import TileWMS from '../src/ol/source/TileWMS.js';
+
+const interval = 3 * 60 * 60 * 1000;
+const step = 15 * 60 * 1000;
+const frameRate = 0.5; // frames per second
+const extent = transformExtent([-126, 24, -66, 50], 'EPSG:4326', 'EPSG:3857');
+
+let wmsTime = new Date();
+let animationId = null;
+
+const stadiaLayer = new TileLayer({
+  source: new StadiaMaps({
+    layer: 'stamen_terrain',
+  }),
+});
+
+const tileWmsLayer = new TileLayer({
+  extent: extent,
+  source: new TileWMS({
+    attributions: ['Iowa State University'],
+    url: 'https://mesonet.agron.iastate.edu/cgi-bin/wms/nexrad/n0r-t.cgi',
+    params: {'LAYERS': 'nexrad-n0r-wmst'},
+    crossOrigin: 'anonymous',
+  }),
+});
+
+const map = new Map({
+  layers: [stadiaLayer, tileWmsLayer],
+  target: 'map',
+  view: new View({
+    center: getCenter(extent),
+    zoom: 4,
+  }),
+});
+
+const el = document.getElementById('info');
+function updateInfo(time) {
+  el.innerHTML = time.toISOString();
+}
+
+function threeHoursAgo() {
+  return new Date(Math.floor((Date.now() - interval) / step) * step);
+}
+
+function setTime() {
+  wmsTime.setMinutes(wmsTime.getMinutes() + 15);
+  if (wmsTime.getTime() > Date.now()) {
+    wmsTime = threeHoursAgo();
+  }
+  tileWmsLayer.getSource().updateParams({'TIME': wmsTime.toISOString()});
+  updateInfo(wmsTime);
+}
+setTime();
+
+const stop = function () {
+  if (animationId !== null) {
+    window.clearInterval(animationId);
+    animationId = null;
+  }
+};
+
+const play = function () {
+  stop();
+  animationId = window.setInterval(setTime, 1000 / frameRate);
+};
+
+const startButton = document.getElementById('play');
+startButton.addEventListener('click', play, false);
+
+const stopButton = document.getElementById('pause');
+stopButton.addEventListener('click', stop, false);

--- a/src/ol/renderer/Layer.js
+++ b/src/ol/renderer/Layer.js
@@ -44,6 +44,12 @@ class LayerRenderer extends Observable {
      * @protected
      */
     this.maxStaleKeys = maxStaleKeys;
+
+    /**
+     * @type {string}
+     * @protected
+     */
+    this.renderedSourceKey_;
   }
 
   /**
@@ -60,6 +66,20 @@ class LayerRenderer extends Observable {
     this.staleKeys_.unshift(key);
     if (this.staleKeys_.length > this.maxStaleKeys) {
       this.staleKeys_.length = this.maxStaleKeys;
+    }
+  }
+
+  /**
+   * Remember the previous source key as stale when the key changes.
+   * @param {string} sourceKey The current source key.
+   * @protected
+   */
+  updateStaleKeys(sourceKey) {
+    if (!this.renderedSourceKey_) {
+      this.renderedSourceKey_ = sourceKey;
+    } else if (this.renderedSourceKey_ !== sourceKey) {
+      this.prependStaleKey(this.renderedSourceKey_);
+      this.renderedSourceKey_ = sourceKey;
     }
   }
 

--- a/src/ol/renderer/canvas/TileLayer.js
+++ b/src/ol/renderer/canvas/TileLayer.js
@@ -156,12 +156,6 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
 
     /**
      * @private
-     * @type {string}
-     */
-    this.renderedSourceKey_;
-
-    /**
-     * @private
      * @type {number}
      */
     this.renderedSourceRevision_;
@@ -606,13 +600,7 @@ class CanvasTileLayerRenderer extends CanvasLayerRenderer {
     const z = tileGrid.getZForResolution(viewResolution, tileSource.zDirection);
     const tileResolution = tileGrid.getResolution(z);
 
-    const sourceKey = tileSource.getKey();
-    if (!this.renderedSourceKey_) {
-      this.renderedSourceKey_ = sourceKey;
-    } else if (this.renderedSourceKey_ !== sourceKey) {
-      this.prependStaleKey(this.renderedSourceKey_);
-      this.renderedSourceKey_ = sourceKey;
-    }
+    this.updateStaleKeys(tileSource.getKey());
 
     let frameExtent = frameState.extent;
     const tilePixelRatio = tileSource.getTilePixelRatio(pixelRatio);

--- a/src/ol/renderer/webgl/TileLayerBase.js
+++ b/src/ol/renderer/webgl/TileLayerBase.js
@@ -90,6 +90,24 @@ function addTileRepresentationToLookup(
 }
 
 /**
+ * Remove a tile representation from the lookup.
+ * @param {TileRepresentationLookup} tileRepresentationLookup Lookup of tile representations by zoom level.
+ * @param {AbstractTileRepresentation} tileRepresentation A tile representation.
+ * @param {number} z The zoom level.
+ */
+function removeTileRepresentationFromLookup(
+  tileRepresentationLookup,
+  tileRepresentation,
+  z,
+) {
+  const representations = tileRepresentationLookup.representationsByZ[z];
+  if (representations) {
+    representations.delete(tileRepresentation);
+  }
+  tileRepresentationLookup.tileIds.delete(getUid(tileRepresentation.tile));
+}
+
+/**
  * @param {import("../../Map.js").FrameState} frameState Frame state.
  * @param {import("../../extent.js").Extent} extent The frame extent.
  * @return {import("../../extent.js").Extent} Frame extent intersected with layer extents.
@@ -119,10 +137,11 @@ function getRenderExtent(frameState, extent) {
 /**
  * @param {import("../../source/Tile.js").default} source The source.
  * @param {import('../../tilecoord.js').TileCoord} tileCoord The tile coordinate.
+ * @param {string} [key] The source key to use; defaults to the current key.
  * @return {string} The cache key.
  */
-export function getCacheKey(source, tileCoord) {
-  return `${getUid(source)},${source.getKey()},${getTileCoordKey(tileCoord)}`;
+export function getCacheKey(source, tileCoord, key = source.getKey()) {
+  return `${getUid(source)},${key},${getTileCoordKey(tileCoord)}`;
 }
 
 /**
@@ -214,6 +233,8 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
      * @protected
      */
     this.tileRepresentationCache = new LRUCache(cacheSize);
+
+    this.maxStaleKeys = cacheSize * 0.5;
 
     /**
      * @protected
@@ -577,6 +598,8 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
       tileSource.zDirection,
     );
 
+    this.updateStaleKeys(tileSource.getKey());
+
     /**
      * @type {TileRepresentationLookup}
      */
@@ -633,6 +656,7 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
         }
         const tileCoord = tile.tileCoord;
 
+        const tileCoordKey = getTileCoordKey(tileCoord);
         if (tileRepresentation.ready) {
           const alpha = tile.getAlpha(uid, time);
           if (alpha === 1) {
@@ -641,10 +665,26 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
             continue;
           }
           blend = true;
-          const tileCoordKey = getTileCoordKey(tileCoord);
           alphaLookup[tileCoordKey] = alpha;
         }
         this.renderComplete = false;
+
+        // look for a tile from a previous key before falling back to other zoom levels
+        const hasStaleTile = this.findStaleTile_(
+          tileCoord,
+          tileRepresentationLookup,
+        );
+        if (hasStaleTile) {
+          // show the stale tile at full opacity until the new tile has faded in
+          delete alphaLookup[tileCoordKey];
+          removeTileRepresentationFromLookup(
+            tileRepresentationLookup,
+            tileRepresentation,
+            z,
+          );
+          frameState.animate = true;
+          continue;
+        }
 
         // first look for child tiles (at z + 1)
         const coveredByChildren = this.findAltTiles_(
@@ -763,6 +803,43 @@ class WebGLBaseTileLayerRenderer extends WebGLLayerRenderer {
    */
   beforeFinalize(frameState) {
     return;
+  }
+
+  /**
+   * Look for a ready tile at the same coordinate from a previous source key.
+   * A match is added to the provided lookup at the target zoom level.
+   * @param {import("../../tilecoord.js").TileCoord} tileCoord The target tile coordinate.
+   * @param {TileRepresentationLookup} tileRepresentationLookup Lookup of
+   * tile representations by zoom level.
+   * @return {boolean} A stale tile was found and added to the lookup.
+   * @private
+   */
+  findStaleTile_(tileCoord, tileRepresentationLookup) {
+    const tileRepresentationCache = this.tileRepresentationCache;
+    const source = this.getLayer().getRenderSource();
+    const z = tileCoord[0];
+    const staleKeys = this.getStaleKeys();
+    for (let i = 0, ii = staleKeys.length; i < ii; ++i) {
+      const cacheKey = getCacheKey(source, tileCoord, staleKeys[i]);
+      if (tileRepresentationCache.containsKey(cacheKey)) {
+        const tileRepresentation = tileRepresentationCache.get(cacheKey);
+        if (
+          tileRepresentation.ready &&
+          !lookupHasTile(tileRepresentationLookup, tileRepresentation.tile)
+        ) {
+          // end the transition so the stale tile renders opaque and is not
+          // re-processed as a target tile (which could loop)
+          tileRepresentation.tile.endTransition(getUid(this));
+          addTileRepresentationToLookup(
+            tileRepresentationLookup,
+            tileRepresentation,
+            z,
+          );
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/TileLayer.test.js
@@ -6,8 +6,12 @@ import {createCanvasContext2D} from '../../../../../../src/ol/dom.js';
 import {VOID} from '../../../../../../src/ol/functions.js';
 import WebGLTileLayer from '../../../../../../src/ol/layer/WebGLTile.js';
 import {get} from '../../../../../../src/ol/proj.js';
-import {newTileRepresentationLookup} from '../../../../../../src/ol/renderer/webgl/TileLayerBase.js';
+import {
+  getCacheKey,
+  newTileRepresentationLookup,
+} from '../../../../../../src/ol/renderer/webgl/TileLayerBase.js';
 import DataTile from '../../../../../../src/ol/source/DataTile.js';
+import {createXYZ} from '../../../../../../src/ol/tilegrid.js';
 import {create} from '../../../../../../src/ol/transform.js';
 import {getUid} from '../../../../../../src/ol/util.js';
 import TileTexture from '../../../../../../src/ol/webgl/TileTexture.js';
@@ -100,6 +104,23 @@ describe('ol/renderer/webgl/TileLayer', function () {
     assert.strictEqual(frameState.tileQueue.getCount(), 1);
     assert.strictEqual(Object.keys(frameState.wantedTiles).length, 1);
     assert.strictEqual(renderer.tileRepresentationCache.count_, 1);
+  });
+
+  it('#findStaleTile_() ends the transition so the stale tile does not loop', () => {
+    const source = tileLayer.getSource();
+    const tile = source.getTile(0, 0, 0);
+    renderer.tileRepresentationCache.set(
+      getCacheKey(source, [0, 0, 0], 'stale'),
+      {
+        ready: true,
+        tile,
+        dispose() {},
+      },
+    );
+    renderer.prependStaleKey('stale');
+    const endTransition = vi.spyOn(tile, 'endTransition');
+    renderer.findStaleTile_([0, 0, 0], newTileRepresentationLookup());
+    assert.strictEqual(endTransition.mock.calls.length, 1);
   });
 
   describe('enqueueTiles()', () => {
@@ -289,5 +310,38 @@ describe('ol/renderer/webgl/TileLayer', function () {
     it('creates a TileTexture instance', () => {
       assert.instanceOf(tileRepresentation, TileTexture);
     });
+  });
+
+  describe('stale tiles', () => {
+    let staleMap;
+    afterEach(() => {
+      disposeMap(staleMap);
+    });
+
+    it('remembers the previous source key as stale when the key changes', () =>
+      new Promise((resolve) => {
+        const layer = new WebGLTileLayer({
+          source: new DataTile({
+            tileSize: 1,
+            tileGrid: createXYZ(),
+            loader: () => new Uint8Array([1, 2, 3, 255]),
+          }),
+        });
+        staleMap = new Map({
+          target: createMapDiv(100, 100),
+          layers: [layer],
+          view: new View({center: [0, 0], zoom: 2}),
+        });
+        staleMap.once('rendercomplete', () => {
+          const renderer = layer.getRenderer();
+          const previousKey = layer.getSource().getKey();
+          assert.deepEqual(renderer.getStaleKeys(), []);
+          layer.getSource().setKey('changed');
+          staleMap.once('rendercomplete', () => {
+            assert.include(renderer.getStaleKeys(), previousKey);
+            resolve();
+          });
+        });
+      }));
   });
 });


### PR DESCRIPTION
In order to be able to switch dimension values in the future (see #17542), this pull request adds stale tile handling like in the Canvas 2D renderer to the WebGL renderer.

Some code shared with the Canvas 2D renderer could be factored out to the `Layer` base renderer, to reduce the amount of added code.

I also created a WebGL version of the `wms-time.html` example to see this in action.