### PR TITLE
Reset loader in setParams for image sources

### DIFF
--- a/src/ol/source/ImageArcGISRest.js
+++ b/src/ol/source/ImageArcGISRest.js
@@ -219,6 +219,8 @@ class ImageArcGISRest extends ImageSource {
    */
   setParams(params) {
     this.params_ = Object.assign({}, params);
+    // Reset loader to pick up new params
+    this.loader = null;
     this.changed();
   }
 

--- a/src/ol/source/ImageMapGuide.js
+++ b/src/ol/source/ImageMapGuide.js
@@ -188,6 +188,8 @@ class ImageMapGuide extends ImageSource {
    */
   setParams(params) {
     this.params_ = Object.assign({}, params);
+    // Reset loader to pick up new params
+    this.loader = null;
     this.changed();
   }
 

--- a/test/browser/spec/ol/source/ImageArcGISRest.test.js
+++ b/test/browser/spec/ol/source/ImageArcGISRest.test.js
@@ -212,6 +212,25 @@ describe('ol/source/ImageArcGISRest', function () {
   });
 
   describe('#setParams', function () {
+    let map;
+    beforeEach(function () {
+      const target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map);
+    });
+
     it('allows params to be set', function () {
       const before = {test: 'before', foo: 'bar'};
       const source = new ImageArcGISRest({params: before});
@@ -222,6 +241,34 @@ describe('ol/source/ImageArcGISRest', function () {
 
       assert.deepEqual(before, {test: 'before', foo: 'bar'});
     });
+
+    it('reloads from server', () =>
+      new Promise((resolve) => {
+        const srcs = [];
+        options.params.TEST = 'value';
+        const source = new ImageArcGISRest(options);
+        source.setImageLoadFunction(function (image, src) {
+          srcs.push(src);
+          image.state = ImageState.LOADED;
+          source.loading = false;
+        });
+        map.addLayer(new ImageLayer({source: source}));
+        map.once('rendercomplete', function () {
+          source.setParams({'TEST': 'newValue'});
+          map.once('rendercomplete', function () {
+            assert.strictEqual(srcs.length, 2);
+            assert.strictEqual(
+              new URL(srcs[0]).searchParams.get('TEST'),
+              'value',
+            );
+            assert.strictEqual(
+              new URL(srcs[1]).searchParams.get('TEST'),
+              'newValue',
+            );
+            resolve();
+          });
+        });
+      }));
   });
 
   describe('#getParams', function () {

--- a/test/browser/spec/ol/source/ImageMapGuide.test.js
+++ b/test/browser/spec/ol/source/ImageMapGuide.test.js
@@ -65,6 +65,25 @@ describe('ol/source/ImageMapGuide', function () {
   });
 
   describe('#setParams', function () {
+    let map;
+    beforeEach(function () {
+      const target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      map = new Map({
+        target: target,
+        view: new View({
+          center: [0, 0],
+          zoom: 0,
+        }),
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map);
+    });
+
     it('allows params to be set', function () {
       const before = {test: 'before', foo: 'bar'};
       const source = new ImageMapGuide({params: before});
@@ -75,6 +94,33 @@ describe('ol/source/ImageMapGuide', function () {
 
       assert.deepEqual(before, {test: 'before', foo: 'bar'});
     });
+
+    it('reloads from server', () =>
+      new Promise((resolve) => {
+        const srcs = [];
+        const source = new ImageMapGuide(options);
+        source.setImageLoadFunction(function (image, src) {
+          srcs.push(src);
+          image.state = ImageState.LOADED;
+          source.loading = false;
+        });
+        map.addLayer(new ImageLayer({source: source}));
+        map.once('rendercomplete', function () {
+          source.setParams({'MAPDEFINITION': 'newValue'});
+          map.once('rendercomplete', function () {
+            assert.strictEqual(srcs.length, 2);
+            assert.strictEqual(
+              new URL(srcs[0]).searchParams.get('MAPDEFINITION'),
+              'mdf',
+            );
+            assert.strictEqual(
+              new URL(srcs[1]).searchParams.get('MAPDEFINITION'),
+              'newValue',
+            );
+            resolve();
+          });
+        });
+      }));
   });
 
   describe('#getParams', function () {


### PR DESCRIPTION
`ImageArcGISRest#setParams()` and `ImageMapGuide#setParams()` replace `this.params_` but keep the
cached `loader`, which still holds the old params object, so requests keep using the old params
until something else invalidates the loader, e.g. a projection change.

Resets the loader in both, matching `ImageWMS#setParams()` and `OGCMap#setParams()`. Regression
tests mirror the existing `#updateParams` "reloads from server" tests.

Fixes #17570