### PR TITLE
Line labels: properly split text by graphemes

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -4,9 +4,9 @@
 
 #### Usage of Intl.Segmenter
 
-TextPath now relies on [Intl.Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter),
-which is only available from Firefox 125 (2024).
-A polyfill is available on FormatJS: https://formatjs.github.io/docs/polyfills/intl-segmenter/.
+TextPath now relies on [Intl.Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter).
+For support of very old browsers (e.g. Firefox before version 125),
+a polyfill is available: https://formatjs.github.io/docs/polyfills/intl-segmenter/.
 
 
 #### Deprecation of `ol/source/BingMaps`

--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,13 @@
 
 ### Next Release
 
+#### Usage of Intl.Segmenter
+
+TextPath now relies on [Intl.Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter),
+which is only available from Firefox 125 (2024).
+A polyfill is available on FormatJS: https://formatjs.github.io/docs/polyfills/intl-segmenter/.
+
+
 #### Deprecation of `ol/source/BingMaps`
 
 Bing Maps for Enterprise is being retired on June 30th, 2028. The `BingMaps` source

--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -4,7 +4,16 @@
 import {lerp} from '../../math.js';
 import {rotate} from './transform.js';
 
-const segmenter = new Intl.Segmenter(undefined, {granularity: 'grapheme'})
+let segmenter;
+/**
+ * @return {Intl.Segmenter} A grapheme segmenter.
+ */
+function getSegmenter() {
+  if (!segmenter) {
+    segmenter = new Intl.Segmenter(undefined, {granularity: 'grapheme'});
+  }
+  return segmenter;
+}
 
 /**
  * @param {Array<number>} flatCoordinates Path to put text on.
@@ -113,7 +122,7 @@ export function drawTextOnPath(
   // rendering across line segments
   text = text.replace(/\n/g, ' '); // ensure rendering in single-line as all calculations below don't handle multi-lines
 
-  text = Array.from(segmenter.segment(text), (s) => s.segment);
+  text = Array.from(getSegmenter().segment(text), (s) => s.segment);
   for (let i = 0, ii = text.length; i < ii;) {
     advance();
     let angle = Math.atan2(y2 - y1, x2 - x1);

--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -122,8 +122,8 @@ export function drawTextOnPath(
   // rendering across line segments
   text = text.replace(/\n/g, ' '); // ensure rendering in single-line as all calculations below don't handle multi-lines
 
-  text = Array.from(getSegmenter().segment(text), (s) => s.segment);
-  for (let i = 0, ii = text.length; i < ii;) {
+  const segments = Array.from(getSegmenter().segment(text), (s) => s.segment);
+  for (let i = 0, ii = segments.length; i < ii;) {
     advance();
     let angle = Math.atan2(y2 - y1, x2 - x1);
     if (reverse) {
@@ -142,7 +142,8 @@ export function drawTextOnPath(
     let charLength = 0;
     for (; i < ii; ++i) {
       const index = reverse ? ii - i - 1 : i;
-      const len = scale * measureAndCacheTextWidth(font, text[index], cache);
+      const len =
+        scale * measureAndCacheTextWidth(font, segments[index], cache);
       if (
         offset + stride < end &&
         segmentM + segmentLength < startM + charLength + len / 2
@@ -155,7 +156,7 @@ export function drawTextOnPath(
       continue;
     }
     const chars = (
-      reverse ? text.slice(ii - i, ii - iStart) : text.slice(iStart, i)
+      reverse ? segments.slice(ii - i, ii - iStart) : segments.slice(iStart, i)
     ).join('');
     interpolate =
       segmentLength === 0

--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -4,11 +4,7 @@
 import {lerp} from '../../math.js';
 import {rotate} from './transform.js';
 
-// Intl.Segmenter only works for baseline >= 2024 in Firefox (version 125)
-const segmenter =
-  typeof Intl !== 'undefined' && Intl.Segmenter
-    ? new Intl.Segmenter(undefined, {granularity: 'grapheme'})
-    : null;
+const segmenter = new Intl.Segmenter(undefined, {granularity: 'grapheme'})
 
 /**
  * @param {Array<number>} flatCoordinates Path to put text on.
@@ -117,8 +113,7 @@ export function drawTextOnPath(
   // rendering across line segments
   text = text.replace(/\n/g, ' '); // ensure rendering in single-line as all calculations below don't handle multi-lines
 
-  // [...text] fallback does not work for combined emojis
-  text = segmenter ? Array.from(segmenter.segment(text), (s) => s.segment) : [...text];
+  text = Array.from(segmenter.segment(text), (s) => s.segment);
   for (let i = 0, ii = text.length; i < ii;) {
     advance();
     let angle = Math.atan2(y2 - y1, x2 - x1);

--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -4,6 +4,12 @@
 import {lerp} from '../../math.js';
 import {rotate} from './transform.js';
 
+// Intl.Segmenter only works for baseline >= 2024 in Firefox (version 125)
+const segmenter =
+  typeof Intl !== 'undefined' && Intl.Segmenter
+    ? new Intl.Segmenter(undefined, {granularity: 'grapheme'})
+    : null;
+
 /**
  * @param {Array<number>} flatCoordinates Path to put text on.
  * @param {number} offset Start offset of the `flatCoordinates`.
@@ -111,6 +117,8 @@ export function drawTextOnPath(
   // rendering across line segments
   text = text.replace(/\n/g, ' '); // ensure rendering in single-line as all calculations below don't handle multi-lines
 
+  // [...text] fallback does not work for combined emojis
+  text = segmenter ? Array.from(segmenter.segment(text), (s) => s.segment) : [...text];
   for (let i = 0, ii = text.length; i < ii;) {
     advance();
     let angle = Math.atan2(y2 - y1, x2 - x1);
@@ -142,9 +150,9 @@ export function drawTextOnPath(
     if (i === iStart) {
       continue;
     }
-    const chars = reverse
-      ? text.substring(ii - iStart, ii - i)
-      : text.substring(iStart, i);
+    const chars = (
+      reverse ? text.slice(ii - i, ii - iStart) : text.slice(iStart, i)
+    ).join('');
     interpolate =
       segmentLength === 0
         ? 0

--- a/test/node/ol/geom/flat/textpath.test.js
+++ b/test/node/ol/geom/flat/textpath.test.js
@@ -165,6 +165,32 @@ describe('ol/geom/flat/drawTextOnPath.js', function () {
     assert.strictEqual(instructions[1][4], 'oo');
   });
 
+  it('keeps a combined emoji as a single grapheme across segments', function () {
+    // '👍🏽' is a single grapheme cluster made of several UTF-16 code units; it
+    // must be measured and placed as a whole, never split across segments.
+    const text = 'f👍🏽oo';
+    const length = lineStringLength(angled, 0, angled.length, 2);
+    const startM = length / 2 - 20;
+    const instructions = drawTextOnPath(
+      angled,
+      0,
+      angled.length,
+      2,
+      text,
+      startM,
+      Infinity,
+      1,
+      measureAndCacheTextWidth,
+      '',
+      {},
+    );
+    assert.strictEqual(instructions.length, 2);
+    assert.strictEqual(instructions[0][4], 'f');
+    assert.strictEqual(instructions[1][4], '👍🏽oo');
+    // the emoji is never broken apart across the two segments
+    assert.strictEqual(instructions[0][4] + instructions[1][4], text);
+  });
+
   it('respects maxAngle', function () {
     const length = lineStringLength(angled, 0, angled.length, 2);
     const startM = length / 2 - 15;


### PR DESCRIPTION
When using an emoji in a Text style with placement: line, it will be truncated in invalid chars:

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/82165f65-0ab4-404f-8546-6a1a13dd0c28" />

Here is the result with this fix:

<img width="480" height="270" alt="image" src="https://github.com/user-attachments/assets/77ff2dbb-f951-4359-8d8a-dd6b5371fac6" />

The fix also covers combined emojis (like 👨‍👩‍👧‍👦).

Thanks!