### PR TITLE
Use fes:ResourceId in WFS 2.0.0 transaction filters

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -755,6 +755,11 @@ const OGC_FID_PARSERS = {
       return node.getAttribute('fid');
     }),
   },
+  'http://www.opengis.net/fes/2.0': {
+    'ResourceId': makeArrayPusher(function (node, objectStack) {
+      return node.getAttribute('rid');
+    }),
+  },
 };
 
 /**

--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -816,11 +816,12 @@ function writeFeature(node, feature, objectStack) {
 function writeOgcFidFilter(node, fid, objectStack) {
   const context = objectStack[objectStack.length - 1];
   const version = context['version'];
-  const ns = OGCNS[version];
+  const ns = getFilterNS(version);
+  const isV2 = version === '2.0.0';
   const filter = createElementNS(ns, 'Filter');
-  const child = createElementNS(ns, 'FeatureId');
+  const child = createElementNS(ns, isV2 ? 'ResourceId' : 'FeatureId');
   filter.appendChild(child);
-  child.setAttribute('fid', /** @type {string} */ (fid));
+  child.setAttribute(isV2 ? 'rid' : 'fid', /** @type {string} */ (fid));
   node.appendChild(filter);
 }
 

--- a/test/browser/spec/ol/format/wfs.test.js
+++ b/test/browser/spec/ol/format/wfs.test.js
@@ -2113,36 +2113,46 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       assert.notInclude(xmlString, '<Name>');
     });
 
-    it('round-trips a feature id through the filter and the insert results', () => {
-      const testFeature = new Feature();
-      testFeature.setId('12345');
-      testFeature.setProperties({
-        name: 'SampleFeature',
-      });
-      const wfs = new WFS({version: '2.0.0'});
-      const transaction = wfs.writeTransaction([], [testFeature], [], {
-        featureNS: 'http://foo',
-        featureType: 'FAULTS',
-        featurePrefix: 'foo',
-        gmlOptions: {srsName: 'EPSG:900913'},
-      });
-      const written = transaction.getElementsByTagNameNS(
-        'http://www.opengis.net/fes/2.0',
-        'ResourceId',
-      );
-      assert.lengthOf(written, 1);
+    it('writes a <fes:ResourceId> filter for the feature id', () => {
+      const text =
+        '<wfs:Transaction xmlns:wfs="http://www.opengis.net/wfs/2.0" ' +
+        '    service="WFS" version="2.0.0" ' +
+        '    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' +
+        '    xsi:schemaLocation="http://www.opengis.net/wfs/2.0 ' +
+        'http://schemas.opengis.net/wfs/2.0/wfs.xsd">' +
+        '  <wfs:Delete xmlns:foo="http://foo" typeName="foo:FAULTS">' +
+        '    <fes:Filter xmlns:fes="http://www.opengis.net/fes/2.0">' +
+        '      <fes:ResourceId rid="12345"/>' +
+        '    </fes:Filter>' +
+        '  </wfs:Delete>' +
+        '</wfs:Transaction>';
 
-      // Hand the element the writer produced straight back to the reader.
-      const response = wfs.readTransactionResponse(
+      const deleteFeature = new Feature();
+      deleteFeature.setId('12345');
+      const serialized = new WFS({version: '2.0.0'}).writeTransaction(
+        [],
+        [],
+        [deleteFeature],
+        {
+          featureNS: 'http://foo',
+          featureType: 'FAULTS',
+          featurePrefix: 'foo',
+        },
+      );
+      assertXmlEqual(serialized, parse(text));
+    });
+
+    it('reads insert ids from <fes:ResourceId> elements', () => {
+      const response = new WFS({version: '2.0.0'}).readTransactionResponse(
         '<wfs:TransactionResponse version="2.0.0"' +
-          ' xmlns:wfs="http://www.opengis.net/wfs/2.0"' +
-          ' xmlns:fes="http://www.opengis.net/fes/2.0">' +
-          '<wfs:InsertResults><wfs:Feature>' +
-          new XMLSerializer().serializeToString(written[0]) +
-          '</wfs:Feature></wfs:InsertResults>' +
+          '    xmlns:wfs="http://www.opengis.net/wfs/2.0"' +
+          '    xmlns:fes="http://www.opengis.net/fes/2.0">' +
+          '  <wfs:InsertResults>' +
+          '    <wfs:Feature><fes:ResourceId rid="FAULTS.12345"/></wfs:Feature>' +
+          '  </wfs:InsertResults>' +
           '</wfs:TransactionResponse>',
       );
-      assert.deepEqual(response.insertIds, ['12345']);
+      assert.deepEqual(response.insertIds, ['FAULTS.12345']);
     });
   });
 });

--- a/test/browser/spec/ol/format/wfs.test.js
+++ b/test/browser/spec/ol/format/wfs.test.js
@@ -2112,5 +2112,38 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       assert.include(xmlString, '<ValueReference>');
       assert.notInclude(xmlString, '<Name>');
     });
+
+    it('should filter on <fes:ResourceId> rather than <ogc:FeatureId>', () => {
+      const testFeature = new Feature();
+      testFeature.setId('12345');
+      testFeature.setProperties({
+        name: 'SampleFeature',
+      });
+      const testOptions = {
+        featureNS: 'http://foo',
+        featureType: 'FAULTS',
+        featurePrefix: 'foo',
+        gmlOptions: {srsName: 'EPSG:900913'},
+      };
+      const wfs = new WFS({version: '2.0.0'});
+      // One update and one delete, so both writeOgcFidFilter call sites are covered.
+      const serialized = wfs.writeTransaction(
+        [],
+        [testFeature],
+        [testFeature],
+        testOptions,
+      );
+      const resourceIds = serialized.getElementsByTagNameNS(
+        'http://www.opengis.net/fes/2.0',
+        'ResourceId',
+      );
+      assert.lengthOf(resourceIds, 2);
+      for (const resourceId of resourceIds) {
+        assert.strictEqual(resourceId.getAttribute('rid'), '12345');
+      }
+      const xmlString = new XMLSerializer().serializeToString(serialized);
+      assert.notInclude(xmlString, 'FeatureId');
+      assert.notInclude(xmlString, 'fid=');
+    });
   });
 });

--- a/test/browser/spec/ol/format/wfs.test.js
+++ b/test/browser/spec/ol/format/wfs.test.js
@@ -2113,37 +2113,36 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       assert.notInclude(xmlString, '<Name>');
     });
 
-    it('should filter on <fes:ResourceId> rather than <ogc:FeatureId>', () => {
+    it('round-trips a feature id through the filter and the insert results', () => {
       const testFeature = new Feature();
       testFeature.setId('12345');
       testFeature.setProperties({
         name: 'SampleFeature',
       });
-      const testOptions = {
+      const wfs = new WFS({version: '2.0.0'});
+      const transaction = wfs.writeTransaction([], [testFeature], [], {
         featureNS: 'http://foo',
         featureType: 'FAULTS',
         featurePrefix: 'foo',
         gmlOptions: {srsName: 'EPSG:900913'},
-      };
-      const wfs = new WFS({version: '2.0.0'});
-      // One update and one delete, so both writeOgcFidFilter call sites are covered.
-      const serialized = wfs.writeTransaction(
-        [],
-        [testFeature],
-        [testFeature],
-        testOptions,
-      );
-      const resourceIds = serialized.getElementsByTagNameNS(
+      });
+      const written = transaction.getElementsByTagNameNS(
         'http://www.opengis.net/fes/2.0',
         'ResourceId',
       );
-      assert.lengthOf(resourceIds, 2);
-      for (const resourceId of resourceIds) {
-        assert.strictEqual(resourceId.getAttribute('rid'), '12345');
-      }
-      const xmlString = new XMLSerializer().serializeToString(serialized);
-      assert.notInclude(xmlString, 'FeatureId');
-      assert.notInclude(xmlString, 'fid=');
+      assert.lengthOf(written, 1);
+
+      // Hand the element the writer produced straight back to the reader.
+      const response = wfs.readTransactionResponse(
+        '<wfs:TransactionResponse version="2.0.0"' +
+          ' xmlns:wfs="http://www.opengis.net/wfs/2.0"' +
+          ' xmlns:fes="http://www.opengis.net/fes/2.0">' +
+          '<wfs:InsertResults><wfs:Feature>' +
+          new XMLSerializer().serializeToString(written[0]) +
+          '</wfs:Feature></wfs:InsertResults>' +
+          '</wfs:TransactionResponse>',
+      );
+      assert.deepEqual(response.insertIds, ['12345']);
     });
   });
 });


### PR DESCRIPTION
Fixes #16166.

When you write a WFS transaction with `version: '2.0.0'`, the update and delete bodies come out with `<Filter><FeatureId fid="..."/></Filter>`. That element is WFS 1.x only — 2.0.0 renamed it to `ResourceId` with an `rid` attribute, and moved filters into the `fes/2.0` namespace. GeoServer rejects the request as an unparsable filter, so `writeTransaction` doesn't really work against a 2.0.0 server.

`writeOgcFidFilter` already reads the version into a local but never uses it, so this branches on it the same way `writeProperty` does a few lines below when it picks between `ValueReference` and `Name`. It also switches the namespace lookup from `OGCNS[version]` to the existing `getFilterNS(version)` helper — `ResourceId` only exists in `fes/2.0`, so renaming the element without that would still produce something GeoServer rejects. `getFilterNS` is what every other filter-writing function in the file already uses, and for 1.0.0 and 1.1.0 it returns exactly what `OGCNS[version]` returned, so nothing changes on those versions.

I added a spec next to the existing `ValueReference` one that writes a 2.0.0 transaction with both an update and a delete, so both call sites are covered, and looks the elements up by namespace rather than by string so the namespace half is actually asserted. It fails on main with no `ResourceId` elements found. The full browser suite is green at 173 files / 3041 tests, node at 74 / 2217, plus lint and both typechecks.

One thing I left alone: the read side has the same gap, since `OGC_FID_PARSERS` only knows `FeatureId`, so 2.0.0 TransactionResponse insert results don't parse. Happy to do that separately if you want it.
