### PR TITLE
Reworked worker handling in examples

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
     ignores: [
       'config/jsdoc/api/template/static/scripts/',
       'examples/resources/*',
+      '!examples/resources/common.js',
       'site/build/*',
     ],
   },

--- a/examples/offscreen-canvas.html
+++ b/examples/offscreen-canvas.html
@@ -8,7 +8,6 @@ tags: "worker, offscreencanvas, vector-tiles"
 experimental: true
 sources:
   - path: offscreen-canvas.worker.js
-    as: worker.js
 cloak:
   - key: get_your_own_D6rA4zTHduk6KOKTXzGB
     value: Get your own API key at https://www.maptiler.com/cloud/

--- a/examples/offscreen-canvas.js
+++ b/examples/offscreen-canvas.js
@@ -1,4 +1,3 @@
-import Worker from 'worker-loader!./offscreen-canvas.worker.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import FullScreen from '../src/ol/control/FullScreen.js';
@@ -11,7 +10,10 @@ import {
   toString as toTransformString,
 } from '../src/ol/transform.js';
 
-const worker = new Worker();
+const worker = new Worker(
+  new URL('./offscreen-canvas.worker.js', import.meta.url),
+  {type: 'module'},
+);
 
 let container,
   transformContainer,

--- a/examples/resources/common.js
+++ b/examples/resources/common.js
@@ -1,13 +1,14 @@
-(function() {
-  "use strict"
+(function () {
+  'use strict';
   /* global LZString */
 
   let lzStringPromise;
   function loadLzString() {
     if (!lzStringPromise) {
       lzStringPromise = new Promise(function (resolve, reject) {
-        const script = document.createElement('script')
-        script.src = 'https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js';
+        const script = document.createElement('script');
+        script.src =
+          'https://cdn.jsdelivr.net/npm/lz-string@1.4.4/libs/lz-string.min.js';
         document.head.append(script);
         script.addEventListener('load', resolve);
         script.addEventListener('error', reject);
@@ -27,23 +28,23 @@
     return new Promise(function (resolve, reject) {
       const isImage = /\.(png|jpe?g|gif|tiff?|svg|kmz)$/.test(resource);
       if (isImage) {
-        resolve ({
+        resolve({
           isBinary: true,
-          content: new URL(resource, window.location.href).href
+          content: new URL(resource, window.location.href).href,
         });
       } else {
         const xhr = new XMLHttpRequest();
         xhr.open('GET', resource);
         xhr.responseType = 'text';
         xhr.addEventListener('load', function () {
-          resolve ({
-            content: xhr.response
+          resolve({
+            content: xhr.response,
           });
         });
         xhr.addEventListener('error', reject);
         xhr.send();
       }
-    })
+    });
   }
 
   const codepenButton = document.getElementById('codepen-button');
@@ -54,15 +55,12 @@
       event.preventDefault();
       const html = document.getElementById('example-html-source').innerText;
       const js = document.getElementById('example-js-source').innerText;
-      const workerContainer = document.getElementById('example-worker-source');
-      const worker = workerContainer ? workerContainer.innerText : undefined;
-      let pkgJson = document.getElementById('example-pkg-source').innerText;
-      pkgJson = JSON.parse(pkgJson);
-      pkgJson['devDependencies']['typescript'] = 'latest';
-      pkgJson = JSON.stringify(pkgJson, undefined, 2);
+      const pkgJson = document.getElementById('example-pkg-source').innerText;
 
       const unique = new Set();
-      const localResources = (js.match(/'(?:\.\/)?(?:data|resources)\/[^']*'/g) || [])
+      const localResources = (
+        js.match(/'(?:\.\/)?(?:data|resources)\/[^']*'/g) || []
+      )
         .map(function (f) {
           return f.replace(/^'(?:\.\/)?|'$/g, '');
         })
@@ -75,43 +73,54 @@
       });
       promises.push(loadLzString());
 
-      Promise.all(promises).then(
-        function (results) {
-          const files = {
-            'index.html': {content: html},
-            'main.js': {content: js},
-            'package.json': {content: pkgJson},
-            'sandbox.config.json': {content: '{"template": "parcel"}'},
-            '.babelrc': {content: '{}'},
-            '.prettierrc': {
-              content: JSON.stringify(
-                {
-                  printWidth: 80,
-                  tabWidth: 2,
-                  useTabs: false,
-                  semi: true,
-                  singleQuote: true,
-                  trailingComma: 'all',
-                  bracketSpacing: false,
-                  jsxBracketSameLine: false,
-                  fluid: false,
-                },
-                undefined,
-                2
-              ),
-            },
-          };
-          if (worker) {
-            files['worker.js'] = {content: worker}
-          }
-          for (let i = 0; i < localResources.length; i++) {
-            files[localResources[i]] = results[i];
-          }
+      Promise.all(promises).then(function (results) {
+        const files = {
+          'index.html': {content: html},
+          'main.js': {content: js},
+          'package.json': {content: pkgJson},
+          // Node container so Vite can run (classic CSB has no dedicated "vite" template).
+          'sandbox.config.json': {
+            content: JSON.stringify(
+              {
+                template: 'node',
+                startScript: 'start',
+              },
+              undefined,
+              2,
+            ),
+          },
+          '.prettierrc': {
+            content: JSON.stringify(
+              {
+                printWidth: 80,
+                tabWidth: 2,
+                useTabs: false,
+                semi: true,
+                singleQuote: true,
+                trailingComma: 'all',
+                bracketSpacing: false,
+                jsxBracketSameLine: false,
+                fluid: false,
+              },
+              undefined,
+              2,
+            ),
+          },
+        };
 
-          form.parameters.value = compress({files: files});
-          form.submit();
+        document
+          .querySelectorAll('code.example-extra-source[data-filename]')
+          .forEach(function (el) {
+            files[el.dataset.filename] = {content: el.innerText};
+          });
+
+        for (let i = 0; i < localResources.length; i++) {
+          files[localResources[i]] = results[i];
         }
-      );
+
+        form.parameters.value = compress({files: files});
+        form.submit();
+      });
     });
   }
 })();

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -155,8 +155,8 @@
       {{#each extraSources}}
       <details open>
         <summary class="source-heading">{{./name}}</summary>
-        <div class="row-fluid extra-source">
-          <pre><code class="language-{{./type}}">{{ ./source }}</code></pre>
+        <div class="row-fluid">
+          <pre><code class="language-{{./type}} example-extra-source" data-filename="{{./name}}">{{ ./source }}</code></pre>
         </div>
       </details>
       {{/each}}

--- a/examples/tiled-layer-rendering-in-offscreen-canvas.html
+++ b/examples/tiled-layer-rendering-in-offscreen-canvas.html
@@ -7,6 +7,5 @@ docs: >
 tags: "worker, offscreencanvas, tiles"
 sources:
   - path: tiled-layer-rendering-in-offscreen-canvas.worker.js
-    as: worker.js
 ---
 <div id="map" class="map"></div>

--- a/examples/tiled-layer-rendering-in-offscreen-canvas.js
+++ b/examples/tiled-layer-rendering-in-offscreen-canvas.js
@@ -1,9 +1,14 @@
-import Worker from 'worker-loader!./tiled-layer-rendering-in-offscreen-canvas.worker.js';
 import Map from '../src/ol/Map.js';
 import View from '../src/ol/View.js';
 import TileLayer from '../src/ol/layer/Tile.js';
 import ImageTileSource from '../src/ol/source/ImageTile.js';
-const worker = new Worker();
+const worker = new Worker(
+  new URL(
+    './tiled-layer-rendering-in-offscreen-canvas.worker.js',
+    import.meta.url,
+  ),
+  {type: 'module'},
+);
 
 const tileQueue = [];
 

--- a/examples/vite-plugin-example-builder.mjs
+++ b/examples/vite-plugin-example-builder.mjs
@@ -154,13 +154,10 @@ class ExampleBuilder {
   }
 
   transformJsSource(source) {
-    return source
-      .replaceAll(
-        /(["'])(\.\.\/src\/ol\/[^"']+\.js)\1/g,
-        (full, quote, importPath) => "'" + importPath.slice(7) + "'",
-      )
-      .replaceAll(/import Worker from 'worker-loader![^\n]*\n/g, '')
-      .replace('new Worker()', "new Worker('./worker.js', {type: 'module'})");
+    return source.replaceAll(
+      /(["'])(\.\.\/src\/ol\/[^"']+\.js)\1/g,
+      (full, quote, importPath) => "'" + importPath.slice(7) + "'",
+    );
   }
 
   cloakSource(source, cloak) {
@@ -254,7 +251,7 @@ class ExampleBuilder {
         name: data.name,
         dependencies: getDependencies(jsSources, pkg),
         devDependencies: {
-          vite: '^3.2.3',
+          vite: pkg.devDependencies.vite,
         },
         scripts: {
           start: 'vite',
@@ -380,27 +377,6 @@ export default function exampleBuilder(config) {
 
   return {
     name: 'example-builder',
-    transform(code, id) {
-      if (!id.includes(`${path.sep}examples${path.sep}`) || id.includes('?')) {
-        return null;
-      }
-      const match = code.match(
-        /import\s+(\w+)\s+from\s+['"]worker-loader!(.+?)['"]/,
-      );
-      if (!match) {
-        return null;
-      }
-      const [, binding, workerPath] = match;
-      return {
-        code: code
-          .replace(/import\s+\w+\s+from\s+['"]worker-loader!.+?['"];?\n?/, '')
-          .replace(
-            new RegExp(`new\\s+${binding}\\(\\)`),
-            `new Worker(new URL('${workerPath}', import.meta.url), {type: 'module'})`,
-          ),
-        map: null,
-      };
-    },
     configureServer(server) {
       server.watcher.on('change', (file) => {
         if (


### PR DESCRIPTION
This change reworks how workers are handled in the examples. The `worker-loader!` import syntax was leftover from webpack and should have been removed in #17568. The changes here are mostly about following Vite-recommended pattern for module workers. I'll leave more specific comments below.