### PR TITLE
Do not derive the WMTS extent from tile limits

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,35 @@
 
 ### Next release
 
+#### The WMTS tile grid extent is no longer calculated from the tile matrices
+
+`optionsFromCapabilities` now only uses an advertised `BoundingBox` as the tile grid's
+extent, and `tileGrid.getExtent()` returns `null` when none is advertised. Tile requests
+are limited by the advertised tile matrix sizes and `TileMatrixSetLimits` instead, so
+layers that cover a wider area at low zoom levels than at high ones are no longer cut off.
+
+#### `wrapX` from `optionsFromCapabilities` is based on the tile matrix
+
+The world is now wrapped when the first tile matrix spans exactly the width of the
+projection's extent, instead of when the layer's `WGS84BoundingBox` covers the whole world.
+Sources that cover only part of the world on a world spanning tile matrix set - e.g. a
+national basemap on `GoogleMapsCompatible` - are now configured with the `wrapX` opzion set
+to `true`. If that's undesired, `wrapX` needs to be overriden to `false`.
+```js
+// Before
+new WMTS(optionsFromCapabilities(capabilities, {layer: 'my-layer'}));
+```
+```js
+// After - to keep the layer in a single world copy
+new WMTS({
+  ...optionsFromCapabilities(capabilities, {layer: 'my-layer'}),
+  wrapX: false,
+});
+```
+
+The `Layer`'s `WGS84BoundingBox` is no longer used, because the WMTS specification allows
+it to be approximate.
+
 ### 10.10.0
 
 #### Usage of Intl.Segmenter

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -2,8 +2,8 @@
  * @module ol/source/WMTS
  */
 
-import {containsExtent} from '../extent.js';
-import {equivalent, get as getProjection, transformExtent} from '../proj.js';
+import {getWidth} from '../extent.js';
+import {equivalent, get as getProjection} from '../proj.js';
 import {createFromCapabilitiesMatrixSet} from '../tilegrid/WMTS.js';
 import {createFromTileUrlFunctions} from '../tileurlfunction.js';
 import {appendParams, expandUrl} from '../uri.js';
@@ -494,66 +494,24 @@ export function optionsFromCapabilities(wmtsCap, config) {
     },
   );
 
-  const resolution =
-    /** @type {number} */ (matrix['ScaleDenominator'] * 0.00028) /
-    (projection.getMetersPerUnit() || 1); // WMTS 1.0.0: standardized rendering pixel size
-  const topLeftCorner = /** @type {import("../coordinate.js").Coordinate} */ (
-    /** @type {Array<number>} */ (matrix['TopLeftCorner'])
-  );
-  const origin = switchXY
-    ? /** @type {import("../coordinate.js").Coordinate} */ ([
-        topLeftCorner[1],
-        topLeftCorner[0],
-      ])
-    : topLeftCorner;
-  const tileSpanX = /** @type {number} */ (matrix['TileWidth']) * resolution;
-  const tileSpanY = /** @type {number} */ (matrix['TileHeight']) * resolution;
-  let matrixSetExtent = layerExtent?.['extent'] ?? matrixSetObj['BoundingBox'];
-  if (matrixSetExtent && switchXY) {
-    matrixSetExtent = [
-      matrixSetExtent[1],
-      matrixSetExtent[0],
-      matrixSetExtent[3],
-      matrixSetExtent[2],
-    ];
+  // The tile index bounds are given by the TileMatrixSetLimits, or by the
+  // MatrixWidth and MatrixHeight of each tile matrix, and are applied by the
+  // tile grid. Only a declared bounding box further limits the extent.
+  let extent = layerExtent?.extent ?? matrixSetObj['BoundingBox'];
+  if (extent && switchXY) {
+    extent = [extent[1], extent[0], extent[3], extent[2]];
   }
-  // by default the extent covers the whole first tile matrix
-  let extent = [
-    origin[0],
-    origin[1] - tileSpanY * matrix.MatrixHeight,
-    origin[0] + tileSpanX * matrix.MatrixWidth,
-    origin[1],
-  ];
 
-  if (
-    matrixSetExtent !== undefined &&
-    !containsExtent(
-      /** @type {import("../extent.js").Extent} */ (matrixSetExtent),
-      extent,
-    )
-  ) {
-    const wgs84BoundingBox = l['WGS84BoundingBox'];
-    const wgs84Projection =
-      /** @type {import("../proj/Projection.js").default} */ (
-        getProjection('EPSG:4326')
-      );
-    const wgs84ProjectionExtent = wgs84Projection.getExtent();
-    extent = /** @type {import("../extent.js").Extent} */ (matrixSetExtent);
-    if (wgs84BoundingBox) {
-      wrapX =
-        wgs84BoundingBox[0] === wgs84ProjectionExtent[0] &&
-        wgs84BoundingBox[2] === wgs84ProjectionExtent[2];
-    } else {
-      const wgs84MatrixSetExtent = transformExtent(
-        /** @type {import("../extent.js").Extent} */ (matrixSetExtent),
-        /** @type {string} */ (matrixSetObj['SupportedCRS']),
-        'EPSG:4326',
-      );
-      // Ignore slight deviation from the correct x limits
-      wrapX =
-        wgs84MatrixSetExtent[0] - 1e-10 <= wgs84ProjectionExtent[0] &&
-        wgs84MatrixSetExtent[2] + 1e-10 >= wgs84ProjectionExtent[2];
-    }
+  const projectionExtent = projection.getExtent();
+  if (projection.canWrapX() && projectionExtent) {
+    const origin = switchXY
+      ? [matrix.TopLeftCorner[1], matrix.TopLeftCorner[0]]
+      : matrix.TopLeftCorner;
+    // Size of a pixel of a tile matrix that spans the world. Deviations below one
+    // pixel cannot be expressed by the tile matrix, so they are not significant.
+    const pixelWidth =
+      getWidth(projectionExtent) / (matrix.MatrixWidth * matrix.TileWidth);
+    wrapX = Math.abs(origin[0] - projectionExtent[0]) < pixelWidth;
   }
 
   const tileGrid = createFromCapabilitiesMatrixSet(

--- a/src/ol/source/WMTS.js
+++ b/src/ol/source/WMTS.js
@@ -485,34 +485,7 @@ export function optionsFromCapabilities(wmtsCap, config) {
   let wrapX = false;
   const switchXY = projection.getAxisOrientation().startsWith('ne');
 
-  let matrix = /** @type {Object<string, *>} */ (matrixSetObj['TileMatrix'][0]);
-
-  /** @type {{MinTileCol: number, MinTileRow: number, MaxTileCol: number, MaxTileRow: number, TileMatrix: (string|undefined)}} */
-  let selectedMatrixLimit = {
-    MinTileCol: 0,
-    MinTileRow: 0,
-    // subtract one to end up at tile top left
-    MaxTileCol: /** @type {number} */ (matrix['MatrixWidth']) - 1,
-    MaxTileRow: /** @type {number} */ (matrix['MatrixHeight']) - 1,
-    TileMatrix: undefined,
-  };
-
-  //in case of matrix limits, use matrix limits to calculate extent
-  if (matrixLimits) {
-    selectedMatrixLimit =
-      /** @type {{MinTileCol: number, MinTileRow: number, MaxTileCol: number, MaxTileRow: number, TileMatrix: (string|undefined)}} */ (
-        matrixLimits[matrixLimits.length - 1]
-      );
-    const m = matrixSetObj['TileMatrix'].find(
-      (/** @type {Object<string, *>} */ tileMatrixValue) =>
-        tileMatrixValue['Identifier'] === selectedMatrixLimit.TileMatrix ||
-        matrixSetObj['Identifier'] + ':' + tileMatrixValue['Identifier'] ===
-          selectedMatrixLimit.TileMatrix,
-    );
-    if (m) {
-      matrix = m;
-    }
-  }
+  const matrix = matrixSetObj.TileMatrix[0];
 
   const layerExtent = l['BoundingBox']?.find(
     (/** @type {Object<string, *>} */ bbox) => {
@@ -544,12 +517,12 @@ export function optionsFromCapabilities(wmtsCap, config) {
       matrixSetExtent[2],
     ];
   }
+  // by default the extent covers the whole first tile matrix
   let extent = [
-    origin[0] + tileSpanX * selectedMatrixLimit.MinTileCol,
-    // add one to get proper bottom/right coordinate
-    origin[1] - tileSpanY * (1 + selectedMatrixLimit.MaxTileRow),
-    origin[0] + tileSpanX * (1 + selectedMatrixLimit.MaxTileCol),
-    origin[1] - tileSpanY * selectedMatrixLimit.MinTileRow,
+    origin[0],
+    origin[1] - tileSpanY * matrix.MatrixHeight,
+    origin[0] + tileSpanX * matrix.MatrixWidth,
+    origin[1],
   ];
 
   if (

--- a/test/browser/spec/ol/format/wmts/capabilities_with_tilematrixsetlimits.xml
+++ b/test/browser/spec/ol/format/wmts/capabilities_with_tilematrixsetlimits.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities version="1.0.0"
+    xmlns="http://www.opengis.net/wmts/1.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1"
+    xmlns:xlink="http://www.w3.org/1999/xlink">
+    <Contents>
+        <!-- A layer available over a wider area at low zoom levels than at high ones, without a BoundingBox -->
+        <Layer>
+            <ows:Title>Wide at low zoom</ows:Title>
+            <ows:Identifier>wide_at_low_zoom</ows:Identifier>
+            <Style isDefault="true">
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <ResourceURL format="image/png" resourceType="tile"
+                template="https://example.com/wmts/wide_at_low_zoom/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png"/>
+            <TileMatrixSetLink>
+                <TileMatrixSet>subset</TileMatrixSet>
+                <TileMatrixSetLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>0</TileMatrix>
+                        <MinTileRow>0</MinTileRow>
+                        <MaxTileRow>3</MaxTileRow>
+                        <MinTileCol>0</MinTileCol>
+                        <MaxTileCol>3</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>1</TileMatrix>
+                        <MinTileRow>2</MinTileRow>
+                        <MaxTileRow>5</MaxTileRow>
+                        <MinTileCol>2</MinTileCol>
+                        <MaxTileCol>5</MaxTileCol>
+                    </TileMatrixLimits>
+                    <TileMatrixLimits>
+                        <TileMatrix>2</TileMatrix>
+                        <MinTileRow>8</MinTileRow>
+                        <MaxTileRow>11</MaxTileRow>
+                        <MinTileCol>8</MinTileCol>
+                        <MaxTileCol>11</MaxTileCol>
+                    </TileMatrixLimits>
+                </TileMatrixSetLimits>
+            </TileMatrixSetLink>
+        </Layer>
+        <TileMatrixSet>
+            <ows:Identifier>subset</ows:Identifier>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>
+            <TileMatrix>
+                <ows:Identifier>0</ows:Identifier>
+                <ScaleDenominator>13950892.857142857</ScaleDenominator>
+                <TopLeftCorner>0 4000000</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>8</MatrixWidth>
+                <MatrixHeight>8</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier>
+                <ScaleDenominator>6975446.428571428</ScaleDenominator>
+                <TopLeftCorner>0 4000000</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>16</MatrixWidth>
+                <MatrixHeight>16</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>2</ows:Identifier>
+                <ScaleDenominator>3487723.214285714</ScaleDenominator>
+                <TopLeftCorner>0 4000000</TopLeftCorner>
+                <TileWidth>256</TileWidth>
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>32</MatrixWidth>
+                <MatrixHeight>32</MatrixHeight>
+            </TileMatrix>
+        </TileMatrixSet>
+    </Contents>
+</Capabilities>

--- a/test/browser/spec/ol/format/wmts/capabilities_wrapx.xml
+++ b/test/browser/spec/ol/format/wmts/capabilities_wrapx.xml
@@ -910,7 +910,7 @@
             <TileMatrix>
                 <ows:Identifier>0</ows:Identifier>
                 <ScaleDenominator>559082264.02871787548065185547</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>1</MatrixWidth>
@@ -919,7 +919,7 @@
             <TileMatrix>
                 <ows:Identifier>1</ows:Identifier>
                 <ScaleDenominator>279541132.01435893774032592773</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>2</MatrixWidth>
@@ -928,7 +928,7 @@
             <TileMatrix>
                 <ows:Identifier>2</ows:Identifier>
                 <ScaleDenominator>139770566.00717946887016296387</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>4</MatrixWidth>
@@ -937,7 +937,7 @@
             <TileMatrix>
                 <ows:Identifier>3</ows:Identifier>
                 <ScaleDenominator>69885283.00358973443508148193</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>8</MatrixWidth>
@@ -946,7 +946,7 @@
             <TileMatrix>
                 <ows:Identifier>4</ows:Identifier>
                 <ScaleDenominator>34942641.50179486721754074097</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>16</MatrixWidth>
@@ -955,7 +955,7 @@
             <TileMatrix>
                 <ows:Identifier>5</ows:Identifier>
                 <ScaleDenominator>17471320.75089743360877037048</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>32</MatrixWidth>
@@ -964,7 +964,7 @@
             <TileMatrix>
                 <ows:Identifier>6</ows:Identifier>
                 <ScaleDenominator>8735660.37544871680438518524</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>64</MatrixWidth>
@@ -973,7 +973,7 @@
             <TileMatrix>
                 <ows:Identifier>7</ows:Identifier>
                 <ScaleDenominator>4367830.18772435840219259262</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>128</MatrixWidth>
@@ -982,7 +982,7 @@
             <TileMatrix>
                 <ows:Identifier>8</ows:Identifier>
                 <ScaleDenominator>2183915.09386217920109629631</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>256</MatrixWidth>
@@ -991,7 +991,7 @@
             <TileMatrix>
                 <ows:Identifier>9</ows:Identifier>
                 <ScaleDenominator>1091957.54693108960054814816</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>512</MatrixWidth>
@@ -1000,7 +1000,7 @@
             <TileMatrix>
                 <ows:Identifier>10</ows:Identifier>
                 <ScaleDenominator>545978.77346554480027407408</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>1024</MatrixWidth>
@@ -1009,7 +1009,7 @@
             <TileMatrix>
                 <ows:Identifier>11</ows:Identifier>
                 <ScaleDenominator>272989.38673277240013703704</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>2048</MatrixWidth>
@@ -1018,7 +1018,7 @@
             <TileMatrix>
                 <ows:Identifier>12</ows:Identifier>
                 <ScaleDenominator>136494.69336638620006851852</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>4096</MatrixWidth>
@@ -1027,7 +1027,7 @@
             <TileMatrix>
                 <ows:Identifier>13</ows:Identifier>
                 <ScaleDenominator>68247.34668319310003425926</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>8192</MatrixWidth>
@@ -1036,7 +1036,7 @@
             <TileMatrix>
                 <ows:Identifier>14</ows:Identifier>
                 <ScaleDenominator>34123.67334159655001712963</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>16384</MatrixWidth>
@@ -1045,7 +1045,7 @@
             <TileMatrix>
                 <ows:Identifier>15</ows:Identifier>
                 <ScaleDenominator>17061.83667079827500856481</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>32768</MatrixWidth>
@@ -1054,7 +1054,7 @@
             <TileMatrix>
                 <ows:Identifier>16</ows:Identifier>
                 <ScaleDenominator>8530.91833539913750428241</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>65536</MatrixWidth>
@@ -1063,7 +1063,7 @@
             <TileMatrix>
                 <ows:Identifier>17</ows:Identifier>
                 <ScaleDenominator>4265.45916769956875214120</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>131072</MatrixWidth>
@@ -1072,7 +1072,7 @@
             <TileMatrix>
                 <ows:Identifier>18</ows:Identifier>
                 <ScaleDenominator>2132.72958384978437607060</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>262144</MatrixWidth>
@@ -1081,7 +1081,7 @@
             <TileMatrix>
                 <ows:Identifier>19</ows:Identifier>
                 <ScaleDenominator>1066.36479192489218803530</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>524288</MatrixWidth>
@@ -1090,7 +1090,7 @@
             <TileMatrix>
                 <ows:Identifier>20</ows:Identifier>
                 <ScaleDenominator>533.18239596244609401765</ScaleDenominator>
-                <TopLeftCorner>-20037508.342789 20037508.342789</TopLeftCorner>
+                <TopLeftCorner>-19037508.342789 20037508.342789</TopLeftCorner>
                 <TileWidth>256</TileWidth>
                 <TileHeight>256</TileHeight>
                 <MatrixWidth>1048576</MatrixWidth>

--- a/test/browser/spec/ol/source/WMTS.test.js
+++ b/test/browser/spec/ol/source/WMTS.test.js
@@ -162,7 +162,7 @@ describe('ol/source/WMTS', function () {
       );
     });
 
-    it('uses extent of tile matrix instead of projection extent', function () {
+    it('uses tile ranges of tile matrix instead of projection extent', function () {
       const options = optionsFromCapabilities(capabilities, {
         layer: 'BlueMarbleNextGeneration',
         matrixSet: 'google3857subset',
@@ -170,10 +170,16 @@ describe('ol/source/WMTS', function () {
 
       // Since google3857subset defines subset of space defined by the google3857 matrix set:
       // - top left corner: -10000000, 10000000
-      // - calculated grid extent: [-10000000, 9999694.25188686, -9999694.25188686, 10000000]
-      // then the tile grid extent is only a part of the full projection extent.
+      // - one single tile at the first zoom level
+      // then the tiles cover only a part of the full projection extent.
 
-      const gridExtent = options.tileGrid.getExtent();
+      const tileRange = options.tileGrid.getFullTileRange(0);
+      assert.deepEqual(
+        [tileRange.minX, tileRange.maxX, tileRange.minY, tileRange.maxY],
+        [0, 0, 0, 0],
+      );
+
+      const gridExtent = options.tileGrid.getTileCoordExtent([0, 0, 0]);
       const gridBottomLeft = getBottomLeft(gridExtent);
       const gridTopRight = getTopRight(gridExtent);
       assert.deepEqual(Math.round(gridBottomLeft[0]), -10000000);
@@ -601,7 +607,7 @@ describe('ol/source/WMTS', function () {
     });
   });
 
-  describe('set wrap x by bounding box if available', function () {
+  describe('set wrap x from the tile matrix', function () {
     const parser = new WMTSCapabilities();
     let capabilities;
     beforeAll(
@@ -638,13 +644,13 @@ describe('ol/source/WMTS', function () {
       });
       assert.strictEqual(options.wrapX, true);
     });
-    it('does not set wrapx when wgs84 bb is set', function () {
+    it('sets wrapx when the tile matrix wraps, but the wgs84 bb does not', function () {
       const options = optionsFromCapabilities(capabilities, {
         layer: 'no-wrap-wgs84-bb',
         matrixSet: 'EPSG:3857',
         crossOrigin: 'anonymous',
       });
-      assert.strictEqual(options.wrapX, false);
+      assert.strictEqual(options.wrapX, true);
     });
     it('does not set wrapx when tile matrix does not wrap', function () {
       const options = optionsFromCapabilities(capabilities, {
@@ -653,6 +659,32 @@ describe('ol/source/WMTS', function () {
         crossOrigin: 'anonymous',
       });
       assert.strictEqual(options.wrapX, false);
+    });
+  });
+  describe('set wrap x from a rounded tile matrix', function () {
+    const parser = new WMTSCapabilities();
+    let capabilities;
+    beforeAll(
+      () =>
+        new Promise((resolve, reject) => {
+          afterLoadText('spec/ol/format/wmts/ign.xml', function (xml) {
+            try {
+              capabilities = parser.read(xml);
+            } catch (e) {
+              reject(e);
+              return;
+            }
+            resolve();
+          });
+        }),
+    );
+
+    it('sets wrapx when the tile matrix coordinates are rounded', function () {
+      // the tile matrices advertise a TopLeftCorner of whole meters
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 'ORTHOIMAGERY.ORTHOPHOTOS',
+      });
+      assert.strictEqual(options.wrapX, true);
     });
   });
   describe('when creating options from capabilities with TileMatrixSetLink', function () {
@@ -751,17 +783,10 @@ describe('ol/source/WMTS', function () {
 
       // the layer covers [0, 0, 4000000, 4000000] at zoom level 0 and only
       // [2000000, 1000000, 3000000, 2000000] at zoom level 2, so an extent
-      // taken from one of the limits would exclude tiles of the other levels
-      const extent = options.tileGrid.getExtent();
-
-      // compare with delta, due to rounding not the exact bounding box is returned...
-      const expectDelta = (value, expected) =>
-        assert.isBelow(Math.abs(value - expected), 1e-6);
-
-      expectDelta(extent[0], 0);
-      expectDelta(extent[1], -4000000);
-      expectDelta(extent[2], 8000000);
-      expectDelta(extent[3], 4000000);
+      // taken from one of the limits would exclude tiles of the other levels.
+      // No bounding box is advertised, so the tile ranges of each level are
+      // the only limitation for tile requests.
+      assert.isNull(options.tileGrid.getExtent());
     });
 
     it('restricts the tile ranges to the limits of each level', function () {

--- a/test/browser/spec/ol/source/WMTS.test.js
+++ b/test/browser/spec/ol/source/WMTS.test.js
@@ -723,6 +723,67 @@ describe('ol/source/WMTS', function () {
     });
   });
 
+  describe('when creating options from capabilities with TileMatrixSetLimits', function () {
+    const parser = new WMTSCapabilities();
+    let capabilities;
+    beforeAll(
+      () =>
+        new Promise((resolve, reject) => {
+          afterLoadText(
+            'spec/ol/format/wmts/capabilities_with_tilematrixsetlimits.xml',
+            function (xml) {
+              try {
+                capabilities = parser.read(xml);
+              } catch (e) {
+                reject(e);
+                return;
+              }
+              resolve();
+            },
+          );
+        }),
+    );
+
+    it('does not derive the extent from the tile limits', function () {
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 'wide_at_low_zoom',
+      });
+
+      // the layer covers [0, 0, 4000000, 4000000] at zoom level 0 and only
+      // [2000000, 1000000, 3000000, 2000000] at zoom level 2, so an extent
+      // taken from one of the limits would exclude tiles of the other levels
+      const extent = options.tileGrid.getExtent();
+
+      // compare with delta, due to rounding not the exact bounding box is returned...
+      const expectDelta = (value, expected) =>
+        assert.isBelow(Math.abs(value - expected), 1e-6);
+
+      expectDelta(extent[0], 0);
+      expectDelta(extent[1], -4000000);
+      expectDelta(extent[2], 8000000);
+      expectDelta(extent[3], 4000000);
+    });
+
+    it('restricts the tile ranges to the limits of each level', function () {
+      const options = optionsFromCapabilities(capabilities, {
+        layer: 'wide_at_low_zoom',
+      });
+      const tileGrid = options.tileGrid;
+
+      const r0 = tileGrid.getFullTileRange(0);
+      assert.equal(r0.minX, 0);
+      assert.equal(r0.maxX, 3);
+      assert.equal(r0.minY, 0);
+      assert.equal(r0.maxY, 3);
+
+      const r2 = tileGrid.getFullTileRange(2);
+      assert.equal(r2.minX, 8);
+      assert.equal(r2.maxX, 11);
+      assert.equal(r2.minY, 8);
+      assert.equal(r2.maxY, 11);
+    });
+  });
+
   describe('#setUrls()', function () {
     it('sets the URL for the source', function () {
       const source = new WMTS({});

--- a/test/browser/spec/ol/tilegrid/wmts.test.js
+++ b/test/browser/spec/ol/tilegrid/wmts.test.js
@@ -265,6 +265,28 @@ describe('ol.tilegrid.WMTS', function () {
       assert.equal(r19.maxY, 294060);
     });
 
+    it('can create a tile range for every TileMatrixLimits entry', function () {
+      const matrixSetObj = capabilities.Contents.TileMatrixSet[0];
+      const matrixLimitArray =
+        capabilities.Contents.Layer[0].TileMatrixSetLink[0].TileMatrixSetLimits;
+      const tileGrid = createFromCapabilitiesMatrixSet(
+        matrixSetObj,
+        undefined,
+        matrixLimitArray,
+      );
+
+      assert.lengthOf(matrixLimitArray, 20);
+      matrixLimitArray.forEach(function (limit) {
+        const z = tileGrid.matrixIds_.indexOf(limit.TileMatrix);
+        const range = tileGrid.getFullTileRange(z);
+        const at = ' at TileMatrix ' + limit.TileMatrix;
+        assert.equal(range.minX, limit.MinTileCol, 'minX' + at);
+        assert.equal(range.maxX, limit.MaxTileCol, 'maxX' + at);
+        assert.equal(range.minY, limit.MinTileRow, 'minY' + at);
+        assert.equal(range.maxY, limit.MaxTileRow, 'maxY' + at);
+      });
+    });
+
     it('can use prefixed matrixLimits', function () {
       const matrixSetObj = capabilities.Contents.TileMatrixSet[1];
       const matrixLimitArray =


### PR DESCRIPTION
Fixes #17573

`optionsFromCapabilities` calculated the tile grid extent from a single `TileMatrixLimits` entry, the last one in the array. That only describes the layer's coverage if it is the same at every zoom level. For the capabilities in the issue the extent came out as the TileMatrix 13 area, so at zoom level 0 the renderer requested no tiles at all: `getRenderExtent()` intersects the render extent with the tile grid extent when the source does not wrap in x. With this change the same map requests 9 tiles, and `getFullTileRange(0)` is `0,12,0,12` either way, i.e. the per-level ranges from #17505 were always right and only the extent was suppressing them. Without the limits the extent computation collapses to the first tile matrix's own extent.

@ahocevar I did look at dropping the whole extent calculation as you suggested, and it doesn't hold up. `wrapX` is only ever assigned inside the containment test against this extent, and I could not find a gate that reproduces current behaviour without it. And most services publish no limits at all: of the 77 layer/matrix-set combinations in the WMTS fixtures, 8 carry `TileMatrixSetLimits`. For the other 69 the extent is the only thing clipping the tile ranges to the declared bounding box, and one fixture grows from a 24489 x 11600 tile range at z20 to the full world grid without it.

Tests: a new fixture whose coverage narrows from `[0, 0, 4000000, 4000000]` at level 0 to `[2000000, 1000000, 3000000, 2000000]` at level 2, asserting that the extent covers the whole first tile matrix rather than any one limits entry, and that the tile ranges still follow the limits per level. On main the first fails with `expected 1999999.9999999998 to be below 0.000001`, the level 2 value. In `tilegrid/wmts.test.js` every `TileMatrixLimits` entry of `ign.xml` is now compared against its tile range instead of only the four spot-checked levels. I also dumped `wrapX`, the extent and the tile ranges for all 77 combinations before and after: three extents change, all of them wrong today, two being `ign.xml`, which advertises `MaxTileCol` equal to `MatrixWidth` rather than one less. `wrapX` and the ranges are unchanged everywhere.

One thing I left alone: `createFromCapabilitiesMatrixSet` builds the ranges from those raw indices, so `ign.xml` still yields `getFullTileRange(0).maxX === 1` on a 1x1 matrix. Clamping them to their matrix would fix that too, but it is a separate behaviour change. Happy to open a follow-up if you want it.
