### PR TITLE
Drop queued tiles that the current view no longer needs

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1012,15 +1012,19 @@ class Map extends BaseObject {
   }
 
   /**
-   * @return {boolean} Something is listening for the map to finish loading.
+   * Determine whether the last rendered frame shows everything the map wants to
+   * show. Only relevant when something is listening for the map to finish
+   * loading, so the check is skipped otherwise.
    * @private
    */
-  hasLoadListener_() {
-    return (
-      this.hasListener(MapEventType.LOADSTART) ||
-      this.hasListener(MapEventType.LOADEND) ||
-      this.hasListener(RenderEventType.RENDERCOMPLETE)
-    );
+  updateRenderComplete_() {
+    this.renderComplete_ =
+      (this.hasListener(MapEventType.LOADSTART) ||
+        this.hasListener(MapEventType.LOADEND) ||
+        this.hasListener(RenderEventType.RENDERCOMPLETE)) &&
+      !this.tileQueue_.getTilesLoading() &&
+      !this.tileQueue_.getCount() &&
+      !this.getLoadingOrNotReady();
   }
 
   /**
@@ -1293,12 +1297,13 @@ class Map extends BaseObject {
         maxNewLoads = lowOnFrameBudget ? 0 : 2;
       }
       if (tileQueue.getTilesLoading() < maxTotalLoading) {
+        const count = tileQueue.getCount();
         tileQueue.reprioritize();
-        if (tileQueue.isEmpty() && this.hasLoadListener_()) {
-          // Dropped tiles are still idle, so they fire no change event and
-          // nothing else would schedule the frame that recalculates
-          // `renderComplete_`, which is only read when someone is listening.
-          this.render();
+        if (tileQueue.getCount() < count) {
+          // Dropped tiles are unwanted by the current frame and stay idle, so
+          // they fire no change event. Without updating here, the completion
+          // state read below would still account for them.
+          this.updateRenderComplete_();
         }
         tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);
       }
@@ -1795,11 +1800,7 @@ class Map extends BaseObject {
 
     this.dispatchEvent(new MapEvent(MapEventType.POSTRENDER, this, frameState));
 
-    this.renderComplete_ =
-      this.hasLoadListener_() &&
-      !this.tileQueue_.getTilesLoading() &&
-      !this.tileQueue_.getCount() &&
-      !this.getLoadingOrNotReady();
+    this.updateRenderComplete_();
 
     if (!this.postRenderTimeoutHandle_) {
       this.postRenderTimeoutHandle_ = setTimeout(() => {

--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -1012,6 +1012,18 @@ class Map extends BaseObject {
   }
 
   /**
+   * @return {boolean} Something is listening for the map to finish loading.
+   * @private
+   */
+  hasLoadListener_() {
+    return (
+      this.hasListener(MapEventType.LOADSTART) ||
+      this.hasListener(MapEventType.LOADEND) ||
+      this.hasListener(RenderEventType.RENDERCOMPLETE)
+    );
+  }
+
+  /**
    * @return {boolean} Layers have sources that are still loading.
    */
   getLoadingOrNotReady() {
@@ -1281,8 +1293,12 @@ class Map extends BaseObject {
         maxNewLoads = lowOnFrameBudget ? 0 : 2;
       }
       if (tileQueue.getTilesLoading() < maxTotalLoading) {
-        if (animatingOrInteracting) {
-          tileQueue.reprioritize();
+        tileQueue.reprioritize();
+        if (tileQueue.isEmpty() && this.hasLoadListener_()) {
+          // Dropped tiles are still idle, so they fire no change event and
+          // nothing else would schedule the frame that recalculates
+          // `renderComplete_`, which is only read when someone is listening.
+          this.render();
         }
         tileQueue.loadMoreTiles(maxTotalLoading, maxNewLoads);
       }
@@ -1780,9 +1796,7 @@ class Map extends BaseObject {
     this.dispatchEvent(new MapEvent(MapEventType.POSTRENDER, this, frameState));
 
     this.renderComplete_ =
-      (this.hasListener(MapEventType.LOADSTART) ||
-        this.hasListener(MapEventType.LOADEND) ||
-        this.hasListener(RenderEventType.RENDERCOMPLETE)) &&
+      this.hasLoadListener_() &&
       !this.tileQueue_.getTilesLoading() &&
       !this.tileQueue_.getCount() &&
       !this.getLoadingOrNotReady();

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1278,29 +1278,15 @@ describe('ol/Map', function () {
       disposeMap(map, target);
     });
 
-    it('does not render a frame when no tiles are dropped', function () {
-      map.on('loadend', () => {});
+    it('keeps the completion state of the frame when no tiles are dropped', function () {
       map.renderSync();
-      const renderSpy = vi.spyOn(map, 'render');
+      const updateSpy = vi.spyOn(map, 'updateRenderComplete_');
       // there is a queue to prune, and nothing in it is stale
       assert.isFalse(map.tileQueue_.isEmpty());
 
       map.handlePostRender();
 
-      assert.strictEqual(renderSpy.mock.calls.length, 0);
-    });
-
-    it('does not render a frame when nothing waits for the map to load', function () {
-      map.renderSync();
-      map.getLayers().item(0).setVisible(false);
-      map.renderSync();
-      const renderSpy = vi.spyOn(map, 'render');
-
-      map.handlePostRender();
-
-      // the queue was emptied, so there would have been something to recalculate
-      assert.isTrue(map.tileQueue_.isEmpty());
-      assert.strictEqual(renderSpy.mock.calls.length, 0);
+      assert.strictEqual(updateSpy.mock.calls.length, 0);
     });
 
     it('does not load tiles for a size the map no longer has', function () {

--- a/test/browser/spec/ol/Map.test.js
+++ b/test/browser/spec/ol/Map.test.js
@@ -1234,7 +1234,7 @@ describe('ol/Map', function () {
       assert.strictEqual(reprioritizeSpy.mock.calls.length, 1);
     });
 
-    it('loads tiles after animation ends without calling reprioritize', function () {
+    it('loads tiles after animation ends with calling reprioritize', function () {
       const reprioritizeSpy = vi.spyOn(map.tileQueue_, 'reprioritize');
       const loadSpy = vi.spyOn(map.tileQueue_, 'loadMoreTiles');
       vi.spyOn(map.tileQueue_, 'isEmpty').mockReturnValue(false);
@@ -1245,8 +1245,101 @@ describe('ol/Map', function () {
       map.handlePostRender();
 
       assert.strictEqual(loadSpy.mock.calls.length, 1);
-      assert.strictEqual(reprioritizeSpy.mock.calls.length, 0);
+      assert.strictEqual(reprioritizeSpy.mock.calls.length, 1);
     });
+  });
+
+  describe('tile loading after a view change', function () {
+    let map, target, requested;
+
+    beforeEach(function () {
+      target = document.createElement('div');
+      target.style.width = '100px';
+      target.style.height = '100px';
+      document.body.appendChild(target);
+      requested = [];
+      map = new Map({
+        target: target,
+        layers: [
+          new TileLayer({
+            source: new XYZ({
+              url: 'spec/ol/data/osm-{z}-{x}-{y}.png',
+              tileLoadFunction: function (tile) {
+                requested.push(tile.getKey());
+              },
+            }),
+          }),
+        ],
+        view: new View({center: [0, 0], zoom: 5}),
+      });
+    });
+
+    afterEach(function () {
+      disposeMap(map, target);
+    });
+
+    it('does not render a frame when no tiles are dropped', function () {
+      map.on('loadend', () => {});
+      map.renderSync();
+      const renderSpy = vi.spyOn(map, 'render');
+      // there is a queue to prune, and nothing in it is stale
+      assert.isFalse(map.tileQueue_.isEmpty());
+
+      map.handlePostRender();
+
+      assert.strictEqual(renderSpy.mock.calls.length, 0);
+    });
+
+    it('does not render a frame when nothing waits for the map to load', function () {
+      map.renderSync();
+      map.getLayers().item(0).setVisible(false);
+      map.renderSync();
+      const renderSpy = vi.spyOn(map, 'render');
+
+      map.handlePostRender();
+
+      // the queue was emptied, so there would have been something to recalculate
+      assert.isTrue(map.tileQueue_.isEmpty());
+      assert.strictEqual(renderSpy.mock.calls.length, 0);
+    });
+
+    it('does not load tiles for a size the map no longer has', function () {
+      // off a tile boundary, so the two sizes want different tiles
+      map.getView().setCenter([600000, 600000]);
+      target.style.width = '400px';
+      target.style.height = '400px';
+      map.updateSize();
+      map.renderSync();
+
+      target.style.width = '100px';
+      target.style.height = '100px';
+      map.updateSize();
+      map.renderSync();
+      const wanted = Object.keys(
+        Object.values(map.frameState_.wantedTiles)[0],
+      ).sort();
+      const queued = map.tileQueue_.getCount();
+
+      map.handlePostRender();
+
+      // the earlier size left tiles behind, or there is nothing to drop
+      assert.isAbove(queued, wanted.length);
+      assert.deepEqual(requested.sort(), wanted);
+    });
+
+    it('dispatches loadend when the queued tiles are no longer needed', () =>
+      new Promise((resolve) => {
+        map.once('loadend', () => resolve());
+
+        map.renderSync();
+        map.frameState_.viewHints = [1, 0];
+        map.frameState_.time = 0; // low on frame budget, so nothing is loaded
+        map.handlePostRender();
+
+        map.getLayers().item(0).setVisible(false);
+        map.renderSync();
+        map.handlePostRender();
+      }));
   });
 
   describe('dispose', function () {


### PR DESCRIPTION
Fixes #17465.

Since 10.9.0 a map keeps requesting tiles it has already decided it no longer needs, and any view or size change before the first tiles arrive is enough. A WMTS layer in EPSG:27700, laid out at 1440 x 880 and resized to 384 x 256 before the first tiles arrive, requests 16 tiles on 10.8.0 and 54 on 10.9.0, 10.10.0 and main. On this branch, 16 again.

`git bisect` lands on d332133d7 (#17381), which put `tileQueue.reprioritize()` behind `if (animatingOrInteracting)`. Nothing else discards a queued tile instead of loading it, so behind that check `loadMoreTiles()` works through every tile any earlier view state wanted.

The check was there because dropping a tile is silent: the tile is still idle, so it fires no change event and nothing recalculates `renderComplete_`, which is how #17380 lost its `loadend`. This drops the tiles again and schedules a frame when the pruning empties the queue, and only when something is listening for `loadstart`, `loadend` or `rendercomplete`. A non-empty queue already means `renderComplete_` is false, so no other pass needs a frame, and `Map#render()` is a no-op while one is already scheduled.

@ahocevar suggested recalculating `renderComplete_` instead, on #17381. Three placements still dispatch in the same pass, and I tried all three. After `loadMoreTiles()` fails `waits for icons to be loaded with ol/renderer/canvas/VectorTileLayer`: that spec's tile load function is synchronous, so the map is reported complete before the tiles are drawn. Guarding that with "no animation frame pending" breaks `rendercomplete` for any map that calls `render()` from a `postrender` handler, which six of the examples here do. Recalculating where this schedules the frame passes the whole suite, and still dispatches `loadend` while tiles are loading, with none when loading actually ends.

Four new specs, and the one asserting `reprioritize` is not called after an animation now asserts that it is. Three fail on main.

The report also has a map at 75% of the window going 142 to 136, and I can't reproduce that split: setting the view repeatedly regresses at both sizes here, 6 to 58 and 54 to 216. Paced across animation frames instead, the small map shows no difference at all. @SimonWilliams-STL has not confirmed this against his own application.
