### PR TITLE
Add storeOptions (headers, credentials) to GeoZarr source

### DIFF
--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -31,6 +31,13 @@ const REQUIRED_ZARR_CONVENTIONS = [
  */
 
 /**
+ * @typedef {Object} GeoZarrStoreOptions
+ * @property {Object<string, string>} [headers] additional key-value pairs of headers to be passed with each request. Key is the header name, value the header value.
+ * @property {string} [credentials] How credentials shall be handled. See
+ * https://developer.mozilla.org/en-US/docs/Web/API/fetch for reference and possible values
+ */
+
+/**
  * @typedef {Object} Options
  * @property {string} url When `bands` contains plain strings, this must be the full URL to the
  * multiscales group (e.g. `'https://example.com/store.zarr/measurements/reflectance'`).
@@ -45,6 +52,8 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * `proj:code`, and `spatial:shape` (or the array shape from consolidated metadata).
  * Bands from additional groups do not need to follow any convention; they can be multi-scale
  * (array located at `<matrixId>/<bandName>`) or single-scale (array at the group root).
+ * @property {GeoZarrStoreOptions} [storeOptions] Additional options to be passed to
+ * [zarrita](https://zarrita.dev/)'s `FetchStore` with each request to the Zarr store.
  * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoZarr metadata
  * will be read for projection information.
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
@@ -91,6 +100,12 @@ export default class GeoZarr extends DataTileSource {
      * @private
      */
     this.url_ = options.url;
+
+    /**
+     * @type {GeoZarrStoreOptions|undefined}
+     * @private
+     */
+    this.storeOptions_ = options.storeOptions;
 
     /**
      * Fixed index per non-spatial dimension name, from the `dimensions` option.
@@ -244,8 +259,9 @@ export default class GeoZarr extends DataTileSource {
   }
 
   async configure_() {
+    const overrides = /** @type {RequestInit} */ (this.storeOptions_) || {};
     const store = /** @type {FetchStore} */ (
-      withRangeCoalescing(new FetchStore(this.url_))
+      withRangeCoalescing(new FetchStore(this.url_, {overrides}))
     );
 
     // Fetch group zarr.json once for both opening the group and extracting

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -172,6 +172,92 @@ describe('ol/source/GeoZarr', function () {
     });
   });
 
+  describe('storeOptions', function () {
+    let fetchStub;
+
+    afterEach(function () {
+      if (fetchStub) {
+        fetchStub.mockRestore();
+        fetchStub = null;
+      }
+    });
+
+    function getRequestHeader(call, name) {
+      const [input, init] = call;
+      if (input instanceof Request) {
+        return input.headers.get(name);
+      }
+      return init && init.headers ? new Headers(init.headers).get(name) : null;
+    }
+
+    it('attaches configured headers to store requests', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch(null);
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['b04'],
+          storeOptions: {
+            headers: {Authorization: 'Bearer test-token'},
+          },
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.isAbove(fetchStub.mock.calls.length, 0);
+            for (const call of fetchStub.mock.calls) {
+              assert.strictEqual(
+                getRequestHeader(call, 'Authorization'),
+                'Bearer test-token',
+              );
+            }
+            resolve();
+          }
+        });
+      }));
+
+    it('applies the configured credentials mode to store requests', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch(null);
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['b04'],
+          storeOptions: {
+            credentials: 'include',
+          },
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.isAbove(fetchStub.mock.calls.length, 0);
+            for (const [input, init] of fetchStub.mock.calls) {
+              const credentials =
+                input instanceof Request
+                  ? input.credentials
+                  : init && init.credentials;
+              assert.strictEqual(credentials, 'include');
+            }
+            resolve();
+          }
+        });
+      }));
+
+    it('sends no extra headers by default', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetch(null);
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          bands: ['b04'],
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.isAbove(fetchStub.mock.calls.length, 0);
+            for (const call of fetchStub.mock.calls) {
+              assert.isNull(getRequestHeader(call, 'Authorization'));
+            }
+            resolve();
+          }
+        });
+      }));
+  });
+
   describe('band data access', function () {
     let source;
 


### PR DESCRIPTION
This adds a sourceOptions parameter for the GeoZarr source, in my case primarily for authentication injection.
Implemented alongside the similar option in the GeoTIFF source.