### PR TITLE
Support visualization of generic n-D GeoZarr datacubes

### DIFF
--- a/examples/geozarr-datacube.html
+++ b/examples/geozarr-datacube.html
@@ -6,7 +6,7 @@ docs: >
 
   Besides one array per band, the GeoZarr source supports datacubes where all bands are
   packed into a single n-dimensional data array (e.g. `(time, band, y, x)`): the `variable`
-  option names the array, and the `selector` option fixes its non-spatial dimensions by
+  option names the array, and the `dimensions` option fixes its non-spatial dimensions by
   index or coordinate label, with one dimension optionally selecting multiple bands.
 
 

--- a/examples/geozarr-datacube.html
+++ b/examples/geozarr-datacube.html
@@ -1,0 +1,43 @@
+---
+layout: example.html
+title: GeoZarr datacubes
+shortdesc: GeoZarr sources rendering bands from a single n-dimensional data array.
+docs: >
+
+  Besides one array per band, the GeoZarr source supports datacubes where all bands are
+  packed into a single n-dimensional data array (e.g. `(time, band, y, x)`): the `variable`
+  option names the array, and the `selector` option fixes its non-spatial dimensions by
+  index or coordinate label, with one dimension optionally selecting multiple bands.
+
+
+  The datasets above are real-world Zarr v2 and v3 stores from different producers, in
+  different projections and multiscale layouts. The extent, resolution, projection and
+  y-axis orientation are read from the store metadata (proj:/spatial: conventions,
+  `bounds`/`proj4`/`spatial_ref` attributes) or inferred from the coordinate arrays;
+  where the store provides neither (Delta FG CO2), the `extent` and `flipY` options
+  fill the gap. Data with non-square pixels (CMIP6) and south-up rows (Delta FG CO2)
+  is handled transparently.
+
+tags: "zarr, geozarr, datacube, multiscale"
+experimental: true
+---
+<div id="map" class="map"></div>
+<div class="row mt-2">
+  <div class="col-auto">
+    <div class="input-group">
+      <label class="input-group-text" for="dataset-select">Dataset</label>
+      <select class="form-select" id="dataset-select">
+        <option value="ftw-rgb" selected>FTW Field Predictions 2025 (RGB, multiscale v3)</option>
+        <option value="ftw-field-2024">FTW Field Probability 2024 (single band, multiscale v3)</option>
+        <option value="usgs-dem">USGS CONUS DEM 10m (multiscale v3)</option>
+        <option value="hurricane">Hurricane Florence — ERA5 surface pressure (v3)</option>
+        <option value="antarctic-era5">Antarctic ERA5 wind speed (v3, polar stereographic)</option>
+        <option value="polar">Thwaites Glacier ice velocity (v2, EPSG:3031)</option>
+        <option value="fgco2">Delta FG CO2 (v2, south-up)</option>
+        <option value="carbonplan-4d">Monthly average temperature (v2 pyramid, EPSG:3857)</option>
+        <option value="cmip6-tasmax">CMIP6 max. temperature (v2 pyramid)</option>
+        <option value="tos-con">Ocean surface temperature (v3 pyramid, EPSG:3857)</option>
+      </select>
+    </div>
+  </div>
+</div>

--- a/examples/geozarr-datacube.js
+++ b/examples/geozarr-datacube.js
@@ -1,0 +1,200 @@
+import proj4 from 'proj4';
+import Map from '../src/ol/Map.js';
+import {
+  getView,
+  withExtentCenter,
+  withHigherResolutions,
+  withLowerResolutions,
+} from '../src/ol/View.js';
+import TileLayer from '../src/ol/layer/WebGLTile.js';
+import {register} from '../src/ol/proj/proj4.js';
+import GeoZarr from '../src/ol/source/GeoZarr.js';
+import OSM from '../src/ol/source/OSM.js';
+
+register(proj4);
+
+// A single-band color ramp style with evenly spaced color stops.
+function ramp(min, max, colors) {
+  const stops = [];
+  for (let i = 0; i < colors.length; i++) {
+    stops.push(min + (i / (colors.length - 1)) * (max - min), colors[i]);
+  }
+  return {color: ['interpolate', ['linear'], ['band', 1], ...stops]};
+}
+
+// An RGB composite style stretching each band from [min, max] to 0..255.
+function rgb(min, max) {
+  const stretch = (band) => [
+    'interpolate',
+    ['linear'],
+    ['band', band],
+    min,
+    0,
+    max,
+    255,
+  ];
+  return {color: ['color', stretch(1), stretch(2), stretch(3)]};
+}
+
+const FTW_URL =
+  'https://data.source.coop/ftw/global-data/predictions/zarr/alpha/global.zarr';
+
+const datasets = {
+  'ftw-rgb': {
+    source: {
+      url: FTW_URL,
+      variable: 'variables',
+      // The three class probabilities as RGB, for the most recent year
+      selector: {band: [0, 1, 2], time: 1},
+    },
+    style: rgb(0, 0.5),
+  },
+  'ftw-field-2024': {
+    source: {
+      url: FTW_URL,
+      variable: 'variables',
+      selector: {band: [1], time: 0}, // band 1 is the `field` probability
+    },
+    style: ramp(0, 1, [
+      [255, 255, 178],
+      [0, 104, 55],
+    ]),
+  },
+  'usgs-dem': {
+    source: {
+      url: 'https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/USGS-CONUS-DEM-10m.zarr',
+      variable: 'DEM',
+    },
+    style: ramp(0, 3500, [
+      [26, 152, 80],
+      [254, 224, 139],
+      [140, 81, 10],
+      [255, 255, 255],
+    ]),
+  },
+  'hurricane': {
+    source: {
+      url: 'https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/hurricanes/era5/florence',
+      variable: 'surface_pressure',
+      selector: {time: 0},
+    },
+    style: ramp(96000, 103000, [
+      [68, 1, 84],
+      [33, 145, 140],
+      [253, 231, 37],
+    ]),
+  },
+  'antarctic-era5': {
+    source: {
+      url: 'https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/antarctic_era5.zarr',
+      variable: 'wind_speed',
+    },
+    style: ramp(0, 12, [
+      [247, 251, 255],
+      [107, 174, 214],
+      [8, 48, 107],
+    ]),
+  },
+  'polar': {
+    source: {
+      url: 'https://carbonplan-share.s3.us-west-2.amazonaws.com/zarr-layer-examples/polar-subset.zarr',
+      variable: 'velocity',
+    },
+    style: ramp(0, 1, [
+      [255, 245, 240],
+      [251, 106, 74],
+      [103, 0, 13],
+    ]),
+  },
+  'fgco2': {
+    source: {
+      url: 'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/fgco2-2021-180x360.zarr',
+      variable: 'FG_CO2_2',
+      selector: {time: 0},
+      // The store has neither spatial metadata nor coordinate arrays, so the
+      // extent and the south-up orientation have to be provided.
+      extent: [-180, -90, 180, 90],
+      flipY: true,
+    },
+    style: ramp(-5, 5, [
+      [230, 97, 1],
+      [255, 255, 255],
+      [5, 113, 176],
+    ]),
+  },
+  'carbonplan-4d': {
+    source: {
+      url: 'https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month',
+      variable: 'climate',
+      // Bands can also be selected by coordinate label
+      selector: {band: ['tavg'], month: 0},
+    },
+    style: ramp(-30, 30, [
+      [5, 113, 176],
+      [255, 255, 255],
+      [202, 0, 32],
+    ]),
+  },
+  'cmip6-tasmax': {
+    source: {
+      url: 'https://carbonplan-benchmarks.s3.us-west-2.amazonaws.com/data/NEX-GDDP-CMIP6/ACCESS-CM2/historical/r1i1p1f1/tasmax/tasmax_day_ACCESS-CM2_historical_r1i1p1f1_gn/pyramids-v2-4326-True-128-1-0-0-f4-0-0-0-gzipL1-100',
+      variable: 'tasmax',
+      selector: {time: 0},
+    },
+    style: ramp(250, 320, [
+      [5, 113, 176],
+      [255, 255, 255],
+      [253, 174, 97],
+      [165, 0, 38],
+    ]),
+  },
+  'tos-con': {
+    source: {
+      url: 'https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca1-era5v1/gn/T1y/tos_con',
+      variable: 'tos_con',
+      selector: {time: 0},
+    },
+    style: ramp(-2, 30, [
+      [5, 48, 97],
+      [247, 247, 247],
+      [178, 24, 43],
+    ]),
+  },
+};
+
+const select = document.getElementById('dataset-select');
+
+let map;
+
+function render() {
+  const dataset = datasets[select.value];
+
+  const source = new GeoZarr(dataset.source);
+
+  if (map) {
+    map.setTarget(null);
+  }
+
+  map = new Map({
+    layers: [
+      new TileLayer({
+        source: new OSM(),
+      }),
+      new TileLayer({
+        style: dataset.style,
+        source,
+      }),
+    ],
+    target: 'map',
+    view: getView(
+      source,
+      withLowerResolutions(2),
+      withHigherResolutions(2),
+      withExtentCenter(),
+    ),
+  });
+}
+
+select.addEventListener('change', render);
+
+render();

--- a/examples/geozarr-datacube.js
+++ b/examples/geozarr-datacube.js
@@ -45,7 +45,7 @@ const datasets = {
       url: FTW_URL,
       variable: 'variables',
       // The three class probabilities as RGB, for the most recent year
-      selector: {band: [0, 1, 2], time: 1},
+      dimensions: {band: [0, 1, 2], time: 1},
     },
     style: rgb(0, 0.5),
   },
@@ -53,7 +53,7 @@ const datasets = {
     source: {
       url: FTW_URL,
       variable: 'variables',
-      selector: {band: [1], time: 0}, // band 1 is the `field` probability
+      dimensions: {band: [1], time: 0}, // band 1 is the `field` probability
     },
     style: ramp(0, 1, [
       [255, 255, 178],
@@ -76,7 +76,7 @@ const datasets = {
     source: {
       url: 'https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/hurricanes/era5/florence',
       variable: 'surface_pressure',
-      selector: {time: 0},
+      dimensions: {time: 0},
     },
     style: ramp(96000, 103000, [
       [68, 1, 84],
@@ -110,7 +110,7 @@ const datasets = {
     source: {
       url: 'https://carbonplan-oae-efficiency.s3.us-west-2.amazonaws.com/fgco2-2021-180x360.zarr',
       variable: 'FG_CO2_2',
-      selector: {time: 0},
+      dimensions: {time: 0},
       // The store has neither spatial metadata nor coordinate arrays, so the
       // extent and the south-up orientation have to be provided.
       extent: [-180, -90, 180, 90],
@@ -127,7 +127,7 @@ const datasets = {
       url: 'https://carbonplan-maps.s3.us-west-2.amazonaws.com/v2/demo/4d/tavg-prec-month',
       variable: 'climate',
       // Bands can also be selected by coordinate label
-      selector: {band: ['tavg'], month: 0},
+      dimensions: {band: ['tavg'], month: 0},
     },
     style: ramp(-30, 30, [
       [5, 113, 176],
@@ -139,7 +139,7 @@ const datasets = {
     source: {
       url: 'https://carbonplan-benchmarks.s3.us-west-2.amazonaws.com/data/NEX-GDDP-CMIP6/ACCESS-CM2/historical/r1i1p1f1/tasmax/tasmax_day_ACCESS-CM2_historical_r1i1p1f1_gn/pyramids-v2-4326-True-128-1-0-0-f4-0-0-0-gzipL1-100',
       variable: 'tasmax',
-      selector: {time: 0},
+      dimensions: {time: 0},
     },
     style: ramp(250, 320, [
       [5, 113, 176],
@@ -152,7 +152,7 @@ const datasets = {
     source: {
       url: 'https://atlantis-vis-o.s3-ext.jc.rl.ac.uk/noc-npd-era5-demo/npd-eorca1-era5v1/gn/T1y/tos_con',
       variable: 'tos_con',
-      selector: {time: 0},
+      dimensions: {time: 0},
     },
     style: ramp(-2, 30, [
       [5, 48, 97],

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -43,7 +43,8 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * multiscales group (e.g. `'https://example.com/store.zarr/measurements/reflectance'`).
  * When `bands` contains {@link Band} objects, this is the base URL from which each band's
  * `group` path is resolved (e.g. `'https://example.com/store.zarr/satellite/sentinel2'`).
- * @property {Array<string|Band>} bands The bands to render.  Each entry is either a band name
+ * @property {Array<string|Band>} [bands] The bands to render, for stores where each
+ * band is a separate array. Mutually exclusive with `variable`.  Each entry is either a band name
  * string (single-group mode) or a {@link Band} object specifying both the band name and the
  * group it belongs to (multi-group mode).  In multi-group mode, the first band's group
  * determines the tile grid and must follow at least the proj: and spatial: conventions.
@@ -54,18 +55,35 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * (array located at `<matrixId>/<bandName>`) or single-scale (array at the group root).
  * @property {GeoZarrStoreOptions} [storeOptions] Additional options to be passed to
  * [zarrita](https://zarrita.dev/)'s `FetchStore` with each request to the Zarr store.
- * @property {import("../proj.js").ProjectionLike} [projection] Source projection.  If not provided, the GeoZarr metadata
- * will be read for projection information.
+ * @property {import("../proj.js").ProjectionLike} [projection] Source projection.
+ * If not provided, the GeoZarr metadata will be read for projection information.
  * @property {number} [transition=250] Duration of the opacity transition for rendering.
  * To disable the opacity transition, pass `transition: 0`.
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
- * @property {ResampleMethod} [resample='nearest'] Resampling method if bands are not available for all multi-scale levels.
+ * @property {ResampleMethod} [resample='linear'] Resampling method if bands are not available for all multi-scale levels.
  * @property {Object<string, number|string>} [dimensions] Fixed index for each non-spatial
  * dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` for the first time step
  * of a `[time, y, x]` cube); unspecified dimensions default to `0`. Names come from each array's
  * `dimension_names`, or are the axis position as a string when it has none. Only integer indices
  * are supported. Use the names from {@link getDimensions}, and change the selection on the fly with
  * {@link module:ol/source/GeoZarr~GeoZarr#updateDimensions}.
+ * @property {string} [variable] The name of an n-dimensional data array (variable) to
+ * render, for stores where all bands are packed into a single array (e.g. a
+ * `(time, band, y, x)` datacube). The array must exist within each multiscale level
+ * group (or at the group root for single-scale stores). Mutually exclusive with `bands`.
+ * @property {Object<string, number|string|Array<number|string>>} [selector] For
+ * `variable` mode: how to slice each non-spatial dimension, keyed by dimension name
+ * (from the array's `dimension_names`). Values are 0-based indices (number), coordinate
+ * labels (string), or an array of these. At most one dimension may map to an array; its
+ * entries are rendered as separate bands (in the given order). Unlisted non-spatial
+ * dimensions default to index 0. Labels are resolved against the dimension's coordinate
+ * array; if that array cannot be read, pass indices instead.
+ * @property {import("../extent.js").Extent} [extent] Fallback extent of the data, in
+ * coordinates of the source projection. Only used when the store neither declares its
+ * extent (`spatial:bbox` or `bounds` attributes) nor has coordinate arrays to infer it.
+ * @property {boolean} [flipY] Fallback orientation: set to `true` when the data is
+ * stored south-up (ascending y). Only used when the orientation can neither be read
+ * from the store metadata nor inferred from its coordinate arrays.
  */
 
 /**
@@ -77,7 +95,16 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * When all three conventions are present, multiple resolution levels are supported.
  * When only proj: and spatial: are present, a single-resolution tile grid is derived
  * from `spatial:bbox`, `proj:code`, and `spatial:shape`.
- * The legacy `tile_matrix_set` attribute is also supported.
+ * The legacy `tile_matrix_set` attribute is also supported, as is the GeoZarr-style
+ * `multiscales` array attribute (`[{tile_matrix_set, datasets: [{path, ...}]}]`).
+ *
+ * Two data layouts are supported:
+ * - One array per band (`bands` option), addressed by name at `<matrixId>/<bandName>`
+ *   (multi-scale) or at the group root (single-scale). Supports Zarr v3.
+ * - A single n-dimensional data array shared by all bands (`variable` + `selector`
+ *   options), e.g. a `(time, band, y, x)` datacube. Supports Zarr v2 and v3; the
+ *   extent, resolution, projection and y-axis orientation are read from the store
+ *   metadata or inferred from the coordinate arrays.
  */
 export default class GeoZarr extends DataTileSource {
   /**
@@ -115,6 +142,63 @@ export default class GeoZarr extends DataTileSource {
     this.dimensions_ = options.dimensions || {};
 
     /**
+     * @type {string|undefined}
+     * @private
+     */
+    this.variable_ = options.variable;
+
+    /**
+     * @type {Object<string, number|string|Array<number|string>>}
+     * @private
+     */
+    this.selector_ = options.selector || {};
+
+    /**
+     * @type {import("../extent.js").Extent|undefined}
+     * @private
+     */
+    this.fallbackExtent_ = options.extent;
+
+    /**
+     * @type {boolean|undefined}
+     * @private
+     */
+    this.fallbackFlipY_ = options.flipY;
+
+    /**
+     * The zarrita open function, pinned to v2 when the store cannot be
+     * probed for v3 metadata (e.g. servers answering 403 for missing keys).
+     * @type {Function}
+     * @private
+     */
+    this.openFn_ = open;
+
+    /**
+     * Group path prefix per tile matrix id, for stores whose levels are not
+     * addressed by the matrix id itself (empty string for the group root).
+     * `null` when the matrix id is the prefix.
+     * @type {Object<string, string>|null}
+     * @private
+     */
+    this.levelPaths_ = null;
+
+    /**
+     * Row axis information per tile matrix id, for data with non-square
+     * pixels or south-up (flipped) rows.
+     * @type {Object<string, {rowResolution: number, shapeY: number|undefined, flip: boolean}>|null}
+     * @private
+     */
+    this.levelRowInfo_ = null;
+
+    /**
+     * The axis selected as multiple bands through the `selector` option,
+     * or -1.
+     * @type {number}
+     * @private
+     */
+    this.multiAxis_ = -1;
+
+    /**
      * @type {Error|null}
      */
     this.error_ = null;
@@ -142,7 +226,7 @@ export default class GeoZarr extends DataTileSource {
 
     const groupOrder = /** @type {Array<string>} */ ([]);
     const bandGroupIndex = /** @type {Array<number>} */ ([]);
-    const bands = options.bands.map((b) => {
+    const bands = (options.bands || []).map((b) => {
       if (typeof b === 'string') {
         bandGroupIndex.push(0);
         return b;
@@ -239,6 +323,21 @@ export default class GeoZarr extends DataTileSource {
      * @type {number}
      */
     this.bandCount = this.bands_.length;
+    if (this.variable_) {
+      let bandCount = 1;
+      for (const key in this.selector_) {
+        const value = this.selector_[key];
+        if (Array.isArray(value)) {
+          if (bandCount > 1) {
+            throw new Error(
+              'Only one selector dimension may select multiple values',
+            );
+          }
+          bandCount = value.length;
+        }
+      }
+      this.bandCount = bandCount;
+    }
 
     /**
      * @type {import("../tilegrid/WMTS.js").default}
@@ -267,7 +366,7 @@ export default class GeoZarr extends DataTileSource {
     // Fetch group zarr.json once for both opening the group and extracting
     // consolidated metadata. Without this, open() and the manual metadata
     // read would each make a separate HTTP request for the same file.
-    const groupBytes = await store.get('/zarr.json');
+    const groupBytes = await probe(store, '/zarr.json');
     if (groupBytes) {
       try {
         this.consolidatedMetadata_ = JSON.parse(
@@ -278,15 +377,34 @@ export default class GeoZarr extends DataTileSource {
       }
     }
 
+    /** @type {Object<string, *>|null} */
+    let v2Metadata = null;
+    if (!this.consolidatedMetadata_) {
+      // Zarr v2: consolidated metadata lives in .zmetadata
+      const v2Bytes = await probe(store, '/.zmetadata');
+      if (v2Bytes) {
+        try {
+          v2Metadata = JSON.parse(new TextDecoder().decode(v2Bytes)).metadata;
+          this.consolidatedMetadata_ = normalizeV2Metadata(
+            /** @type {Object<string, *>} */ (v2Metadata),
+          );
+        } catch {
+          // no consolidated metadata
+        }
+      }
+    }
+
     // Wrap the store so that child metadata (groups, arrays) is served from
     // the consolidated metadata instead of making per-child HTTP requests.
-    const cachedStore = this.consolidatedMetadata_
-      ? createCachedStore(
-          store,
-          /** @type {Uint8Array} */ (groupBytes),
-          this.consolidatedMetadata_,
-        )
-      : store;
+    const cachedStore = v2Metadata
+      ? createCachedStoreV2(store, v2Metadata)
+      : this.consolidatedMetadata_
+        ? createCachedStore(
+            store,
+            /** @type {Uint8Array} */ (groupBytes),
+            this.consolidatedMetadata_,
+          )
+        : withChunkCache(store);
 
     const groupPromises = [];
     if (this.groupPaths_) {
@@ -297,7 +415,7 @@ export default class GeoZarr extends DataTileSource {
       }
     } else {
       // Single group mode
-      groupPromises.push(open(cachedStore, {kind: 'group'}));
+      groupPromises.push(this.openGroup_(cachedStore));
     }
     this.groups_.push(...(await Promise.all(groupPromises)));
 
@@ -323,8 +441,13 @@ export default class GeoZarr extends DataTileSource {
         ? getSubMetadata(this.consolidatedMetadata_, this.groupPaths_[0])
         : this.consolidatedMetadata_;
 
+    if (this.variable_) {
+      await this.configureDatacube_(attributes, store);
+    }
+
     let hasTileSizes = false;
     if (
+      !this.tileGrid &&
       'zarr_conventions' in attributes &&
       Array.isArray(attributes.zarr_conventions) &&
       REQUIRED_ZARR_CONVENTIONS.every((uuid) =>
@@ -412,7 +535,7 @@ export default class GeoZarr extends DataTileSource {
       this.resolveBandOwnership_();
     }
     if (this.fillValue_ !== null && this.fillValue_ !== undefined) {
-      this.bandCount = this.bands_.length + 1;
+      this.bandCount += 1;
       this.nodataBandIndex = this.bandCount;
       this.hasAlpha = true;
     }
@@ -422,14 +545,18 @@ export default class GeoZarr extends DataTileSource {
 
     // Resolve, per band, the spatial axes and the fixed indices for any
     // non-spatial dimensions, and record the selectable dimensions.
-    for (let i = 0, ii = this.bands_.length; i < ii; ++i) {
+    // (In `variable` mode, configureDatacube_ resolves these instead.)
+    for (let i = 0, ii = this.variable_ ? 0 : this.bands_.length; i < ii; ++i) {
       const arrayMeta = this.getBandArrayMeta_(
         this.bands_[i],
         this.bandGroupIndex_[i],
       );
       const {row, col} = this.axesOf_(arrayMeta);
       this.bandSpatialAxes_[i] = {row, col};
-      this.bandExtraSelection_[i] = this.resolveExtraSelection_(arrayMeta);
+      this.bandExtraSelection_[i] = this.resolveExtraSelection_(
+        arrayMeta,
+        this.dimensions_,
+      );
       if (this.extraDimensions_.length === 0) {
         this.extraDimensions_ = this.extraDimsOf_(arrayMeta);
       }
@@ -467,7 +594,7 @@ export default class GeoZarr extends DataTileSource {
     const tileExtent = this.tileGrid.getTileCoordExtent([z, x, y]);
 
     // First pass: resolve band metadata (no async)
-    /** @type {Array<{path: string, groupIndex: number, minRow: number, maxRow: number, minCol: number, maxCol: number, bandResolution: number}>} */
+    /** @type {Array<{path: string, groupIndex: number, minRow: number, maxRow: number, minCol: number, maxCol: number, bandResolution: number, rowResolution: number, flip: boolean}>} */
     const bandInfos = [];
     for (let i = 0, ii = this.bands_.length; i < ii; ++i) {
       const band = this.bands_[i];
@@ -518,6 +645,19 @@ export default class GeoZarr extends DataTileSource {
         bandResolution ?? resolvedBandResolution
       );
 
+      // Pixels are not necessarily square (e.g. a square array covering the
+      // full EPSG:4326 world), and rows may be stored south-up.
+      const rowInfo = this.levelRowInfo_?.[bandMatrixId];
+      const rowResolution =
+        !isSingleScale && rowInfo ? rowInfo.rowResolution : effectiveResolution;
+      const flip = !!rowInfo?.flip && rowInfo.shapeY !== undefined;
+
+      // The matrix id addresses the level group, unless the level has its
+      // own group path (empty for the group root).
+      const levelPath = this.levelPaths_
+        ? this.levelPaths_[bandMatrixId]
+        : bandMatrixId;
+
       const origin = this.tileGrid.getOrigin(bandZ);
       const minCol = Math.round(
         (tileExtent[0] - origin[0]) / effectiveResolution,
@@ -525,21 +665,28 @@ export default class GeoZarr extends DataTileSource {
       const maxCol = Math.round(
         (tileExtent[2] - origin[0]) / effectiveResolution,
       );
-      const minRow = Math.round(
-        (origin[1] - tileExtent[3]) / effectiveResolution,
-      );
-      const maxRow = Math.round(
-        (origin[1] - tileExtent[1]) / effectiveResolution,
-      );
+      let minRow = Math.round((origin[1] - tileExtent[3]) / rowResolution);
+      let maxRow = Math.round((origin[1] - tileExtent[1]) / rowResolution);
+      if (flip) {
+        // South-up: read the vertically mirrored row range and flip the
+        // rows after reading.
+        const shapeY = /** @type {number} */ (rowInfo.shapeY);
+        [minRow, maxRow] = [
+          Math.max(0, shapeY - maxRow),
+          Math.max(0, shapeY - minRow),
+        ];
+      }
 
       bandInfos.push({
-        path: isSingleScale ? band : `${bandMatrixId}/${band}`,
+        path: isSingleScale || !levelPath ? band : `${levelPath}/${band}`,
         groupIndex,
         minRow,
         maxRow,
         minCol,
         maxCol,
         bandResolution: effectiveResolution,
+        rowResolution,
+        flip,
       });
     }
 
@@ -551,7 +698,8 @@ export default class GeoZarr extends DataTileSource {
     // Fire all get() calls synchronously so getRange() calls from all bands
     // land in the same macrotask tick and can be batched together.
     const bandResolutions = bandInfos.map((info) => info.bandResolution);
-    const bandChunks = await Promise.all(
+    const bandRowResolutions = bandInfos.map((info) => info.rowResolution);
+    let bandChunks = await Promise.all(
       arrays.map((array, i) => {
         const info = bandInfos[i];
         const rowSlice = slice(info.minRow, info.maxRow);
@@ -570,6 +718,9 @@ export default class GeoZarr extends DataTileSource {
         return get(array, selection);
       }),
     );
+    bandChunks = bandChunks.map((chunk, i) =>
+      bandInfos[i].flip ? flipChunkRows(chunk) : chunk,
+    );
     const [tileColCount, tileRowCount] = toSize(this.tileGrid.getTileSize(z));
     return composeData(
       bandChunks,
@@ -578,7 +729,8 @@ export default class GeoZarr extends DataTileSource {
       tileRowCount,
       tileResolution,
       this.resampleMethod_,
-      this.fillValue_ ?? NaN,
+      this.fillValue_,
+      bandRowResolutions,
     );
   }
 
@@ -671,12 +823,15 @@ export default class GeoZarr extends DataTileSource {
     const cacheKey = `${groupIndex}:${path}`;
     let array = this.arrayCache_.get(cacheKey);
     if (!array) {
-      array = open(this.groups_[groupIndex].resolve(path), {
-        kind: 'array',
-      }).catch((err) => {
-        this.arrayCache_.delete(cacheKey);
-        throw err;
-      });
+      array =
+        /** @type {Promise<import('zarrita').Array<import('zarrita').DataType, any>>} */ (
+          this.openFn_(this.groups_[groupIndex].resolve(path), {
+            kind: 'array',
+          })
+        ).catch((/** @type {Error} */ err) => {
+          this.arrayCache_.delete(cacheKey);
+          throw err;
+        });
       this.arrayCache_.set(cacheKey, array);
     }
     return array;
@@ -814,22 +969,58 @@ export default class GeoZarr extends DataTileSource {
    *     to change; see the `dimensions` constructor option.
    */
   updateDimensions(dimensions) {
-    this.dimensions_ = {...this.dimensions_, ...dimensions};
+    const merged = {...this.dimensions_, ...dimensions};
     if (this.getState() !== 'ready') {
       // configure_ reads dimensions_ when it resolves; nothing to do yet.
+      this.dimensions_ = merged;
       return;
     }
-    // Resolve every band before assigning, so an invalid index throws (via
-    // resolveExtraSelection_) without leaving a half-updated selection.
-    const selection = this.bands_.map((band, i) =>
-      this.resolveExtraSelection_(
-        this.getBandArrayMeta_(band, this.bandGroupIndex_[i]),
-      ),
-    );
+    // Resolve every band before assigning, so an invalid name or index
+    // throws without leaving a half-updated selection.
+    const selection = this.bands_.map((band, i) => {
+      const arrayMeta = this.getBandArrayMeta_(band, this.bandGroupIndex_[i]);
+      if (!this.variable_) {
+        return this.resolveExtraSelection_(arrayMeta, merged);
+      }
+      // In `variable` mode, merge into the current selection so the axes
+      // fixed through the `selector` option are kept.
+      const dims = this.extraDimsOf_(arrayMeta);
+      const current = this.bandExtraSelection_[i];
+      const updated = current ? current.slice() : undefined;
+      for (const [name, index] of Object.entries(dimensions)) {
+        const dim = dims.find((d) => d.name === name);
+        if (!dim || !updated) {
+          throw new Error(
+            `GeoZarr: unknown dimension "${name}"; ` +
+              `available: [${dims.map((d) => d.name).join(', ')}].`,
+          );
+        }
+        if (dim.axis === this.multiAxis_) {
+          throw new Error(
+            `GeoZarr: dimension "${name}" selects the rendered bands; ` +
+              `set it through the \`selector\` option instead.`,
+          );
+        }
+        if (
+          typeof index !== 'number' ||
+          !Number.isInteger(index) ||
+          index < 0 ||
+          index >= dim.size
+        ) {
+          throw new Error(
+            `GeoZarr: invalid index ${index} for dimension "${name}" ` +
+              `(size ${dim.size}).`,
+          );
+        }
+        updated[dim.axis] = index;
+      }
+      return updated;
+    });
+    this.dimensions_ = merged;
     this.bandExtraSelection_ = selection;
     // Bump the tile key to reload tiles. Deriving it from the selection (rather
     // than a counter) keeps prior selections' tiles cached, so revisiting hits.
-    this.setKey(getUid(this) + ':' + JSON.stringify(this.dimensions_));
+    this.setKey(getUid(this) + ':' + JSON.stringify(selection));
   }
 
   /**
@@ -886,10 +1077,12 @@ export default class GeoZarr extends DataTileSource {
    * `null` at the two spatial axes (e.g. `[2, null, null]` for a `[time, y, x]`
    * array with `{time: 2}`).
    * @param {Object<string, *>|undefined} arrayMeta Zarr v3 array metadata.
+   * @param {Object<string, number|string>} dimensions The dimension indices
+   *     to resolve against.
    * @return {Array<number|null>|undefined} The extra-axis selection template.
    * @private
    */
-  resolveExtraSelection_(arrayMeta) {
+  resolveExtraSelection_(arrayMeta, dimensions) {
     if (!arrayMeta) {
       return undefined;
     }
@@ -898,7 +1091,7 @@ export default class GeoZarr extends DataTileSource {
       return undefined;
     }
     const names = dims.map((d) => d.name);
-    const dimKeys = Object.keys(this.dimensions_);
+    const dimKeys = Object.keys(dimensions);
     // A single unnamed dimension is lenient: any single key binds to it.
     const singleUnnamed =
       dims.length === 1 && !Array.isArray(arrayMeta['dimension_names']);
@@ -918,10 +1111,10 @@ export default class GeoZarr extends DataTileSource {
     for (const dim of dims) {
       const name = dim.name;
       let index;
-      if (name in this.dimensions_) {
-        index = this.dimensions_[name];
+      if (name in dimensions) {
+        index = dimensions[name];
       } else if (singleUnnamed && dimKeys.length === 1) {
-        index = this.dimensions_[dimKeys[0]];
+        index = dimensions[dimKeys[0]];
       } else {
         index = 0; // unspecified extra dimension defaults to the first slice
       }
@@ -941,6 +1134,489 @@ export default class GeoZarr extends DataTileSource {
       selection[dim.axis] = index;
     }
     return selection;
+  }
+
+  /**
+   * Open the group, retrying as Zarr v2 without probing for v3 metadata
+   * first, for servers that answer 403 for missing keys.
+   * @param {*} source The store or location to open.
+   * @return {Promise<import('zarrita').Group<any>>} The opened group.
+   * @private
+   */
+  async openGroup_(source) {
+    try {
+      return await this.openFn_(source, {kind: 'group'});
+    } catch (err) {
+      if (this.openFn_ !== open) {
+        throw err;
+      }
+      const group = await open.v2(source, {kind: 'group'});
+      this.openFn_ = open.v2;
+      return group;
+    }
+  }
+
+  /**
+   * @param {Object<string, *>} attributes The dataset attributes.
+   * @param {FetchStore} store The store, for metadata requests not covered
+   * by consolidated metadata.
+   * @private
+   */
+  async configureDatacube_(attributes, store) {
+    const variable = /** @type {string} */ (this.variable_);
+    const consolidatedMetadata = this.consolidatedMetadata_;
+
+    // Collect the multiscale level paths; without multiscale metadata the
+    // group itself is the only level.
+    const multiscales = attributes['multiscales'];
+    /** @type {Array<{path: string, transform: Array<number>|undefined, shape: Array<number>|undefined}>} */
+    const rawLevels = [];
+    /** @type {string|null} */
+    let crsHint = null;
+    if (
+      Array.isArray(multiscales) &&
+      multiscales.length > 0 &&
+      Array.isArray(multiscales[0].datasets)
+    ) {
+      for (const dataset of multiscales[0].datasets) {
+        const path =
+          dataset.path === '.' || !dataset.path
+            ? ''
+            : String(dataset.path).replace(/\/+$/, '');
+        rawLevels.push({
+          path,
+          transform: dataset['spatial:transform'],
+          shape: dataset['spatial:shape'],
+        });
+        if (!crsHint && typeof dataset['crs'] === 'string') {
+          crsHint = dataset['crs'];
+        }
+      }
+    } else if (multiscales && Array.isArray(multiscales.layout)) {
+      for (const entry of multiscales.layout) {
+        rawLevels.push({
+          path: String(entry.asset),
+          transform: undefined,
+          shape: entry['spatial:shape'],
+        });
+      }
+    } else {
+      rawLevels.push({
+        path: '',
+        transform: attributes['spatial:transform'],
+        shape: attributes['spatial:shape'],
+      });
+    }
+
+    /** @type {Array<{path: string, arrayPath: string, meta: any, transform: Array<number>|undefined, shape: Array<number>|undefined}>} */
+    const levels = [];
+    for (const raw of rawLevels) {
+      const arrayPath = raw.path ? `${raw.path}/${variable}` : variable;
+      const meta = consolidatedMetadata
+        ? consolidatedMetadata[arrayPath]
+        : undefined;
+      if (consolidatedMetadata && !meta) {
+        warn(`Variable "${variable}" not found at level "${raw.path || '.'}"`);
+        continue;
+      }
+      levels.push({...raw, arrayPath, meta});
+    }
+    if (levels.length === 0) {
+      throw new Error(`Variable "${variable}" not found in any level`);
+    }
+
+    // The dimension layout is the same for all levels
+    let meta = levels.find((level) => level.meta)?.meta;
+    if (!meta) {
+      meta = await getArrayMeta(store, levels[0].arrayPath);
+      levels[0].meta = meta;
+    }
+    if (!meta || !Array.isArray(meta.shape)) {
+      throw new Error(`Could not read metadata for variable "${variable}"`);
+    }
+    const ndim = meta.shape.length;
+    let dimensionNames = meta['dimension_names'];
+    if (!dimensionNames && ndim === 2) {
+      dimensionNames = ['y', 'x'];
+    }
+    if (!dimensionNames) {
+      throw new Error(
+        `Cannot determine dimension names for variable "${variable}"`,
+      );
+    }
+    const {row, col} = getSpatialAxes(attributes['spatial:dimensions'], meta);
+
+    // Determine the extent and y axis orientation: declared metadata is
+    // authoritative, otherwise both are inferred from the coordinate arrays.
+    let extent = attributes['spatial:bbox'] || attributes['bounds'];
+    let flipY = false;
+    let orientationKnown = false;
+    const transform0 = levels[0].transform;
+    if (
+      extent &&
+      Array.isArray(transform0) &&
+      transform0.length >= 6 &&
+      transform0[4] !== 0
+    ) {
+      flipY = transform0[4] > 0;
+      orientationKnown = true;
+    } else {
+      // All levels share the extent; the smallest level is cheapest to read
+      let coordLevel = levels[0];
+      for (const level of levels) {
+        if (
+          level.meta &&
+          coordLevel.meta &&
+          level.meta.shape[col] < coordLevel.meta.shape[col]
+        ) {
+          coordLevel = level;
+        }
+      }
+      try {
+        const [x0, x1, xCount] = await this.readCoordinateEndpoints_(
+          coordLevel.path,
+          dimensionNames[col],
+        );
+        const [y0, y1, yCount] = await this.readCoordinateEndpoints_(
+          coordLevel.path,
+          dimensionNames[row],
+        );
+        flipY = y1 > y0;
+        orientationKnown = true;
+        if (x1 < x0) {
+          warn('Descending x coordinates are not supported.');
+        }
+        if (!extent) {
+          // Coordinates are pixel centers; pad by half a pixel
+          const xResolution = Math.abs(x1 - x0) / (xCount - 1);
+          const yResolution = Math.abs(y1 - y0) / (yCount - 1);
+          extent = [
+            Math.min(x0, x1) - xResolution / 2,
+            Math.min(y0, y1) - yResolution / 2,
+            Math.max(x0, x1) + xResolution / 2,
+            Math.max(y0, y1) + yResolution / 2,
+          ];
+          // Normalize [0, 360]-style longitudes to [-180, 180]
+          if (extent[0] >= 0 && extent[2] > 180 && extent[2] <= 360.001) {
+            extent = [extent[0] - 360, extent[1], extent[2] - 360, extent[3]];
+          }
+        }
+      } catch (err) {
+        if (!extent && !this.fallbackExtent_) {
+          throw new Error(
+            `Could not determine the extent of variable "${variable}" ` +
+              `from metadata or coordinate arrays: ${/** @type {Error} */ (err).message}`,
+          );
+        }
+      }
+    }
+    if (!extent) {
+      extent = this.fallbackExtent_;
+    }
+    if (!orientationKnown && this.fallbackFlipY_ !== undefined) {
+      flipY = this.fallbackFlipY_;
+    }
+
+    const extentWidth = extent[2] - extent[0];
+    const extentHeight = extent[3] - extent[1];
+    /** @type {Array<{path: string, arrayPath: string, meta: any, resolution: number, rowResolution: number, origin: import("../coordinate.js").Coordinate}>} */
+    const configured = [];
+    for (const level of levels) {
+      let resolution;
+      // Pixels are not necessarily square (e.g. a square array covering the
+      // full EPSG:4326 world), so the row resolution is tracked separately.
+      let rowResolution;
+      let origin;
+      if (
+        Array.isArray(level.transform) &&
+        level.transform.length >= 6 &&
+        level.transform[4] < 0
+      ) {
+        resolution = level.transform[0];
+        rowResolution = -level.transform[4];
+        origin = [level.transform[2], level.transform[5]];
+      } else if (Array.isArray(level.shape)) {
+        resolution = extentWidth / level.shape[1];
+        rowResolution = extentHeight / level.shape[0];
+        origin = [extent[0], extent[3]];
+      } else if (level.meta && Array.isArray(level.meta.shape)) {
+        resolution = extentWidth / level.meta.shape[col];
+        rowResolution = extentHeight / level.meta.shape[row];
+        origin = [extent[0], extent[3]];
+      } else {
+        warn(`No resolution information for level "${level.path || '.'}"`);
+        continue;
+      }
+      configured.push({
+        path: level.path,
+        arrayPath: level.arrayPath,
+        meta: level.meta,
+        resolution,
+        rowResolution,
+        origin,
+      });
+    }
+    if (configured.length === 0) {
+      throw new Error(`No usable level found for variable "${variable}"`);
+    }
+    configured.sort((a, b) => b.resolution - a.resolution);
+
+    if (!this.projection) {
+      this.projection = this.inferProjection_(attributes, crsHint, extent);
+    }
+
+    // Resolve the selector to per-axis indices; labels are resolved against
+    // the finest level's coordinate arrays
+    const finestPath = configured[configured.length - 1].path;
+    /** @type {Array<{axis: number, indices: Array<number>}>} */
+    const slots = [];
+    this.multiAxis_ = -1;
+    this.extraDimensions_ = [];
+    for (let axis = 0; axis < ndim; ++axis) {
+      if (axis === row || axis === col) {
+        continue;
+      }
+      const dimName = dimensionNames[axis];
+      this.extraDimensions_.push({name: dimName, size: meta.shape[axis]});
+      // `dimensions` (also merged by updateDimensions) takes precedence
+      // over the initial `selector` for scalar values
+      let value =
+        dimName in this.dimensions_
+          ? this.dimensions_[dimName]
+          : this.selector_[dimName];
+      if (value === undefined) {
+        warn(
+          `No selector value given for dimension "${dimName}", using index 0.`,
+        );
+        value = 0;
+      }
+      /** @type {Array<number|string>} */
+      let values;
+      if (Array.isArray(value)) {
+        values = value;
+        this.multiAxis_ = axis;
+      } else {
+        values = [value];
+      }
+      const indices = [];
+      for (const v of values) {
+        if (typeof v === 'number') {
+          indices.push(v);
+        } else {
+          indices.push(
+            await this.resolveCoordinateLabel_(dimName, v, finestPath),
+          );
+        }
+      }
+      for (const index of indices) {
+        if (
+          !Number.isInteger(index) ||
+          index < 0 ||
+          index >= meta.shape[axis]
+        ) {
+          throw new Error(
+            `GeoZarr: invalid index ${index} for dimension "${dimName}" ` +
+              `(size ${meta.shape[axis]}).`,
+          );
+        }
+      }
+      slots.push({axis, indices});
+    }
+
+    // Materialize the datacube as the per-band state that loadTile_
+    // consumes: each rendered band is the variable array with fixed indices
+    // at the non-spatial axes.
+    const count = this.bandCount;
+    this.bands_ = new Array(count).fill(variable);
+    this.bandGroupIndex_ = new Array(count).fill(0);
+    this.bandSingleScaleResolution_ = new Array(count).fill(undefined);
+    this.bandSpatialAxes_ = new Array(count).fill({row, col});
+    this.bandExtraSelection_ = new Array(count)
+      .fill(undefined)
+      .map((_, bandIndex) => {
+        if (slots.length === 0) {
+          return undefined;
+        }
+        const selection = new Array(ndim).fill(null);
+        for (const slot of slots) {
+          selection[slot.axis] =
+            slot.axis === this.multiAxis_
+              ? slot.indices[bandIndex]
+              : slot.indices[0];
+        }
+        return selection;
+      });
+
+    this.fillValue_ = parseFillValue(meta['fill_value']);
+
+    // Align tiles to shards or chunks: every tile decodes all chunks it
+    // touches, so tiles much smaller than a chunk would decode the same
+    // chunk over and over.
+    const tileSizes = configured.map((level) => {
+      if (!level.meta) {
+        return undefined;
+      }
+      const shardInfo = getShardInfo(level.meta, row, col);
+      if (shardInfo) {
+        return /** @type {import("../size.js").Size} */ ([
+          getTileSizeForShard(
+            shardInfo.shardShape[1],
+            shardInfo.innerChunkShape[1],
+          ),
+          getTileSizeForShard(
+            shardInfo.shardShape[0],
+            shardInfo.innerChunkShape[0],
+          ),
+        ]);
+      }
+      const chunkShape = level.meta['chunk_grid']?.configuration?.chunk_shape;
+      if (Array.isArray(chunkShape)) {
+        return /** @type {import("../size.js").Size} */ ([
+          getTileSizeForChunk(chunkShape[col], level.meta.shape[col]),
+          getTileSizeForChunk(chunkShape[row], level.meta.shape[row]),
+        ]);
+      }
+      return undefined;
+    });
+    const hasTileSizes = tileSizes.some((s) => s !== undefined);
+
+    this.bandsByLevel_ = {};
+    this.levelPaths_ = {};
+    this.levelRowInfo_ = {};
+    const matrixIds = configured.map((level, i) => level.path || String(i));
+    for (let i = 0; i < configured.length; ++i) {
+      const level = configured[i];
+      this.bandsByLevel_[matrixIds[i]] = this.bands_;
+      this.levelPaths_[matrixIds[i]] = level.path;
+      this.levelRowInfo_[matrixIds[i]] = {
+        rowResolution: level.rowResolution,
+        shapeY:
+          level.meta && Array.isArray(level.meta.shape)
+            ? level.meta.shape[row]
+            : undefined,
+        flip: flipY,
+      };
+    }
+    this.tileGrid = new WMTSTileGrid({
+      extent: extent,
+      origins: configured.map((level) => level.origin),
+      resolutions: configured.map((level) => level.resolution),
+      matrixIds: matrixIds,
+      ...(hasTileSizes
+        ? {tileSizes: tileSizes.map((s) => s || [256, 256])}
+        : {}),
+    });
+  }
+
+  /**
+   * Determine the projection from the store metadata: the proj: convention,
+   * a CRS code from the multiscale metadata or xarray-style attributes, a
+   * `proj4` definition, or (for degree-like extents) EPSG:4326.
+   * @param {Object<string, *>} attributes The dataset attributes.
+   * @param {string|null} crsHint A CRS code from the multiscale metadata.
+   * @param {import("../extent.js").Extent} extent The extent.
+   * @return {import("../proj/Projection.js").default} The projection.
+   * @private
+   */
+  inferProjection_(attributes, crsHint, extent) {
+    try {
+      const projection = getProjectionFromAttributes(
+        /** @type {DatasetAttributes} */ (attributes),
+      );
+      if (projection) {
+        return projection;
+      }
+    } catch {
+      // not declared through the proj: convention
+    }
+    const code =
+      crsHint ||
+      (typeof attributes['spatial_ref'] === 'string' &&
+      attributes['spatial_ref'].includes(':')
+        ? attributes['spatial_ref']
+        : null);
+    if (code) {
+      const projection = getProjection(code);
+      if (projection) {
+        return projection;
+      }
+    }
+    const definition = attributes['proj4'] || attributes['proj4_params'];
+    if (typeof definition === 'string') {
+      try {
+        const projection = fromProjectionDefinition(definition);
+        if (projection) {
+          return projection;
+        }
+      } catch (err) {
+        warn(
+          `Could not register the proj4 definition: ${/** @type {Error} */ (err).message}`,
+        );
+      }
+    }
+    if (
+      extent &&
+      extent[0] >= -360 &&
+      extent[2] <= 360.001 &&
+      extent[1] >= -90 &&
+      extent[3] <= 90
+    ) {
+      // Extent magnitude suggests degrees
+      return /** @type {import('../proj/Projection.js').default} */ (
+        getProjection('EPSG:4326')
+      );
+    }
+    throw new Error('Could not determine the projection');
+  }
+
+  /**
+   * Read the first and last value of a 1-dimensional coordinate array.
+   * @param {string} levelPath The level group path ('' for the root).
+   * @param {string} dimName The dimension (and coordinate array) name.
+   * @return {Promise<Array<number>>} The first value, last value, and length.
+   * @private
+   */
+  async readCoordinateEndpoints_(levelPath, dimName) {
+    const path = levelPath ? `${levelPath}/${dimName}` : dimName;
+    const array = await this.openArray_(0, path);
+    const length = array.shape[0];
+    const first = await get(array, [slice(0, 1)]);
+    const last = await get(array, [slice(length - 1, length)]);
+    return [
+      Number(/** @type {ArrayLike<number>} */ (first.data)[0]),
+      Number(/** @type {ArrayLike<number>} */ (last.data)[0]),
+      length,
+    ];
+  }
+
+  /**
+   * Resolve a coordinate label to its index by reading the dimension's
+   * coordinate array.
+   * @param {string} dimName The dimension name.
+   * @param {string} label The label to resolve.
+   * @param {string} [levelPath] The level group path ('' for the root).
+   * @return {Promise<number>} The index of the label.
+   * @private
+   */
+  async resolveCoordinateLabel_(dimName, label, levelPath = '') {
+    try {
+      const path = levelPath ? `${levelPath}/${dimName}` : dimName;
+      const array = await this.openArray_(0, path);
+      const chunk = await get(array, [null]);
+      const values = Array.from(chunk.data, (v) => String(v));
+      const index = values.indexOf(label);
+      if (index < 0) {
+        throw new Error(
+          `Label not found. Available: ${values.slice(0, 10).join(', ')}`,
+        );
+      }
+      return index;
+    } catch (err) {
+      throw new Error(
+        `Could not resolve label "${label}" for dimension "${dimName}": ` +
+          `${/** @type {Error} */ (err).message} Pass a numeric index instead.`,
+      );
+    }
   }
 }
 
@@ -981,7 +1657,7 @@ function createCachedStore(store, groupBytes, consolidatedMetadata) {
       encoder.encode(JSON.stringify(value)),
     );
   }
-  return {
+  return withChunkCache({
     async get(
       /** @type {string} */ key,
       /** @type {import('zarrita').GetOptions|undefined} */ opts,
@@ -992,7 +1668,7 @@ function createCachedStore(store, groupBytes, consolidatedMetadata) {
       return store.get(/** @type {`/${string}`} */ (key), opts);
     },
     getRange: store.getRange?.bind(store),
-  };
+  });
 }
 
 /***
@@ -1121,6 +1797,16 @@ function getShardInfo(arrayMeta, row, col) {
  * @return {number} The tile size.
  */
 function getTileSizeForShard(shardSize, innerChunkSize) {
+  if (innerChunkSize > MAX_TILE_SIZE) {
+    // Use the largest divisor of the inner chunk size that fits, so that a
+    // whole number of tiles covers each inner chunk.
+    for (let size = MAX_TILE_SIZE; size >= MIN_TILE_SIZE; --size) {
+      if (innerChunkSize % size === 0) {
+        return size;
+      }
+    }
+    return MAX_TILE_SIZE;
+  }
   // Find the largest multiple of innerChunkSize that divides shardSize
   // and is within [MIN_TILE_SIZE, MAX_TILE_SIZE].
   const maxChunks = Math.floor(MAX_TILE_SIZE / innerChunkSize);
@@ -1300,7 +1986,9 @@ function getTileGridInfoFromLegacyAttributes(attributes) {
  * @param {number} tileRowCount The number of rows in the output data.
  * @param {number} tileResolution The tile resolution.
  * @param {ResampleMethod} resampleMethod The resampling method.
- * @param {number} fillValue The fill value.
+ * @param {number|undefined} fillValue The fill value.
+ * @param {Array<number>} [chunkRowResolutions] The row resolutions for each
+ * band, for data with non-square pixels. Defaults to `chunkResolutions`.
  * @return {Float32Array} The tile data.
  */
 function composeData(
@@ -1311,6 +1999,7 @@ function composeData(
   tileResolution,
   resampleMethod,
   fillValue,
+  chunkRowResolutions = chunkResolutions,
 ) {
   const chunkCount = chunks.length;
   const addAlpha = fillValue !== null && fillValue !== undefined;
@@ -1328,15 +2017,16 @@ function composeData(
         const chunkColCount = chunk.shape[1];
         const chunkData = /** @type {ArrayLike<number>} */ (chunk.data);
         const scaleFactor = tileResolution / chunkResolutions[chunkIndex];
+        const rowScaleFactor = tileResolution / chunkRowResolutions[chunkIndex];
         let value = 0;
         let inBounds = false;
-        if (scaleFactor === 1) {
+        if (scaleFactor === 1 && rowScaleFactor === 1) {
           if (tileRow < chunkRowCount && tileCol < chunkColCount) {
             inBounds = true;
             value = chunkData[tileRow * chunkColCount + tileCol];
           }
         } else {
-          const chunkRow = tileRow * scaleFactor;
+          const chunkRow = tileRow * rowScaleFactor;
           const chunkCol = tileCol * scaleFactor;
           switch (resampleMethod) {
             case 'nearest': {
@@ -1408,4 +2098,214 @@ function getProjectionFromAttributes(attributes) {
   return /** @type {import("../proj/Projection.js").default} */ (
     fromProjectionDefinition(projDef)
   );
+}
+
+/**
+ * Maximum number of requests to keep in the per-source chunk cache.
+ * @type {number}
+ */
+const MAX_CACHED_CHUNKS = 32;
+
+/**
+ * Wrap a store with a small LRU cache for chunk requests. Adjacent tiles
+ * often read from the same chunk (in the extreme case, a store with a single
+ * chunk per array); without this cache each tile would fetch the chunk
+ * again, as zarrita does not cache requests.
+ * @param {import('zarrita').FetchStore|import('zarrita').Readable} store The store to wrap.
+ * @return {import('zarrita').Readable} A store-compatible object.
+ */
+function withChunkCache(store) {
+  /** @type {Map<string, Promise<Uint8Array|undefined>>} */
+  const chunkCache = new Map();
+  return /** @type {import('zarrita').Readable} */ ({
+    async get(
+      /** @type {string} */ key,
+      /** @type {import('zarrita').GetOptions|undefined} */ opts,
+    ) {
+      if (chunkCache.has(key)) {
+        // Re-insert to mark the entry as most recently used
+        const cached = /** @type {Promise<Uint8Array|undefined>} */ (
+          chunkCache.get(key)
+        );
+        chunkCache.delete(key);
+        chunkCache.set(key, cached);
+        return cached;
+      }
+      const promise = /** @type {Promise<Uint8Array|undefined>} */ (
+        store.get(/** @type {`/${string}`} */ (key), opts)
+      );
+      chunkCache.set(key, promise);
+      promise.catch(() => chunkCache.delete(key));
+      if (chunkCache.size > MAX_CACHED_CHUNKS) {
+        chunkCache.delete(
+          /** @type {string} */ (chunkCache.keys().next().value),
+        );
+      }
+      return promise;
+    },
+    getRange: /** @type {*} */ (store).getRange?.bind(store),
+  });
+}
+
+/**
+ * Like {@link createCachedStore}, for Zarr v2 consolidated metadata: the
+ * .zmetadata entries are served under their raw keys (e.g. `path/.zarray`).
+ * @param {import('zarrita').FetchStore} store The underlying store.
+ * @param {Object<string, *>} v2Metadata The .zmetadata `metadata` entries.
+ * @return {import('zarrita').Readable} A store-compatible object.
+ */
+function createCachedStoreV2(store, v2Metadata) {
+  const cache = new Map();
+  const encoder = new TextEncoder();
+  for (const [key, value] of Object.entries(v2Metadata)) {
+    cache.set(`/${key}`, encoder.encode(JSON.stringify(value)));
+  }
+  return withChunkCache({
+    async get(
+      /** @type {string} */ key,
+      /** @type {import('zarrita').GetOptions|undefined} */ opts,
+    ) {
+      if (cache.has(key)) {
+        return cache.get(key);
+      }
+      return store.get(/** @type {`/${string}`} */ (key), opts);
+    },
+    getRange: store.getRange?.bind(store),
+  });
+}
+
+/**
+ * Maximum tile size when tiles are aligned to (unsharded) chunks. Larger
+ * than MAX_TILE_SIZE because decoding one big chunk into a single tile is
+ * cheaper than decoding it once per covering tile.
+ * @type {number}
+ */
+const MAX_CHUNK_TILE_SIZE = 2048;
+
+/**
+ * Compute a tile size for an unsharded array along one dimension: a multiple
+ * of the chunk size when chunks are small, or (a cap of) the chunk size
+ * itself when chunks are large.
+ * @param {number} chunkSize The chunk size in pixels along one dimension.
+ * @param {number} arraySize The array size in pixels along the same dimension.
+ * @return {number} The tile size.
+ */
+function getTileSizeForChunk(chunkSize, arraySize) {
+  let size;
+  if (chunkSize >= MAX_TILE_SIZE) {
+    size = Math.min(chunkSize, MAX_CHUNK_TILE_SIZE);
+  } else {
+    size = Math.floor(MAX_TILE_SIZE / chunkSize) * chunkSize;
+  }
+  return Math.max(MIN_TILE_SIZE, Math.min(size, arraySize));
+}
+
+/**
+ * Parse a Zarr fill value (which may be encoded as a string like "NaN").
+ * @param {number|string|null|undefined} value The raw fill value.
+ * @return {number|undefined} The fill value as a number, or undefined.
+ */
+function parseFillValue(value) {
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    return Number(value);
+  }
+  return undefined;
+}
+
+/**
+ * Normalize Zarr v2 consolidated metadata (.zmetadata entries like
+ * `path/.zarray` and `path/.zattrs`) into the Zarr v3 shape that this
+ * source reads.
+ * @param {Object<string, *>} v2Metadata The .zmetadata `metadata` entries.
+ * @return {Object<string, *>} Array metadata by path.
+ */
+function normalizeV2Metadata(v2Metadata) {
+  /** @type {Object<string, *>} */
+  const normalized = {};
+  for (const [key, value] of Object.entries(v2Metadata)) {
+    if (!key.endsWith('/.zarray')) {
+      continue;
+    }
+    const path = key.slice(0, -'/.zarray'.length);
+    const attributes = v2Metadata[`${path}/.zattrs`] || {};
+    normalized[path] = {
+      shape: value['shape'],
+      fill_value: value['fill_value'],
+      dimension_names: attributes['_ARRAY_DIMENSIONS'],
+      chunk_grid: {
+        name: 'regular',
+        configuration: {chunk_shape: value['chunks']},
+      },
+      attributes,
+    };
+  }
+  return normalized;
+}
+
+/**
+ * Probe the store for an optional metadata document. Absence is an expected
+ * outcome (version probing), and some servers answer 403 instead of 404 for
+ * missing keys, which zarrita treats as an error.
+ * @param {FetchStore} store The store.
+ * @param {string} key The key to probe.
+ * @return {Promise<Uint8Array|undefined>} The document, if present.
+ */
+function probe(store, key) {
+  return store.get(/** @type {`/${string}`} */ (key)).catch(() => undefined);
+}
+
+/**
+ * Read a single array's metadata directly from the store, for stores
+ * without consolidated metadata (Zarr v3 zarr.json or v2 .zarray/.zattrs).
+ * @param {FetchStore} store The store.
+ * @param {string} path The array path.
+ * @return {Promise<Object|undefined>} The array metadata (v3 shape).
+ */
+async function getArrayMeta(store, path) {
+  const decoder = new TextDecoder();
+  let bytes = await probe(store, `/${path}/zarr.json`);
+  if (bytes) {
+    return JSON.parse(decoder.decode(bytes));
+  }
+  bytes = await probe(store, `/${path}/.zarray`);
+  if (bytes) {
+    const zarray = JSON.parse(decoder.decode(bytes));
+    const attrBytes = await probe(store, `/${path}/.zattrs`);
+    const attributes = attrBytes ? JSON.parse(decoder.decode(attrBytes)) : {};
+    return {
+      shape: zarray['shape'],
+      fill_value: zarray['fill_value'],
+      dimension_names: attributes['_ARRAY_DIMENSIONS'],
+      chunk_grid: {
+        name: 'regular',
+        configuration: {chunk_shape: zarray['chunks']},
+      },
+      attributes,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Flip the row order of a 2-dimensional chunk (for south-up data).
+ * @param {{data: any, shape: Array<number>, stride: Array<number>}} chunk The chunk.
+ * @return {{data: any, shape: Array<number>, stride: Array<number>}} The flipped chunk.
+ */
+function flipChunkRows(chunk) {
+  const [rowCount, colCount] = chunk.shape;
+  const source = chunk.data;
+  const data = new source.constructor(source.length);
+  for (let row = 0; row < rowCount; ++row) {
+    data.set(
+      source.subarray(
+        (rowCount - 1 - row) * colCount,
+        (rowCount - row) * colCount,
+      ),
+      row * colCount,
+    );
+  }
+  return {data, shape: chunk.shape, stride: [colCount, 1]};
 }

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -1323,7 +1323,7 @@ export default class GeoZarr extends DataTileSource {
 
     const extentWidth = extent[2] - extent[0];
     const extentHeight = extent[3] - extent[1];
-    /** @type {Array<{path: string, bands: Array<string>, meta: any, resolution: number, rowResolution: number, origin: import("../coordinate.js").Coordinate}>} */
+    /** @type {Array<{path: string, bands: Array<string>, meta: any, shape: Array<number>|undefined, resolution: number, rowResolution: number, origin: import("../coordinate.js").Coordinate}>} */
     const configured = [];
     for (const level of levels) {
       let resolution;
@@ -1355,6 +1355,7 @@ export default class GeoZarr extends DataTileSource {
         path: level.path,
         bands: level.bands,
         meta: level.meta,
+        shape: level.shape,
         resolution,
         rowResolution,
         origin,
@@ -1500,12 +1501,15 @@ export default class GeoZarr extends DataTileSource {
       const level = configured[i];
       this.bandsByLevel_[matrixIds[i]] = level.bands;
       this.levelPaths_[matrixIds[i]] = level.path;
+      let shapeY;
+      if (level.meta && Array.isArray(level.meta.shape)) {
+        shapeY = level.meta.shape[row];
+      } else if (Array.isArray(level.shape)) {
+        shapeY = level.shape[0];
+      }
       this.levelRowInfo_[matrixIds[i]] = {
         rowResolution: level.rowResolution,
-        shapeY:
-          level.meta && Array.isArray(level.meta.shape)
-            ? level.meta.shape[row]
-            : undefined,
+        shapeY,
         flip: flipY,
       };
     }

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -63,23 +63,21 @@ import {parseTileMatrixSet} from './ogcTileUtil.js';
  * To disable the opacity transition, pass `transition: 0`.
  * @property {boolean} [wrapX=false] Render tiles beyond the tile grid extent.
  * @property {ResampleMethod} [resample='linear'] Resampling method if bands are not available for all multi-scale levels.
- * @property {Object<string, number|string>} [dimensions] Fixed index for each non-spatial
- * dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` for the first time step
- * of a `[time, y, x]` cube); unspecified dimensions default to `0`. Names come from each array's
- * `dimension_names`, or are the axis position as a string when it has none. Only integer indices
- * are supported. Use the names from {@link getDimensions}, and change the selection on the fly with
+ * @property {Object<string, number|string|Array<number|string>>} [dimensions] How to slice
+ * each non-spatial dimension of the band arrays, keyed by dimension name (e.g. `{time: 0}` for
+ * the first time step of a `[time, y, x]` cube). Values are 0-based indices (number) or
+ * coordinate labels (string); unlisted dimensions default to index 0. Names come from each
+ * array's `dimension_names`, or are the axis position as a string when it has none; use the
+ * names from {@link getDimensions}. Labels are resolved against the dimension's coordinate
+ * array; if that array cannot be read, pass indices instead. With `variable`, at most one
+ * dimension may map to an array of values, whose entries are rendered as separate bands in
+ * the given order. Change the selection on the fly with
  * {@link module:ol/source/GeoZarr~GeoZarr#updateDimensions}.
  * @property {string} [variable] The name of an n-dimensional data array (variable) to
  * render, for stores where all bands are packed into a single array (e.g. a
  * `(time, band, y, x)` datacube). The array must exist within each multiscale level
- * group (or at the group root for single-scale stores). Mutually exclusive with `bands`.
- * @property {Object<string, number|string|Array<number|string>>} [selector] For
- * `variable` mode: how to slice each non-spatial dimension, keyed by dimension name
- * (from the array's `dimension_names`). Values are 0-based indices (number), coordinate
- * labels (string), or an array of these. At most one dimension may map to an array; its
- * entries are rendered as separate bands (in the given order). Unlisted non-spatial
- * dimensions default to index 0. Labels are resolved against the dimension's coordinate
- * array; if that array cannot be read, pass indices instead.
+ * group (or at the group root for single-scale stores). Mutually exclusive with `bands`,
+ * and required to select several bands from one dimension through `dimensions`.
  * @property {import("../extent.js").Extent} [extent] Fallback extent of the data, in
  * coordinates of the source projection. Only used when the store neither declares its
  * extent (`spatial:bbox` or `bounds` attributes) nor has coordinate arrays to infer it.
@@ -109,7 +107,7 @@ import {parseTileMatrixSet} from './ogcTileUtil.js';
  * Two data layouts are supported:
  * - One array per band (`bands` option), addressed by name at `<matrixId>/<bandName>`
  *   (multi-scale) or at the group root (single-scale).
- * - A single n-dimensional data array shared by all bands (`variable` + `selector`
+ * - A single n-dimensional data array shared by all bands (`variable` + `dimensions`
  *   options), e.g. a `(time, band, y, x)` datacube.
  *
  * Both layouts support Zarr v2 and v3.
@@ -143,8 +141,9 @@ export default class GeoZarr extends DataTileSource {
     this.storeOptions_ = options.storeOptions;
 
     /**
-     * Fixed index per non-spatial dimension name, from the `dimensions` option.
-     * @type {Object<string, number|string>}
+     * Selection per non-spatial dimension name, from the `dimensions` option.
+     * Coordinate labels are replaced by their index once resolved.
+     * @type {Object<string, number|string|Array<number|string>>}
      * @private
      */
     this.dimensions_ = options.dimensions || {};
@@ -154,12 +153,6 @@ export default class GeoZarr extends DataTileSource {
      * @private
      */
     this.variable_ = options.variable;
-
-    /**
-     * @type {Object<string, number|string|Array<number|string>>}
-     * @private
-     */
-    this.selector_ = options.selector || {};
 
     /**
      * @type {import("../extent.js").Extent|undefined}
@@ -200,7 +193,7 @@ export default class GeoZarr extends DataTileSource {
     this.levelRowInfo_ = null;
 
     /**
-     * The axis selected as multiple bands through the `selector` option,
+     * The axis selected as multiple bands through the `dimensions` option,
      * or -1.
      * @type {number}
      * @private
@@ -331,21 +324,29 @@ export default class GeoZarr extends DataTileSource {
      * Number of bands.
      * @type {number}
      */
-    this.bandCount = this.bands_.length;
-    if (this.variable_) {
-      let bandCount = 1;
-      for (const key in this.selector_) {
-        const value = this.selector_[key];
-        if (Array.isArray(value)) {
-          if (bandCount > 1) {
-            throw new Error(
-              'Only one selector dimension may select multiple values',
-            );
-          }
-          bandCount = value.length;
-        }
+    this.bandCount = this.variable_ ? 1 : this.bands_.length;
+    // A dimension listing several values renders one band per value. Only
+    // `variable` can do that, since `bands` names one array per band.
+    let multiName;
+    for (const name in this.dimensions_) {
+      const value = this.dimensions_[name];
+      if (!Array.isArray(value)) {
+        continue;
       }
-      this.bandCount = bandCount;
+      if (!this.variable_) {
+        throw new Error(
+          `GeoZarr: dimension "${name}" selects several bands, which requires ` +
+            'the `variable` option.',
+        );
+      }
+      if (multiName) {
+        throw new Error(
+          `GeoZarr: dimensions "${multiName}" and "${name}" both select ` +
+            'several bands; at most one may.',
+        );
+      }
+      multiName = name;
+      this.bandCount = value.length;
     }
 
     /**
@@ -507,9 +508,24 @@ export default class GeoZarr extends DataTileSource {
       throw new Error('Could not determine tile grid');
     }
 
+    // Replace coordinate labels by their index once, so that the per-band
+    // resolution below and `updateDimensions` can stay synchronous.
+    // (In `variable` mode, configureLevels_ resolves them per band instead.)
+    if (!this.variable_) {
+      for (const [name, value] of Object.entries(this.dimensions_)) {
+        if (typeof value === 'string') {
+          this.dimensions_[name] = await this.resolveCoordinateLabel_(
+            name,
+            value,
+            this.coordinateArray_(name)?.path ?? name,
+          );
+        }
+      }
+    }
+
     // Resolve, per band, the spatial axes and the fixed indices for any
     // non-spatial dimensions, and record the selectable dimensions.
-    // (In `variable` mode, configureDatacube_ resolves these instead.)
+    // (In `variable` mode, configureLevels_ resolves these instead.)
     for (let i = 0, ii = this.variable_ ? 0 : this.bands_.length; i < ii; ++i) {
       const arrayMeta = this.getBandArrayMeta_(
         this.bands_[i],
@@ -928,8 +944,9 @@ export default class GeoZarr extends DataTileSource {
    * another `time` slice) without rebuilding the source. Values are merged into
    * the current selection, so a partial update like `{time: 3}` leaves the other
    * dimensions untouched. Takes effect immediately when the source is `ready`,
-   * otherwise once it becomes ready.
-   * @param {Object<string, number|string>} dimensions Index per dimension name
+   * otherwise once it becomes ready. Only integer indices are accepted here;
+   * coordinate labels are resolved once, when the source configures.
+   * @param {Object<string, number>} dimensions Index per dimension name
    *     to change; see the `dimensions` constructor option.
    */
   updateDimensions(dimensions) {
@@ -947,7 +964,7 @@ export default class GeoZarr extends DataTileSource {
         return this.resolveExtraSelection_(arrayMeta, merged);
       }
       // In `variable` mode, merge into the current selection so the axes
-      // fixed through the `selector` option are kept.
+      // fixed through the `dimensions` option are kept.
       const dims = this.extraDimsOf_(arrayMeta);
       const current = this.bandExtraSelection_[i];
       const updated = current ? current.slice() : undefined;
@@ -962,7 +979,7 @@ export default class GeoZarr extends DataTileSource {
         if (dim.axis === this.multiAxis_) {
           throw new Error(
             `GeoZarr: dimension "${name}" selects the rendered bands; ` +
-              `set it through the \`selector\` option instead.`,
+              `set it when constructing the source instead.`,
           );
         }
         if (
@@ -1041,8 +1058,8 @@ export default class GeoZarr extends DataTileSource {
    * `null` at the two spatial axes (e.g. `[2, null, null]` for a `[time, y, x]`
    * array with `{time: 2}`).
    * @param {Object<string, *>|undefined} arrayMeta Zarr v3 array metadata.
-   * @param {Object<string, number|string>} dimensions The dimension indices
-   *     to resolve against.
+   * @param {Object<string, number|string|Array<number|string>>} dimensions The
+   *     dimension indices to resolve against.
    * @return {Array<number|null>|undefined} The extra-axis selection template.
    * @private
    */
@@ -1083,19 +1100,23 @@ export default class GeoZarr extends DataTileSource {
         index = 0; // unspecified extra dimension defaults to the first slice
       }
       if (typeof index === 'string') {
-        // Datetime-label selection is not implemented yet; only integer indices.
+        // Labels are resolved once, when the source configures.
         throw new Error(
-          `GeoZarr: datetime-label selection for dimension "${name}" is not yet ` +
-            `implemented; pass an integer index in the \`dimensions\` option.`,
+          `GeoZarr: coordinate labels cannot be passed to updateDimensions; ` +
+            `pass an integer index for dimension "${name}".`,
         );
       }
-      if (!Number.isInteger(index) || index < 0 || index >= dim.size) {
+      if (
+        !Number.isInteger(index) ||
+        /** @type {number} */ (index) < 0 ||
+        /** @type {number} */ (index) >= dim.size
+      ) {
         throw new Error(
           `GeoZarr: invalid index ${index} for dimension "${name}" ` +
             `(size ${dim.size}).`,
         );
       }
-      selection[dim.axis] = index;
+      selection[dim.axis] = /** @type {number} */ (index);
     }
     return selection;
   }
@@ -1350,7 +1371,7 @@ export default class GeoZarr extends DataTileSource {
     }
 
     if (variable) {
-      // Resolve the selector to per-axis indices; labels are resolved against
+      // Resolve the selection to per-axis indices; labels are resolved against
       // the finest level's coordinate arrays
       const finestPath = configured[configured.length - 1].path;
       /** @type {Array<{axis: number, indices: Array<number>}>} */
@@ -1363,16 +1384,9 @@ export default class GeoZarr extends DataTileSource {
         }
         const dimName = dimensionNames[axis];
         this.extraDimensions_.push({name: dimName, size: meta.shape[axis]});
-        // `dimensions` (also merged by updateDimensions) takes precedence
-        // over the initial `selector` for scalar values
-        let value =
-          dimName in this.dimensions_
-            ? this.dimensions_[dimName]
-            : this.selector_[dimName];
+        let value = this.dimensions_[dimName];
         if (value === undefined) {
-          warn(
-            `No selector value given for dimension "${dimName}", using index 0.`,
-          );
+          warn(`No value given for dimension "${dimName}", using index 0.`);
           value = 0;
         }
         /** @type {Array<number|string>} */
@@ -1389,7 +1403,11 @@ export default class GeoZarr extends DataTileSource {
             indices.push(v);
           } else {
             indices.push(
-              await this.resolveCoordinateLabel_(dimName, v, finestPath),
+              await this.resolveCoordinateLabel_(
+                dimName,
+                v,
+                arrayPathOf(finestPath, dimName),
+              ),
             );
           }
         }
@@ -1588,13 +1606,12 @@ export default class GeoZarr extends DataTileSource {
    * coordinate array.
    * @param {string} dimName The dimension name.
    * @param {string} label The label to resolve.
-   * @param {string} [levelPath] The level group path ('' for the root).
+   * @param {string} path The coordinate array path, relative to the group.
    * @return {Promise<number>} The index of the label.
    * @private
    */
-  async resolveCoordinateLabel_(dimName, label, levelPath = '') {
+  async resolveCoordinateLabel_(dimName, label, path) {
     try {
-      const path = levelPath ? `${levelPath}/${dimName}` : dimName;
       const array = await this.openArray_(0, path);
       const chunk = await get(array, [null]);
       const values = Array.from(chunk.data, (v) => String(v));

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -2,7 +2,14 @@
  * @module ol/source/GeoZarr
  */
 
-import {FetchStore, get, open, slice, withRangeCoalescing} from 'zarrita';
+import {
+  FetchStore,
+  NotFoundError,
+  get,
+  open,
+  slice,
+  withRangeCoalescing,
+} from 'zarrita';
 import {warn} from '../console.js';
 import {getCenter} from '../extent.js';
 import {get as getProjection, toUserCoordinate, toUserExtent} from '../proj.js';
@@ -166,12 +173,13 @@ export default class GeoZarr extends DataTileSource {
     this.fallbackFlipY_ = options.flipY;
 
     /**
-     * The zarrita open function, pinned to v2 when the store cannot be
-     * probed for v3 metadata (e.g. servers answering 403 for missing keys).
+     * The zarrita open function, pinned to the store's Zarr version by
+     * `configure_`. Never the unpinned `open`, which probes v2 metadata first
+     * and so requests keys that a v3 store does not have.
      * @type {Function}
      * @private
      */
-    this.openFn_ = open;
+    this.openFn_ = open.v3;
 
     /**
      * Group path prefix per tile matrix id, for stores whose levels are not
@@ -352,7 +360,15 @@ export default class GeoZarr extends DataTileSource {
         this.setState('ready');
       })
       .catch((err) => {
-        this.error_ = err;
+        // A 403 reads as a missing key, so the two causes are indistinguishable.
+        this.error_ =
+          err instanceof NotFoundError
+            ? new Error(
+                `GeoZarr: could not read ${this.url_}; it is missing, or ` +
+                  `access to it is denied.`,
+                {cause: err},
+              )
+            : err;
         this.setState('error');
       });
   }
@@ -360,13 +376,15 @@ export default class GeoZarr extends DataTileSource {
   async configure_() {
     const overrides = /** @type {RequestInit} */ (this.storeOptions_) || {};
     const store = /** @type {FetchStore} */ (
-      withRangeCoalescing(new FetchStore(this.url_, {overrides}))
+      withRangeCoalescing(
+        new FetchStore(this.url_, {overrides, fetch: storeFetch}),
+      )
     );
 
-    // Fetch group zarr.json once for both opening the group and extracting
-    // consolidated metadata. Without this, open() and the manual metadata
-    // read would each make a separate HTTP request for the same file.
+    // Fetch group zarr.json once for opening the group, extracting consolidated
+    // metadata, and pinning the detected Zarr version.
     const groupBytes = await probe(store, '/zarr.json');
+    this.openFn_ = groupBytes ? open.v3 : open.v2;
     if (groupBytes) {
       try {
         this.consolidatedMetadata_ = JSON.parse(
@@ -379,7 +397,7 @@ export default class GeoZarr extends DataTileSource {
 
     /** @type {Object<string, *>|null} */
     let v2Metadata = null;
-    if (!this.consolidatedMetadata_) {
+    if (!groupBytes) {
       // Zarr v2: consolidated metadata lives in .zmetadata
       const v2Bytes = await probe(store, '/.zmetadata');
       if (v2Bytes) {
@@ -409,13 +427,15 @@ export default class GeoZarr extends DataTileSource {
     const groupPromises = [];
     if (this.groupPaths_) {
       // Multi-group mode: open root, then each sub-group
-      const rootGroup = await open(cachedStore, {kind: 'group'});
+      const rootGroup = await this.openFn_(cachedStore, {kind: 'group'});
       for (const groupPath of this.groupPaths_) {
-        groupPromises.push(open(rootGroup.resolve(groupPath), {kind: 'group'}));
+        groupPromises.push(
+          this.openFn_(rootGroup.resolve(groupPath), {kind: 'group'}),
+        );
       }
     } else {
       // Single group mode
-      groupPromises.push(this.openGroup_(cachedStore));
+      groupPromises.push(this.openFn_(cachedStore, {kind: 'group'}));
     }
     this.groups_.push(...(await Promise.all(groupPromises)));
 
@@ -1137,26 +1157,6 @@ export default class GeoZarr extends DataTileSource {
   }
 
   /**
-   * Open the group, retrying as Zarr v2 without probing for v3 metadata
-   * first, for servers that answer 403 for missing keys.
-   * @param {*} source The store or location to open.
-   * @return {Promise<import('zarrita').Group<any>>} The opened group.
-   * @private
-   */
-  async openGroup_(source) {
-    try {
-      return await this.openFn_(source, {kind: 'group'});
-    } catch (err) {
-      if (this.openFn_ !== open) {
-        throw err;
-      }
-      const group = await open.v2(source, {kind: 'group'});
-      this.openFn_ = open.v2;
-      return group;
-    }
-  }
-
-  /**
    * @param {Object<string, *>} attributes The dataset attributes.
    * @param {FetchStore} store The store, for metadata requests not covered
    * by consolidated metadata.
@@ -1228,7 +1228,11 @@ export default class GeoZarr extends DataTileSource {
     // The dimension layout is the same for all levels
     let meta = levels.find((level) => level.meta)?.meta;
     if (!meta) {
-      meta = await getArrayMeta(store, levels[0].arrayPath);
+      meta = await getArrayMeta(
+        store,
+        levels[0].arrayPath,
+        this.openFn_ === open.v2,
+      );
       levels[0].meta = meta;
     }
     if (!meta || !Array.isArray(meta.shape)) {
@@ -2246,15 +2250,28 @@ function normalizeV2Metadata(v2Metadata) {
 }
 
 /**
- * Probe the store for an optional metadata document. Absence is an expected
- * outcome (version probing), and some servers answer 403 instead of 404 for
- * missing keys, which zarrita treats as an error.
+ * Probe the store for an optional metadata document. Absence yields
+ * `undefined`; any other failure is thrown, so that a server error is not
+ * mistaken for a missing document.
  * @param {FetchStore} store The store.
  * @param {string} key The key to probe.
  * @return {Promise<Uint8Array|undefined>} The document, if present.
  */
 function probe(store, key) {
-  return store.get(/** @type {`/${string}`} */ (key)).catch(() => undefined);
+  return store.get(/** @type {`/${string}`} */ (key));
+}
+
+/**
+ * Fetch for the Zarr store, reporting a 403 as a missing key. S3 answers 403
+ * for a key that is not there whenever the caller lacks `s3:ListBucket`, the
+ * usual setup for publicly readable objects.
+ * @param {Request} request The request.
+ * @return {Promise<Response>} The response.
+ */
+function storeFetch(request) {
+  return fetch(request).then((response) =>
+    response.status === 403 ? new Response(null, {status: 404}) : response,
+  );
 }
 
 /**
@@ -2262,31 +2279,32 @@ function probe(store, key) {
  * without consolidated metadata (Zarr v3 zarr.json or v2 .zarray/.zattrs).
  * @param {FetchStore} store The store.
  * @param {string} path The array path.
+ * @param {boolean} v2 Whether the store is Zarr v2.
  * @return {Promise<Object|undefined>} The array metadata (v3 shape).
  */
-async function getArrayMeta(store, path) {
+async function getArrayMeta(store, path, v2) {
   const decoder = new TextDecoder();
-  let bytes = await probe(store, `/${path}/zarr.json`);
-  if (bytes) {
-    return JSON.parse(decoder.decode(bytes));
+  if (!v2) {
+    const bytes = await probe(store, `/${path}/zarr.json`);
+    return bytes ? JSON.parse(decoder.decode(bytes)) : undefined;
   }
-  bytes = await probe(store, `/${path}/.zarray`);
-  if (bytes) {
-    const zarray = JSON.parse(decoder.decode(bytes));
-    const attrBytes = await probe(store, `/${path}/.zattrs`);
-    const attributes = attrBytes ? JSON.parse(decoder.decode(attrBytes)) : {};
-    return {
-      shape: zarray['shape'],
-      fill_value: zarray['fill_value'],
-      dimension_names: attributes['_ARRAY_DIMENSIONS'],
-      chunk_grid: {
-        name: 'regular',
-        configuration: {chunk_shape: zarray['chunks']},
-      },
-      attributes,
-    };
+  const bytes = await probe(store, `/${path}/.zarray`);
+  if (!bytes) {
+    return undefined;
   }
-  return undefined;
+  const zarray = JSON.parse(decoder.decode(bytes));
+  const attrBytes = await probe(store, `/${path}/.zattrs`);
+  const attributes = attrBytes ? JSON.parse(decoder.decode(attrBytes)) : {};
+  return {
+    shape: zarray['shape'],
+    fill_value: zarray['fill_value'],
+    dimension_names: attributes['_ARRAY_DIMENSIONS'],
+    chunk_grid: {
+      name: 'regular',
+      configuration: {chunk_shape: zarray['chunks']},
+    },
+    attributes,
+  };
 }
 
 /**

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -16,15 +16,10 @@ import {get as getProjection, toUserCoordinate, toUserExtent} from '../proj.js';
 import {fromProjectionDefinition} from '../proj/proj4.js';
 import {toSize} from '../size.js';
 import WMTSTileGrid from '../tilegrid/WMTS.js';
+import {DEFAULT_TILE_SIZE} from '../tilegrid/common.js';
 import {getUid} from '../util.js';
 import DataTileSource from './DataTile.js';
 import {parseTileMatrixSet} from './ogcTileUtil.js';
-
-const REQUIRED_ZARR_CONVENTIONS = [
-  'd35379db-88df-4056-af3a-620245f8e347', // multiscales
-  'f17cb550-5864-4468-aeb7-f3180cfb622f', // proj:
-  '689b58e2-cf7b-45e0-9fff-9cfc0883d6b4', // spatial:
-];
 
 /**
  * @typedef {'nearest'|'linear'} ResampleMethod
@@ -99,19 +94,25 @@ const REQUIRED_ZARR_CONVENTIONS = [
  * - [Geospatial projection convention](https://github.com/zarr-conventions/geo-proj)
  * - [Spatial convention](https://github.com/zarr-conventions/spatial)
  *
- * When all three conventions are present, multiple resolution levels are supported.
- * When only proj: and spatial: are present, a single-resolution tile grid is derived
- * from `spatial:bbox`, `proj:code`, and `spatial:shape`.
- * The legacy `tile_matrix_set` attribute is also supported, as is the GeoZarr-style
- * `multiscales` array attribute (`[{tile_matrix_set, datasets: [{path, ...}]}]`).
+ * The store is read as a stack of resolution levels, enumerated from the
+ * `multiscales` attribute in either its `{layout: [{asset, ...}]}` or its
+ * `[{datasets: [{path, ...}]}]` form; a store with neither has the group itself as
+ * its only level. The legacy `tile_matrix_set` attribute is also supported, and
+ * describes the levels itself.
+ *
+ * Extent, resolution, projection and y-axis orientation are read from the store
+ * metadata (`spatial:bbox`, `spatial:shape`, `spatial:transform`, `proj:code`,
+ * ...) where declared, and otherwise inferred from the coordinate arrays. The
+ * conventions above are what make that metadata available, but none of them has
+ * to be declared for a store that provides the attributes.
  *
  * Two data layouts are supported:
  * - One array per band (`bands` option), addressed by name at `<matrixId>/<bandName>`
- *   (multi-scale) or at the group root (single-scale). Supports Zarr v3.
+ *   (multi-scale) or at the group root (single-scale).
  * - A single n-dimensional data array shared by all bands (`variable` + `selector`
- *   options), e.g. a `(time, band, y, x)` datacube. Supports Zarr v2 and v3; the
- *   extent, resolution, projection and y-axis orientation are read from the store
- *   metadata or inferred from the coordinate arrays.
+ *   options), e.g. a `(time, band, y, x)` datacube.
+ *
+ * Both layouts support Zarr v2 and v3.
  */
 export default class GeoZarr extends DataTileSource {
   /**
@@ -454,99 +455,42 @@ export default class GeoZarr extends DataTileSource {
       this.spatialDimensionNames_ = spatialDimensions;
     }
 
-    // For multi-group mode, use sub-metadata for the first group so that
-    // consolidated metadata keys match the expected relative paths.
-    const consolidatedMetadata =
-      this.groupPaths_ && this.consolidatedMetadata_
-        ? getSubMetadata(this.consolidatedMetadata_, this.groupPaths_[0])
-        : this.consolidatedMetadata_;
-
-    if (this.variable_) {
-      await this.configureDatacube_(attributes, store);
-    }
+    const multiscales = attributes.multiscales;
+    // The two multiscale layouts that enumerate level groups: the GeoZarr
+    // `[{datasets: [...]}]` form and the convention's `{layout: [...]}` form.
+    const hasMultiscaleLevels =
+      Array.isArray(multiscales) ||
+      Array.isArray(/** @type {Multiscales} */ (multiscales)?.layout);
+    // The legacy tile_matrix_set describes the levels itself, so a store that
+    // has nothing else to enumerate them by is configured from it alone.
+    const legacyOnly =
+      !!multiscales && 'tile_matrix_set' in multiscales && !hasMultiscaleLevels;
 
     let hasTileSizes = false;
     if (
-      !this.tileGrid &&
-      'zarr_conventions' in attributes &&
-      Array.isArray(attributes.zarr_conventions) &&
-      REQUIRED_ZARR_CONVENTIONS.every((uuid) =>
-        attributes.zarr_conventions.find((c) => c.uuid === uuid),
-      ) &&
-      'layout' in attributes.multiscales
+      this.variable_ ||
+      (!legacyOnly &&
+        (hasMultiscaleLevels ||
+          'spatial:bbox' in attributes ||
+          'bounds' in attributes))
     ) {
-      const {tileGrid, projection, bandsByLevel, fillValue, tileSizes} =
-        getTileGridInfoFromAttributes(
-          /** @type {DatasetAttributes} */ (attributes),
-          consolidatedMetadata,
-          this.bands_,
-        );
-      this.bandsByLevel_ = bandsByLevel;
-      this.tileGrid = tileGrid;
-      this.projection = projection;
-      this.fillValue_ = fillValue;
-      hasTileSizes = !!tileSizes;
+      hasTileSizes = await this.configureLevels_(attributes, store);
     }
-    if (
-      !hasTileSizes &&
-      attributes.multiscales &&
-      'tile_matrix_set' in attributes.multiscales
-    ) {
+    if (!hasTileSizes && multiscales && 'tile_matrix_set' in multiscales) {
       // If available, use tile_matrix_set (legacy attributes) to get a tile grid, because it
       // should provide a better mapping of tiles to zarr chunks.
       const {tileGrid, projection} = getTileGridInfoFromLegacyAttributes(
         /** @type {LegacyDatasetAttributes} */ (attributes),
       );
       this.tileGrid = tileGrid;
+      // The tile matrix set brings its own matrix ids, which the levels
+      // resolved above are not keyed by.
+      this.bandsByLevel_ = null;
+      this.levelPaths_ = null;
+      this.levelRowInfo_ = null;
       if (!this.projection) {
-        // If there were no required zarr conventions, we don't have a projection yet
+        // Only the tile matrix set declares one for a legacy-only store
         this.projection = projection;
-      }
-    }
-    if (!this.tileGrid && 'spatial:bbox' in attributes) {
-      // Standalone single-scale group: build tile grid directly from
-      // spatial:bbox and spatial:shape (`[height, width]`), or the x axis size
-      // from the array metadata.
-      let xSize = attributes['spatial:shape']?.[1];
-      if (xSize === undefined && consolidatedMetadata) {
-        for (const band of this.bands_) {
-          const bandMeta = consolidatedMetadata[band];
-          if (bandMeta?.shape) {
-            xSize = bandMeta.shape[this.axesOf_(bandMeta).col];
-            break;
-          }
-        }
-      }
-      if (xSize !== undefined) {
-        const extent = attributes['spatial:bbox'];
-        const resolution = (extent[2] - extent[0]) / xSize;
-        if (!this.projection) {
-          this.projection = getProjectionFromAttributes(attributes);
-        }
-        if (consolidatedMetadata) {
-          this.bandsByLevel_ = {level0: []};
-          for (const band of this.bands_) {
-            if (consolidatedMetadata[band]) {
-              this.bandsByLevel_['level0'].push(band);
-              if (this.fillValue_ === undefined) {
-                this.fillValue_ = Number(
-                  consolidatedMetadata[band]['fill_value'],
-                );
-              }
-            }
-          }
-        }
-        this.tileGrid = new WMTSTileGrid({
-          extent: extent,
-          origins: [[extent[0], extent[3]]],
-          resolutions: [resolution],
-          matrixIds: ['level0'],
-        });
-        for (let i = 0; i < this.bands_.length; ++i) {
-          if (this.bandGroupIndex_[i] === 0) {
-            this.bandSingleScaleResolution_[i] = resolution;
-          }
-        }
       }
     }
     // For multi-group: determine which group owns each band and supplement
@@ -1157,14 +1101,27 @@ export default class GeoZarr extends DataTileSource {
   }
 
   /**
+   * Build the tile grid and the per-level band layout. Every store is read as a
+   * stack of levels holding n-dimensional arrays: in `variable` mode all bands
+   * are slices of one array, otherwise each band has an array of its own.
    * @param {Object<string, *>} attributes The dataset attributes.
    * @param {FetchStore} store The store, for metadata requests not covered
    * by consolidated metadata.
+   * @return {Promise<boolean>} Whether the tile grid has explicit tile sizes.
    * @private
    */
-  async configureDatacube_(attributes, store) {
-    const variable = /** @type {string} */ (this.variable_);
-    const consolidatedMetadata = this.consolidatedMetadata_;
+  async configureLevels_(attributes, store) {
+    const variable = this.variable_;
+    // The arrays to look for at each level, and how to name them in messages.
+    const arrayNames = variable ? [variable] : this.bands_;
+    const what = variable
+      ? `variable "${variable}"`
+      : `bands [${arrayNames.join(', ')}]`;
+    // For multi-group mode, use sub-metadata for the first group so that
+    // consolidated metadata keys match the expected relative paths.
+    const consolidatedMetadata = this.consolidatedMetadata_
+      ? this.groupMetadata_(0)
+      : null;
 
     // Collect the multiscale level paths; without multiscale metadata the
     // group itself is the only level.
@@ -1194,6 +1151,11 @@ export default class GeoZarr extends DataTileSource {
       }
     } else if (multiscales && Array.isArray(multiscales.layout)) {
       for (const entry of multiscales.layout) {
+        // The declared `spatial:transform` is deliberately ignored here: its
+        // resolution is rounded in real stores (e.g. 720 where the extent and
+        // shape give 722.37), which leaves a sliver of a tile beyond the last
+        // full one. All layout levels share the group origin, so deriving the
+        // resolution from the extent and shape is both exact and sufficient.
         rawLevels.push({
           path: String(entry.asset),
           transform: undefined,
@@ -1208,47 +1170,60 @@ export default class GeoZarr extends DataTileSource {
       });
     }
 
-    /** @type {Array<{path: string, arrayPath: string, meta: any, transform: Array<number>|undefined, shape: Array<number>|undefined}>} */
+    // Keep only the levels that hold at least one of the wanted arrays. Without
+    // consolidated metadata their presence cannot be checked up front.
+    /** @type {Array<{path: string, bands: Array<string>, meta: any, transform: Array<number>|undefined, shape: Array<number>|undefined}>} */
     const levels = [];
     for (const raw of rawLevels) {
-      const arrayPath = raw.path ? `${raw.path}/${variable}` : variable;
-      const meta = consolidatedMetadata
-        ? consolidatedMetadata[arrayPath]
-        : undefined;
-      if (consolidatedMetadata && !meta) {
-        warn(`Variable "${variable}" not found at level "${raw.path || '.'}"`);
+      const bands = consolidatedMetadata
+        ? arrayNames.filter(
+            (name) => consolidatedMetadata[arrayPathOf(raw.path, name)],
+          )
+        : arrayNames.slice();
+      if (bands.length === 0) {
+        warn(`No ${what} found at level "${raw.path || '.'}"`);
         continue;
       }
-      levels.push({...raw, arrayPath, meta});
+      levels.push({
+        ...raw,
+        bands,
+        meta: consolidatedMetadata
+          ? consolidatedMetadata[arrayPathOf(raw.path, bands[0])]
+          : undefined,
+      });
     }
     if (levels.length === 0) {
-      throw new Error(`Variable "${variable}" not found in any level`);
+      throw new Error(`No level found holding ${what}`);
     }
 
-    // The dimension layout is the same for all levels
+    // The dimension layout is the same for all levels. It is only needed when
+    // the levels do not declare their shape, or to slice a `variable`.
     let meta = levels.find((level) => level.meta)?.meta;
-    if (!meta) {
+    if (!meta && (variable || !levels.every((l) => Array.isArray(l.shape)))) {
       meta = await getArrayMeta(
         store,
-        levels[0].arrayPath,
+        arrayPathOf(levels[0].path, levels[0].bands[0]),
         this.openFn_ === open.v2,
       );
       levels[0].meta = meta;
     }
-    if (!meta || !Array.isArray(meta.shape)) {
+    const hasMeta = !!meta && Array.isArray(meta.shape);
+    if (variable && !hasMeta) {
       throw new Error(`Could not read metadata for variable "${variable}"`);
     }
-    const ndim = meta.shape.length;
-    let dimensionNames = meta['dimension_names'];
+    const ndim = hasMeta ? meta.shape.length : 2;
+    let dimensionNames = hasMeta ? meta['dimension_names'] : undefined;
     if (!dimensionNames && ndim === 2) {
       dimensionNames = ['y', 'x'];
     }
-    if (!dimensionNames) {
+    if (variable && !dimensionNames) {
       throw new Error(
         `Cannot determine dimension names for variable "${variable}"`,
       );
     }
-    const {row, col} = getSpatialAxes(attributes['spatial:dimensions'], meta);
+    const {row, col} = hasMeta
+      ? getSpatialAxes(attributes['spatial:dimensions'], meta)
+      : {row: 0, col: 1};
 
     // Determine the extent and y axis orientation: declared metadata is
     // authoritative, otherwise both are inferred from the coordinate arrays.
@@ -1263,6 +1238,11 @@ export default class GeoZarr extends DataTileSource {
       transform0[4] !== 0
     ) {
       flipY = transform0[4] > 0;
+      orientationKnown = true;
+    } else if (extent && levels.every((l) => Array.isArray(l.shape))) {
+      // Levels that declare their `spatial:shape` alongside a declared extent
+      // follow the spatial: convention, which stores rasters north-up. Reading
+      // coordinate arrays would only confirm that, at the cost of two requests.
       orientationKnown = true;
     } else {
       // All levels share the extent; the smallest level is cheapest to read
@@ -1323,7 +1303,7 @@ export default class GeoZarr extends DataTileSource {
 
     const extentWidth = extent[2] - extent[0];
     const extentHeight = extent[3] - extent[1];
-    /** @type {Array<{path: string, arrayPath: string, meta: any, resolution: number, rowResolution: number, origin: import("../coordinate.js").Coordinate}>} */
+    /** @type {Array<{path: string, bands: Array<string>, meta: any, resolution: number, rowResolution: number, origin: import("../coordinate.js").Coordinate}>} */
     const configured = [];
     for (const level of levels) {
       let resolution;
@@ -1353,7 +1333,7 @@ export default class GeoZarr extends DataTileSource {
       }
       configured.push({
         path: level.path,
-        arrayPath: level.arrayPath,
+        bands: level.bands,
         meta: level.meta,
         resolution,
         rowResolution,
@@ -1361,7 +1341,7 @@ export default class GeoZarr extends DataTileSource {
       });
     }
     if (configured.length === 0) {
-      throw new Error(`No usable level found for variable "${variable}"`);
+      throw new Error(`No usable level found for ${what}`);
     }
     configured.sort((a, b) => b.resolution - a.resolution);
 
@@ -1369,89 +1349,93 @@ export default class GeoZarr extends DataTileSource {
       this.projection = this.inferProjection_(attributes, crsHint, extent);
     }
 
-    // Resolve the selector to per-axis indices; labels are resolved against
-    // the finest level's coordinate arrays
-    const finestPath = configured[configured.length - 1].path;
-    /** @type {Array<{axis: number, indices: Array<number>}>} */
-    const slots = [];
-    this.multiAxis_ = -1;
-    this.extraDimensions_ = [];
-    for (let axis = 0; axis < ndim; ++axis) {
-      if (axis === row || axis === col) {
-        continue;
-      }
-      const dimName = dimensionNames[axis];
-      this.extraDimensions_.push({name: dimName, size: meta.shape[axis]});
-      // `dimensions` (also merged by updateDimensions) takes precedence
-      // over the initial `selector` for scalar values
-      let value =
-        dimName in this.dimensions_
-          ? this.dimensions_[dimName]
-          : this.selector_[dimName];
-      if (value === undefined) {
-        warn(
-          `No selector value given for dimension "${dimName}", using index 0.`,
-        );
-        value = 0;
-      }
-      /** @type {Array<number|string>} */
-      let values;
-      if (Array.isArray(value)) {
-        values = value;
-        this.multiAxis_ = axis;
-      } else {
-        values = [value];
-      }
-      const indices = [];
-      for (const v of values) {
-        if (typeof v === 'number') {
-          indices.push(v);
+    if (variable) {
+      // Resolve the selector to per-axis indices; labels are resolved against
+      // the finest level's coordinate arrays
+      const finestPath = configured[configured.length - 1].path;
+      /** @type {Array<{axis: number, indices: Array<number>}>} */
+      const slots = [];
+      this.multiAxis_ = -1;
+      this.extraDimensions_ = [];
+      for (let axis = 0; axis < ndim; ++axis) {
+        if (axis === row || axis === col) {
+          continue;
+        }
+        const dimName = dimensionNames[axis];
+        this.extraDimensions_.push({name: dimName, size: meta.shape[axis]});
+        // `dimensions` (also merged by updateDimensions) takes precedence
+        // over the initial `selector` for scalar values
+        let value =
+          dimName in this.dimensions_
+            ? this.dimensions_[dimName]
+            : this.selector_[dimName];
+        if (value === undefined) {
+          warn(
+            `No selector value given for dimension "${dimName}", using index 0.`,
+          );
+          value = 0;
+        }
+        /** @type {Array<number|string>} */
+        let values;
+        if (Array.isArray(value)) {
+          values = value;
+          this.multiAxis_ = axis;
         } else {
-          indices.push(
-            await this.resolveCoordinateLabel_(dimName, v, finestPath),
-          );
+          values = [value];
         }
-      }
-      for (const index of indices) {
-        if (
-          !Number.isInteger(index) ||
-          index < 0 ||
-          index >= meta.shape[axis]
-        ) {
-          throw new Error(
-            `GeoZarr: invalid index ${index} for dimension "${dimName}" ` +
-              `(size ${meta.shape[axis]}).`,
-          );
+        const indices = [];
+        for (const v of values) {
+          if (typeof v === 'number') {
+            indices.push(v);
+          } else {
+            indices.push(
+              await this.resolveCoordinateLabel_(dimName, v, finestPath),
+            );
+          }
         }
+        for (const index of indices) {
+          if (
+            !Number.isInteger(index) ||
+            index < 0 ||
+            index >= meta.shape[axis]
+          ) {
+            throw new Error(
+              `GeoZarr: invalid index ${index} for dimension "${dimName}" ` +
+                `(size ${meta.shape[axis]}).`,
+            );
+          }
+        }
+        slots.push({axis, indices});
       }
-      slots.push({axis, indices});
+
+      // Materialize the datacube as the per-band state that loadTile_
+      // consumes: each rendered band is the variable array with fixed indices
+      // at the non-spatial axes.
+      const count = this.bandCount;
+      this.bands_ = new Array(count).fill(variable);
+      this.bandGroupIndex_ = new Array(count).fill(0);
+      this.bandSingleScaleResolution_ = new Array(count).fill(undefined);
+      this.bandSpatialAxes_ = new Array(count).fill({row, col});
+      this.bandExtraSelection_ = new Array(count)
+        .fill(undefined)
+        .map((_, bandIndex) => {
+          if (slots.length === 0) {
+            return undefined;
+          }
+          const selection = new Array(ndim).fill(null);
+          for (const slot of slots) {
+            selection[slot.axis] =
+              slot.axis === this.multiAxis_
+                ? slot.indices[bandIndex]
+                : slot.indices[0];
+          }
+          return selection;
+        });
     }
 
-    // Materialize the datacube as the per-band state that loadTile_
-    // consumes: each rendered band is the variable array with fixed indices
-    // at the non-spatial axes.
-    const count = this.bandCount;
-    this.bands_ = new Array(count).fill(variable);
-    this.bandGroupIndex_ = new Array(count).fill(0);
-    this.bandSingleScaleResolution_ = new Array(count).fill(undefined);
-    this.bandSpatialAxes_ = new Array(count).fill({row, col});
-    this.bandExtraSelection_ = new Array(count)
-      .fill(undefined)
-      .map((_, bandIndex) => {
-        if (slots.length === 0) {
-          return undefined;
-        }
-        const selection = new Array(ndim).fill(null);
-        for (const slot of slots) {
-          selection[slot.axis] =
-            slot.axis === this.multiAxis_
-              ? slot.indices[bandIndex]
-              : slot.indices[0];
-        }
-        return selection;
-      });
-
-    this.fillValue_ = parseFillValue(meta['fill_value']);
+    if (meta) {
+      this.fillValue_ = parseFillValue(meta['fill_value']);
+    }
 
     // Align tiles to shards or chunks: every tile decodes all chunks it
     // touches, so tiles much smaller than a chunk would decode the same
@@ -1473,8 +1457,13 @@ export default class GeoZarr extends DataTileSource {
           ),
         ]);
       }
+      // Unsharded chunks only need alignment when they are larger than a
+      // default tile, which would decode the same chunk for every tile it spans.
       const chunkShape = level.meta['chunk_grid']?.configuration?.chunk_shape;
-      if (Array.isArray(chunkShape)) {
+      if (
+        Array.isArray(chunkShape) &&
+        Math.max(chunkShape[row], chunkShape[col]) > DEFAULT_TILE_SIZE
+      ) {
         return /** @type {import("../size.js").Size} */ ([
           getTileSizeForChunk(chunkShape[col], level.meta.shape[col]),
           getTileSizeForChunk(chunkShape[row], level.meta.shape[row]),
@@ -1490,7 +1479,7 @@ export default class GeoZarr extends DataTileSource {
     const matrixIds = configured.map((level, i) => level.path || String(i));
     for (let i = 0; i < configured.length; ++i) {
       const level = configured[i];
-      this.bandsByLevel_[matrixIds[i]] = this.bands_;
+      this.bandsByLevel_[matrixIds[i]] = level.bands;
       this.levelPaths_[matrixIds[i]] = level.path;
       this.levelRowInfo_[matrixIds[i]] = {
         rowResolution: level.rowResolution,
@@ -1510,6 +1499,7 @@ export default class GeoZarr extends DataTileSource {
         ? {tileSizes: tileSizes.map((s) => s || [256, 256])}
         : {}),
     });
+    return hasTileSizes;
   }
 
   /**
@@ -1708,9 +1698,6 @@ function createCachedStore(store, groupBytes, consolidatedMetadata) {
  * @typedef {Object} TileGridInfo
  * @property {WMTSTileGrid} tileGrid The tile grid.
  * @property {import("../proj/Projection.js").default} projection The projection.
- * @property {Object<string, Array<string>>} [bandsByLevel] Available bands by level.
- * @property {number} [fillValue] The fill value.
- * @property {Array<import("../size.js").Size>|undefined} [tileSizes] The tile sizes for each level, if available.
  */
 
 /**
@@ -1730,6 +1717,16 @@ const MIN_TILE_SIZE = 64;
  * @property {Array<number>} shardShape The shard (outer chunk) shape [rows, cols].
  * @property {Array<number>} innerChunkShape The inner chunk shape [rows, cols].
  */
+
+/**
+ * The path of a band array within its group.
+ * @param {string} levelPath The level group path (empty for the group root).
+ * @param {string} name The array name.
+ * @return {string} The path, relative to the group.
+ */
+function arrayPathOf(levelPath, name) {
+  return levelPath ? `${levelPath}/${name}` : name;
+}
 
 /**
  * Locate the row (y) and column (x) axis positions of an array by matching the
@@ -1829,109 +1826,6 @@ function getTileSizeForShard(shardSize, innerChunkSize) {
     return MIN_TILE_SIZE;
   }
   return Math.max(maxChunks * innerChunkSize, MIN_TILE_SIZE);
-}
-
-/**
- * @param {DatasetAttributes} attributes The dataset attributes.
- * @param {Object<string, *>|null|undefined} consolidatedMetadata The consolidated metadata.
- * @param {Array<string>} wantedBands The wanted bands.
- * @return {TileGridInfo} The tile grid info.
- */
-function getTileGridInfoFromAttributes(
-  attributes,
-  consolidatedMetadata,
-  wantedBands,
-) {
-  const multiscales = attributes.multiscales;
-  const extent = attributes['spatial:bbox'];
-  const projection = getProjectionFromAttributes(attributes);
-  const extentWidth = extent[2] - extent[0];
-  const origin = [extent[0], extent[3]];
-  /** @type {Array<{matrixId: string, resolution: number, origin: import("../coordinate.js").Coordinate, tileSize: import("../size.js").Size|undefined}>} */
-  const groupInfo = [];
-  /** @type {Object<string, Array<string>>|undefined} */
-  const bandsByLevel = consolidatedMetadata ? {} : undefined;
-  let fillValue;
-  for (const groupMetadata of multiscales.layout) {
-    const matrixId = /** @type {string} */ (groupMetadata['asset']);
-    const spatialShape = /** @type {Array<number>} */ (
-      groupMetadata['spatial:shape']
-    );
-    const resolution = extentWidth / spatialShape[1];
-    /** @type {import("../size.js").Size|undefined} */
-    let tileSize;
-    if (consolidatedMetadata && bandsByLevel) {
-      const availableBands = [];
-      for (const band of wantedBands) {
-        const bandArray = /** @type {Object<string, *>|undefined} */ (
-          consolidatedMetadata[`${matrixId}/${band}`]
-        );
-        if (bandArray) {
-          availableBands.push(band);
-          if (fillValue === undefined) {
-            fillValue = Number(bandArray['fill_value']);
-          }
-          //FIXME Remove this when GeoZarr datasets provide correct TileMatrixSet info or similar
-          if (!tileSize) {
-            const {row, col} = getSpatialAxes(
-              attributes['spatial:dimensions'],
-              bandArray,
-            );
-            const shardInfo = getShardInfo(bandArray, row, col);
-            if (shardInfo) {
-              tileSize = [
-                getTileSizeForShard(
-                  shardInfo.shardShape[1],
-                  shardInfo.innerChunkShape[1],
-                ),
-                getTileSizeForShard(
-                  shardInfo.shardShape[0],
-                  shardInfo.innerChunkShape[0],
-                ),
-              ];
-            }
-          }
-        }
-      }
-      bandsByLevel[matrixId] = availableBands;
-    }
-    groupInfo.push({
-      matrixId,
-      resolution,
-      origin,
-      tileSize,
-    });
-  }
-  groupInfo.sort((a, b) => b.resolution - a.resolution);
-
-  const tileSizes = groupInfo.map((g) => g.tileSize);
-  const hasTileSizes = tileSizes.some((s) => s !== undefined);
-
-  const tileGrid = new WMTSTileGrid({
-    extent: extent,
-    origins: groupInfo.map((g) => g.origin),
-    resolutions: groupInfo.map((g) => g.resolution),
-    matrixIds: groupInfo.map((g) => g.matrixId),
-    ...(hasTileSizes
-      ? {
-          tileSizes: /** @type {Array<import("../size.js").Size>} */ (
-            tileSizes.map((s) => s || [256, 256])
-          ),
-        }
-      : {}),
-  });
-
-  return {
-    tileGrid,
-    projection,
-    bandsByLevel,
-    fillValue,
-    tileSizes: hasTileSizes
-      ? /** @type {Array<import("../size.js").Size>} */ (
-          tileSizes.map((s) => s || [256, 256])
-        )
-      : undefined,
-  };
 }
 
 /**

--- a/src/ol/source/GeoZarr.js
+++ b/src/ol/source/GeoZarr.js
@@ -346,7 +346,6 @@ export default class GeoZarr extends DataTileSource {
         );
       }
       multiName = name;
-      this.bandCount = value.length;
     }
 
     /**
@@ -1429,7 +1428,9 @@ export default class GeoZarr extends DataTileSource {
       // Materialize the datacube as the per-band state that loadTile_
       // consumes: each rendered band is the variable array with fixed indices
       // at the non-spatial axes.
-      const count = this.bandCount;
+      const multiSlot = slots.find((slot) => slot.axis === this.multiAxis_);
+      const count = multiSlot ? multiSlot.indices.length : 1;
+      this.bandCount = count;
       this.bands_ = new Array(count).fill(variable);
       this.bandGroupIndex_ = new Array(count).fill(0);
       this.bandSingleScaleResolution_ = new Array(count).fill(undefined);

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -212,6 +212,24 @@ describe('ol/source/GeoZarr', function () {
       assert.deepEqual(source.bands_, bands);
       assert.strictEqual(source.bandCount, bands.length);
     });
+
+    it('rejects dimensions that select several bands ambiguously', function () {
+      const url = 'https://example.com/test.zarr';
+      assert.throws(
+        () =>
+          new GeoZarr({url, bands: ['climate'], dimensions: {band: [0, 1]}}),
+        /requires the `variable` option/,
+      );
+      assert.throws(
+        () =>
+          new GeoZarr({
+            url,
+            variable: 'climate',
+            dimensions: {band: [0, 1], time: [0, 1]},
+          }),
+        /at most one may/,
+      );
+    });
   });
 
   describe('storeOptions', function () {
@@ -966,7 +984,7 @@ describe('ol/source/GeoZarr', function () {
       }
     });
 
-    it('renders one band per selector entry, across pyramid levels', () =>
+    it('renders one band per dimension value, across pyramid levels', () =>
       new Promise((resolve) => {
         fetchStub = stubFetchWithAttrs(
           {
@@ -994,7 +1012,7 @@ describe('ol/source/GeoZarr', function () {
         const source = new GeoZarr({
           url: ZARR_URL,
           variable: 'climate',
-          selector: {band: [0, 2], month: 1},
+          dimensions: {band: [0, 2], month: 1},
         });
         source.on('change', function () {
           if (source.getState() === 'ready') {
@@ -1029,7 +1047,7 @@ describe('ol/source/GeoZarr', function () {
         const source = new GeoZarr({
           url: ZARR_URL,
           variable: 't2m',
-          selector: {time: 1},
+          dimensions: {time: 1},
         });
         source.on('change', function () {
           if (source.getState() === 'ready') {
@@ -1056,7 +1074,7 @@ describe('ol/source/GeoZarr', function () {
         const source = new GeoZarr({
           url: ZARR_URL,
           variable: 'fgco2',
-          selector: {time: 0},
+          dimensions: {time: 0},
           extent: [-180, -90, 180, 90],
           flipY: true,
         });
@@ -1310,7 +1328,7 @@ describe('ol/source/GeoZarr', function () {
         });
       }));
 
-    it('errors on a string (datetime-label) value as not yet implemented', () =>
+    it('errors on a label without a coordinate array to resolve it', () =>
       new Promise((resolve) => {
         fetchStub = stubFetch({
           ['level0/vv']: createArrayMeta({
@@ -1325,7 +1343,8 @@ describe('ol/source/GeoZarr', function () {
         });
         source.on('change', function () {
           if (source.getState() === 'error') {
-            assert.include(source.error_.message, 'not yet implemented');
+            assert.include(source.error_.message, 'Could not resolve label');
+            assert.include(source.error_.message, 'numeric index');
             resolve();
           }
         });

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -903,6 +903,62 @@ describe('ol/source/GeoZarr', function () {
   describe('variable (datacube)', function () {
     let fetchStub;
 
+    /**
+     * Zarr v3 metadata and chunk bytes for a 1-D float64 coordinate array.
+     * @param {Array<number>} values The coordinate values.
+     * @return {{meta: Object, chunk: Uint8Array}} The metadata and its chunk.
+     */
+    function coordinateArray(values) {
+      return {
+        meta: {
+          zarr_format: 3,
+          node_type: 'array',
+          shape: [values.length],
+          data_type: 'float64',
+          fill_value: 0,
+          chunk_grid: {
+            name: 'regular',
+            configuration: {chunk_shape: [values.length]},
+          },
+          chunk_key_encoding: {
+            name: 'default',
+            configuration: {separator: '/'},
+          },
+          codecs: [{name: 'bytes', configuration: {endian: 'little'}}],
+          attributes: {},
+        },
+        chunk: new Uint8Array(new Float64Array(values).buffer),
+      };
+    }
+
+    /**
+     * Stub a v3 store with consolidated metadata, group attributes, and the
+     * chunk bytes of any coordinate arrays.
+     * @param {Object} metadata Consolidated metadata, by path.
+     * @param {Object} attributes The group attributes.
+     * @param {Object<string, Uint8Array>} [chunks] Chunk bytes, by path.
+     * @return {import('vitest').MockInstance} The fetch stub.
+     */
+    function stubDatacube(metadata, attributes, chunks) {
+      const group = JSON.stringify({
+        zarr_format: 3,
+        node_type: 'group',
+        attributes,
+        consolidated_metadata: {metadata},
+      });
+      return vi.spyOn(window, 'fetch').mockImplementation(function (input) {
+        const url = input instanceof Request ? input.url : input;
+        if (url === `${ZARR_URL}/zarr.json`) {
+          return Promise.resolve(new Response(group, {status: 200}));
+        }
+        const key = url.slice(`${ZARR_URL}/`.length);
+        if (chunks && key in chunks) {
+          return Promise.resolve(new Response(chunks[key], {status: 200}));
+        }
+        return Promise.resolve(new Response('', {status: 404}));
+      });
+    }
+
     afterEach(function () {
       if (fetchStub) {
         fetchStub.mockRestore();
@@ -910,7 +966,7 @@ describe('ol/source/GeoZarr', function () {
       }
     });
 
-    it('renders one band per selector entry from a single array', () =>
+    it('renders one band per selector entry, across pyramid levels', () =>
       new Promise((resolve) => {
         fetchStub = stubFetchWithAttrs(
           {
@@ -918,11 +974,20 @@ describe('ol/source/GeoZarr', function () {
               shape: [2, 3, 256, 256],
               dimensionNames: ['month', 'band', 'y', 'x'],
             }),
+            ['1/climate']: createArrayMeta({
+              shape: [2, 3, 128, 128],
+              dimensionNames: ['month', 'band', 'y', 'x'],
+            }),
           },
           {
             zarr_conventions: undefined,
             multiscales: [
-              {datasets: [{path: '0', 'spatial:shape': [256, 256]}]},
+              {
+                datasets: [
+                  {path: '0', 'spatial:shape': [256, 256]},
+                  {path: '1', 'spatial:shape': [128, 128]},
+                ],
+              },
             ],
           },
         );
@@ -933,11 +998,72 @@ describe('ol/source/GeoZarr', function () {
         });
         source.on('change', function () {
           if (source.getState() === 'ready') {
-            assert.deepEqual(source.tileGrid.getResolutions(), [1]);
+            assert.deepEqual(source.tileGrid.getResolutions(), [2, 1]);
             assert.deepEqual(source.bandExtraSelection_, [
               [1, 0, null, null],
               [1, 2, null, null],
             ]);
+            resolve();
+          }
+        });
+      }));
+
+    it('infers the extent and south-up rows from the coordinate arrays', () =>
+      new Promise((resolve) => {
+        // Ascending y coordinates mean the rows are stored south-up. The
+        // coordinates are pixel centers, so the extent is padded by half a pixel.
+        const x = coordinateArray([0.5, 1.5, 2.5, 3.5]);
+        const y = coordinateArray([0.5, 1.5, 2.5, 3.5]);
+        fetchStub = stubDatacube(
+          {
+            t2m: createArrayMeta({
+              shape: [2, 4, 4],
+              dimensionNames: ['time', 'y', 'x'],
+            }),
+            x: x.meta,
+            y: y.meta,
+          },
+          {},
+          {'x/c/0': x.chunk, 'y/c/0': y.chunk},
+        );
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          variable: 't2m',
+          selector: {time: 1},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.tileGrid.getExtent(), [0, 0, 4, 4]);
+            assert.strictEqual(source.levelRowInfo_['0'].flip, true);
+            assert.strictEqual(source.getProjection(), get('EPSG:4326'));
+            resolve();
+          }
+        });
+      }));
+
+    it('falls back to the extent and flipY options', () =>
+      new Promise((resolve) => {
+        // A store with neither spatial metadata nor coordinate arrays.
+        fetchStub = stubDatacube(
+          {
+            fgco2: createArrayMeta({
+              shape: [1, 180, 360],
+              dimensionNames: ['time', 'y', 'x'],
+            }),
+          },
+          {},
+        );
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          variable: 'fgco2',
+          selector: {time: 0},
+          extent: [-180, -90, 180, 90],
+          flipY: true,
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.tileGrid.getExtent(), [-180, -90, 180, 90]);
+            assert.strictEqual(source.levelRowInfo_['0'].flip, true);
             resolve();
           }
         });

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -64,6 +64,48 @@ function createArrayMeta({
 }
 
 /**
+ * Wait for a source to finish configuring, successfully or not.
+ * @param {GeoZarr} source The source.
+ * @return {Promise<GeoZarr>} The source, once ready or in error.
+ */
+function settled(source) {
+  return new Promise((resolve) => {
+    source.on('change', function () {
+      const state = source.getState();
+      if (state === 'ready' || state === 'error') {
+        resolve(source);
+      }
+    });
+  });
+}
+
+/**
+ * Consolidated metadata (.zmetadata) for a minimal single-scale Zarr v2 store.
+ * @return {Object} The .zmetadata document.
+ */
+function v2Zmetadata() {
+  return {
+    zarr_consolidated_format: 1,
+    metadata: {
+      '.zgroup': {zarr_format: 2},
+      '.zattrs': {
+        'spatial:bbox': [0, 0, 256, 256],
+        'spatial:shape': [256, 256],
+        'proj:code': 'EPSG:4326',
+      },
+      'b04/.zarray': {
+        zarr_format: 2,
+        shape: [256, 256],
+        chunks: [256, 256],
+        dtype: '<f4',
+        fill_value: 0,
+      },
+      'b04/.zattrs': {_ARRAY_DIMENSIONS: ['y', 'x']},
+    },
+  };
+}
+
+/**
  * Stub fetch for a minimal v3 Zarr store with the given consolidated metadata
  * and custom group attributes (layout, bbox, etc.).
  * @param {Object|null} consolidatedMetadata Consolidated metadata, or null for none.
@@ -695,6 +737,67 @@ describe('ol/source/GeoZarr', function () {
           }
         });
       }));
+  });
+
+  describe('Zarr v2 store', function () {
+    let fetchStub;
+    let urls;
+
+    /**
+     * Stub fetch, serving .zmetadata and answering `missingStatus` elsewhere.
+     * @param {number} missingStatus Status for any other key.
+     */
+    function stubV2Store(missingStatus) {
+      urls = [];
+      fetchStub = vi
+        .spyOn(window, 'fetch')
+        .mockImplementation(function (input) {
+          const url = input instanceof Request ? input.url : input;
+          urls.push(url);
+          return Promise.resolve(
+            url.endsWith('/.zmetadata')
+              ? new Response(JSON.stringify(v2Zmetadata()))
+              : new Response(null, {status: missingStatus}),
+          );
+        });
+    }
+
+    afterEach(function () {
+      fetchStub.mockRestore();
+      fetchStub = null;
+    });
+
+    it('determines the version from zarr.json alone and opens as v2', async () => {
+      stubV2Store(404);
+      const source = await settled(
+        new GeoZarr({url: ZARR_URL, bands: ['b04']}),
+      );
+      // The missing zarr.json is the only version probe; the group is then
+      // opened as v2 off the consolidated .zmetadata.
+      assert.deepEqual(urls, [
+        `${ZARR_URL}/zarr.json`,
+        `${ZARR_URL}/.zmetadata`,
+      ]);
+      assert.deepEqual(source.tileGrid.getResolutions(), [1]);
+    });
+
+    it('reads a 403 on a missing key as absent, as S3 reports it', async () => {
+      stubV2Store(403);
+      const source = await settled(
+        new GeoZarr({url: ZARR_URL, bands: ['b04']}),
+      );
+      assert.strictEqual(source.getState(), 'ready');
+    });
+
+    it('reports a forbidden store as missing or denied', async () => {
+      fetchStub = vi.spyOn(window, 'fetch').mockImplementation(function () {
+        return Promise.resolve(new Response(null, {status: 403}));
+      });
+      const source = await settled(
+        new GeoZarr({url: ZARR_URL, bands: ['b04']}),
+      );
+      assert.match(source.error_.message, /missing, or access to it is denied/);
+    });
   });
 
   describe('multi-group bands', function () {

--- a/test/browser/spec/ol/source/GeoZarr.test.js
+++ b/test/browser/spec/ol/source/GeoZarr.test.js
@@ -711,7 +711,7 @@ describe('ol/source/GeoZarr', function () {
         source.on('change', function () {
           if (source.getState() === 'ready') {
             assert.deepEqual(source.tileGrid.getResolutions(), [1]);
-            assert.strictEqual(source.bandSingleScaleResolution_[0], 1);
+            assert.deepEqual(source.bandsByLevel_, {'0': ['b04']});
             resolve();
           }
         });
@@ -731,8 +731,6 @@ describe('ol/source/GeoZarr', function () {
         source.on('change', function () {
           if (source.getState() === 'ready') {
             assert.deepEqual(source.tileGrid.getResolutions(), [1]);
-            assert.strictEqual(source.bandsByLevel_, null);
-            assert.strictEqual(source.bandSingleScaleResolution_[0], 1);
             resolve();
           }
         });
@@ -896,6 +894,50 @@ describe('ol/source/GeoZarr', function () {
             assert.strictEqual(source.bandSingleScaleResolution_[0], undefined);
             assert.notEqual(source.bandSingleScaleResolution_[1], undefined);
             assert.include(source.bandsByLevel_['level0'], 'aot');
+            resolve();
+          }
+        });
+      }));
+  });
+
+  describe('variable (datacube)', function () {
+    let fetchStub;
+
+    afterEach(function () {
+      if (fetchStub) {
+        fetchStub.mockRestore();
+        fetchStub = null;
+      }
+    });
+
+    it('renders one band per selector entry from a single array', () =>
+      new Promise((resolve) => {
+        fetchStub = stubFetchWithAttrs(
+          {
+            ['0/climate']: createArrayMeta({
+              shape: [2, 3, 256, 256],
+              dimensionNames: ['month', 'band', 'y', 'x'],
+            }),
+          },
+          {
+            zarr_conventions: undefined,
+            multiscales: [
+              {datasets: [{path: '0', 'spatial:shape': [256, 256]}]},
+            ],
+          },
+        );
+        const source = new GeoZarr({
+          url: ZARR_URL,
+          variable: 'climate',
+          selector: {band: [0, 2], month: 1},
+        });
+        source.on('change', function () {
+          if (source.getState() === 'ready') {
+            assert.deepEqual(source.tileGrid.getResolutions(), [1]);
+            assert.deepEqual(source.bandExtraSelection_, [
+              [1, 0, null, null],
+              [1, 2, null, null],
+            ]);
             resolve();
           }
         });


### PR DESCRIPTION
Add support for visualizing generic n-D GeoZarr datacubes and some Zarr v2 stores:

- New `variable` + `selector` options: render bands packed into a single n-dimensional array (e.g. `(time, band, y, x)`), with selection by index or coordinate label, one dimension expandable to multiple bands
- Zarr v2 support: `.zmetadata` consolidated metadata and `.zarray`/`.zattrs` fallbacks
- More multiscale dialects: GeoZarr-style `multiscales` array (`datasets`) and ndpyramid-style level groups
- Grid inference for stores without proj:/spatial: conventions: extent and y-orientation from coordinate arrays; CRS from `crs`/`spatial_ref`/`proj4` attributes or a degrees heuristic; new `extent`/`flipY` options as last-resort fallbacks
- Handle non-square pixels (per-level row resolution) and south-up data (row flipping)
- Chunk-request LRU cache and chunk-aligned tile sizes, so tiles never re-fetch/re-decode the same chunk (incl. inner chunks larger than a tile and single-chunk arrays)
- `getDimensions()`/`updateDimensions()` now also work for datacubes; dimension updates are validated before being committed
- Fixed "phantom" alpha channel when the store declares no fill value
- Documented the actual `resample` default (`'linear'`)
- Probably debatable: Tolerate servers answering 403 for missing keys (metadata probing, v2 open fallback)

Code inspired by https://github.com/carbonplan/zarr-layer
Tested with the examples from https://zarr-layer.demo.carbonplan.org

Converted from deck.gl to ol with with AI assistance, but fully tested (see also examples) and reviewed by me.