### PR TITLE
Fix deploy preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'}}
     steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          sparse-checkout: .nvmrc
       - uses: actions/setup-node@v7
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
Since the introduction of the `.nvmrc` file, the deploy preview is broken. This is because that job does not check out the repository, so there is no `.nvmrc` file. With the change in this pull request, a minimal repo checkout is done before anything that relies on `.nvmrc` is run.