### PR TITLE
Stacking context without zIndex

### DIFF
--- a/src/ol/Map.js
+++ b/src/ol/Map.js
@@ -396,19 +396,19 @@ class Map extends BaseObject {
 
       this.overlayContainer_ = document.createElement('div');
       this.overlayContainer_.style.position = 'absolute';
-      this.overlayContainer_.style.zIndex = '0';
       this.overlayContainer_.style.width = '100%';
       this.overlayContainer_.style.height = '100%';
       this.overlayContainer_.style.pointerEvents = 'none';
+      this.overlayContainer_.style.isolation = 'isolate';
       this.overlayContainer_.className = 'ol-overlaycontainer';
       this.viewport_.appendChild(this.overlayContainer_);
 
       this.overlayContainerStopEvent_ = document.createElement('div');
       this.overlayContainerStopEvent_.style.position = 'absolute';
-      this.overlayContainerStopEvent_.style.zIndex = '0';
       this.overlayContainerStopEvent_.style.width = '100%';
       this.overlayContainerStopEvent_.style.height = '100%';
       this.overlayContainerStopEvent_.style.pointerEvents = 'none';
+      this.overlayContainerStopEvent_.style.isolation = 'isolate';
       this.overlayContainerStopEvent_.className =
         'ol-overlaycontainer-stopevent';
       this.viewport_.appendChild(this.overlayContainerStopEvent_);

--- a/src/ol/renderer/Composite.js
+++ b/src/ol/renderer/Composite.js
@@ -48,7 +48,7 @@ class CompositeMapRenderer extends MapRenderer {
     style.position = 'absolute';
     style.width = '100%';
     style.height = '100%';
-    style.zIndex = '0';
+    style.isolation = 'isolate';
 
     this.element_.className = CLASS_UNSELECTABLE + ' ol-layers';
 


### PR DESCRIPTION
A stacking context without determined `zIndex` allows users to set a custom `zIndex` in css without requiring `!important`.

- [ ] See if there are other benefits of this change
- [ ] Based on that, decide whether the change is worthwhile at all