### PR TITLE
Replace broken example source with working one

### DIFF
--- a/examples/cog-stretch.js
+++ b/examples/cog-stretch.js
@@ -40,7 +40,7 @@ const layer = new TileLayer({
     normalize: false,
     sources: [
       {
-        url: 'https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif',
+        url: 'https://cloudlessdownloads.eox.at/api/public/dl/jvu06wnt/exploitation-ready-epsg-4326/exploitation-ready_eoxcloudless-sentinel-2-2025_zoom-4_4bands_16bit.tif',
       },
     ],
   }),

--- a/examples/cog-style.js
+++ b/examples/cog-style.js
@@ -109,7 +109,7 @@ const layer = new TileLayer({
     normalize: false,
     sources: [
       {
-        url: 'https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif',
+        url: 'https://cloudlessdownloads.eox.at/api/public/dl/jvu06wnt/exploitation-ready-epsg-4326/exploitation-ready_eoxcloudless-sentinel-2-2024_zoom-1_4bands_16bit.tif',
       },
     ],
   }),


### PR DESCRIPTION
The https://s2downloads.eox.at/demo/EOxCloudless/2020/rgbnir/s2cloudless2020-16bits_sinlge-file_z0-4.tif COG is on a server that has been down for a while, so I went ahead and replaced that COG with the one around the Nile we have for other examples already.

I did not change the cog-pyramid and cog-math-multisource examples, so these are still broken. But the whole point of these examples is to show features that cannot be shown with the Nile COG.

I also contacted EOX and asked about that server and whether it would be coming back online again, but did not get a reply so far.