### PR TITLE
Avoid invalid rings when quantizing polygon simplification

### DIFF
--- a/src/ol/geom/flat/simplify.js
+++ b/src/ol/geom/flat/simplify.js
@@ -420,6 +420,7 @@ export function quantizeArray(
 ) {
   for (let i = 0, ii = ends.length; i < ii; ++i) {
     const end = ends[i];
+    const ringOffset = simplifiedOffset;
     simplifiedOffset = quantize(
       flatCoordinates,
       offset,
@@ -429,6 +430,16 @@ export function quantizeArray(
       simplifiedFlatCoordinates,
       simplifiedOffset,
     );
+    // a linear ring needs at least 3 positions to be valid; if quantization
+    // collapsed the ring below that, keep the ring's original coordinates
+    // instead of an invalid ring (quantize() writes 2 ordinates per position)
+    if (simplifiedOffset - ringOffset < 6) {
+      simplifiedOffset = ringOffset;
+      for (let j = offset; j < end; j += stride) {
+        simplifiedFlatCoordinates[simplifiedOffset++] = flatCoordinates[j];
+        simplifiedFlatCoordinates[simplifiedOffset++] = flatCoordinates[j + 1];
+      }
+    }
     simplifiedEnds.push(simplifiedOffset);
     offset = end;
   }

--- a/test/node/ol/geom/flat/simplify.test.js
+++ b/test/node/ol/geom/flat/simplify.test.js
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import {
   douglasPeucker,
   quantize,
+  quantizeArray,
   radialDistance,
   simplifyLineString,
 } from '../../../../../src/ol/geom/flat/simplify.js';
@@ -490,6 +491,75 @@ describe('ol/geom/flat/simplify.js', function () {
         8,
       );
       assert.deepEqual(simplifiedFlatCoordinates, [0, 0, 2, 0, 0, 0, 4, 0]);
+    });
+  });
+
+  describe('quantizeArray', function () {
+    it('keeps a ring that simplifies to a valid linear ring', function () {
+      const simplifiedFlatCoordinates = [];
+      const simplifiedEnds = [];
+      const offset = quantizeArray(
+        [0, 0, 0, 10, 10, 10, 10, 0, 0, 0],
+        0,
+        [10],
+        2,
+        1,
+        simplifiedFlatCoordinates,
+        0,
+        simplifiedEnds,
+      );
+      assert.strictEqual(offset, 10);
+      assert.deepEqual(
+        simplifiedFlatCoordinates,
+        [0, 0, 0, 10, 10, 10, 10, 0, 0, 0],
+      );
+      assert.deepEqual(simplifiedEnds, [10]);
+    });
+
+    it('keeps the original ring when quantization would collapse it', function () {
+      const flatCoordinates = [0, 0, 0, 1, 1, 1, 1, 0, 0, 0];
+      const simplifiedFlatCoordinates = [];
+      const simplifiedEnds = [];
+      const offset = quantizeArray(
+        flatCoordinates,
+        0,
+        [10],
+        2,
+        10,
+        simplifiedFlatCoordinates,
+        0,
+        simplifiedEnds,
+      );
+      assert.strictEqual(offset, 10);
+      assert.deepEqual(simplifiedFlatCoordinates, flatCoordinates);
+      assert.deepEqual(simplifiedEnds, [10]);
+    });
+
+    it('keeps the original ring for only the ring that collapses', function () {
+      const flatCoordinates = [
+        // exterior ring, survives simplification
+        0, 0, 0, 10, 10, 10, 10, 0, 0, 0,
+        // hole, collapses below a valid linear ring
+        1, 1, 1, 2, 2, 2, 2, 1, 1, 1,
+      ];
+      const simplifiedFlatCoordinates = [];
+      const simplifiedEnds = [];
+      const offset = quantizeArray(
+        flatCoordinates,
+        0,
+        [10, 20],
+        2,
+        10,
+        simplifiedFlatCoordinates,
+        0,
+        simplifiedEnds,
+      );
+      assert.strictEqual(offset, 20);
+      assert.deepEqual(
+        simplifiedFlatCoordinates,
+        [0, 0, 0, 10, 10, 10, 10, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1],
+      );
+      assert.deepEqual(simplifiedEnds, [10, 20]);
     });
   });
 });


### PR DESCRIPTION
quantizeArray() could collapse a small polygon ring down to two identical points, which is not a valid linear ring. Keep the ring's original coordinates instead when quantization would drop it below 3 distinct points.

fixes #17565

<!--
Thank you for your interest in making OpenLayers better!

Before submitting a pull request, it is best to open an issue describing the bug you are fixing or the feature you are proposing to add.

Here are some other tips that make pull requests easier to review:

 * Commits in the branch are small and logically separated (with no unnecessary merge commits).
 * Commit messages are clear.
 * Existing tests pass, new functionality is covered by new tests, and fixes have regression tests.

Thanks
-->
