### PR TITLE
Load the text overlay worker on demand

### DIFF
--- a/config/rollup-full-build.js
+++ b/config/rollup-full-build.js
@@ -11,6 +11,7 @@ export default {
     exports: 'default',
     file: 'build/full/ol.js',
     sourcemap: true,
+    inlineDynamicImports: true,
   },
   plugins: [
     resolve({moduleDirectories: ['build', 'node_modules']}),

--- a/src/ol/render/webgl/VectorStyleRenderer.js
+++ b/src/ol/render/webgl/VectorStyleRenderer.js
@@ -11,7 +11,6 @@ import {ARRAY_BUFFER, DYNAMIC_DRAW, ELEMENT_ARRAY_BUFFER} from '../../webgl.js';
 import WebGLArrayBuffer from '../../webgl/Buffer.js';
 import {AttributeType} from '../../webgl/Helper.js';
 import LabelsArray from '../../webgl/LabelsArray.js';
-import {create as createTextOverlayWorker} from '../../worker/textOverlay.js';
 import {create as createWebGLWorker} from '../../worker/webgl.js';
 import {
   TextOverlayWorkerMessageType,
@@ -409,10 +408,12 @@ class VectorStyleRenderer extends Disposable {
       this.textOverlayRenderFrameState_ = null;
 
       /**
-       * @type {Worker}
+       * @type {Promise<Worker>}
        * @private
        */
-      this.textOverlayWorker_ = createTextOverlayWorker();
+      this.textOverlayWorker_ = import('../../worker/textOverlay.js').then(
+        ({create}) => create(),
+      );
 
       /** @type {Set<string>} */
       this.textOverlayRenderList_ = new Set();
@@ -675,8 +676,9 @@ class VectorStyleRenderer extends Disposable {
       resolution,
     };
 
-    return messageWorker(this.textOverlayWorker_, message, transferables).then(
-      (data) => {
+    return this.textOverlayWorker_
+      .then((worker) => messageWorker(worker, message, transferables))
+      .then((data) => {
         const received =
           /** @type {import('./constants.js').TextOverlayWorkerMessage} */ (
             data
@@ -684,8 +686,7 @@ class VectorStyleRenderer extends Disposable {
 
         // we're getting a key from the worker: these will be used later on to ask for render or disposal
         return received.instructionsSetKey ?? null;
-      },
-    );
+      });
   }
 
   /**
@@ -821,37 +822,41 @@ class VectorStyleRenderer extends Disposable {
       batchesToRender: this.textOverlayRenderList_,
     };
 
-    return messageWorker(this.textOverlayWorker_, message).then((data) => {
-      const received =
-        /** @type {import('./constants.js').TextOverlayWorkerMessage} */ (data);
-
-      // if no render data returned, do not process it
-      if (received.imageData) {
-        this.textOverlayRenderFrameState_ =
-          received.frameState !== undefined ? received.frameState : null;
-
-        // the rendered image data is copied to the canvas and then given back to the worker
-        const imageData = received.imageData;
-        if (
-          imageData.width !== textOverlayCanvas.width ||
-          imageData.height !== textOverlayCanvas.height
-        ) {
-          textOverlayCanvas.width = imageData.width;
-          textOverlayCanvas.height = imageData.height;
-        } else {
-          textOverlayContext.clearRect(
-            0,
-            0,
-            textOverlayCanvas.width,
-            textOverlayCanvas.height,
+    return this.textOverlayWorker_
+      .then((worker) => messageWorker(worker, message))
+      .then((data) => {
+        const received =
+          /** @type {import('./constants.js').TextOverlayWorkerMessage} */ (
+            data
           );
-        }
-        textOverlayContext.drawImage(imageData, 0, 0);
-        imageData.close();
-      }
 
-      this.textOverlayRenderList_.clear();
-    });
+        // if no render data returned, do not process it
+        if (received.imageData) {
+          this.textOverlayRenderFrameState_ =
+            received.frameState !== undefined ? received.frameState : null;
+
+          // the rendered image data is copied to the canvas and then given back to the worker
+          const imageData = received.imageData;
+          if (
+            imageData.width !== textOverlayCanvas.width ||
+            imageData.height !== textOverlayCanvas.height
+          ) {
+            textOverlayCanvas.width = imageData.width;
+            textOverlayCanvas.height = imageData.height;
+          } else {
+            textOverlayContext.clearRect(
+              0,
+              0,
+              textOverlayCanvas.width,
+              textOverlayCanvas.height,
+            );
+          }
+          textOverlayContext.drawImage(imageData, 0, 0);
+          imageData.close();
+        }
+
+        this.textOverlayRenderList_.clear();
+      });
   }
 
   /**
@@ -915,10 +920,12 @@ class VectorStyleRenderer extends Disposable {
    * @param {string} key Key corresponding to the instructions set to dispose
    */
   disposeTextInstructions(key) {
-    this.textOverlayWorker_?.postMessage({
-      type: TextOverlayWorkerMessageType.DISPOSE_INSTRUCTIONS,
-      instructionsSetKey: key,
-    });
+    this.textOverlayWorker_?.then((worker) =>
+      worker.postMessage({
+        type: TextOverlayWorkerMessageType.DISPOSE_INSTRUCTIONS,
+        instructionsSetKey: key,
+      }),
+    );
   }
 
   /**
@@ -926,7 +933,7 @@ class VectorStyleRenderer extends Disposable {
    * @override
    */
   disposeInternal() {
-    this.textOverlayWorker_?.terminate();
+    this.textOverlayWorker_?.then((worker) => worker.terminate());
     super.disposeInternal();
   }
 }

--- a/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
+++ b/test/browser/spec/ol/render/webgl/VectorStyleRenderer.test.js
@@ -758,12 +758,14 @@ describe('VectorStyleRenderer', () => {
       },
     ];
 
-    beforeEach(() => {
+    let textOverlayWorker;
+    beforeEach(async () => {
       vectorStyleRenderer = new VectorStyleRenderer(
         SAMPLE_STYLE_TEXT_AND_CIRCLE,
         {},
         helper,
       );
+      textOverlayWorker = await vectorStyleRenderer.textOverlayWorker_;
     });
 
     it('creates a VectorStyleRenderer with text rendering', () => {
@@ -774,7 +776,7 @@ describe('VectorStyleRenderer', () => {
     describe('generateBuffers', () => {
       let buffers;
       beforeEach(async () => {
-        vi.spyOn(vectorStyleRenderer.textOverlayWorker_, 'postMessage');
+        vi.spyOn(textOverlayWorker, 'postMessage');
         buffers = await vectorStyleRenderer.generateBuffers(
           geometryBatch,
           SAMPLE_TRANSFORM,
@@ -782,8 +784,7 @@ describe('VectorStyleRenderer', () => {
         );
       });
       it('sends a message to worker with render instructions and style', () => {
-        const message =
-          vectorStyleRenderer.textOverlayWorker_.postMessage.mock.calls[0][0];
+        const message = textOverlayWorker.postMessage.mock.calls[0][0];
         assert.strictEqual(message.type, 'BUILD_INSTRUCTIONS');
         assert.instanceOf(message.polygonRenderInstructions, ArrayBuffer);
         assert.instanceOf(message.lineStringRenderInstructions, ArrayBuffer);
@@ -833,7 +834,7 @@ describe('VectorStyleRenderer', () => {
           SAMPLE_TRANSFORM,
         );
         vi.spyOn(helper, 'useProgram');
-        vi.spyOn(vectorStyleRenderer.textOverlayWorker_, 'postMessage');
+        vi.spyOn(textOverlayWorker, 'postMessage');
         preRenderCb = vi.fn();
         vectorStyleRenderer.render(buffers, SAMPLE_FRAMESTATE, preRenderCb);
       });
@@ -872,13 +873,13 @@ describe('VectorStyleRenderer', () => {
         vectorStyleRenderer.textOverlayCanvas_.height =
           SAMPLE_FRAMESTATE.size[1];
 
-        vi.spyOn(vectorStyleRenderer.textOverlayWorker_, 'postMessage');
+        vi.spyOn(textOverlayWorker, 'postMessage');
         vi.spyOn(vectorStyleRenderer.textOverlayContext_, 'clearRect');
         vi.spyOn(vectorStyleRenderer.textOverlayContext_, 'drawImage');
 
         // this does a copy of the `batchesToRender` Set, otherwise we can't properly test its value afterwards (because it's mutated)
-        vectorStyleRenderer.textOverlayWorker_.postMessage = new Proxy(
-          vectorStyleRenderer.textOverlayWorker_.postMessage,
+        textOverlayWorker.postMessage = new Proxy(
+          textOverlayWorker.postMessage,
           {
             apply(target, thisArg, [message, ...args]) {
               return target.call(
@@ -896,12 +897,8 @@ describe('VectorStyleRenderer', () => {
         await vectorStyleRenderer.finalizeTextRender(SAMPLE_FRAMESTATE);
       });
       it('asks for a render of the text overlay worker', async () => {
-        assert.strictEqual(
-          vectorStyleRenderer.textOverlayWorker_.postMessage.mock.calls.length,
-          1,
-        );
-        const firstMessage =
-          vectorStyleRenderer.textOverlayWorker_.postMessage.mock.calls[0][0];
+        assert.strictEqual(textOverlayWorker.postMessage.mock.calls.length, 1);
+        const firstMessage = textOverlayWorker.postMessage.mock.calls[0][0];
         assert.strictEqual(firstMessage.type, 'RENDER');
         assert.deepEqual(
           firstMessage.frameState,
@@ -958,13 +955,11 @@ describe('VectorStyleRenderer', () => {
     });
 
     describe('dispose', () => {
-      it('terminates its worker', () => {
-        vi.spyOn(vectorStyleRenderer.textOverlayWorker_, 'terminate');
+      it('terminates its worker', async () => {
+        vi.spyOn(textOverlayWorker, 'terminate');
         vectorStyleRenderer.dispose();
-        assert.strictEqual(
-          vectorStyleRenderer.textOverlayWorker_.terminate.mock.calls.length,
-          1,
-        );
+        await vectorStyleRenderer.textOverlayWorker_;
+        assert.strictEqual(textOverlayWorker.terminate.mock.calls.length, 1);
       });
     });
   });


### PR DESCRIPTION
The addition of WebGL text rendering (#16693) increased the build size of any OpenLayers application that used WebGL vector or vectortile layers by 37 kB (gzipped), because of the `textOverlay` worker — even when no text rendering was needed (e.g. for Heatmap layers).

This pull request makes the `textOverlay` worker a dynamic import.

The full build is unaffected by this change, thanks to the added `inlineDynamicImports: true` in the rollup config.