### PR TITLE
Interpolate colors in sRGB, and add interpolate-hcl

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,36 @@
 
 ### Next release
 
+#### Fixed: `interpolate` mixed colors differently on the Canvas and WebGL renderers
+
+The `['interpolate', ...]` operator interpolated colors in the Hue-Chroma-Luminance space on
+the Canvas renderer, but component-wise in sRGB on the WebGL renderer. The same style
+produced different gradients depending on which renderer drew it, and neither behaviour was
+documented. Both now interpolate in sRGB.
+
+Gradients built with `interpolate` over colors will look slightly different on the Canvas
+renderer. To keep the previous appearance, use the new `interpolate-hcl` operator:
+
+```js
+// Before
+const style = {
+  'fill-color': ['interpolate', ['linear'], ['get', 'value'], 0, 'red', 1, 'green'],
+};
+```
+
+```js
+// After - to keep the perceptual gradient
+const style = {
+  'fill-color': ['interpolate-hcl', ['linear'], ['get', 'value'], 0, 'red', 1, 'green'],
+};
+```
+
+`interpolate-hcl` is only supported by the Canvas renderer for now.
+
+With the `['interpolate', ...]` operator, channels now keep their fractional part, so operations
+applied on top of an interpolated color are more accurate. Code reading back a color from an
+evaluated style may now see a fractional channel.
+
 #### The WMTS tile grid extent is no longer calculated from the tile matrices
 
 `optionsFromCapabilities` now only uses an advertised `BoundingBox` as the tile grid's

--- a/src/ol/expr/cpu.js
+++ b/src/ol/expr/cpu.js
@@ -174,7 +174,8 @@ function compileExpression(expression, context) {
     case Ops.Match: {
       return compileMatchExpression(expression, context);
     }
-    case Ops.Interpolate: {
+    case Ops.Interpolate:
+    case Ops.InterpolateHcl: {
       return compileInterpolateExpression(expression, context);
     }
     case Ops.ToString: {
@@ -526,6 +527,12 @@ function compileInterpolateExpression(expression, context) {
   for (let i = 0; i < length; ++i) {
     args[i] = compileExpression(expression.args[i], context);
   }
+  const interpolateColorFn =
+    expression.operator === Ops.InterpolateHcl
+      ? // perceptual interpolation
+        interpolateHclColor
+      : // sRGB interpolation, equivalent to GLSL `mix()` in `gpu.js`
+        interpolateRgbColor;
   return (context) => {
     const base = args[0](context);
     const value = args[1](context);
@@ -544,7 +551,7 @@ function compileInterpolateExpression(expression, context) {
           return output;
         }
         if (isColor) {
-          return interpolateColor(
+          return interpolateColorFn(
             base,
             value,
             previousInput,
@@ -621,6 +628,7 @@ function interpolateNumber(base, value, input1, output1, input2, output2) {
 }
 
 /**
+ * Interpolate two colors component-wise in sRGB
  * @param {number} base The base.
  * @param {number} value The value.
  * @param {number} input1 The first input value.
@@ -629,7 +637,33 @@ function interpolateNumber(base, value, input1, output1, input2, output2) {
  * @param {import('../color.js').Color} rgba2 The second output value.
  * @return {import('../color.js').Color} The interpolated color.
  */
-function interpolateColor(base, value, input1, rgba1, input2, rgba2) {
+function interpolateRgbColor(base, value, input1, rgba1, input2, rgba2) {
+  const delta = input2 - input1;
+  if (delta === 0) {
+    return rgba1;
+  }
+  // channels are left unrounded, so that a pipeline applying gamma or contrast on top
+  // does not compound a quantization error at every stop
+  return [
+    interpolateNumber(base, value, input1, rgba1[0], input2, rgba2[0]),
+    interpolateNumber(base, value, input1, rgba1[1], input2, rgba2[1]),
+    interpolateNumber(base, value, input1, rgba1[2], input2, rgba2[2]),
+    interpolateNumber(base, value, input1, rgba1[3], input2, rgba2[3]),
+  ];
+}
+
+/**
+ * Interpolate two colors in the Hue-Chroma-Luminance space, for the
+ * `interpolate-hcl` operator.
+ * @param {number} base The base.
+ * @param {number} value The value.
+ * @param {number} input1 The first input value.
+ * @param {import('../color.js').Color} rgba1 The first output value.
+ * @param {number} input2 The second input value.
+ * @param {import('../color.js').Color} rgba2 The second output value.
+ * @return {import('../color.js').Color} The interpolated color.
+ */
+function interpolateHclColor(base, value, input1, rgba1, input2, rgba2) {
   const delta = input2 - input1;
   if (delta === 0) {
     return rgba1;

--- a/src/ol/expr/expression.js
+++ b/src/ol/expr/expression.js
@@ -72,8 +72,12 @@ import {toSize} from '../size.js';
  *     the rate of increase from stop A to stop B (i.e. power to which the interpolation ratio is raised); a value
  *     of 1 is equivalent to `['linear']`.
  *     `input` and `stopX` values must all be of type `number`. `outputX` values can be `number` or `color` values.
+ *     Colors are interpolated component-wise in sRGB.
  *     Note: `input` will be clamped between `stop1` and `stopN`, meaning that all output values will be comprised
  *     between `output1` and `outputN`.
+ *   * `['interpolate-hcl', interpolation, input, stop1, output1, ...stopN, outputN]` works like `interpolate`, but
+ *     the `outputX` values must be colors, and they are interpolated in the Hue-Chroma-Luminance color space.
+ *     This keeps gradients bright where sRGB interpolation would take them through a muddy midpoint (Canvas only).
  *   * `['string', value1, value2, ...]` returns the first value in the list that evaluates to a string.
  *     An example would be to provide a default value for get: `['string', ['get', 'propertyname'], 'default value']]`
  *     (Canvas only).
@@ -430,6 +434,7 @@ export const Ops = {
   Match: 'match',
   Between: 'between',
   Interpolate: 'interpolate',
+  InterpolateHcl: 'interpolate-hcl',
   Coalesce: 'coalesce',
   Case: 'case',
   In: 'in',
@@ -579,6 +584,12 @@ const parsers = {
   [Ops.Interpolate]: createCallExpressionParser(
     hasArgsCount(6, Infinity),
     hasEvenArgs,
+    withInterpolateArgs,
+  ),
+  [Ops.InterpolateHcl]: createCallExpressionParser(
+    hasArgsCount(6, Infinity),
+    hasEvenArgs,
+    returnsColor,
     withInterpolateArgs,
   ),
   [Ops.Case]: createCallExpressionParser(
@@ -935,6 +946,18 @@ function withMatchArgs(encoded, returnType, context) {
   const input = parse(encoded[1], inputType, context);
 
   return [input, ...args, fallback];
+}
+
+/**
+ * Assert that the call is being used where a color is expected.
+ * @type {ArgValidator}
+ */
+function returnsColor(encoded, returnType, context) {
+  if (!includesType(returnType, ColorType)) {
+    throw new Error(
+      `the ${encoded[0]} operator can only return a color, got ${typeName(returnType)}`,
+    );
+  }
 }
 
 /**

--- a/test/browser/spec/ol/expr/cpu.test.js
+++ b/test/browser/spec/ol/expr/cpu.test.js
@@ -28,6 +28,20 @@ describe('ol/expr/cpu.js', () => {
         name: 'interpolate (linear color)',
         type: ColorType,
         expression: ['interpolate', ['linear'], 0.5, 0, 'red', 1, [0, 255, 0]],
+        expected: [127.5, 127.5, 0, 1],
+      },
+      {
+        name: 'interpolate-hcl (linear color)',
+        type: ColorType,
+        expression: [
+          'interpolate-hcl',
+          ['linear'],
+          0.5,
+          0,
+          'red',
+          1,
+          [0, 255, 0],
+        ],
         expected: [209, 169, 0, 1],
       },
     ];


### PR DESCRIPTION
This pull request removes a discrepancy between `interpolate` expressions in Canvas and WebGL, when used with colors. Now both use the same sRGB interpolation. For the Canvas renderer, a new `interpolate-hcl` expression is added, which matches the previous `interpolate` behavior.