### PR TITLE
Respect the stride parameter in deflateCoordinate

### DIFF
--- a/src/ol/geom/flat/deflate.js
+++ b/src/ol/geom/flat/deflate.js
@@ -10,7 +10,7 @@
  * @return {number} offset Offset.
  */
 export function deflateCoordinate(flatCoordinates, offset, coordinate, stride) {
-  for (let i = 0, ii = coordinate.length; i < ii; ++i) {
+  for (let i = 0; i < stride; ++i) {
     flatCoordinates[offset++] = coordinate[i];
   }
   return offset;

--- a/test/node/ol/geom/Point.test.js
+++ b/test/node/ol/geom/Point.test.js
@@ -126,6 +126,24 @@ describe('ol/geom/Point.js', function () {
     });
   });
 
+  describe('#setCoordinates()', function () {
+    it('drops the extra dimensions when the layout is reduced', function () {
+      const geom = new Point([1, 2, 3], 'XYZ');
+      geom.setCoordinates(geom.getCoordinates(), 'XY');
+      assert.strictEqual(geom.getLayout(), 'XY');
+      assert.strictEqual(geom.getStride(), 2);
+      assert.deepEqual(geom.getFlatCoordinates(), [1, 2]);
+      assert.deepEqual(geom.getCoordinates(), [1, 2]);
+    });
+
+    it('keeps the extra dimensions when the layout is not reduced', function () {
+      const geom = new Point([1, 2]);
+      geom.setCoordinates([3, 4, 5, 6], 'XYZM');
+      assert.strictEqual(geom.getLayout(), 'XYZM');
+      assert.deepEqual(geom.getCoordinates(), [3, 4, 5, 6]);
+    });
+  });
+
   describe('#scale()', function () {
     it('scales a point', function () {
       const geom = new Point([1, 2]);

--- a/test/node/ol/geom/flat/deflate.test.js
+++ b/test/node/ol/geom/flat/deflate.test.js
@@ -1,10 +1,30 @@
 import {assert} from 'chai';
 import {
+  deflateCoordinate,
   deflateCoordinates,
   deflateCoordinatesArray,
 } from '../../../../../src/ol/geom/flat/deflate.js';
 
 describe('ol/geom/flat/deflate.js', function () {
+  describe('deflateCoordinate', function () {
+    let flatCoordinates;
+    beforeEach(function () {
+      flatCoordinates = [];
+    });
+
+    it('flattens a coordinate', function () {
+      const offset = deflateCoordinate(flatCoordinates, 0, [1, 2], 2);
+      assert.strictEqual(offset, 2);
+      assert.deepEqual(flatCoordinates, [1, 2]);
+    });
+
+    it('ignores ordinates beyond the stride', function () {
+      const offset = deflateCoordinate(flatCoordinates, 0, [1, 2, 3], 2);
+      assert.strictEqual(offset, 2);
+      assert.deepEqual(flatCoordinates, [1, 2]);
+    });
+  });
+
   describe('deflateCoordinates', function () {
     let flatCoordinates;
     beforeEach(function () {


### PR DESCRIPTION
Fixes #15754.

`deflateCoordinate` takes a `stride` but loops over `coordinate.length`, so a coordinate with more ordinates than the layout allows writes the extras into the flat coordinates. Its callers are `Point#setCoordinates` and `Circle#setCenterAndRadius`, which are then left with a `stride` and `layout` that no longer describe their own data. `Circle` also reports a wrong radius and extent, because `setCenterAndRadius` writes the radius at the offset the deflate returned.

```js
const point = new Point([1, 2, 3], 'XYZ');
point.setCoordinates(point.getCoordinates(), 'XY');
point.getCoordinates(); // [1, 2, 3], expected [1, 2]
```

Tests cover `deflateCoordinate` directly and the `Point#setCoordinates` case.

The two `GeoJSON` tests for empty coordinate arrays fail on this branch, as expected, and #17615 fixes them.
