### PR TITLE
Handle empty geojson coordinate arrays correctly

### DIFF
--- a/changelog/upgrade-notes.md
+++ b/changelog/upgrade-notes.md
@@ -2,6 +2,10 @@
 
 ### Next release
 
+#### Fixed GeoJSON parsing of geometries with empty coordinate arrays
+
+Previously, a GeoJSON geometry with an empty coordinates array (e.g. `{"type": "Point", "coordinates": []}`) produced a geometry with an empty coordinates array. We have now changed this to match the GeoJSON spec's recommendation to treat such geometries (except `GeometryCollection`) as `null` geometries. This change should not affect application code, unless it had special handling for geometries with empty coordinates arrays.
+
 #### The WMTS tile grid extent is no longer calculated from the tile matrices
 
 `optionsFromCapabilities` now only uses an advertised `BoundingBox` as the tile grid's

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -207,15 +207,11 @@ class GeoJSON extends JSONFeature {
    * @param {GeoJSONGeometry} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {import("../geom/Geometry.js").default} Geometry.
+   * @return {import("../geom/Geometry.js").default|null} Geometry.
    * @override
    */
   readGeometryFromObject(object, options) {
-    const geometry = readGeometry(object, options);
-    if (!geometry) {
-      throw new Error('Cannot read geometry from object');
-    }
-    return geometry;
+    return readGeometry(object, options);
   }
 
   /**
@@ -331,7 +327,12 @@ class GeoJSON extends JSONFeature {
  * @return {import("./Feature.js").GeometryObject|null} Geometry.
  */
 function readGeometryInternal(object, options) {
-  if (!object) {
+  if (
+    !object ||
+    (object.type !== 'GeometryCollection' &&
+      Array.isArray(object.coordinates) &&
+      !object.coordinates.length)
+  ) {
     return null;
   }
 

--- a/src/ol/format/GeoJSON.js
+++ b/src/ol/format/GeoJSON.js
@@ -403,19 +403,15 @@ function readGeometry(object, options) {
  * @return {import("./Feature.js").GeometryCollectionObject} Geometry collection.
  */
 function readGeometryCollectionGeometry(object, options) {
-  const geometries = object['geometries'].map(
-    /**
-     * @param {GeoJSONGeometry} geometry Geometry.
-     * @return {import("./Feature.js").GeometryObject} geometry Geometry.
-     */
-    function (geometry) {
-      const geom = readGeometryInternal(geometry, options);
-      if (!geom) {
-        throw new Error('Invalid geometry in GeometryCollection');
-      }
-      return geom;
-    },
-  );
+  const geometryObjects = object['geometries'];
+  const geometries = [];
+  for (const geometry of geometryObjects) {
+    const geom = readGeometryInternal(geometry, options);
+    if (!geom) {
+      continue;
+    }
+    geometries.push(geom);
+  }
   return geometries;
 }
 

--- a/src/ol/format/JSONFeature.js
+++ b/src/ol/format/JSONFeature.js
@@ -96,7 +96,7 @@ class JSONFeature extends FeatureFormat {
    *
    * @param {ArrayBuffer|Document|Element|Object|string} source Source.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
-   * @return {import("../geom/Geometry.js").default} Geometry.
+   * @return {import("../geom/Geometry.js").default|null} Geometry.
    * @api
    * @override
    */
@@ -116,7 +116,7 @@ class JSONFeature extends FeatureFormat {
    * @param {Object} object Object.
    * @param {import("./Feature.js").ReadOptions} [options] Read options.
    * @protected
-   * @return {import("../geom/Geometry.js").default} Geometry.
+   * @return {import("../geom/Geometry.js").default|null} Geometry.
    */
   readGeometryFromObject(object, options) {
     return abstract();

--- a/test/node/ol/format/GeoJSON.test.js
+++ b/test/node/ol/format/GeoJSON.test.js
@@ -612,6 +612,25 @@ describe('ol/format/GeoJSON.js', function () {
       });
     });
 
+    it('omits geometry collection members with empty coordinate arrays', () => {
+      const geojson = {
+        type: 'GeometryCollection',
+        geometries: [
+          {type: 'Point', coordinates: [10, 20]},
+          {type: 'LineString', coordinates: []},
+          {type: 'Point', coordinates: [30, 40]},
+        ],
+      };
+      const geometry = format.readGeometry(geojson);
+      assert.instanceOf(geometry, GeometryCollection);
+      const geometries = geometry.getGeometries();
+      assert.strictEqual(geometries.length, 2);
+      assert.instanceOf(geometries[0], Point);
+      assert.deepEqual(geometries[0].getCoordinates(), [10, 20]);
+      assert.instanceOf(geometries[1], Point);
+      assert.deepEqual(geometries[1].getCoordinates(), [30, 40]);
+    });
+
     it('works with empty coordinate array and reprojection', () => {
       const types = [
         'Point',

--- a/test/node/ol/format/GeoJSON.test.js
+++ b/test/node/ol/format/GeoJSON.test.js
@@ -608,7 +608,7 @@ describe('ol/format/GeoJSON.js', function () {
           coordinates: [],
         };
         const geometry = format.readGeometry(geojson);
-        assert.deepEqual(geometry.getCoordinates(), []);
+        assert.equal(geometry, null);
       });
     });
 
@@ -629,7 +629,7 @@ describe('ol/format/GeoJSON.js', function () {
         const geometry = format.readGeometry(geojson, {
           featureProjection: 'EPSG:3857',
         });
-        assert.deepEqual(geometry.getCoordinates(), []);
+        assert.equal(geometry, null);
       });
     });
   });


### PR DESCRIPTION
#15388 fixed a valid concern, but in the incorrect way. According to the [GeoJSON spec](https://datatracker.ietf.org/doc/html/rfc7946):

> A GeoJSON Geometry object of any type other than "GeometryCollection" has a member with the name "coordinates". The value of the "coordinates" member is an array.  The structure of the elements in this array is determined by the type of geometry. GeoJSON processors MAY interpret Geometry objects with empty "coordinates" arrays as null objects.

What we currently do is produce geometries with empty coordinates arrays, but the GeoJSON spec says

> A position is the fundamental geometry construct.  The "coordinates" member of a Geometry object is composed of either:
>   * one position in the case of a Point geometry,
>   * an array of positions in the case of a LineString or MultiPoint geometry,
>   * an array of LineString or linear ring (see [Section 3.1.6](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6)) coordinates in the case of a Polygon or MultiLineString geometry, or
>   * an array of Polygon coordinates in the case of a MultiPolygon geometry.
>
> A position is an array of numbers.  There MUST be two or more elements.

So it does not make much sense to create geometries with empty coordinates arrays from GeoJSON with empty coordinates arrays.

The fix this pull request proposes as alternative is to return `null` geomertries, according to the spec.