### PR TITLE
Align text to visible part of line only when textAlign is undefined

### DIFF
--- a/src/ol/render/canvas/TextBuilder.js
+++ b/src/ol/render/canvas/TextBuilder.js
@@ -227,6 +227,7 @@ class CanvasTextBuilder extends CanvasBuilder {
         }
       }
       if (
+        textState.textAlign === undefined &&
         (geometryType == 'LineString' || geometryType == 'MultiLineString') &&
         !containsExtent(this.getBufferedMaxExtent(), geometryExtent)
       ) {

--- a/test/browser/spec/ol/render/canvas/textbuilder.test.js
+++ b/test/browser/spec/ol/render/canvas/textbuilder.test.js
@@ -335,6 +335,39 @@ describe('ol.render.canvas.TextBuilder', function () {
     assert.strictEqual(geometryWidths[0], 120);
   });
 
+  describe('line label clipping to the rendered extent', function () {
+    const geometry = new LineString([
+      [-360, 0],
+      [360, 0],
+    ]);
+    const feature = new Feature(geometry);
+
+    it('clips the line to the rendered extent when textAlign is not set', function () {
+      const builder = createBuilder();
+      builder.setTextStyle(
+        new Text({
+          text: 'text',
+          placement: 'line',
+        }),
+      );
+      builder.drawText(geometry, feature);
+      assert.deepEqual(builder.coordinates, [-180, 0, 180, 0]);
+    });
+
+    it('keeps the full line when textAlign is set explicitly', function () {
+      const builder = createBuilder();
+      builder.setTextStyle(
+        new Text({
+          text: 'text',
+          placement: 'line',
+          textAlign: 'center',
+        }),
+      );
+      builder.drawText(geometry, feature);
+      assert.deepEqual(builder.coordinates, [-360, 0, 360, 0]);
+    });
+  });
+
   describe('offsetX for text along a line', function () {
     function drawCharsInstruction(offsetX, pixelRatio) {
       const builder = new TextBuilder(


### PR DESCRIPTION
Fixes #17618 