### PR TITLE
fix: fix RTL text along lines

### DIFF
--- a/src/ol/geom/flat/textpath.js
+++ b/src/ol/geom/flat/textpath.js
@@ -8,6 +8,23 @@ import {rotate} from './transform.js';
  * @type {Intl.Segmenter|undefined}
  */
 let segmenter;
+
+/**
+ * Matches characters of right-to-left scripts.
+ * @type {RegExp}
+ */
+export const rtlRegEx = new RegExp(
+  /* eslint-disable prettier/prettier */
+  '[' +
+    String.fromCharCode(0x00591) + '-' + String.fromCharCode(0x008ff) +
+    String.fromCharCode(0x0fb1d) + '-' + String.fromCharCode(0x0fdff) +
+    String.fromCharCode(0x0fe70) + '-' + String.fromCharCode(0x0fefc) +
+    String.fromCharCode(0x10800) + '-' + String.fromCharCode(0x10fff) +
+    String.fromCharCode(0x1e800) + '-' + String.fromCharCode(0x1efff) +
+  ']'
+  /* eslint-enable prettier/prettier */
+);
+
 /**
  * @return {Intl.Segmenter} A grapheme segmenter.
  */
@@ -126,6 +143,9 @@ export function drawTextOnPath(
   text = text.replace(/\n/g, ' '); // ensure rendering in single-line as all calculations below don't handle multi-lines
 
   const segments = Array.from(getSegmenter().segment(text), (s) => s.segment);
+  // Right-to-left text starts at the visual end of the path, so its chunks are
+  // placed in reverse order unless the path itself is reversed.
+  const reverseChunks = reverse !== rtlRegEx.test(text);
   for (let i = 0, ii = segments.length; i < ii;) {
     advance();
     let angle = Math.atan2(y2 - y1, x2 - x1);
@@ -144,7 +164,7 @@ export function drawTextOnPath(
     const iStart = i;
     let charLength = 0;
     for (; i < ii; ++i) {
-      const index = reverse ? ii - i - 1 : i;
+      const index = reverseChunks ? ii - i - 1 : i;
       const len =
         scale * measureAndCacheTextWidth(font, segments[index], cache);
       if (
@@ -159,7 +179,9 @@ export function drawTextOnPath(
       continue;
     }
     const chars = (
-      reverse ? segments.slice(ii - i, ii - iStart) : segments.slice(iStart, i)
+      reverseChunks
+        ? segments.slice(ii - i, ii - iStart)
+        : segments.slice(iStart, i)
     ).join('');
     interpolate =
       segmentLength === 0

--- a/src/ol/render/canvas/Executor.js
+++ b/src/ol/render/canvas/Executor.js
@@ -8,7 +8,7 @@ import {
   offsetLineString,
   removeOffsetCycles,
 } from '../../geom/flat/lineoffset.js';
-import {drawTextOnPath} from '../../geom/flat/textpath.js';
+import {drawTextOnPath, rtlRegEx} from '../../geom/flat/textpath.js';
 import {transform2D} from '../../geom/flat/transform.js';
 import {
   apply as applyTransform,
@@ -79,18 +79,6 @@ const p4 = [];
 function getDeclutterBox(replayImageOrLabelArgs) {
   return replayImageOrLabelArgs[3].declutterBox;
 }
-
-const rtlRegEx = new RegExp(
-  /* eslint-disable prettier/prettier */
-  '[' +
-    String.fromCharCode(0x00591) + '-' + String.fromCharCode(0x008ff) +
-    String.fromCharCode(0x0fb1d) + '-' + String.fromCharCode(0x0fdff) +
-    String.fromCharCode(0x0fe70) + '-' + String.fromCharCode(0x0fefc) +
-    String.fromCharCode(0x10800) + '-' + String.fromCharCode(0x10fff) +
-    String.fromCharCode(0x1e800) + '-' + String.fromCharCode(0x1efff) +
-  ']'
-  /* eslint-enable prettier/prettier */
-);
 
 /**
  * @param {string} text Text.

--- a/test/node/ol/geom/flat/textpath.test.js
+++ b/test/node/ol/geom/flat/textpath.test.js
@@ -165,6 +165,62 @@ describe('ol/geom/flat/drawTextOnPath.js', function () {
     assert.strictEqual(instructions[1][4], 'oo');
   });
 
+  it('renders right-to-left text in reverse chunk order', function () {
+    const length = lineStringLength(angled, 0, angled.length, 2);
+    const startM = length / 2 - 20;
+    const instructions = drawTextOnPath(
+      angled,
+      0,
+      angled.length,
+      2,
+      'ابجد',
+      startM,
+      Infinity,
+      1,
+      measureAndCacheTextWidth,
+      '',
+      {},
+    );
+    assert.deepEqual(instructions[0][3], (45 * Math.PI) / 180);
+    assert.strictEqual(instructions[0][4], 'جد');
+    assert.deepEqual(instructions[1][3], (-45 * Math.PI) / 180);
+    assert.strictEqual(instructions[1][4], 'اب');
+  });
+
+  it('renders right-to-left text upright on a reversed path', function () {
+    const reversedAngled = angled.slice().reverse();
+    // reverse() swapped x and y, swap them back
+    for (let i = 0; i < reversedAngled.length; i += 2) {
+      const x = reversedAngled[i + 1];
+      reversedAngled[i + 1] = reversedAngled[i];
+      reversedAngled[i] = x;
+    }
+    const length = lineStringLength(
+      reversedAngled,
+      0,
+      reversedAngled.length,
+      2,
+    );
+    const startM = length / 2 - 20;
+    const instructions = drawTextOnPath(
+      reversedAngled,
+      0,
+      reversedAngled.length,
+      2,
+      'ابجد',
+      startM,
+      Infinity,
+      1,
+      measureAndCacheTextWidth,
+      '',
+      {},
+    );
+    assert.deepEqual(instructions[0][3], (-45 * Math.PI) / 180);
+    assert.strictEqual(instructions[0][4], 'اب');
+    assert.deepEqual(instructions[1][3], (45 * Math.PI) / 180);
+    assert.strictEqual(instructions[1][4], 'جد');
+  });
+
   it('keeps a combined emoji as a single grapheme across segments', function () {
     // '👍🏽' is a single grapheme cluster made of several UTF-16 code units; it
     // must be measured and placed as a whole, never split across segments.


### PR DESCRIPTION
Fixes #15062.

Place chunks of right-to-left text in reverse order when split across line segments, so Arabic and Hebrew labels read correctly. Text on bending lines is split into chunks placed along the path in logical order. RTL text needs its first chunk at the visual right, so chunk order is reversed for RTL scripts.

### Before

<img width="960" height="660" alt="image" src="https://github.com/user-attachments/assets/07a24ae3-b20b-4c57-8e7b-dd2c5b66565e" />

### After

<img width="960" height="660" alt="image" src="https://github.com/user-attachments/assets/3a0815a5-5496-4c59-a896-2c6a19299155" />
