### PR TITLE
fix: read nested WFS 2.0 FeatureCollections

### DIFF
--- a/src/ol/format/WFS.js
+++ b/src/ol/format/WFS.js
@@ -44,9 +44,50 @@ const FEATURE_COLLECTION_PARSERS = {
     ),
   },
   'http://www.opengis.net/wfs/2.0': {
-    'member': makeArrayPusher(GMLBase.prototype.readFeaturesInternal),
+    'member': readMember,
   },
 };
+
+/**
+ * Reads a `wfs:member`, which contains either a feature or, in GetFeature
+ * responses for multiple type names, a nested `wfs:FeatureCollection`.
+ * @param {Element} node Node.
+ * @param {Array<*>} objectStack Object stack.
+ * @this {GMLBase}
+ */
+function readMember(node, objectStack) {
+  const features = /** @type {Array<*>} */ (
+    objectStack[objectStack.length - 1]
+  );
+  const child = node.firstElementChild;
+  if (child && child.localName === 'FeatureCollection') {
+    // Each nested collection holds one feature type, so let it be detected
+    // per collection when no `featureType` was configured.
+    const context = objectStack[0];
+    const featureType = context['featureType'];
+    const featureNS = context['featureNS'];
+    features.push(
+      ...pushParseAndPop(
+        [],
+        FEATURE_COLLECTION_PARSERS,
+        child,
+        objectStack,
+        this,
+      ),
+    );
+    context['featureType'] = featureType;
+    context['featureNS'] = featureNS;
+    return;
+  }
+  const feature = GMLBase.prototype.readFeaturesInternal.call(
+    this,
+    node,
+    objectStack,
+  );
+  if (feature !== undefined) {
+    features.push(feature);
+  }
+}
 
 /**
  * @const

--- a/test/browser/spec/ol/format/wfs.test.js
+++ b/test/browser/spec/ol/format/wfs.test.js
@@ -1,10 +1,6 @@
 import {assert} from 'chai';
 import proj4 from 'proj4';
 import Feature from '../../../../../src/ol/Feature.js';
-import GML2 from '../../../../../src/ol/format/GML2.js';
-import GML3 from '../../../../../src/ol/format/GML3.js';
-import GML32 from '../../../../../src/ol/format/GML32.js';
-import WFS, {writeFilter} from '../../../../../src/ol/format/WFS.js';
 import {
   and as andFilter,
   bbox as bboxFilter,
@@ -26,10 +22,15 @@ import {
   resourceId as resourceIdFilter,
   within as withinFilter,
 } from '../../../../../src/ol/format/filter.js';
+import GML2 from '../../../../../src/ol/format/GML2.js';
+import GML3 from '../../../../../src/ol/format/GML3.js';
+import GML32 from '../../../../../src/ol/format/GML32.js';
+import WFS, {writeFilter} from '../../../../../src/ol/format/WFS.js';
 import LineString from '../../../../../src/ol/geom/LineString.js';
 import MultiLineString from '../../../../../src/ol/geom/MultiLineString.js';
 import MultiPoint from '../../../../../src/ol/geom/MultiPoint.js';
 import MultiPolygon from '../../../../../src/ol/geom/MultiPolygon.js';
+import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
 import {
   addCommon,
@@ -1852,6 +1853,75 @@ describe('ol.format.WFS', function () {
       const features = wfs.readFeatures(parse(response));
       assert.strictEqual(features.length, 1);
       assert.instanceOf(features[0], Feature);
+    });
+
+    it('can parse GetFeature response with nested FeatureCollections', function () {
+      const response = `
+<?xml version="1.0" encoding="UTF-8"?>
+<wfs:FeatureCollection xmlns:sf="http://www.openplans.org/spearfish"
+    xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2" numberMatched="3" numberReturned="3">
+    <wfs:member>
+        <wfs:FeatureCollection numberMatched="2" numberReturned="2">
+            <wfs:member>
+                <sf:bugsites gml:id="bugsites.1">
+                    <sf:the_geom>
+                        <gml:Point srsName="urn:ogc:def:crs:EPSG::26713" srsDimension="2">
+                            <gml:pos>590529 4914625</gml:pos>
+                        </gml:Point>
+                    </sf:the_geom>
+                    <sf:cat>1</sf:cat>
+                </sf:bugsites>
+            </wfs:member>
+            <wfs:member>
+                <sf:bugsites gml:id="bugsites.2">
+                    <sf:the_geom>
+                        <gml:Point srsName="urn:ogc:def:crs:EPSG::26713" srsDimension="2">
+                            <gml:pos>590530 4914626</gml:pos>
+                        </gml:Point>
+                    </sf:the_geom>
+                    <sf:cat>2</sf:cat>
+                </sf:bugsites>
+            </wfs:member>
+        </wfs:FeatureCollection>
+    </wfs:member>
+    <wfs:member>
+        <wfs:FeatureCollection numberMatched="1" numberReturned="1">
+            <wfs:member>
+                <sf:roads gml:id="roads.1">
+                    <sf:the_geom>
+                        <gml:Point srsName="urn:ogc:def:crs:EPSG::26713" srsDimension="2">
+                            <gml:pos>590531 4914627</gml:pos>
+                        </gml:Point>
+                    </sf:the_geom>
+                    <sf:name>Main</sf:name>
+                </sf:roads>
+            </wfs:member>
+        </wfs:FeatureCollection>
+    </wfs:member>
+</wfs:FeatureCollection>
+    `.trim();
+      // explicit feature types
+      let features = new WFS({
+        version: '2.0.0',
+        featureNS: 'http://www.openplans.org/spearfish',
+        featureType: ['bugsites', 'roads'],
+      }).readFeatures(parse(response));
+      assert.strictEqual(features.length, 3);
+      assert.deepEqual(
+        features.map((f) => f.getId()),
+        ['bugsites.1', 'bugsites.2', 'roads.1'],
+      );
+      assert.strictEqual(features[2].get('name'), 'Main');
+      assert.instanceOf(features[2].getGeometry(), Point);
+
+      // auto-detected feature types
+      features = new WFS({version: '2.0.0'}).readFeatures(parse(response));
+      assert.strictEqual(features.length, 3);
+      assert.deepEqual(
+        features.map((f) => f.getId()),
+        ['bugsites.1', 'bugsites.2', 'roads.1'],
+      );
     });
 
     describe('when writing out a Transaction request', function () {


### PR DESCRIPTION
Fixes #12389.

Handle wfs:member elements that wrap a nested wfs:FeatureCollection, as returned by GetFeature requests with multiple type names. 


### Test E2E

Both screens load the same test page: it feeds a WFS 2.0 GetFeature response for two type names (bugsites, roads), structured as nested wfs:FeatureCollections exactly like the issue describes, into WFS.readFeatures() and puts the result on a map. The label at the top prints how many features were parsed and their ids.

#### Before (code without the fix): 

label says 0 features [] and the map is empty. The parser skipped the nested collections, which is the bug from #12389.

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/44bd72db-ba83-46f4-9a8f-b94e7c4c324e" />

#### After (with the fix): 

label says 3 features [bugsites.1, bugsites.2, roads.1] and three points are drawn, blue for bugsites, red for roads. Both feature types were read from the nested collections.

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/74d2f488-791f-4fc0-a16a-906b55401993" />