### PR TITLE
fix: fix WebGL points hit detection precision

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -318,6 +318,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
           this.renderInstructions_ = new Float32Array(
             event.data.renderInstructions,
           );
+          this.hitUids_ = received.hitUids;
           if (received.id === this.lastSentId) {
             this.ready = true;
           }
@@ -339,6 +340,14 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
      * @private
      */
     this.featureCount_ = 0;
+
+    /**
+     * Feature uids of the current render instructions, indexed by the id
+     * encoded in the hit detection color (minus one).
+     * @type {Array<string>}
+     * @private
+     */
+    this.hitUids_ = [];
 
     const source = /** @type {import("../../source/Vector.js").default} */ (
       this.getLayer().getSource()
@@ -598,6 +607,8 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     let tmpCoords = [];
     /** @type {Array<number>} */
     const tmpColor = [];
+    /** @type {Array<string>} */
+    const hitUids = [];
     let idx = -1;
     const projection = frameState.viewState.projection;
     for (const featureUid in this.featureCache_) {
@@ -616,13 +627,18 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
       renderInstructions[++idx] = tmpCoords[0];
       renderInstructions[++idx] = tmpCoords[1];
 
-      // for hit detection, the feature uid is saved in the opacity value
-      // and the index of the opacity value is encoded in the color values
+      // for hit detection, the feature uid is stored in `hitUids` and its
+      // index (starting at 1, 0 means no feature) is encoded in the color
+      // values. Uids are not stored in the instructions directly because they
+      // may exceed the integer precision of Float32.
       if (this.hitDetectionEnabled_) {
-        const hitColor = colorEncodeIdAndPack(idx + 3, tmpColor);
+        const hitColor = colorEncodeIdAndPack(
+          hitUids.push(featureUid),
+          tmpColor,
+        );
         renderInstructions[++idx] = hitColor[0];
         renderInstructions[++idx] = hitColor[1];
-        renderInstructions[++idx] = Number(featureUid);
+        renderInstructions[++idx] = hitUids.length - 1;
       }
 
       // pushing custom attributes
@@ -645,6 +661,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     // additional properties will be sent back as-is by the worker
     /** @type {Record<string, *>} */ (message)['projectionTransform'] =
       projectionTransform;
+    /** @type {Record<string, *>} */ (message)['hitUids'] = hitUids;
     this.ready = false;
     this.worker_.postMessage(message, [renderInstructions.buffer]);
   }
@@ -681,9 +698,7 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
 
     const data = this.hitRenderTarget_.readPixel(pixel[0] / 2, pixel[1] / 2);
     const color = [data[0] / 255, data[1] / 255, data[2] / 255, data[3] / 255];
-    const index = colorDecodeId(color);
-    const opacity = this.renderInstructions_[index];
-    const uid = Math.floor(opacity).toString();
+    const uid = this.hitUids_[colorDecodeId(color) - 1];
 
     const source = this.getLayer().getSource();
     const feature = source.getFeatureByUid(uid);

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -372,6 +372,69 @@ describe('ol/renderer/webgl/PointsLayer', function () {
         });
       }));
 
+    it('correctly hit detects features with uids beyond Float32 precision', () =>
+      new Promise((resolve) => {
+        renderer.dispose();
+        // 2^24 + 1 is the first integer that cannot be represented in Float32
+        feature = new Feature({geometry: new Point([0, 0])});
+        feature.ol_uid = '16777217';
+        feature2 = new Feature({geometry: new Point([14, 14])});
+        feature2.ol_uid = '16777218';
+        layer = new VectorLayer({
+          source: new VectorSource({features: [feature, feature2]}),
+        });
+        renderer = new WebGLPointsLayerRenderer(layer, {
+          vertexShader: simpleVertexShader,
+          fragmentShader: simpleFragmentShader,
+          hitDetectionEnabled: true,
+        });
+        const transform = composeTransform(
+          createTransform(),
+          20,
+          20,
+          1,
+          -1,
+          0,
+          0,
+          0,
+        );
+        const frameState = Object.assign({}, baseFrameState, {
+          extent: [-20, -20, 20, 20],
+          size: [40, 40],
+          coordinateToPixelTransform: transform,
+          layerStatesArray: [layer.getLayerState()],
+        });
+
+        renderer.prepareFrame(frameState);
+        renderer.worker_.addEventListener('message', function () {
+          if (!renderer.renderInstructions_) {
+            return;
+          }
+          renderer.prepareFrame(frameState);
+          renderer.renderFrame(frameState);
+
+          function checkHit(x, y, expected) {
+            let found = null;
+            renderer.forEachFeatureAtCoordinate(
+              [x, y],
+              frameState,
+              0,
+              (feature) => {
+                found = feature;
+              },
+              null,
+            );
+            assert.strictEqual(found, expected);
+          }
+
+          checkHit(0, 0, feature);
+          checkHit(14, 14, feature2);
+          checkHit(7, 7, null);
+
+          resolve();
+        });
+      }));
+
     it('correctly hit detects with pixelratio != 1', () =>
       new Promise((resolve) => {
         const transform = composeTransform(


### PR DESCRIPTION
Fixes #16368.

Keep feature uids outside the Float32 render instructions and encode their index in the hit color, so WebGLPointsLayer hit detection stays correct once uids exceed 2^24.

### Test E2E

Both screens run the same test page: five points A–E drawn with WebGLPointsLayer, each given a uid just above 2^24 (16777217…16777221), simulating an app that has created millions of features. After rendering, the page asks map.forEachFeatureAtPixel at each point's exact pixel and prints what came back, in the box at the top and under each point as expected→hit (green = correct, red = wrong).

#### Before: A→none, B→B, C→D, D→D, E→D. 

Hit detection returns the wrong neighbour or nothing for 3 of 5 points, because the uid stored in the Float32 buffer rounds to the same value for adjacent uids. This is the bug from #16368.

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/41855a4d-8d94-42ed-9116-6b64377b86bc" />

#### After: A→A … E→E, all five correct.

<img width="960" height="600" alt="image" src="https://github.com/user-attachments/assets/b8ae791d-6e24-4e3f-9fa5-02421eb37a4d" />
