### PR TITLE
fix: add fetchSessionToken option to Google

### DIFF
--- a/src/ol/source/Google.js
+++ b/src/ol/source/Google.js
@@ -42,6 +42,11 @@ const maxZoom = 22;
  * Choose whether to use tiles with a higher or lower zoom level when between integer
  * zoom levels. See {@link module:ol/tilegrid/TileGrid~TileGrid#getZForResolution}.
  * @property {string} [url='https://tile.googleapis.com/'] The Google Tile server URL.
+ * @property {function(string, RequestInit): Promise<Response>} [fetchSessionToken] Function to
+ * fetch a session token, called with the `createSession` URL and the request config. Defaults to
+ * `fetch`. Use this e.g. to persist session tokens across page reloads, so tile URLs stay the same
+ * and cached tiles can be reused. Note that the session token response includes an `expiry`, which
+ * is used to renew the session before it expires.
  */
 
 /**
@@ -177,6 +182,10 @@ class Google extends TileImage {
      */
     this.createSessionUrl_ = baseUrl + 'v1/createSession';
 
+    if (options.fetchSessionToken) {
+      this.fetchSessionToken = options.fetchSessionToken;
+    }
+
     /**
      * @type {string}
      * @private
@@ -209,7 +218,7 @@ class Google extends TileImage {
   }
 
   /**
-   * Exposed here so it can be overridden in the tests.
+   * Fetch a session token. Can be replaced with the `fetchSessionToken` option.
    * @param {string} url The URL.
    * @param {RequestInit} config The config.
    * @return {Promise<Response>} A promise that resolves with the response.

--- a/test/browser/spec/ol/source/Google.test.js
+++ b/test/browser/spec/ol/source/Google.test.js
@@ -102,6 +102,40 @@ describe('ol/source/Google', () => {
       }));
   });
 
+  describe('fetchSessionToken option', () => {
+    it('uses the provided function instead of the default', () =>
+      new Promise((resolve) => {
+        let calls = 0;
+        source = new Google({
+          key: validKey,
+          fetchSessionToken: async (url, config) => {
+            ++calls;
+            assert.strictEqual(config.method, 'POST');
+            assert.strictEqual(new URL(url).searchParams.get('key'), validKey);
+            const response = await fetchSessionToken(url, config);
+            const body = await response.json();
+            body.session = 'stored-session';
+            return new Response(JSON.stringify(body), {
+              status: 200,
+              headers: {'Content-Type': 'application/json'},
+            });
+          },
+        });
+
+        source.on('change', () => {
+          if (source.getState() !== 'ready') {
+            return;
+          }
+          assert.strictEqual(calls, 1);
+          const url = new URL(
+            source.tileUrlFunction([0, 0, 0], 1, source.getProjection()),
+          );
+          assert.strictEqual(url.searchParams.get('session'), 'stored-session');
+          resolve();
+        });
+      }));
+  });
+
   describe('tileUrlFunction()', () => {
     it('returns a url that includes the session and api key', () =>
       new Promise((resolve) => {


### PR DESCRIPTION
Fixes #17526

Allow passing a custom fetchSessionToken(url, config) to ol/source/Google, so applications can reuse a stored session token across page reloads and keep tile URLs cacheable. 