### PR TITLE
Modify interaction: improve condition handling

### DIFF
--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -138,6 +138,9 @@ const ModifyEventType = {
  * function that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and
  * returns a boolean to indicate whether a new vertex should be added to the sketch
  * features. Default is {@link module:ol/events/condition.always}.
+ * @property {import("../events/condition.js").Condition} [moveVertexCondition] A function that takes
+ * a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a boolean to indicate whether a vertex
+ * should be moved in the sketch features. Default is {@link module:ol/events/condition.always}.
  * @property {number} [pixelTolerance=10] Pixel tolerance for considering the
  * pointer close enough to a segment or vertex for editing.
  * @property {import("../style/Style.js").StyleLike|import("../style/flat.js").FlatStyleLike} [style]
@@ -339,6 +342,14 @@ class Modify extends PointerInteraction {
      */
     this.insertVertexCondition_ = options.insertVertexCondition
       ? options.insertVertexCondition
+      : always;
+
+    /**
+     * @type {import("../events/condition.js").Condition}
+     * @private
+     */
+    this.moveVertexCondition_ = options.moveVertexCondition
+      ? options.moveVertexCondition
       : always;
 
     /**
@@ -1816,6 +1827,10 @@ class Modify extends PointerInteraction {
    * @override
    */
   handleDragEvent(evt) {
+    if (!this.moveVertexCondition_(evt)) {
+      return;
+    }
+
     this.ignoreNextSingleClick_ = false;
     this.willModifyFeatures_(
       evt,

--- a/src/ol/interaction/Modify.js
+++ b/src/ol/interaction/Modify.js
@@ -118,9 +118,8 @@ const ModifyEventType = {
  * @typedef {Object} Options
  * @property {import("../events/condition.js").Condition} [condition] A function that
  * takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
- * boolean to indicate whether that event will be considered to add or move a
- * vertex to the sketch. Default is
- * {@link module:ol/events/condition.primaryAction}.
+ * boolean to indicate whether that event will be considered to modify a
+ * vertex in the sketch. Default is {@link module:ol/events/condition.primaryAction}.
  * @property {import("../events/condition.js").Condition} [deleteCondition] A function
  * that takes a {@link module:ol/MapBrowserEvent~MapBrowserEvent} and returns a
  * boolean to indicate whether that event should be handled. By default,
@@ -1134,12 +1133,16 @@ class Modify extends PointerInteraction {
     ) {
       this.handlePointerMove_(mapBrowserEvent);
     }
-    if (this.vertexFeature_ && this.deleteCondition_(mapBrowserEvent)) {
+    if (
+      this.vertexFeature_ &&
+      this.condition_(mapBrowserEvent) &&
+      this.deleteCondition_(mapBrowserEvent)
+    ) {
       if (
         mapBrowserEvent.type != MapBrowserEventType.SINGLECLICK ||
         !this.ignoreNextSingleClick_
       ) {
-        handled = this.removePoint();
+        handled = this.removePoint(mapBrowserEvent.coordinate);
       } else {
         handled = true;
       }


### PR DESCRIPTION
This PR fixes #17617 and improves the condition logic of the Modify interaction. Previously the situation was:

- `condition` is a pre-condition filtering events to consider for inserting or moving vertices
- `insertVertexCondition` further filters those events for ones that insert vertices
- `moveVertexCondition` doesn't exist, decreasing the flexibility of the Modify interaction substantially
- `deleteCondition` filters all events, even those that don't meet `condition`, for ones that should delete vertices. In cases where `condition` wasn't met, but `deleteCondition` was, or if you tried to implement deleting vertices on a `pointerdown` event, this would fail because the internal structure wouldn't update before the deletion.

The new situation after this PR is:
- `condition` is a pre-condition filtering events to consider for all three types of modification
- `insertVertexCondition` stays the same
- `moveVertexCondition` is introduced with a default value of `always` to increase the flexibility of the Modify interaction
- `deleteCondition` only filters events that already got through `condition`. Before deletion happens, the internal structure is always updated to prevent deletion of the wrong vertex.

This is a breaking change, as deletion is now locked behind an additional condition.

I have not added or changed any tests alongside this PR yet. If that is needed or desired please leave a comment to let me know.