### PR TITLE
Upload the instance attributes buffer again when the points layer helper is recreated

### DIFF
--- a/src/ol/renderer/webgl/PointsLayer.js
+++ b/src/ol/renderer/webgl/PointsLayer.js
@@ -414,6 +414,9 @@ class WebGLPointsLayerRenderer extends WebGLLayerRenderer {
     if (this.indicesBuffer_.getArray()) {
       this.helper.flushBufferData(this.indicesBuffer_);
     }
+    if (this.instanceAttributesBuffer_.getArray()) {
+      this.helper.flushBufferData(this.instanceAttributesBuffer_);
+    }
   }
 
   /**

--- a/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/PointsLayer.test.js
@@ -21,6 +21,7 @@ import {
   create as createTransform,
 } from '../../../../../../src/ol/transform.js';
 import {getUid} from '../../../../../../src/ol/util.js';
+import WebGLHelper from '../../../../../../src/ol/webgl/Helper.js';
 import {assertArrayLikeEqual} from '../../../../../util/equal.js';
 
 const baseFrameState = {
@@ -221,6 +222,35 @@ describe('ol/renderer/webgl/PointsLayer', function () {
           assertArrayLikeEqual(renderer.indicesBuffer_.getArray().length, 6);
 
           resolve();
+        });
+      }));
+
+    it('uploads the instance attributes buffer again when the helper is recreated', () =>
+      new Promise((resolve, reject) => {
+        layer.getSource().addFeature(
+          new Feature({
+            geometry: new Point([10, 20]),
+          }),
+        );
+        renderer.prepareFrame(frameState);
+
+        renderer.worker_.addEventListener('message', function (event) {
+          if (
+            event.data.type !== WebGLWorkerMessageType.GENERATE_POINT_BUFFERS
+          ) {
+            return;
+          }
+          renderer.removeHelper();
+          const spy = vi.spyOn(WebGLHelper.prototype, 'flushBufferData');
+          renderer.prepareFrame(frameState);
+          const uploaded = spy.mock.calls.map((call) => call[0]);
+          spy.mockRestore();
+          try {
+            assert.include(uploaded, renderer.instanceAttributesBuffer_);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
         });
       }));
 


### PR DESCRIPTION
Fixes #17627

Since #16959 the point data of `WebGLPointsLayerRenderer` lives in `instanceAttributesBuffer_`, but `afterHelperCreated()` only uploads `verticesBuffer_` and `indicesBuffer_` again. After the helper is recreated, for example when the layer is removed from the map and added back, the layer draws with an empty instance buffer until the next worker rebuild is done. This uploads the instance buffer as well.

The new test removes the helper after the buffers were generated, lets `prepareFrame()` recreate it and checks that the instance buffer is uploaded again. It fails without the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
