### PR TITLE
Fix fullscreen control icon on mobile

### DIFF
--- a/src/ol/control/FullScreen.js
+++ b/src/ol/control/FullScreen.js
@@ -49,7 +49,7 @@ const FullScreenEventType = {
 /**
  * @typedef {Object} Options
  * @property {string} [className='ol-full-screen'] CSS class name.
- * @property {string|Text|HTMLElement} [label='\u2922'] Text label to use for the button.
+ * @property {string|Text|HTMLElement} [label='\u26F6'] Text label to use for the button.
  * Instead of text, also an element (e.g. a `span` element) can be used.
  * @property {string|Text|HTMLElement} [labelActive='\u00d7'] Text label to use for the
  * button when full-screen is active.
@@ -163,7 +163,7 @@ class FullScreen extends Control {
         ? options.inactiveClassName.split(' ')
         : [this.cssClassName_ + '-false'];
 
-    const label = options.label !== undefined ? options.label : '\u2922';
+    const label = options.label !== undefined ? options.label : '\u26F6';
 
     /**
      * @private

--- a/test/browser/spec/ol/control/fullscreen.test.js
+++ b/test/browser/spec/ol/control/fullscreen.test.js
@@ -27,4 +27,35 @@ describe('ol.control.FullScreen', function () {
       });
     });
   });
+
+  describe('the default label', function () {
+    it('uses the U+26F6 expand glyph instead of the font-dependent U+2922', function () {
+      const instance = new FullScreen();
+      const label = instance.labelNode_;
+      assert.instanceOf(label, Text);
+      assert.equal(label.data, '\u26F6');
+      assert.notEqual(label.data, '\u2922');
+    });
+  });
+
+  describe('custom labels', function () {
+    it('renders a string label as a text node', function () {
+      const instance = new FullScreen({label: 'F'});
+      assert.equal(instance.labelNode_.data, 'F');
+    });
+
+    it('accepts an HTMLElement label', function () {
+      const span = document.createElement('span');
+      span.textContent = 'custom';
+      const instance = new FullScreen({label: span});
+      assert.strictEqual(instance.labelNode_, span);
+    });
+
+    it('accepts an HTMLElement labelActive', function () {
+      const span = document.createElement('span');
+      span.textContent = 'close';
+      const instance = new FullScreen({labelActive: span});
+      assert.strictEqual(instance.labelActiveNode_, span);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #17551

The default fullscreen control icon uses U+2922 (⤢), which is not consistently supported by fonts on mobile browsers and can render as a missing glyph.

This changes the default icon to U+26F6 (⛶), following the approach suggested by @ahocevar in the issue.

Custom `label` and `labelActive` options remain unchanged.

A regression test was added for the new default label and existing custom label behavior.