### PR TITLE
fix: add hit detection to the WebGL vector tile renderer

### DIFF
--- a/examples/webgl-vector-tile-info.css
+++ b/examples/webgl-vector-tile-info.css
@@ -1,0 +1,17 @@
+#map {
+  position: relative;
+}
+
+#info {
+  z-index: 1;
+  opacity: 0;
+  pointer-events: none;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  margin: 0;
+  background: rgba(0, 60, 136, 0.7);
+  color: white;
+  border: 0;
+  transition: opacity 100ms ease-in;
+}

--- a/examples/webgl-vector-tile-info.html
+++ b/examples/webgl-vector-tile-info.html
@@ -1,0 +1,12 @@
+---
+layout: example.html
+title: WebGL Vector Tile Info
+shortdesc: Getting feature information from vector tiles rendered with WebGL.
+docs: >
+  <p>Move your pointer over rendered features to display feature properties. The vector tiles are rendered using WebGL, and features are retrieved with <code>map.getFeaturesAtPixel()</code>.</p>
+tags: "vector tiles, webgl, hit detection"
+experimental: true
+---
+<div id="map" class="map">
+  <pre id="info"></pre>
+</div>

--- a/examples/webgl-vector-tile-info.js
+++ b/examples/webgl-vector-tile-info.js
@@ -1,0 +1,76 @@
+import Map from '../src/ol/Map.js';
+import View from '../src/ol/View.js';
+import MVT from '../src/ol/format/MVT.js';
+import WebGLVectorTileLayer from '../src/ol/layer/WebGLVectorTile.js';
+import VectorTileSource from '../src/ol/source/VectorTile.js';
+
+const style = [
+  {
+    filter: ['==', ['geometry-type'], 'Polygon'],
+    style: {
+      'fill-color': [
+        'match',
+        ['get', 'layer'],
+        'Water area',
+        '#a0c8f0',
+        '#eee',
+      ],
+      'stroke-color': '#c8c8c8',
+      'stroke-width': 1,
+    },
+  },
+  {
+    filter: ['==', ['geometry-type'], 'LineString'],
+    style: {
+      'stroke-color': '#a06060',
+      'stroke-width': 2,
+    },
+  },
+  {
+    filter: ['==', ['geometry-type'], 'Point'],
+    style: {
+      'circle-radius': 4,
+      'circle-fill-color': '#336699',
+    },
+  },
+];
+
+const map = new Map({
+  target: 'map',
+  view: new View({
+    center: [0, 0],
+    zoom: 2,
+  }),
+  layers: [
+    new WebGLVectorTileLayer({
+      source: new VectorTileSource({
+        format: new MVT(),
+        url: 'https://basemaps.arcgis.com/arcgis/rest/services/World_Basemap_v2/VectorTileServer/tile/{z}/{y}/{x}.pbf',
+      }),
+      style,
+    }),
+  ],
+});
+
+const mapTarget = map.getTargetElement();
+mapTarget.addEventListener('pointerleave', showInfo);
+map.on('pointermove', (evt) => {
+  if (evt.dragging) {
+    return;
+  }
+  showInfo(evt);
+});
+
+const info = document.getElementById('info');
+function showInfo(event) {
+  const features =
+    event.type === 'pointerleave' ? [] : map.getFeaturesAtPixel(event.pixel);
+  if (features.length == 0) {
+    info.innerText = '';
+    info.style.opacity = '0';
+    return;
+  }
+  const properties = features[0].getProperties();
+  info.innerText = JSON.stringify(properties, null, 2);
+  info.style.opacity = '1';
+}

--- a/src/ol/render/webgl/MixedGeometryBatch.js
+++ b/src/ol/render/webgl/MixedGeometryBatch.js
@@ -51,6 +51,27 @@ import {getUid} from '../../util.js';
  */
 
 /**
+ * Pool of hit detection refs. Refs are numerical ids encoded as colors in the hit detection render pass;
+ * the pool maps them back to features.
+ * @typedef {Object} HitDetectionRefs
+ * @property {number} counter Highest ref allocated so far
+ * @property {Array<number>} free Refs that were released and can be reused. The precision in WebGL shaders is limited,
+ * so refs are kept as small as possible by reusing freed up references.
+ * @property {Map<number, Feature|RenderFeature>} refToFeature Lookup of features by ref
+ */
+
+/**
+ * @return {HitDetectionRefs} A new, empty pool of hit detection refs
+ */
+export function createHitDetectionRefs() {
+  return {
+    counter: 0,
+    free: [],
+    refToFeature: new Map(),
+  };
+}
+
+/**
  * @classdesc This class is used to group several geometries of various types together for faster rendering.
  * Three inner batches are maintained for polygons, lines and points. Each time a feature is added, changed or removed
  * from the batch, these inner batches are modified accordingly in order to keep them up-to-date.
@@ -70,18 +91,23 @@ import {getUid} from '../../util.js';
  * the WebGL buffers.
  */
 class MixedGeometryBatch {
-  constructor() {
+  /**
+   * @param {HitDetectionRefs} [hitDetectionRefs] Pool of hit detection refs; when provided, the pool
+   * is shared with other batches so that refs stay unique across all of them (e.g. across vector tiles).
+   */
+  constructor(hitDetectionRefs) {
     /**
+     * Whether the hit detection refs pool is shared with other batches
      * @private
      */
-    this.globalCounter_ = 0;
+    this.sharedRefs_ = !!hitDetectionRefs;
 
     /**
      * Refs are used as keys for hit detection.
-     * @type {Map<number, Feature|RenderFeature>}
+     * @type {HitDetectionRefs}
      * @private
      */
-    this.refToFeature_ = new Map();
+    this.refs_ = hitDetectionRefs ?? createHitDetectionRefs();
 
     /**
      * Features are split in "entries", which are individual geometries. We use the following map to share a single ref for all those entries.
@@ -89,14 +115,6 @@ class MixedGeometryBatch {
      * @private
      */
     this.uidToRef_ = new Map();
-
-    /**
-     * The precision in WebGL shaders is limited.
-     * To keep the refs as small as possible we maintain an array of freed up references.
-     * @type {Array<number>}
-     * @private
-     */
-    this.freeGlobalRef_ = [];
 
     /**
      * @type {PolygonGeometryBatch}
@@ -511,11 +529,11 @@ class MixedGeometryBatch {
     const currentRef = this.uidToRef_.get(featureUid);
 
     // the ref starts at 1 to distinguish from white color (no feature)
-    const ref =
-      currentRef || this.freeGlobalRef_.pop() || ++this.globalCounter_;
+    const refs = this.refs_;
+    const ref = currentRef || refs.free.pop() || ++refs.counter;
     entry.ref = ref;
     if (!currentRef) {
-      this.refToFeature_.set(ref, entry.feature);
+      refs.refToFeature.set(ref, entry.feature);
       this.uidToRef_.set(featureUid, ref);
     }
     return entry;
@@ -531,9 +549,9 @@ class MixedGeometryBatch {
     if (!ref) {
       throw new Error('This feature has no ref: ' + featureUid);
     }
-    this.refToFeature_.delete(ref);
+    this.refs_.refToFeature.delete(ref);
     this.uidToRef_.delete(featureUid);
-    this.freeGlobalRef_.push(ref);
+    this.refs_.free.push(ref);
   }
 
   /**
@@ -579,9 +597,18 @@ class MixedGeometryBatch {
     this.lineStringBatch.verticesCount = 0;
     this.pointBatch.entries = {};
     this.pointBatch.geometriesCount = 0;
-    this.globalCounter_ = 0;
-    this.freeGlobalRef_ = [];
-    this.refToFeature_.clear();
+    const refs = this.refs_;
+    if (this.sharedRefs_) {
+      // only release the refs owned by this batch
+      for (const ref of this.uidToRef_.values()) {
+        refs.refToFeature.delete(ref);
+        refs.free.push(ref);
+      }
+    } else {
+      refs.counter = 0;
+      refs.free.length = 0;
+      refs.refToFeature.clear();
+    }
     this.uidToRef_.clear();
   }
 
@@ -591,11 +618,11 @@ class MixedGeometryBatch {
    * @return {Feature|RenderFeature|undefined} feature
    */
   getFeatureFromRef(ref) {
-    return this.refToFeature_.get(ref);
+    return this.refs_.refToFeature.get(ref);
   }
 
   isEmpty() {
-    return this.globalCounter_ === 0;
+    return this.uidToRef_.size === 0;
   }
 
   /**
@@ -605,13 +632,12 @@ class MixedGeometryBatch {
    * @return {MixedGeometryBatch} Filtered geometry batch
    */
   filter(featureFilter) {
-    const filtered = new MixedGeometryBatch();
-    filtered.globalCounter_ = this.globalCounter_;
+    const filtered = new MixedGeometryBatch(this.refs_);
     filtered.uidToRef_ = this.uidToRef_;
-    filtered.refToFeature_ = this.refToFeature_;
     let empty = true;
-    for (const feature of this.refToFeature_.values()) {
-      if (featureFilter(feature)) {
+    for (const ref of this.uidToRef_.values()) {
+      const feature = this.refs_.refToFeature.get(ref);
+      if (feature && featureFilter(feature)) {
         filtered.addFeature(feature);
         empty = false;
       }

--- a/src/ol/renderer/webgl/VectorTileLayer.js
+++ b/src/ol/renderer/webgl/VectorTileLayer.js
@@ -1,7 +1,10 @@
 /**
  * @module ol/renderer/webgl/VectorTileLayer
  */
+import {assert} from '../../asserts.js';
 import EventType from '../../events/EventType.js';
+import {colorDecodeId} from '../../render/webgl/encodeUtil.js';
+import {createHitDetectionRefs} from '../../render/webgl/MixedGeometryBatch.js';
 import {ShaderBuilder} from '../../render/webgl/ShaderBuilder.js';
 import {
   createPostProcessDefinition,
@@ -13,6 +16,7 @@ import VectorStyleRenderer, {
   toFlatStyleLike,
 } from '../../render/webgl/VectorStyleRenderer.js';
 import {
+  apply as applyTransform,
   create as createTransform,
   makeInverse as makeInverseTransform,
   multiply as multiplyTransform,
@@ -65,6 +69,15 @@ export const Attributes = {
  */
 
 /**
+ * Everything needed to render a tile again in the hit detection pass
+ * @typedef {Object} HitDetectionTile
+ * @property {import("../../render/webgl/VectorStyleRenderer.js").WebGLBuffers} buffers Tile buffers
+ * @property {import("../../extent.js").Extent} tileExtent Tile extent
+ * @property {number} tileZ Tile zoom level
+ * @property {number} depth Depth
+ */
+
+/**
  * @classdesc
  * WebGL renderer for vector tile layers. Experimental.
  * @extends {WebGLBaseTileLayerRenderer<any, import("../../VectorRenderTile.js").default, import("../../webgl/TileGeometry.js").default>}
@@ -90,6 +103,26 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
      * @private
      */
     this.hitDetectionEnabled_ = !options.disableHitDetection;
+
+    /**
+     * Pool of hit detection refs shared by all tiles of the layer
+     * @type {import("../../render/webgl/MixedGeometryBatch.js").HitDetectionRefs}
+     * @private
+     */
+    this.hitDetectionRefs_ = createHitDetectionRefs();
+
+    /**
+     * @type {WebGLRenderTarget|null}
+     * @private
+     */
+    this.hitRenderTarget_ = null;
+
+    /**
+     * Tiles rendered in the current frame, to be rendered again in the hit detection pass
+     * @type {Array<HitDetectionTile>}
+     * @private
+     */
+    this.hitDetectionTiles_ = [];
 
     /**
      * @type {LayerStyle|null}
@@ -274,6 +307,9 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
   afterHelperCreated() {
     this.createRenderers_();
     this.initTileMask_();
+    if (this.hitDetectionEnabled_) {
+      this.hitRenderTarget_ = new WebGLRenderTarget(this.helper);
+    }
   }
 
   /**
@@ -286,6 +322,7 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
       /** @type {import("../../render/webgl/VectorStyleRenderer.js").default} */ (
         this.styleRenderer_
       ),
+      this.hitDetectionRefs_,
     );
     // redraw the layer when the tile is ready
     const listener = () => {
@@ -312,6 +349,8 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
     if (layerChanged) {
       this.skipNextTextRender_ = false;
     }
+
+    this.hitDetectionTiles_.length = 0;
 
     this.helper.makeProjectionTransform(
       frameState,
@@ -352,6 +391,9 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
    */
   beforeFinalize(frameState) {
     const styleRenderer = this.styleRenderer_;
+    if (this.hitDetectionEnabled_ && styleRenderer) {
+      this.renderHitDetection_(frameState, styleRenderer);
+    }
     if (this.hasText_ && styleRenderer) {
       styleRenderer.finalizeTextRender(frameState).then(() => {
         if (this.skipNextTextRender_) {
@@ -489,7 +531,101 @@ class WebGLVectorTileLayerRenderer extends WebGLBaseTileLayerRenderer {
         depth,
         frameState,
       );
+      this.helper.applyHitDetectionUniform(false);
     });
+    if (this.hitDetectionEnabled_) {
+      this.hitDetectionTiles_.push({buffers, tileExtent, tileZ, depth});
+    }
+  }
+
+  /**
+   * Render all the tiles drawn in the current frame again into the hit detection
+   * render target, using hit detection colors instead of the actual style.
+   * @param {import("../../Map.js").FrameState} frameState Frame state.
+   * @param {VectorStyleRenderer} styleRenderer Style renderer.
+   * @private
+   */
+  renderHitDetection_(frameState, styleRenderer) {
+    const hitRenderTarget = this.hitRenderTarget_;
+    const tiles = this.hitDetectionTiles_;
+    if (!hitRenderTarget) {
+      tiles.length = 0;
+      return;
+    }
+    hitRenderTarget.setSize([
+      Math.floor(frameState.size[0] / 2),
+      Math.floor(frameState.size[1] / 2),
+    ]);
+    // depth testing is needed so that tiles from different zoom levels do not overwrite each other
+    this.helper.prepareDrawToRenderTarget(
+      frameState,
+      hitRenderTarget,
+      true,
+      true,
+    );
+    for (let i = 0, ii = tiles.length; i < ii; ++i) {
+      const tile = tiles[i];
+      styleRenderer.render(tile.buffers, frameState, () => {
+        this.applyUniforms_(
+          1,
+          tile.tileExtent,
+          tile.buffers.invertVerticesTransform,
+          tile.tileZ,
+          tile.depth,
+          frameState,
+        );
+        this.helper.applyHitDetectionUniform(true);
+      });
+    }
+    hitRenderTarget.clearCachedData();
+    tiles.length = 0;
+  }
+
+  /**
+   * @param {import("../../coordinate.js").Coordinate} coordinate Coordinate.
+   * @param {import("../../Map.js").FrameState} frameState Frame state.
+   * @param {number} hitTolerance Hit tolerance in pixels.
+   * @param {import("../vector.js").FeatureCallback<T>} callback Feature callback.
+   * @param {Array<import("../Map.js").HitMatch<T>>} matches The hit detected matches with tolerance.
+   * @return {T|undefined} Callback result.
+   * @template T
+   * @override
+   */
+  forEachFeatureAtCoordinate(
+    coordinate,
+    frameState,
+    hitTolerance,
+    callback,
+    matches,
+  ) {
+    assert(
+      this.hitDetectionEnabled_,
+      '`forEachFeatureAtCoordinate` cannot be used on a WebGL layer if the hit detection logic has been disabled using the `disableHitDetection: true` option.',
+    );
+    const hitRenderTarget = this.hitRenderTarget_;
+    if (!this.styleRenderer_ || !hitRenderTarget) {
+      return undefined;
+    }
+
+    const pixel = applyTransform(
+      frameState.coordinateToPixelTransform,
+      coordinate.slice(),
+    );
+
+    const data = hitRenderTarget.readPixel(pixel[0] / 2, pixel[1] / 2);
+    const color = [data[0] / 255, data[1] / 255, data[2] / 255, data[3] / 255];
+    const ref = colorDecodeId(color);
+    const feature = this.hitDetectionRefs_.refToFeature.get(ref);
+    if (feature) {
+      return callback(
+        feature,
+        this.getLayer(),
+        /** @type {import("../../geom/SimpleGeometry.js").default} */ (
+          /** @type {unknown} */ (null)
+        ),
+      );
+    }
+    return undefined;
   }
 
   /**

--- a/src/ol/webgl/TileGeometry.js
+++ b/src/ol/webgl/TileGeometry.js
@@ -22,14 +22,16 @@ class TileGeometry extends BaseTileRepresentation {
   /**
    * @param {import("./BaseTileRepresentation.js").TileRepresentationOptions<TileType>} options The tile texture options.
    * @param {import("../render/webgl/VectorStyleRenderer.js").default} styleRenderer Vector style renderer
+   * @param {import("../render/webgl/MixedGeometryBatch.js").HitDetectionRefs} [hitDetectionRefs] Pool of hit detection refs
+   * shared across tiles, so that refs remain unique for the whole layer
    */
-  constructor(options, styleRenderer) {
+  constructor(options, styleRenderer, hitDetectionRefs) {
     super(options);
 
     /**
      * @private
      */
-    this.batch_ = new MixedGeometryBatch();
+    this.batch_ = new MixedGeometryBatch(hitDetectionRefs);
 
     /**
      * @private
@@ -152,6 +154,8 @@ class TileGeometry extends BaseTileRepresentation {
         this.buffers.textInstructionsKey ?? '',
       );
     }
+    // release the hit detection refs held by this tile
+    this.batch_.clear();
     super.disposeInternal();
   }
 }

--- a/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
+++ b/test/browser/spec/ol/render/webgl/MixedGeometryBatch.test.js
@@ -10,7 +10,9 @@ import Point from '../../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../../src/ol/geom/Polygon.js';
 import {getTransform} from '../../../../../../src/ol/proj.js';
 import RenderFeature from '../../../../../../src/ol/render/Feature.js';
-import MixedGeometryBatch from '../../../../../../src/ol/render/webgl/MixedGeometryBatch.js';
+import MixedGeometryBatch, {
+  createHitDetectionRefs,
+} from '../../../../../../src/ol/render/webgl/MixedGeometryBatch.js';
 import {getUid} from '../../../../../../src/ol/util.js';
 
 describe('MixedGeometryBatch', function () {
@@ -85,8 +87,8 @@ describe('MixedGeometryBatch', function () {
         assert.lengthOf(Object.keys(mixedBatch.lineStringBatch.entries), 0);
       });
       it('assigns a hit detection ref to the entry', () => {
-        assert.strictEqual(mixedBatch.globalCounter_, 2);
-        assert.strictEqual(mixedBatch.freeGlobalRef_.length, 0);
+        assert.strictEqual(mixedBatch.refs_.counter, 2);
+        assert.strictEqual(mixedBatch.refs_.free.length, 0);
         assert.strictEqual(mixedBatch.getFeatureFromRef(1), feature1);
         assert.strictEqual(mixedBatch.getFeatureFromRef(2), feature2);
       });
@@ -504,9 +506,9 @@ describe('MixedGeometryBatch', function () {
         assert.strictEqual(mixedBatch.polygonBatch.ringsCount, 3);
       });
       it('keeps the removed ref for later use', () => {
-        assert.deepEqual(mixedBatch.freeGlobalRef_, [1]);
-        assert.strictEqual(mixedBatch.globalCounter_, 2);
-        assert.strictEqual(mixedBatch.refToFeature_.size, 1);
+        assert.deepEqual(mixedBatch.refs_.free, [1]);
+        assert.strictEqual(mixedBatch.refs_.counter, 2);
+        assert.strictEqual(mixedBatch.refs_.refToFeature.size, 1);
       });
     });
   });
@@ -1297,6 +1299,61 @@ describe('MixedGeometryBatch', function () {
     it('clears point batch', () => {
       assert.lengthOf(Object.keys(mixedBatch.pointBatch.entries), 0);
       assert.strictEqual(mixedBatch.pointBatch.geometriesCount, 0);
+    });
+
+    it('resets the hit detection refs', () => {
+      assert.strictEqual(mixedBatch.refs_.counter, 0);
+      assert.lengthOf(mixedBatch.refs_.free, 0);
+      assert.strictEqual(mixedBatch.refs_.refToFeature.size, 0);
+      assert.isTrue(mixedBatch.isEmpty());
+    });
+  });
+
+  describe('shared hit detection refs', () => {
+    let refs, batch1, batch2, feature1, feature2, feature3;
+    beforeEach(() => {
+      refs = createHitDetectionRefs();
+      batch1 = new MixedGeometryBatch(refs);
+      batch2 = new MixedGeometryBatch(refs);
+      feature1 = new Feature(new Point([101, 102]));
+      feature2 = new Feature(new Point([201, 202]));
+      feature3 = new Feature(new Point([301, 302]));
+      batch1.addFeature(feature1);
+      batch2.addFeature(feature2);
+      batch1.addFeature(feature3);
+    });
+
+    it('assigns unique refs across batches', () => {
+      assert.strictEqual(refs.counter, 3);
+      assert.strictEqual(batch1.pointBatch.entries[getUid(feature1)].ref, 1);
+      assert.strictEqual(batch2.pointBatch.entries[getUid(feature2)].ref, 2);
+      assert.strictEqual(batch1.pointBatch.entries[getUid(feature3)].ref, 3);
+    });
+
+    it('resolves features from any batch', () => {
+      assert.strictEqual(batch1.getFeatureFromRef(2), feature2);
+      assert.strictEqual(batch2.getFeatureFromRef(1), feature1);
+      assert.strictEqual(refs.refToFeature.get(3), feature3);
+    });
+
+    it('only releases its own refs when cleared', () => {
+      batch1.clear();
+      assert.isTrue(batch1.isEmpty());
+      assert.isFalse(batch2.isEmpty());
+      assert.strictEqual(refs.counter, 3);
+      assert.sameMembers(refs.free, [1, 3]);
+      assert.strictEqual(refs.refToFeature.size, 1);
+      assert.strictEqual(refs.refToFeature.get(2), feature2);
+      assert.isUndefined(batch2.getFeatureFromRef(1));
+    });
+
+    it('reuses released refs', () => {
+      batch1.removeFeature(feature1);
+      const feature4 = new Feature(new Point([401, 402]));
+      batch2.addFeature(feature4);
+      assert.strictEqual(batch2.pointBatch.entries[getUid(feature4)].ref, 1);
+      assert.strictEqual(refs.counter, 3);
+      assert.strictEqual(refs.refToFeature.get(1), feature4);
     });
   });
 

--- a/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
+++ b/test/browser/spec/ol/renderer/webgl/VectorTileLayer.test.js
@@ -108,7 +108,7 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
               [],
               2,
               {
-                'color': 'red',
+                color: 'red',
               },
               2,
             ),
@@ -452,41 +452,41 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
     it('sets the size of the tile mask target according to frame state', () => {
       assert.deepEqual(renderer.tileMaskTarget_.getSize(), [400, 200]);
     });
-    it('sets TILE_ZOOM_LEVEL uniform three times for each tile and style renderer, plus two times for tile masks', () => {
+    it('sets TILE_ZOOM_LEVEL uniform three times for each tile and style renderer (main and hit detection passes), plus two times for tile masks', () => {
       const calls = renderer.helper.setUniformFloatValue.mock.calls.filter(
         (args) => args[0] === Uniforms.TILE_ZOOM_LEVEL,
       );
-      assert.strictEqual(calls.length, 14);
+      assert.strictEqual(calls.length, 26);
       assertArrayLikeEqual(calls[0], [Uniforms.TILE_ZOOM_LEVEL, 2]);
       assertArrayLikeEqual(calls[1], [Uniforms.TILE_ZOOM_LEVEL, 2]);
       assertArrayLikeEqual(calls[2], [Uniforms.TILE_ZOOM_LEVEL, 2]);
       assertArrayLikeEqual(calls[8], [Uniforms.TILE_ZOOM_LEVEL, 2]);
     });
-    it('sets GLOBAL_ALPHA uniform three times for each tile and style renderer, plus two times for tile masks', () => {
+    it('sets GLOBAL_ALPHA uniform three times for each tile and style renderer (main and hit detection passes), plus two times for tile masks', () => {
       const calls = renderer.helper.setUniformFloatValue.mock.calls.filter(
         (args) => args[0] === Uniforms.GLOBAL_ALPHA,
       );
-      assert.strictEqual(calls.length, 14);
+      assert.strictEqual(calls.length, 26);
       assertArrayLikeEqual(calls[0], [Uniforms.GLOBAL_ALPHA, 1]);
       assertArrayLikeEqual(calls[1], [Uniforms.GLOBAL_ALPHA, 1]);
       assertArrayLikeEqual(calls[2], [Uniforms.GLOBAL_ALPHA, 1]);
       assertArrayLikeEqual(calls[8], [Uniforms.GLOBAL_ALPHA, 1]);
     });
-    it('sets RENDER_EXTENT uniform three times for each tile and style renderer, plus two times for tile masks', () => {
+    it('sets RENDER_EXTENT uniform three times for each tile and style renderer (main and hit detection passes), plus two times for tile masks', () => {
       const calls = renderer.helper.setUniformFloatVec4.mock.calls.filter(
         (args) => args[0] === Uniforms.RENDER_EXTENT,
       );
-      assert.strictEqual(calls.length, 14);
+      assert.strictEqual(calls.length, 26);
       assertArrayLikeEqual(calls[0], [Uniforms.RENDER_EXTENT, [0, 0, 64, 64]]);
       assertArrayLikeEqual(calls[1], [Uniforms.RENDER_EXTENT, [0, 0, 64, 64]]);
       assertArrayLikeEqual(calls[2], [Uniforms.RENDER_EXTENT, [0, 0, 64, 64]]);
       assertArrayLikeEqual(calls[8], [Uniforms.RENDER_EXTENT, [0, 0, 64, 64]]);
     });
-    it('sets PROJECTION matrix uniform three times for each tile and style renderer, plus one time per tiles for their mask', () => {
+    it('sets PROJECTION matrix uniform three times for each tile and style renderer (main and hit detection passes), plus one time per tiles for their mask', () => {
       const calls = renderer.helper.setUniformMatrixValue.mock.calls.filter(
         (args) => args[0] === Uniforms.PROJECTION_MATRIX,
       );
-      assert.strictEqual(calls.length, 14);
+      assert.strictEqual(calls.length, 26);
       assertArrayLikeEqual(calls[0], [
         Uniforms.PROJECTION_MATRIX,
         // 0.04   0     0     0      combination of:
@@ -512,11 +512,11 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
         [0.04, 0, 0, 0, 0, 0.08, 0, 0, 0, 0, 1, 0, 0, -1.28, 0, 1],
       ]);
     });
-    it('sets INVERT_PROJECTION_MATRIX matrix uniform three times for each tile and style renderer, plus one time per tiles for their mask', () => {
+    it('sets INVERT_PROJECTION_MATRIX matrix uniform three times for each tile and style renderer (main and hit detection passes), plus one time per tiles for their mask', () => {
       const calls = renderer.helper.setUniformMatrixValue.mock.calls.filter(
         (args) => args[0] === Uniforms.INVERT_PROJECTION_MATRIX,
       );
-      assert.strictEqual(calls.length, 14);
+      assert.strictEqual(calls.length, 26);
       assertArrayLikeEqual(calls[0], [
         Uniforms.INVERT_PROJECTION_MATRIX,
         // 25     0     0     0      combination of:
@@ -534,23 +534,223 @@ describe('ol/renderer/webgl/VectorTileLayer', function () {
         [25, 0, 0, 0, 0, 12.5, 0, 0, 0, 0, 1, 0, 0, 16, 0, 1],
       ]);
     });
-    it('bind TILE_MASK_TEXTURE uniform three times for each tile and style renderer, plus one time before rendering tile masks', () => {
+    it('bind TILE_MASK_TEXTURE uniform three times for each tile and style renderer (main and hit detection passes), plus one time before rendering tile masks', () => {
       const calls = renderer.helper.bindTexture.mock.calls;
-      assert.strictEqual(calls.length, 13);
+      assert.strictEqual(calls.length, 25);
       assertArrayLikeEqual(calls[0], [
         renderer.tileMaskTarget_.getTexture(),
         0,
         Uniforms.TILE_MASK_TEXTURE,
       ]);
     });
-    it('calls render for each tile on each renderer', () => {
-      assert.strictEqual(renderer.styleRenderer_.render.mock.calls.length, 2);
+    it('calls render for each tile on each renderer, for the main and the hit detection passes', () => {
+      assert.strictEqual(renderer.styleRenderer_.render.mock.calls.length, 4);
     });
     it('does not call styleRenderer.finalizeTextRender (no text style)', () => {
       assert.strictEqual(
         renderer.styleRenderer_.finalizeTextRender.mock.calls.length,
         0,
       );
+    });
+  });
+  describe('hit detection', () => {
+    describe('#afterHelperCreated', () => {
+      it('creates a hit detection render target', () => {
+        renderer.prepareFrame(frameState);
+        assert.instanceOf(renderer.hitRenderTarget_, WebGLRenderTarget);
+      });
+      it('does not create a hit detection render target if hit detection is disabled', () => {
+        renderer.dispose();
+        renderer = new WebGLVectorTileLayerRenderer(vectorTileLayer, {
+          style: SAMPLE_RULES,
+          disableHitDetection: true,
+        });
+        renderer.prepareFrame(frameState);
+        assert.isNull(renderer.hitRenderTarget_);
+      });
+    });
+
+    describe('#createTileRepresentation', () => {
+      it('shares the hit detection refs pool with all tiles', () => {
+        renderer.prepareFrame(frameState);
+        const tileRep1 = renderer.createTileRepresentation({
+          tile: new VectorRenderTile(
+            [0, 0, 0],
+            TileState.IDLE,
+            [0, 0, 0],
+            () => [],
+            () => {},
+          ),
+          grid: vectorTileLayer.getSource().getTileGrid(),
+          helper: renderer.helper,
+          gutter: 0,
+        });
+        const tileRep2 = renderer.createTileRepresentation({
+          tile: new VectorRenderTile(
+            [0, 1, 0],
+            TileState.IDLE,
+            [0, 1, 0],
+            () => [],
+            () => {},
+          ),
+          grid: vectorTileLayer.getSource().getTileGrid(),
+          helper: renderer.helper,
+          gutter: 0,
+        });
+        assert.strictEqual(tileRep1.batch_.refs_, renderer.hitDetectionRefs_);
+        assert.strictEqual(tileRep2.batch_.refs_, renderer.hitDetectionRefs_);
+      });
+    });
+
+    describe('#renderFrame', () => {
+      beforeEach(async () => {
+        renderer.prepareFrame(frameState);
+        renderer.renderFrame(frameState);
+        frameState.tileQueue.loadMoreTiles(Infinity, Infinity);
+        await vi.waitFor(() => {
+          let ready = 0;
+          renderer.tileRepresentationCache.forEach((rep) => {
+            if (rep.ready) {
+              ready++;
+            }
+          });
+          assert.strictEqual(ready, 2);
+        });
+        vi.spyOn(renderer.helper, 'prepareDrawToRenderTarget');
+        vi.spyOn(renderer.helper, 'applyHitDetectionUniform');
+        vi.spyOn(renderer.hitRenderTarget_, 'clearCachedData');
+        renderer.renderFrame(frameState);
+      });
+      it('assigns unique hit detection refs to the features of all tiles', () => {
+        const refToFeature = renderer.hitDetectionRefs_.refToFeature;
+        // 3 features per tile, 2 tiles
+        assert.strictEqual(refToFeature.size, 6);
+        assert.deepEqual(
+          [...refToFeature.keys()].sort((a, b) => a - b),
+          [1, 2, 3, 4, 5, 6],
+        );
+        assert.strictEqual(new Set(refToFeature.values()).size, 6);
+      });
+      it('renders to the hit detection render target with depth enabled and the hit detection uniform on', () => {
+        const calls =
+          renderer.helper.prepareDrawToRenderTarget.mock.calls.filter(
+            (args) => args[1] === renderer.hitRenderTarget_,
+          );
+        assert.lengthOf(calls, 1);
+        assert.isTrue(calls[0][3]);
+        // 2 tiles * 2 style shaders * 3 render passes
+        const uniformCalls =
+          renderer.helper.applyHitDetectionUniform.mock.calls.filter(
+            (args) => args[0] === true,
+          );
+        assert.lengthOf(uniformCalls, 12);
+      });
+      it('sizes the hit detection render target to half the frame state size', () => {
+        assert.deepEqual(renderer.hitRenderTarget_.getSize(), [100, 50]);
+      });
+      it('invalidates the cached hit detection data and clears the list of tiles', () => {
+        assert.strictEqual(
+          renderer.hitRenderTarget_.clearCachedData.mock.calls.length,
+          1,
+        );
+        assert.lengthOf(renderer.hitDetectionTiles_, 0);
+      });
+    });
+
+    describe('#forEachFeatureAtCoordinate', () => {
+      beforeEach(async () => {
+        renderer.prepareFrame(frameState);
+        renderer.renderFrame(frameState);
+        frameState.tileQueue.loadMoreTiles(Infinity, Infinity);
+        await vi.waitFor(() => {
+          let ready = 0;
+          renderer.tileRepresentationCache.forEach((rep) => {
+            if (rep.ready) {
+              ready++;
+            }
+          });
+          assert.strictEqual(ready, 2);
+        });
+        renderer.renderFrame(frameState);
+        frameState.coordinateToPixelTransform = create();
+      });
+      it('throws if hit detection is disabled', () => {
+        renderer.dispose();
+        renderer = new WebGLVectorTileLayerRenderer(vectorTileLayer, {
+          style: SAMPLE_RULES,
+          disableHitDetection: true,
+        });
+        assert.throws(() => {
+          renderer.forEachFeatureAtCoordinate(
+            [0, 0],
+            frameState,
+            0,
+            () => {},
+            [],
+          );
+        });
+      });
+      it('resolves the feature from the color read in the hit detection render target', () => {
+        const ref = 5;
+        const expected = renderer.hitDetectionRefs_.refToFeature.get(ref);
+        assert.instanceOf(expected, RenderFeature);
+        vi.spyOn(renderer.hitRenderTarget_, 'readPixel').mockReturnValue(
+          new Uint8Array([0, 0, 0, ref]),
+        );
+        const callback = vi.fn(() => 'result');
+        const result = renderer.forEachFeatureAtCoordinate(
+          [10, 20],
+          frameState,
+          0,
+          callback,
+          [],
+        );
+        assert.strictEqual(result, 'result');
+        assert.strictEqual(callback.mock.calls.length, 1);
+        assert.strictEqual(callback.mock.calls[0][0], expected);
+        assert.strictEqual(callback.mock.calls[0][1], vectorTileLayer);
+        // pixel coordinates are halved to match the hit detection render target size
+        assert.deepEqual(
+          renderer.hitRenderTarget_.readPixel.mock.calls[0],
+          [5, 10],
+        );
+      });
+      it('does not call the callback if no feature was hit', () => {
+        vi.spyOn(renderer.hitRenderTarget_, 'readPixel').mockReturnValue(
+          new Uint8Array([0, 0, 0, 0]),
+        );
+        const callback = vi.fn();
+        const result = renderer.forEachFeatureAtCoordinate(
+          [10, 20],
+          frameState,
+          0,
+          callback,
+          [],
+        );
+        assert.isUndefined(result);
+        assert.strictEqual(callback.mock.calls.length, 0);
+      });
+    });
+
+    describe('tile disposal', () => {
+      it('releases the hit detection refs of disposed tiles', async () => {
+        renderer.prepareFrame(frameState);
+        renderer.renderFrame(frameState);
+        frameState.tileQueue.loadMoreTiles(Infinity, Infinity);
+        await vi.waitFor(() => {
+          let ready = 0;
+          renderer.tileRepresentationCache.forEach((rep) => {
+            if (rep.ready) {
+              ready++;
+            }
+          });
+          assert.strictEqual(ready, 2);
+        });
+        assert.strictEqual(renderer.hitDetectionRefs_.refToFeature.size, 6);
+        renderer.clearCache();
+        assert.strictEqual(renderer.hitDetectionRefs_.refToFeature.size, 0);
+        assert.lengthOf(renderer.hitDetectionRefs_.free, 6);
+      });
     });
   });
 });

--- a/test/browser/spec/ol/webgl/TileGeometry.test.js
+++ b/test/browser/spec/ol/webgl/TileGeometry.test.js
@@ -6,7 +6,9 @@ import VectorTile from '../../../../../src/ol/VectorTile.js';
 import {VOID} from '../../../../../src/ol/functions.js';
 import Point from '../../../../../src/ol/geom/Point.js';
 import Polygon from '../../../../../src/ol/geom/Polygon.js';
-import MixedGeometryBatch from '../../../../../src/ol/render/webgl/MixedGeometryBatch.js';
+import MixedGeometryBatch, {
+  createHitDetectionRefs,
+} from '../../../../../src/ol/render/webgl/MixedGeometryBatch.js';
 import {createXYZ} from '../../../../../src/ol/tilegrid.js';
 import WebGLHelper from '../../../../../src/ol/webgl/Helper.js';
 import TileGeometry from '../../../../../src/ol/webgl/TileGeometry.js';
@@ -63,6 +65,20 @@ describe('ol/webgl/TileGeometry', function () {
   describe('tile provided initially', () => {
     it('assigns the given tile', () => {
       assert.instanceOf(tileGeometry.tile, VectorRenderTile);
+    });
+    it('uses the provided hit detection refs pool for its geometry batch', () => {
+      const refs = createHitDetectionRefs();
+      const withSharedRefs = new TileGeometry(
+        {
+          tile,
+          grid,
+          helper,
+        },
+        styleRenderer,
+        refs,
+      );
+      assert.strictEqual(withSharedRefs.batch_.refs_, refs);
+      withSharedRefs.dispose();
     });
     it('creates a new geometry batch', () => {
       assert.instanceOf(tileGeometry.batch_, MixedGeometryBatch);
@@ -171,6 +187,9 @@ describe('ol/webgl/TileGeometry', function () {
           styleRenderer.disposeTextInstructions.mock.calls.length,
           1,
         );
+      });
+      it('clears the geometry batch to release hit detection refs', () => {
+        assert.isTrue(tileGeometry.batch_.isEmpty());
       });
     });
   });


### PR DESCRIPTION
Closes #16246

Adds hit detection to the WebGL vector tile renderer: a shared per-layer ref pool, a depth-tested hit render pass, and forEachFeatureAtCoordinate, so getFeaturesAtPixel works on WebGLVectorTileLayer.